### PR TITLE
feat: instruct cartography skill to register codemap in AGENTS.md

### DIFF
--- a/src/skills/cartography/SKILL.md
+++ b/src/skills/cartography/SKILL.md
@@ -83,8 +83,9 @@ Once all specific directories are mapped, the Orchestrator must create or update
 
 **OpenCode auto-loads `AGENTS.md` into agent context on every session.** To ensure agents automatically discover and use the codemap, update (or create) `AGENTS.md` at the repo root:
 
-1. If `AGENTS.md` already exists, **append** the following section.
-2. If it doesn't exist, **create** it with the section below.
+1. If `AGENTS.md` already exists and already contains a `## Repository Map` section, **skip this step** — the reference is already set up.
+2. If `AGENTS.md` exists but has no `## Repository Map` section, **append** the section below.
+3. If `AGENTS.md` doesn't exist, **create** it with the section below.
 
 ```markdown
 ## Repository Map
@@ -99,7 +100,7 @@ Before working on any task, read `codemap.md` to understand:
 For deep work on a specific folder, also read that folder's `codemap.md`.
 ```
 
-This is a one-time setup — once in `AGENTS.md`, every future agent session will know to consult the codemap without any additional injection or hooks.
+This is idempotent — repeated cartography runs will detect the existing section and skip. No duplication.
 
 
 ## Codemap Content


### PR DESCRIPTION
## Summary

Adds a Step 5 to the cartography skill workflow that tells agents to add a reference to `codemap.md` in `AGENTS.md`. OpenCode auto-loads `AGENTS.md` into every session, so agents will naturally discover and read the codemap — no runtime hooks or injection needed.

Fixes #159

## Approach

Instead of injecting codemap content into every session via a transform hook (context bloat), this leverages OpenCode's existing `AGENTS.md` auto-loading. The cartography skill already generates the codemap; now it also tells the agent to register it where OpenCode looks for project context.

## What changed

**** — Added Step 5 "Register Codemap in AGENTS.md" with instructions to create or update `AGENTS.md` with a section pointing agents to `codemap.md`.

## Why this over hooks

- Zero runtime overhead — no file reads or message transforms on every session
- No context bloat — agents read the codemap when they need it, not on every first message
- Respects OpenCode conventions — `AGENTS.md` is the intended mechanism for project context
- Simple — a one-line SKILL.md change, no new code

@greptileai