### PR TITLE
fix: respect user's default_agent config instead of overwriting

### DIFF
--- a/oh-my-opencode-slim.schema.json
+++ b/oh-my-opencode-slim.schema.json
@@ -5,6 +5,9 @@
     "preset": {
       "type": "string"
     },
+    "setDefaultAgent": {
+      "type": "boolean"
+    },
     "scoringEngineVersion": {
       "type": "string",
       "enum": [
@@ -374,6 +377,11 @@
         },
         "timeoutMs": {
           "default": 15000,
+          "type": "number",
+          "minimum": 0
+        },
+        "retryDelayMs": {
+          "default": 500,
           "type": "number",
           "minimum": 0
         },

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -151,6 +151,7 @@ export type FailoverConfig = z.infer<typeof FailoverConfigSchema>;
 // Main plugin config
 export const PluginConfigSchema = z.object({
   preset: z.string().optional(),
+  setDefaultAgent: z.boolean().optional(),
   scoringEngineVersion: z.enum(['v1', 'v2-shadow', 'v2']).optional(),
   balanceProviderUsage: z.boolean().optional(),
   manualPlan: ManualPlanSchema.optional(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,8 +110,15 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
     mcp: mcps,
 
     config: async (opencodeConfig: Record<string, unknown>) => {
-      (opencodeConfig as { default_agent?: string }).default_agent =
-        'orchestrator';
+      // Only set default_agent if not already configured by the user
+      // and the plugin config doesn't explicitly disable this behavior
+      if (
+        config.setDefaultAgent !== false &&
+        !(opencodeConfig as { default_agent?: string }).default_agent
+      ) {
+        (opencodeConfig as { default_agent?: string }).default_agent =
+          'orchestrator';
+      }
 
       // Merge Agent configs — per-agent shallow merge to preserve
       // user-supplied fields (e.g. tools, permission) from opencode.json


### PR DESCRIPTION
## Summary

The plugin unconditionally overwrote `default_agent` to `'orchestrator'`, ignoring any user preference from `opencode.json`. Now it respects the user's existing setting and adds an opt-out config option.

Fixes #134

## Changes

- **src/index.ts** — Only sets `default_agent` if not already configured by the user AND `setDefaultAgent` is not `false`
- **src/config/schema.ts** — Added `setDefaultAgent` boolean option (default: `true` for backward compatibility)

## Behavior

| User has `default_agent` in opencode.json | `setDefaultAgent` in plugin config | Result |
|---|---|---|
| No | not set / `true` | Plugin sets `orchestrator` (existing behavior) |
| No | `false` | Plugin does NOT set `default_agent` |
| Yes | any | User's value is preserved |

Users who want to keep using OpenCode's built-in plan agent can either:
1. Set their `default_agent` in `opencode.json` (preserved automatically), or
2. Set `setDefaultAgent: false` in plugin config

@greptileai