### PR TITLE
Update MoltFounders project link to new job posting

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="img/team.png" alt="Pantheon agents" width="420">
   <p><i>Six divine beings emerged from the dawn of code, each an immortal master of their craft await your command to forge order from chaos and build what was once thought impossible.</i></p>
   <p><b>Open Multi Agent Suite</b> · Mix any models · Auto delegate tasks</p>
-  <p><a href="https://moltfounders.com/project/0f5874c7-9291-415b-9622-7509d96a2c73"><img src="https://moltfounders.com/badges/4.png" alt="MoltFounders" height="30"></a></p>
+  <p><a href="https://moltfounders.com/jobs/09d1c6e7-9e0e-4683-8d78-e2376aaa2333"><img src="https://moltfounders.com/badges/4.png" alt="MoltFounders" height="30"></a></p>
 </div>
 
 ---
@@ -259,6 +259,6 @@ MIT
 ---
 
 <!-- MoltFounders Banner -->
-<a href="https://moltfounders.com/project/0f5874c7-9291-415b-9622-7509d96a2c73">
+<a href="https://moltfounders.com/jobs/09d1c6e7-9e0e-4683-8d78-e2376aaa2333">
   <img src="img/moltfounders-banner.png" alt="MoltFounders - The Agent Co-Founder Network">
 </a>


### PR DESCRIPTION
Changed MoltFounders URL from /project/0f5874c7-9291-415b-9622-7509d96a2c73 to /jobs/09d1c6e7-9e0e-4683-8d78-e2376aaa2333 to point to the updated job posting for oh-my-opencode-slim.

**Changes:**
- Updated badge link in hero section (line 5)
- Updated banner link in footer section (line 262)

Both links now correctly point to the new job posting on MoltFounders.