### PR TITLE
feat: add JSONC support for configuration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ opencode auth login
 
 Run `ping all agents` to verify everything works.
 
-> **💡 Models are fully customizable.** Edit `~/.config/opencode/oh-my-opencode-slim.json` to assign any model to any agent.
+> **💡 Models are fully customizable.** Edit `~/.config/opencode/oh-my-opencode-slim.json` (or `.jsonc` for comments support) to assign any model to any agent.
 
 ### For LLM Agents
 

--- a/docs/antigravity.md
+++ b/docs/antigravity.md
@@ -114,7 +114,7 @@ Edit `~/.config/opencode/opencode.json` and add the "google" provider configurat
 
 ### Step 2: Configure Agent Models
 
-Edit `~/.config/opencode/oh-my-opencode-slim.json` and add the Antigravity preset:
+Edit `~/.config/opencode/oh-my-opencode-slim.json` (or `.jsonc`) and add the Antigravity preset:
 
 ```json
 {
@@ -368,7 +368,7 @@ To test different configurations:
 export OH_MY_OPENCODE_SLIM_PRESET=openai
 opencode
 
-# Or edit ~/.config/opencode/oh-my-opencode-slim.json
+# Or edit ~/.config/opencode/oh-my-opencode-slim.json (or .jsonc)
 # Change the "preset" field and restart OpenCode
 ```
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -39,7 +39,7 @@ opencode auth login
 
 Once authenticated, run opencode and `ping all agents` to verify all agents respond.
 
