### PR TITLE
fix: Improve CLI tools with better error handling and options

### DIFF
--- a/src/tools/ast-grep/cli.ts
+++ b/src/tools/ast-grep/cli.ts
@@ -56,7 +56,9 @@ export async function getAstGrepPath(): Promise<string | null> {
 export function startBackgroundInit(): void {
   if (!initPromise) {
     initPromise = getAstGrepPath();
-    initPromise.catch(() => {});
+    initPromise.catch((err) => {
+      console.warn('[ast-grep] Background initialization failed:', err?.message ?? err);
+    });
   }
 }
 

--- a/src/tools/grep/tools.ts
+++ b/src/tools/grep/tools.ts
@@ -7,7 +7,7 @@ export const grep: ToolDefinition = tool({
     'Fast content search tool with safety limits (60s timeout, 10MB output). ' +
     'Searches file contents using regular expressions. ' +
     'Supports full regex syntax (eg. "log.*Error", "function\\s+\\w+", etc.). ' +
-    'Filter files by pattern with the include parameter (eg. "*.js", "*.{ts,tsx}"). ' +
+    'Filter files by pattern with the include parameter (e.g. "*.js", "*.{ts,tsx}"). ' +
     'Returns file paths with matches sorted by modification time.',
   args: {
     pattern: tool.schema
@@ -25,6 +25,21 @@ export const grep: ToolDefinition = tool({
       .describe(
         'The directory to search in. Defaults to the current working directory.',
       ),
+    caseSensitive: tool.schema
+      .boolean()
+      .optional()
+      .default(false)
+      .describe('Perform case-sensitive search (default: false)'),
+    wholeWord: tool.schema
+      .boolean()
+      .optional()
+      .default(false)
+      .describe('Match whole words only (default: false)'),
+    fixedStrings: tool.schema
+      .boolean()
+      .optional()
+      .default(false)
+      .describe('Treat pattern as literal string (default: false)'),
   },
   execute: async (args) => {
     try {
@@ -36,6 +51,9 @@ export const grep: ToolDefinition = tool({
         paths,
         globs,
         context: 0,
+        caseSensitive: args.caseSensitive ?? false,
+        wholeWord: args.wholeWord ?? false,
+        fixedStrings: args.fixedStrings ?? false,
       });
 
       return formatGrepResult(result);


### PR DESCRIPTION
## Summary
This PR fixes two issues in the CLI tools:

### 1. Silent error swallowing in ast-grep background init
**File:** `src/tools/ast-grep/cli.ts`

The `startBackgroundInit()` function was silently catching errors from the background initialization promise. This makes debugging difficult when ast-grep binary download or setup fails.

**Fix:** Changed from `.catch(() => {})` to log the error message for visibility.

### 2. Missing grep tool options
**File:** `src/tools/grep/tools.ts`

The `grep` tool definition was missing several useful options that the underlying `runRg` function supports: `caseSensitive`, `wholeWord`, and `fixedStrings`.

**Fix:** Added these options to the tool definition with appropriate defaults.

## Changes
- `src/tools/ast-grep/cli.ts`: Improved error logging in background init
- `src/tools/grep/tools.ts`: Added caseSensitive, wholeWord, fixedStrings options

## Testing
These changes don't modify core logic, so existing tests should continue to pass. The new grep options can be tested manually.