### PR TITLE
docs: add ping all agents section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,27 @@ https://raw.githubusercontent.com/alvinunreal/oh-my-opencode-slim/refs/heads/mas
 - **[Provider Configurations](docs/provider-configurations.md)** - Config examples for all supported providers
 - **[Tmux Integration](docs/tmux-integration.md)** - Real-time agent monitoring with tmux
 
+### ✅ Verify Your Setup
+
+After installation and authentication, verify all agents are configured and responding:
+
+```bash
+opencode
+```
+
+Then run:
+
+```
+ping all agents
+```
+
+<div align="center">
+  <img src="img/ping.png" alt="Ping all agents" width="600">
+  <p><i>Confirmation that all six agents are online and ready.</i></p>
+</div>
+
+If any agent fails to respond, check your provider authentication and config file.
+
 ---
 
 ## 🏛️ Meet the Pantheon


### PR DESCRIPTION
Adds a quick section in the README about verifying the setup by running `ping all agents` in OpenCode after installation.

- Includes the existing `img/ping.png` screenshot showing the command output
- Placed after Installation section, before Meet the Pantheon
- Helps users confirm all six agents are configured and responding