### PR TITLE
feat: add serve-mode orchestrator prompt injection + fix CJS build for GitHub installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   ],
   "scripts": {
     "build": "bun build src/index.ts --outdir dist --target bun --format esm --packages external && bun build src/cli/index.ts --outdir dist/cli --target bun --format esm --packages external && tsc --emitDeclarationOnly && bun run generate-schema",
+    "prepare": "bun build src/index.ts --outdir dist --target bun --format esm --external @ast-grep/napi --external @opencode-ai/plugin --external @opencode-ai/sdk",
     "contributors:add": "all-contributors add",
     "contributors:check": "all-contributors check",
     "contributors:generate": "all-contributors generate",

--- a/src/agents/orchestrator.ts
+++ b/src/agents/orchestrator.ts
@@ -23,7 +23,7 @@ export function resolvePrompt(
   return base;
 }
 
-const ORCHESTRATOR_PROMPT = `<Role>
+export const ORCHESTRATOR_PROMPT = `<Role>
 You are an AI coding orchestrator that optimizes for quality, speed, cost, and reliability by delegating to specialists when it provides net efficiency gains.
 </Role>
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -164,6 +164,9 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
     config.fallback?.enabled !== false && Object.keys(runtimeChains).length > 0,
   );
 
+  // Track session → agent mapping for serve-mode system prompt injection
+  const sessionAgentMap = new Map<string, string>();
+
   // Initialize todo-continuation hook (opt-in auto-continue for incomplete todos)
   const todoContinuationHook = createTodoContinuationHook(ctx, {
     maxContinuations: config.todoContinuation?.maxContinuations ?? 5,
@@ -449,6 +452,41 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
     },
 
     'chat.headers': chatHeadersHook['chat.headers'],
+
+    // Track which agent each session uses (needed for serve-mode prompt injection)
+    'chat.message': async (input: {
+      sessionID: string;
+      agent?: string;
+    }) => {
+      if (input.agent) {
+        sessionAgentMap.set(input.sessionID, input.agent);
+      }
+    },
+
+    // Inject orchestrator system prompt for serve-mode sessions.
+    // In serve mode, the agent's prompt field may be absent from the agents registry
+    // (built before plugin config hooks run). This hook injects it at LLM call time.
+    'experimental.chat.system.transform': async (
+      input: { sessionID?: string },
+      output: { system: string[] },
+    ): Promise<void> => {
+      const agentName = input.sessionID
+        ? sessionAgentMap.get(input.sessionID)
+        : undefined;
+      if (agentName === 'orchestrator') {
+        const alreadyInjected = output.system.some(
+          (s) =>
+            typeof s === 'string' &&
+            s.includes('<Role>') &&
+            s.includes('orchestrator'),
+        );
+        if (!alreadyInjected) {
+          // Prepend the orchestrator prompt to the system array
+          const { ORCHESTRATOR_PROMPT } = await import('./agents/orchestrator');
+          output.system[0] = ORCHESTRATOR_PROMPT + (output.system[0] ? '\n\n' + output.system[0] : '');
+        }
+      }
+    },
 
     // Inject phase reminder and filter available skills before sending to API (doesn't show in UI)
     'experimental.chat.messages.transform': async (


### PR DESCRIPTION
Fixes #260

## Summary

Plugin-provided agents (orchestrator, etc.) are not accessible via `opencode serve` API due to two issues:

1. **Agent state timing**: The agents map is built once from raw config before plugin config hooks run, and `GET /agent` never triggers Plugin initialization. The orchestrator prompt is therefore never injected.

2. **Plugin load failure**: The `--packages external` build leaves CJS imports (`jsdom`, `turndown`, `vscode-jsonrpc`) as runtime imports that fail in OpenCode's embedded Bun runtime, preventing the plugin from loading in serve mode entirely.

## Changes

### `src/agents/orchestrator.ts`
- Export `ORCHESTRATOR_PROMPT` constant (previously unexported)

### `src/index.ts`
- Add `sessionAgentMap: Map<string, string>` to track session → agent
- Add `chat.message` hook to populate the map
- Add `experimental.chat.system.transform` hook: when a session uses the `orchestrator` agent, inject the full `ORCHESTRATOR_PROMPT` at LLM call time — bypasses the frozen agents map entirely

### `package.json`
- Add `prepare` script with bundled build (`--external @ast-grep/napi --external @opencode-ai/plugin --external @opencode-ai/sdk`) for GitHub installations
- Original `build` script is **unchanged**

## How it works

Add a minimal entry to `opencode.json` so the agent is visible in `GET /agent`:
```json
{
  "agent": {
    "orchestrator": { "model": "openai/gpt-5.4" }
  }
}
```

The `experimental.chat.system.transform` hook then injects the full orchestrator system prompt at LLM call time, regardless of whether `GET /agent` was called first.

## Test plan

- [x] `GET /agent` returns orchestrator (from raw config entry)
- [x] `POST /session/:id/message` with `agent: "orchestrator"` responds with full orchestrator persona and specialist knowledge (@explorer, @librarian, @oracle, @fixer stats)
- [x] Works when `GET /agent` is called before any session (edge case that bypasses Plugin initialization)
- [x] Works when session message is sent first
- [x] Plugin loads successfully from GitHub install via `prepare` script