### PR TITLE
feat: add static toggle for todo continuation enforcer

### DIFF
--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -498,5 +498,21 @@ The installer generates this file based on your providers. You can manually cust
 | `tmux.layout` | string | `"main-vertical"` | Layout preset: `main-vertical`, `main-horizontal`, `tiled`, `even-horizontal`, `even-vertical` |
 | `tmux.main_pane_size` | number | `60` | Main pane size as percentage (20-80) |
 | `disabled_mcps` | string[] | `[]` | MCP server IDs to disable globally (e.g., `"websearch"`) |
+| `todo_continuation.enabled` | boolean | `true` | Static ON/OFF toggle for `todo-continuation-enforcer` hook. Set `false` to hard-disable auto continuation. |
 
 > **Note:** Agent configuration should be defined within `presets`. The root-level `agents` field is deprecated.
+
+### Todo Continuation Toggle
+
+If auto continuation feels too aggressive, use a deterministic static toggle:
+
+```jsonc
+{
+  "todo_continuation": {
+    "enabled": false
+  }
+}
+```
+
+- `true` (default): keeps `todo-continuation-enforcer` active
+- `false`: disables `todo-continuation-enforcer` via `disabled_hooks` (hard OFF)

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -79,6 +79,23 @@ describe('loadPluginConfig', () => {
     expect(config.balanceProviderUsage).toBe(true);
   });
 
+  test('loads todo_continuation static toggle when configured', () => {
+    const projectDir = path.join(tempDir, 'project');
+    const projectConfigDir = path.join(projectDir, '.opencode');
+    fs.mkdirSync(projectConfigDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(projectConfigDir, 'oh-my-opencode-slim.json'),
+      JSON.stringify({
+        todo_continuation: {
+          enabled: false,
+        },
+      }),
+    );
+
+    const config = loadPluginConfig(projectDir);
+    expect(config.todo_continuation?.enabled).toBe(false);
+  });
+
   test('loads manual plan structure when configured', () => {
     const projectDir = path.join(tempDir, 'project');
     const projectConfigDir = path.join(projectDir, '.opencode');

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -132,6 +132,14 @@ export const FailoverConfigSchema = z.object({
 export type FailoverConfig = z.infer<typeof FailoverConfigSchema>;
 
 // Main plugin config
+export const TodoContinuationConfigSchema = z.object({
+  enabled: z.boolean().default(true),
+});
+
+export type TodoContinuationConfig = z.infer<
+  typeof TodoContinuationConfigSchema
+>;
+
 export const PluginConfigSchema = z.object({
   preset: z.string().optional(),
   scoringEngineVersion: z.enum(['v1', 'v2-shadow', 'v2']).optional(),
@@ -143,6 +151,7 @@ export const PluginConfigSchema = z.object({
   tmux: TmuxConfigSchema.optional(),
   background: BackgroundTaskConfigSchema.optional(),
   fallback: FailoverConfigSchema.optional(),
+  todo_continuation: TodoContinuationConfigSchema.optional(),
 });
 
 export type PluginConfig = z.infer<typeof PluginConfigSchema>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,6 +90,29 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
       (opencodeConfig as { default_agent?: string }).default_agent =
         'orchestrator';
 
+      // Static toggle for todo continuation enforcement.
+      // enabled=true  -> remove hook from disabled_hooks (allow continuation)
+      // enabled=false -> add hook to disabled_hooks (hard off)
+      const continuationEnabled = config.todo_continuation?.enabled ?? true;
+      const disabledHooks = Array.isArray(
+        (opencodeConfig as { disabled_hooks?: unknown }).disabled_hooks,
+      )
+        ? [
+            ...((opencodeConfig as { disabled_hooks: unknown[] })
+              .disabled_hooks as string[]),
+          ]
+        : [];
+
+      const continuationHook = 'todo-continuation-enforcer';
+      const withoutContinuationHook = disabledHooks.filter(
+        (name) => name !== continuationHook,
+      );
+
+      (opencodeConfig as { disabled_hooks?: string[] }).disabled_hooks =
+        continuationEnabled
+          ? withoutContinuationHook
+          : [...withoutContinuationHook, continuationHook];
+
       // Merge Agent configs
       if (!opencodeConfig.agent) {
         opencodeConfig.agent = { ...agents };


### PR DESCRIPTION
## Summary
Adds a clean, deterministic ON/OFF toggle for todo continuation behavior (no AI intent detection).

## What changed
- Added `todo_continuation.enabled` to plugin config schema (`true` by default).
- Wired config handling to control OpenCode `disabled_hooks`:
  - `enabled: false` => adds `todo-continuation-enforcer` to `disabled_hooks` (hard OFF)
  - `enabled: true` => removes `todo-continuation-enforcer` from `disabled_hooks`
- Added loader test coverage for the new config key.
- Updated docs (`docs/quick-reference.md`) with option reference and example.

## Why
Issue #147 requests a clean static toggle approach instead of heuristic/AI-based detection. This implements exactly that with deterministic behavior.

Closes #147
