### PR TITLE
feat: use gpt-5.4-mini for OpenAI worker agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 bunx oh-my-opencode-slim@latest install
 ```
 
-The installer generates an OpenAI configuration by default (using `gpt-5.4` and `gpt-5-codex`). No provider questions asked.
+The installer generates an OpenAI configuration by default (using `gpt-5.4` and `gpt-5.4-mini`). No provider questions asked.
 
 For non-interactive mode:
 
@@ -124,12 +124,12 @@ https://raw.githubusercontent.com/alvinunreal/oh-my-opencode-slim/refs/heads/mas
   </tr>
   <tr>
     <td colspan="2">
-      <b>Default Model:</b> <code>openai/gpt-5-codex</code>
+      <b>Default Model:</b> <code>openai/gpt-5.4-mini</code>
     </td>
   </tr>
   <tr>
     <td colspan="2">
-      <b>Recommended Models:</b> <code>cerebras/zai-glm-4.7</code> <code>google/gemini-3.1-pro-preview</code> <code>openai/gpt-5-codex</code>
+      <b>Recommended Models:</b> <code>cerebras/zai-glm-4.7</code> <code>google/gemini-3.1-pro-preview</code> <code>openai/gpt-5.4-mini</code>
     </td>
   </tr>
 </table>
@@ -196,12 +196,12 @@ https://raw.githubusercontent.com/alvinunreal/oh-my-opencode-slim/refs/heads/mas
   </tr>
   <tr>
     <td colspan="2">
-      <b>Default Model:</b> <code>openai/gpt-5-codex</code>
+      <b>Default Model:</b> <code>openai/gpt-5.4-mini</code>
     </td>
   </tr>
   <tr>
     <td colspan="2">
-      <b>Recommended Models:</b> <code>google/gemini-3.1-pro-preview</code> <code>openai/gpt-5-codex</code>
+      <b>Recommended Models:</b> <code>google/gemini-3.1-pro-preview</code> <code>openai/gpt-5.4-mini</code>
     </td>
   </tr>
 </table>
@@ -268,12 +268,12 @@ https://raw.githubusercontent.com/alvinunreal/oh-my-opencode-slim/refs/heads/mas
   </tr>
   <tr>
     <td colspan="2">
-      <b>Default Model:</b> <code>openai/gpt-5-codex</code>
+      <b>Default Model:</b> <code>openai/gpt-5.4-mini</code>
     </td>
   </tr>
   <tr>
     <td colspan="2">
-      <b>Recommended Models:</b> <code>cerebras/zai-glm-4.7</code> <code>google/gemini-3.1-pro-preview</code> <code>openai/gpt-5-codex</code>
+      <b>Recommended Models:</b> <code>cerebras/zai-glm-4.7</code> <code>google/gemini-3.1-pro-preview</code> <code>openai/gpt-5.4-mini</code>
     </td>
   </tr>
 </table>

--- a/docs/provider-configurations.md
+++ b/docs/provider-configurations.md
@@ -17,10 +17,10 @@ The installer generates this configuration automatically:
     "openai": {
       "orchestrator": { "model": "openai/gpt-5.4", "variant": "high", "skills": ["*"], "mcps": ["websearch"] },
       "oracle": { "model": "openai/gpt-5.4", "variant": "high", "skills": [], "mcps": [] },
-      "librarian": { "model": "openai/gpt-5-codex", "variant": "low", "skills": [], "mcps": ["websearch", "context7", "grep_app"] },
-      "explorer": { "model": "openai/gpt-5-codex", "variant": "low", "skills": [], "mcps": [] },
-      "designer": { "model": "openai/gpt-5-codex", "variant": "medium", "skills": ["agent-browser"], "mcps": [] },
-      "fixer": { "model": "openai/gpt-5-codex", "variant": "low", "skills": [], "mcps": [] }
+      "librarian": { "model": "openai/gpt-5.4-mini", "variant": "low", "skills": [], "mcps": ["websearch", "context7", "grep_app"] },
+      "explorer": { "model": "openai/gpt-5.4-mini", "variant": "low", "skills": [], "mcps": [] },
+      "designer": { "model": "openai/gpt-5.4-mini", "variant": "medium", "skills": ["agent-browser"], "mcps": [] },
+      "fixer": { "model": "openai/gpt-5.4-mini", "variant": "low", "skills": [], "mcps": [] }
     }
   }
 }
@@ -118,7 +118,7 @@ You can mix models from different providers across agents. Create a custom prese
       "librarian": { "model": "kimi-for-coding/k2p5", "variant": "low", "skills": [], "mcps": ["websearch", "context7", "grep_app"] },
       "explorer": { "model": "github-copilot/grok-code-fast-1", "variant": "low", "skills": [], "mcps": [] },
       "designer": { "model": "kimi-for-coding/k2p5", "variant": "medium", "skills": ["agent-browser"], "mcps": [] },
-      "fixer": { "model": "openai/gpt-5-codex", "variant": "low", "skills": [], "mcps": [] }
+      "fixer": { "model": "openai/gpt-5.4-mini", "variant": "low", "skills": [], "mcps": [] }
     }
   }
 }

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -51,10 +51,10 @@ Uses OpenAI models exclusively:
     "openai": {
       "orchestrator": { "model": "openai/gpt-5.4", "skills": ["*"], "mcps": ["websearch"] },
       "oracle": { "model": "openai/gpt-5.4", "variant": "high", "skills": [], "mcps": [] },
-      "librarian": { "model": "openai/gpt-5-codex", "variant": "low", "skills": [], "mcps": ["websearch", "context7", "grep_app"] },
-      "explorer": { "model": "openai/gpt-5-codex", "variant": "low", "skills": [], "mcps": [] },
-      "designer": { "model": "openai/gpt-5-codex", "variant": "medium", "skills": ["agent-browser"], "mcps": [] },
-      "fixer": { "model": "openai/gpt-5-codex", "variant": "low", "skills": [], "mcps": [] }
+      "librarian": { "model": "openai/gpt-5.4-mini", "variant": "low", "skills": [], "mcps": ["websearch", "context7", "grep_app"] },
+      "explorer": { "model": "openai/gpt-5.4-mini", "variant": "low", "skills": [], "mcps": [] },
+      "designer": { "model": "openai/gpt-5.4-mini", "variant": "medium", "skills": ["agent-browser"], "mcps": [] },
+      "fixer": { "model": "openai/gpt-5.4-mini", "variant": "low", "skills": [], "mcps": [] }
     }
   }
 }
@@ -401,7 +401,7 @@ The plugin supports **JSONC** format for configuration files, allowing you to:
     "openai": {
       // Fast models for quick iteration
       "oracle": { "model": "openai/gpt-5.4" },
-      "explorer": { "model": "openai/gpt-5-codex" },
+      "explorer": { "model": "openai/gpt-5.4-mini" },
     },
   },
 

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -239,7 +239,7 @@ async function runInstall(config: InstallConfig): Promise<number> {
   console.log(`     ${BLUE}$ opencode${RESET}`);
   console.log();
   console.log(
-    `${BOLD}Default configuration uses OpenAI models (gpt-5.4 / gpt-5-codex).${RESET}`,
+    `${BOLD}Default configuration uses OpenAI models (gpt-5.4 / gpt-5.4-mini).${RESET}`,
   );
   console.log(
     `${BOLD}For alternative providers (Kimi, GitHub Copilot, ZAI Coding Plan), see:${RESET}`,

--- a/src/cli/providers.test.ts
+++ b/src/cli/providers.test.ts
@@ -21,7 +21,7 @@ describe('providers', () => {
     expect(agents).toBeDefined();
     expect(agents.orchestrator.model).toBe('openai/gpt-5.4');
     expect(agents.orchestrator.variant).toBeUndefined();
-    expect(agents.fixer.model).toBe('openai/gpt-5-codex');
+    expect(agents.fixer.model).toBe('openai/gpt-5.4-mini');
     expect(agents.fixer.variant).toBe('low');
   });
 
@@ -38,11 +38,11 @@ describe('providers', () => {
     );
     expect(agents.oracle.model).toBe('openai/gpt-5.4');
     expect(agents.oracle.variant).toBe('high');
-    expect(agents.librarian.model).toBe('openai/gpt-5-codex');
+    expect(agents.librarian.model).toBe('openai/gpt-5.4-mini');
     expect(agents.librarian.variant).toBe('low');
-    expect(agents.explorer.model).toBe('openai/gpt-5-codex');
+    expect(agents.explorer.model).toBe('openai/gpt-5.4-mini');
     expect(agents.explorer.variant).toBe('low');
-    expect(agents.designer.model).toBe('openai/gpt-5-codex');
+    expect(agents.designer.model).toBe('openai/gpt-5.4-mini');
     expect(agents.designer.variant).toBe('medium');
   });
 

--- a/src/cli/providers.ts
+++ b/src/cli/providers.ts
@@ -18,10 +18,10 @@ export const MODEL_MAPPINGS = {
   openai: {
     orchestrator: { model: 'openai/gpt-5.4' },
     oracle: { model: 'openai/gpt-5.4', variant: 'high' },
-    librarian: { model: 'openai/gpt-5-codex', variant: 'low' },
-    explorer: { model: 'openai/gpt-5-codex', variant: 'low' },
-    designer: { model: 'openai/gpt-5-codex', variant: 'medium' },
-    fixer: { model: 'openai/gpt-5-codex', variant: 'low' },
+    librarian: { model: 'openai/gpt-5.4-mini', variant: 'low' },
+    explorer: { model: 'openai/gpt-5.4-mini', variant: 'low' },
+    designer: { model: 'openai/gpt-5.4-mini', variant: 'medium' },
+    fixer: { model: 'openai/gpt-5.4-mini', variant: 'low' },
   },
   kimi: {
     orchestrator: { model: 'kimi-for-coding/k2p5' },

--- a/src/config/codemap.md
+++ b/src/config/codemap.md
@@ -230,10 +230,10 @@ deepMerge(base, override)
 |------------|--------------------------------|
 | orchestrator | runtime-resolved              |
 | oracle      | `openai/gpt-5.4`        |
-| librarian   | `openai/gpt-5-codex`   |
-| explorer    | `openai/gpt-5-codex`   |
-| designer    | `openai/gpt-5-codex`          |
-| fixer       | `openai/gpt-5-codex`   |
+| librarian   | `openai/gpt-5.4-mini`   |
+| explorer    | `openai/gpt-5.4-mini`   |
+| designer    | `openai/gpt-5.4-mini`   |
+| fixer       | `openai/gpt-5.4-mini`   |
 
 ## File Organization
 

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -39,10 +39,10 @@ export const SUBAGENT_DELEGATION_RULES: Record<AgentName, readonly string[]> = {
 export const DEFAULT_MODELS: Record<AgentName, string | undefined> = {
   orchestrator: undefined,
   oracle: 'openai/gpt-5.4',
-  librarian: 'openai/gpt-5-codex',
-  explorer: 'openai/gpt-5-codex',
-  designer: 'openai/gpt-5-codex',
-  fixer: 'openai/gpt-5-codex',
+  librarian: 'openai/gpt-5.4-mini',
+  explorer: 'openai/gpt-5.4-mini',
+  designer: 'openai/gpt-5.4-mini',
+  fixer: 'openai/gpt-5.4-mini',
 };
 
 // Polling configuration


### PR DESCRIPTION
## Summary
- keep `openai/gpt-5.4` for primary OpenAI roles
- replace `openai/gpt-5-codex` with `openai/gpt-5.4-mini` for OpenAI worker agents
- keep the `kimi` preset using Kimi models

## Changes
- `src/cli/providers.ts`: update OpenAI preset mappings for librarian/explorer/designer/fixer
- `src/config/constants.ts`: update runtime defaults for librarian/explorer/designer/fixer
- `src/cli/providers.test.ts`: update expectations
- `src/cli/install.ts`, `README.md`, `docs/quick-reference.md`, `docs/provider-configurations.md`, `src/config/codemap.md`: refresh docs/examples

## Validation
- `bun test src/cli/providers.test.ts src/config/loader.test.ts src/background/background-manager.test.ts src/agents/index.test.ts`