### PR TITLE
Fix tmux pane spawn health check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ local
 
 .sisyphus/
 .hive/
+
+.ignore


### PR DESCRIPTION
I believe solves issue #31.

I found that often the loading of the opencode server takes more than 1 second and results in tmux not using session panes as it thinks there is no server. loosen it to 3 seconds and have a 2nd retry.