### PR TITLE
Changed Anti Gravity link to google antigravity page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 > Slimmed-down fork of [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode) - focused on core agent orchestration without the extra bells and whistles.
 
-> **[Antigravity](https://antigravity.ai) subscription recommended.** The pantheon is tuned for Antigravity's model routing. Other providers work, but you'll get the best experience with Antigravity.
+> **[Antigravity](https://antigravity.google) subscription recommended.** The pantheon is tuned for Antigravity's model routing. Other providers work, but you'll get the best experience with Antigravity.
 
 ---
 


### PR DESCRIPTION
Was redirecting to go daddy domain purchasing page is it was just antigravity.ai 

not sure I formatted this properly as this is my first ever public pull request. 