### PR TITLE
Fix auto-update bun install cwd

### DIFF
--- a/src/hooks/auto-update-checker/index.test.ts
+++ b/src/hooks/auto-update-checker/index.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, mock, test } from 'bun:test';
+
+mock.module('./constants', () => ({
+  CACHE_DIR: '/mock/cache/opencode',
+  PACKAGE_NAME: 'oh-my-opencode-slim',
+}));
+
+mock.module('./checker', () => ({
+  extractChannel: mock(() => 'latest'),
+  findPluginEntry: mock(() => null),
+  getCachedVersion: mock(() => null),
+  getLatestVersion: mock(async () => null),
+  getLocalDevVersion: mock(() => null),
+}));
+
+mock.module('./cache', () => ({
+  invalidatePackage: mock(() => false),
+}));
+
+mock.module('../../utils/logger', () => ({
+  log: mock(() => {}),
+}));
+
+import { getAutoUpdateInstallDir } from './index';
+
+describe('auto-update-checker/index', () => {
+  test('uses OpenCode cache dir for auto-update installs', () => {
+    expect(getAutoUpdateInstallDir()).toBe('/mock/cache/opencode');
+  });
+});

--- a/src/hooks/auto-update-checker/index.ts
+++ b/src/hooks/auto-update-checker/index.ts
@@ -1,6 +1,7 @@
 import type { PluginInput } from '@opencode-ai/plugin';
 import { log } from '../../utils/logger';
 import { invalidatePackage } from './cache';
+import { CACHE_DIR, PACKAGE_NAME } from './constants';
 import {
   extractChannel,
   findPluginEntry,
@@ -8,7 +9,6 @@ import {
   getLatestVersion,
   getLocalDevVersion,
 } from './checker';
-import { PACKAGE_NAME } from './constants';
 import type { AutoUpdateCheckerOptions } from './types';
 
 /**
@@ -167,6 +167,10 @@ async function runBackgroundUpdateCheck(
   }
 }
 
+export function getAutoUpdateInstallDir(): string {
+  return CACHE_DIR;
+}
+
 /**
  * Spawns a background process to run 'bun install'.
  * Includes a 60-second timeout to prevent stalling OpenCode.
@@ -175,8 +179,9 @@ async function runBackgroundUpdateCheck(
  */
 async function runBunInstallSafe(ctx: PluginInput): Promise<boolean> {
   try {
+    const installDir = getAutoUpdateInstallDir();
     const proc = Bun.spawn(['bun', 'install'], {
-      cwd: ctx.directory,
+      cwd: installDir,
       stdout: 'pipe',
       stderr: 'pipe',
     });

--- a/src/hooks/auto-update-checker/index.ts
+++ b/src/hooks/auto-update-checker/index.ts
@@ -142,7 +142,7 @@ async function runBackgroundUpdateCheck(
 
   invalidatePackage(PACKAGE_NAME);
 
-  const installSuccess = await runBunInstallSafe(ctx);
+  const installSuccess = await runBunInstallSafe();
 
   if (installSuccess) {
     showToast(
@@ -177,7 +177,7 @@ export function getAutoUpdateInstallDir(): string {
  * @param ctx The plugin input context.
  * @returns True if the installation succeeded within the timeout.
  */
-async function runBunInstallSafe(ctx: PluginInput): Promise<boolean> {
+async function runBunInstallSafe(): Promise<boolean> {
   try {
     const installDir = getAutoUpdateInstallDir();
     const proc = Bun.spawn(['bun', 'install'], {


### PR DESCRIPTION
## Summary
- run auto-update \\`bun install\\` from the OpenCode cache directory instead of the active project directory
- add a regression test that locks the auto-update install directory to the cache path
- avoid creating \\`bun.lock\\` and \\`node_modules\\` in pnpm project roots when the plugin checks for updates

## Validation
- `bun run build` *(fails in this repo due existing TypeScript issues unrelated to this change)*
- `bun test src/hooks/auto-update-checker/index.test.ts src/hooks/auto-update-checker/checker.test.ts src/hooks/auto-update-checker/cache.test.ts` *(fails in this repo due existing test/dependency setup issues unrelated to this change)*