-> **💡 Tip: Models are fully customizable.** The installer sets sensible defaults, but you can assign *any* model to *any* agent. Edit `~/.config/opencode/oh-my-opencode-slim.json` to override models, adjust reasoning effort, or disable agents entirely. See [Configuration](quick-reference.md#configuration) for details.
+> **💡 Tip: Models are fully customizable.** The installer sets sensible defaults, but you can assign *any* model to *any* agent. Edit `~/.config/opencode/oh-my-opencode-slim.json` (or `.jsonc` for comments support) to override models, adjust reasoning effort, or disable agents entirely. See [Configuration](quick-reference.md#configuration) for details.
 
 ### Alternative: Ask Any Coding Agent
 
@@ -74,7 +74,7 @@ Ask these questions **one at a time**, waiting for responses:
 Help the user understand the tradeoffs:
 - Kimi For Coding provides powerful k1.5 models for coding tasks.
 - OpenAI is optional; it enables `openai/` models.
-- If the user has **no providers**, the plugin still works using **OpenCode Zen** free models (`opencode/big-pickle`). They can switch to paid providers later by editing `~/.config/opencode/oh-my-opencode-slim.json`.
+- If the user has **no providers**, the plugin still works using **OpenCode Zen** free models (`opencode/big-pickle`). They can switch to paid providers later by editing `~/.config/opencode/oh-my-opencode-slim.json` (or `.jsonc`).
 
 ### Step 3: Run the Installer
 
@@ -98,12 +98,12 @@ bunx oh-my-opencode-slim@latest install --no-tui --kimi=no --openai=no --tmux=no
 
 The installer automatically:
 - Adds the plugin to `~/.config/opencode/opencode.json`
-- Generates agent model mappings in `~/.config/opencode/oh-my-opencode-slim.json`
+- Generates agent model mappings in `~/.config/opencode/oh-my-opencode-slim.json` (or `.jsonc`)
 
 **Crucial Advice for the User:**
-- They can easily assign **different models to different agents** by editing `~/.config/opencode/oh-my-opencode-slim.json`.
+- They can easily assign **different models to different agents** by editing `~/.config/opencode/oh-my-opencode-slim.json` (or `.jsonc`).
 - If they add a new provider later, they just need to update this file.
-- Read generated `~/.config/opencode/oh-my-opencode-slim.json` file and report the model configuration.
+- Read generated `~/.config/opencode/oh-my-opencode-slim.json` (or `.jsonc`) file and report the model configuration.
 
 ### Step 4: Authenticate with Providers
 
@@ -135,7 +135,7 @@ bunx oh-my-opencode-slim@latest install --help
 ```
 
 Then manually create the config files at:
-- `~/.config/opencode/oh-my-opencode-slim.json`
+- `~/.config/opencode/oh-my-opencode-slim.json` (or `.jsonc`)
 
 ### Agents Not Responding
 

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -21,7 +21,7 @@ Presets are pre-configured agent model mappings for different provider combinati
 
 **Method 1: Edit Config File**
 
-Edit `~/.config/opencode/oh-my-opencode-slim.json` and change the `preset` field:
+Edit `~/.config/opencode/oh-my-opencode-slim.json` (or `.jsonc`) and change the `preset` field:
 
 ```json
 {
@@ -229,7 +229,7 @@ python3 ~/.config/opencode/skills/cartography/scripts/cartographer.py update --r
 
 ### Skills Assignment
 
-You can customize which skills each agent is allowed to use in `~/.config/opencode/oh-my-opencode-slim.json`.
+You can customize which skills each agent is allowed to use in `~/.config/opencode/oh-my-opencode-slim.json` (or `.jsonc`).
 
 **Syntax:**
 
@@ -290,7 +290,7 @@ Control which agents can access which MCP servers using per-agent allowlists:
 
 ### Configuration & Syntax
 
-You can configure MCP access in your plugin configuration file: `~/.config/opencode/oh-my-opencode-slim.json`.
+You can configure MCP access in your plugin configuration file: `~/.config/opencode/oh-my-opencode-slim.json` (or `.jsonc`).
 
 **Per-Agent Permissions**
 
@@ -345,7 +345,7 @@ You can disable specific MCP servers globally by adding them to the `disabled_mc
 
 #### Quick Setup
 
-1. **Enable tmux integration** in `oh-my-opencode-slim.json`:
+1. **Enable tmux integration** in `oh-my-opencode-slim.json` (or `.jsonc`):
 
    ```json
    {
@@ -423,8 +423,10 @@ OpenCode automatically formats files after they're written or edited using langu
 | File | Purpose |
 |------|---------|
 | `~/.config/opencode/opencode.json` | OpenCode core settings |
-| `~/.config/opencode/oh-my-opencode-slim.json` | Plugin settings (agents, tmux, MCPs) |
-| `.opencode/oh-my-opencode-slim.json` | Project-local plugin overrides (optional) |
+| `~/.config/opencode/oh-my-opencode-slim.json` or `.jsonc` | Plugin settings (agents, tmux, MCPs) |
+| `.opencode/oh-my-opencode-slim.json` or `.jsonc` | Project-local plugin overrides (optional) |
+
+> **💡 JSONC Support:** Configuration files support JSONC format (JSON with Comments). Use `.jsonc` extension to enable comments and trailing commas. If both `.jsonc` and `.json` exist, `.jsonc` takes precedence.
 
 ### Prompt Overriding
 
@@ -455,7 +457,42 @@ You can customize agent prompts by creating markdown files in `~/.config/opencod
 
 This allows you to fine-tune agent behavior without modifying the source code.
 
-### Plugin Config (`oh-my-opencode-slim.json`)
+### JSONC Format (JSON with Comments)
+
+The plugin supports **JSONC** format for configuration files, allowing you to:
+
+- Add single-line comments (`//`)
+- Add multi-line comments (`/* */`)
+- Use trailing commas in arrays and objects
+
+**File Priority:**
+1. `oh-my-opencode-slim.jsonc` (preferred if exists)
+2. `oh-my-opencode-slim.json` (fallback)
+
+**Example JSONC Configuration:**
+
+```jsonc
+{
+  // Use preset for development
+  "preset": "dev",
+
+  /* Presets definition - customize agent models here */
+  "presets": {
+    "dev": {
+      // Fast models for quick iteration
+      "oracle": { "model": "google/gemini-3-flash" },
+      "explorer": { "model": "google/gemini-3-flash" },
+    },
+  },
+
+  "tmux": {
+    "enabled": true,  // Enable for monitoring
+    "layout": "main-vertical",
+  },
+}
+```
+
+### Plugin Config (`oh-my-opencode-slim.json` or `oh-my-opencode-slim.jsonc`)
 
 The installer generates this file based on your providers. You can manually customize it to mix and match models. See the [Presets](#presets) section for detailed configuration options.
 

--- a/docs/tmux-integration.md
+++ b/docs/tmux-integration.md
@@ -34,7 +34,7 @@ Complete guide for using tmux integration with oh-my-opencode-slim to watch agen
 
 ### Step 1: Enable Tmux Integration
 
-Edit `~/.config/opencode/oh-my-opencode-slim.json`:
+Edit `~/.config/opencode/oh-my-opencode-slim.json` (or `.jsonc`):
 
 ```json
 {
@@ -64,7 +64,7 @@ That's it! Your agents will now spawn panes automatically.
 
 ### Tmux Settings
 
-Configure tmux behavior in `~/.config/opencode/oh-my-opencode-slim.json`:
+Configure tmux behavior in `~/.config/opencode/oh-my-opencode-slim.json` (or `.jsonc`):
 
 ```json
 {
@@ -196,7 +196,7 @@ tmux switch -t project2
 **Solutions:**
 1. **Verify tmux integration is enabled:**
    ```bash
-   cat ~/.config/opencode/oh-my-opencode-slim.json | grep tmux
+    cat ~/.config/opencode/oh-my-opencode-slim.json | grep tmux # (or .jsonc)
    ```
 
 2. **Check port configuration:**


### PR DESCRIPTION
Ref. https://github.com/alvinunreal/oh-my-opencode-slim/issues/112
Closes #112

## Summary
- Implements all requirements from #112: JSONC support for configuration files with comments and trailing commas
- Maintains full backward compatibility with existing .json files
- Updates documentation across all docs to reflect the new format support

## Changes
### Core Implementation
- Modified `src/config/loader.ts` to use `stripJsonComments()` for parsing both .json and .jsonc files
- Added `findConfigPath()` helper that prefers .jsonc over .json when both exist
- Imported existing `stripJsonComments` utility from `../cli/config-io`
### Test Coverage
- Added 8 new tests in `src/config/loader.test.ts` covering:
  - Single-line comments (`//`)
  - Multi-line comments (`/* */`)
  - Trailing commas
  - File priority (.jsonc > .json)
  - Complex JSONC with mixed features
### Documentation Updates
- `docs/quick-reference.md`: Added new "JSONC Format" section with examples and updated all config file references
- `README.md`: Updated tip about model customization to mention .jsonc
- `docs/installation.md`: Updated 5 references to mention .jsonc support
- `docs/tmux-integration.md`: Updated 2 references
- `docs/antigravity.md`: Updated 2 references
### Backward Compatibility
- Existing .json files work without any changes
- No breaking changes to the API or configuration schema
- If both .jsonc and .json exist, .jsonc takes precedence (opt-in behavior)