### PR TITLE
fix: allow question permission for orchestrator only

### DIFF
--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -22,6 +22,13 @@ function applyOverrides(agent: AgentDefinition, override: AgentOverrideConfig): 
   }
 }
 
+type PermissionValue = "ask" | "allow" | "deny";
+
+function applyDefaultPermissions(agent: AgentDefinition): void {
+  const existing = (agent.config.permission ?? {}) as Record<string, PermissionValue>;
+  agent.config.permission = { ...existing, question: "allow" } as SDKAgentConfig["permission"];
+}
+
 type SubagentName = Exclude<AgentName, "orchestrator">;
 
 /** Agent factories indexed by name */
@@ -64,6 +71,7 @@ export function createAgents(config?: PluginConfig): AgentDefinition[] {
   const orchestratorModel =
     agentOverrides["orchestrator"]?.model ?? DEFAULT_MODELS["orchestrator"];
   const orchestrator = createOrchestratorAgent(orchestratorModel);
+  applyDefaultPermissions(orchestrator);
   const oOverride = agentOverrides["orchestrator"];
   if (oOverride) {
     applyOverrides(orchestrator, oOverride);


### PR DESCRIPTION
## Summary

- Restrict `question` permission to orchestrator only
- Keep permission wiring centralized in `src/agents/index.ts`

## Changes

- Apply `permission.question = "allow"` only to orchestrator
- Remove default permission injection for subagents

## Manual Verification

1) Rebuild and restart OpenCode.
2) Ask orchestrator to ask you a question and see it uses the tool

## Tests

Not run (not requested)

## Related Issues

#3 Probably doesnt close it, as decision needed for primary vs subagents and which agents should get access to question (and other tools) in the future