### PR TITLE
fix: align prepare script with build to prevent hardcoded absolute paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   ],
   "scripts": {
     "build": "bun build src/index.ts --outdir dist --target bun --format esm --packages external && bun build src/cli/index.ts --outdir dist/cli --target bun --format esm --packages external && tsc --emitDeclarationOnly && bun run generate-schema",
-    "prepare": "bun build src/index.ts --outdir dist --target bun --format esm --external @ast-grep/napi --external @opencode-ai/plugin --external @opencode-ai/sdk",
+    "prepare": "bun build src/index.ts --outdir dist --target bun --format esm --packages external --external @ast-grep/napi --external @opencode-ai/plugin --external @opencode-ai/sdk",
     "contributors:add": "all-contributors add",
     "contributors:check": "all-contributors check",
     "contributors:generate": "all-contributors generate",


### PR DESCRIPTION
## Problem

The `prepare` lifecycle script bundles `jsdom` inline instead of externalizing it. This causes Bun to resolve `require.resolve("./xhr-sync-worker.js")` to an **absolute path on the build machine** (`/Users/alvin/repos/oh-my-opencode-slim/node_modules/jsdom/...`), which is then baked into the published `dist/index.js`.

When users install the plugin, it fails with:
```
ENOENT: no such file or directory, open '/Users/alvin/repos/oh-my-opencode-slim/node_modules/jsdom/lib/jsdom/living/xhr/xhr-sync-worker.js'
```

During `npm publish`, scripts run in this order:
1. `prepublishOnly` → `bun run build` (produces clean 0.35MB bundle with `--packages external`)
2. `prepare` → rebuilds **without** `--packages external` (produces broken 7.0MB bundle with hardcoded paths, overwriting the clean one)

## Fix

Add `--packages external` to the `prepare` script, aligning it with the `build` script.

**Before:**
```
"prepare": "bun build src/index.ts --outdir dist --target bun --format esm --external @ast-grep/napi --external @opencode-ai/plugin --external @opencode-ai/sdk"
```

**After:**
```
"prepare": "bun build src/index.ts --outdir dist --target bun --format esm --packages external --external @ast-grep/napi --external @opencode-ai/plugin --external @opencode-ai/sdk"
```

## Verification

- Build size: 0.35MB (was 7.0MB)
- No hardcoded absolute paths in `dist/index.js`
- `jsdom` is properly externalized as an import
- `opencode debug config` loads plugin without errors
- All pantheon agents (orchestrator, explorer, oracle, etc.) register correctly
- `bun run typecheck` passes