### PR TITLE
fix: support variant overrides in agent config

### DIFF
--- a/src/agents/index.test.ts
+++ b/src/agents/index.test.ts
@@ -66,6 +66,17 @@ describe('agent alias backward compatibility', () => {
     const explorer = agents.find((a) => a.name === 'explorer');
     expect(explorer?.config.temperature).toBe(0.5);
   });
+
+  test('variant override via old alias', () => {
+    const config: PluginConfig = {
+      agents: {
+        explore: { variant: 'low' },
+      },
+    };
+    const agents = createAgents(config);
+    const explorer = agents.find((a) => a.name === 'explorer');
+    expect(explorer?.config.variant).toBe('low');
+  });
 });
 
 describe('fixer agent fallback', () => {
@@ -117,6 +128,17 @@ describe('orchestrator agent', () => {
     const orchestrator = agents.find((a) => a.name === 'orchestrator');
     expect(orchestrator?.config.model).toBe('custom-orchestrator-model');
     expect(orchestrator?.config.temperature).toBe(0.3);
+  });
+
+  test('orchestrator accepts variant override', () => {
+    const config: PluginConfig = {
+      agents: {
+        orchestrator: { variant: 'high' },
+      },
+    };
+    const agents = createAgents(config);
+    const orchestrator = agents.find((a) => a.name === 'orchestrator');
+    expect(orchestrator?.config.variant).toBe('high');
   });
 });
 

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -1,4 +1,4 @@
-import type { AgentConfig as SDKAgentConfig } from '@opencode-ai/sdk';
+import type { AgentConfig as SDKAgentConfig } from '@opencode-ai/sdk/v2';
 import { getSkillPermissionsForAgent } from '../cli/skills';
 import {
   type AgentOverrideConfig,
@@ -29,13 +29,14 @@ type AgentFactory = (
 
 /**
  * Apply user-provided overrides to an agent's configuration.
- * Supports overriding model and temperature.
+ * Supports overriding model, variant, and temperature.
  */
 function applyOverrides(
   agent: AgentDefinition,
   override: AgentOverrideConfig,
 ): void {
   if (override.model) agent.config.model = override.model;
+  if (override.variant) agent.config.variant = override.variant;
   if (override.temperature !== undefined)
     agent.config.temperature = override.temperature;
 }

--- a/src/agents/orchestrator.ts
+++ b/src/agents/orchestrator.ts
@@ -1,4 +1,4 @@
-import type { AgentConfig } from '@opencode-ai/sdk';
+import type { AgentConfig } from '@opencode-ai/sdk/v2';
 
 export interface AgentDefinition {
   name: string;
@@ -67,7 +67,7 @@ Each specialist delivers 10x results in their domain:
 - @explorer → Parallel discovery when you need to find unknowns, not read knowns
 - @librarian → Complex/evolving APIs where docs prevent errors, not basic usage
 - @oracle → High-stakes decisions where wrong choice is costly, not routine calls
-- @designer → User-facing experiences where polish matters, not internal logic  
+- @designer → User-facing experiences where polish matters, not internal logic
 - @fixer → Parallel execution of clear specs, not explaining trivial changes
 
 **Delegation efficiency:**

--- a/src/tools/ast-grep/cli.ts
+++ b/src/tools/ast-grep/cli.ts
@@ -57,7 +57,10 @@ export function startBackgroundInit(): void {
   if (!initPromise) {
     initPromise = getAstGrepPath();
     initPromise.catch((err) => {
-      console.warn('[ast-grep] Background initialization failed:', err?.message ?? err);
+      console.warn(
+        '[ast-grep] Background initialization failed:',
+        err?.message ?? err,
+      );
     });
   }
 }


### PR DESCRIPTION
## Summary
- Fix agent configuration overrides to support `variant` values in addition to `model` and `temperature`.
- Ensure backward-compatible alias configs (e.g. `explore`) can override `variant` correctly.
- Add regression tests to verify variant override behavior for both explorer and orchestrator agents.

## Changes
- Updated override application logic in `src/agents/index.ts` to apply `override.variant` to agent configs.
- Added tests in `src/agents/index.test.ts`:
  - `variant override via old alias`
  - `orchestrator accepts variant override`
- Switched `AgentConfig` type imports to `@opencode-ai/sdk/v2` in:
  - `src/agents/index.ts`
  - `src/agents/orchestrator.ts`
- Applied formatting-only cleanup in `src/tools/ast-grep/cli.ts` and whitespace normalization in `src/agents/orchestrator.ts`.

