### PR TITLE
fix(auto-update): clarify failed install state

### DIFF
--- a/src/hooks/auto-update-checker/cache.test.ts
+++ b/src/hooks/auto-update-checker/cache.test.ts
@@ -18,48 +18,82 @@ mock.module('../../cli/config-manager', () => ({
 let importCounter = 0;
 
 describe('auto-update-checker/cache', () => {
-  describe('invalidatePackage', () => {
-    test('returns false when nothing to invalidate', async () => {
+  describe('resolveInstallContext', () => {
+    test('detects OpenCode packages install root from runtime package path', async () => {
+      const existsSpy = spyOn(fs, 'existsSync').mockImplementation(
+        (p: string) =>
+          p ===
+          '/home/user/.cache/opencode/packages/oh-my-opencode-slim@latest/package.json',
+      );
+      const { resolveInstallContext } = await import(
+        `./cache?test=${importCounter++}`
+      );
+
+      const context = resolveInstallContext(
+        '/home/user/.cache/opencode/packages/oh-my-opencode-slim@latest/node_modules/oh-my-opencode-slim/package.json',
+      );
+
+      expect(context).toEqual({
+        installDir:
+          '/home/user/.cache/opencode/packages/oh-my-opencode-slim@latest',
+        packageJsonPath:
+          '/home/user/.cache/opencode/packages/oh-my-opencode-slim@latest/package.json',
+      });
+
+      existsSpy.mockRestore();
+    });
+
+    test('does not fall back to legacy cache when runtime path is active but wrapper root is invalid', async () => {
+      const existsSpy = spyOn(fs, 'existsSync').mockImplementation(() => false);
+      const { resolveInstallContext } = await import(
+        `./cache?test=${importCounter++}`
+      );
+
+      const context = resolveInstallContext(
+        '/home/user/.cache/opencode/packages/oh-my-opencode-slim@latest/node_modules/oh-my-opencode-slim/package.json',
+      );
+
+      expect(context).toBeNull();
+
+      existsSpy.mockRestore();
+    });
+  });
+
+  describe('preparePackageUpdate', () => {
+    test('returns null when no install context is available', async () => {
       const existsSpy = spyOn(fs, 'existsSync').mockReturnValue(false);
-      const { invalidatePackage } = await import(
+      const { preparePackageUpdate } = await import(
         `./cache?test=${importCounter++}`
       );
 
-      const result = invalidatePackage();
-      expect(result).toBe(false);
+      const result = preparePackageUpdate('1.0.1');
+      expect(result).toBeNull();
 
       existsSpy.mockRestore();
     });
 
-    test('returns true and removes directory if node_modules path exists', async () => {
+    test('updates packages wrapper dependency and removes installed package', async () => {
       const existsSpy = spyOn(fs, 'existsSync').mockImplementation(
-        (p: string) => p.includes('node_modules'),
+        (p: string) =>
+          p ===
+            '/home/user/.cache/opencode/packages/oh-my-opencode-slim@latest/package.json' ||
+          p ===
+            '/home/user/.cache/opencode/packages/oh-my-opencode-slim@latest/node_modules/oh-my-opencode-slim',
       );
-      const rmSyncSpy = spyOn(fs, 'rmSync').mockReturnValue(undefined);
-      const { invalidatePackage } = await import(
-        `./cache?test=${importCounter++}`
-      );
-
-      const result = invalidatePackage();
-
-      expect(rmSyncSpy).toHaveBeenCalled();
-      expect(result).toBe(true);
-
-      existsSpy.mockRestore();
-      rmSyncSpy.mockRestore();
-    });
-
-    test('removes dependency from package.json if present', async () => {
-      const existsSpy = spyOn(fs, 'existsSync').mockImplementation(
-        (p: string) => p.includes('package.json'),
-      );
-      const readSpy = spyOn(fs, 'readFileSync').mockReturnValue(
-        JSON.stringify({
-          dependencies: {
-            'oh-my-opencode-slim': '1.0.0',
-            'other-pkg': '1.0.0',
-          },
-        }),
+      const readSpy = spyOn(fs, 'readFileSync').mockImplementation(
+        (p: string) => {
+          if (
+            p ===
+            '/home/user/.cache/opencode/packages/oh-my-opencode-slim@latest/package.json'
+          ) {
+            return JSON.stringify({
+              dependencies: {
+                'oh-my-opencode-slim': '0.9.1',
+              },
+            });
+          }
+          return '';
+        },
       );
       const writtenData: string[] = [];
       const writeSpy = spyOn(fs, 'writeFileSync').mockImplementation(
@@ -67,21 +101,66 @@ describe('auto-update-checker/cache', () => {
           writtenData.push(data);
         },
       );
-      const { invalidatePackage } = await import(
+      const rmSyncSpy = spyOn(fs, 'rmSync').mockReturnValue(undefined);
+      const { preparePackageUpdate } = await import(
         `./cache?test=${importCounter++}`
       );
 
-      const result = invalidatePackage();
+      const result = preparePackageUpdate(
+        '0.9.11',
+        'oh-my-opencode-slim',
+        '/home/user/.cache/opencode/packages/oh-my-opencode-slim@latest/node_modules/oh-my-opencode-slim/package.json',
+      );
 
-      expect(result).toBe(true);
+      expect(result).toBe(
+        '/home/user/.cache/opencode/packages/oh-my-opencode-slim@latest',
+      );
+      expect(rmSyncSpy).toHaveBeenCalledWith(
+        '/home/user/.cache/opencode/packages/oh-my-opencode-slim@latest/node_modules/oh-my-opencode-slim',
+        { recursive: true, force: true },
+      );
       expect(writtenData.length).toBeGreaterThan(0);
-      const savedJson = JSON.parse(writtenData[0]);
-      expect(savedJson.dependencies['oh-my-opencode-slim']).toBeUndefined();
-      expect(savedJson.dependencies['other-pkg']).toBe('1.0.0');
+      expect(JSON.parse(writtenData[0])).toEqual({
+        dependencies: {
+          'oh-my-opencode-slim': '0.9.11',
+        },
+      });
 
       existsSpy.mockRestore();
       readSpy.mockRestore();
       writeSpy.mockRestore();
+      rmSyncSpy.mockRestore();
+    });
+
+    test('keeps working when dependency is already on target version', async () => {
+      const existsSpy = spyOn(fs, 'existsSync').mockImplementation(
+        (p: string) =>
+          p.endsWith('/.cache/opencode/package.json') ||
+          p.endsWith('/.cache/opencode/node_modules/oh-my-opencode-slim'),
+      );
+      const readSpy = spyOn(fs, 'readFileSync').mockReturnValue(
+        JSON.stringify({
+          dependencies: {
+            'oh-my-opencode-slim': '1.0.1',
+          },
+        }),
+      );
+      const writeSpy = spyOn(fs, 'writeFileSync').mockImplementation(() => {});
+      const rmSyncSpy = spyOn(fs, 'rmSync').mockReturnValue(undefined);
+      const { preparePackageUpdate } = await import(
+        `./cache?test=${importCounter++}`
+      );
+
+      const result = preparePackageUpdate('1.0.1', 'oh-my-opencode-slim', null);
+
+      expect(result?.endsWith('/.cache/opencode')).toBe(true);
+      expect(writeSpy).not.toHaveBeenCalled();
+      expect(rmSyncSpy).toHaveBeenCalled();
+
+      existsSpy.mockRestore();
+      readSpy.mockRestore();
+      writeSpy.mockRestore();
+      rmSyncSpy.mockRestore();
     });
   });
 });

--- a/src/hooks/auto-update-checker/cache.ts
+++ b/src/hooks/auto-update-checker/cache.ts
@@ -2,6 +2,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { stripJsonComments } from '../../cli/config-manager';
 import { log } from '../../utils/logger';
+import { getCurrentRuntimePackageJsonPath } from './checker';
 import { CACHE_DIR, PACKAGE_NAME } from './constants';
 
 interface BunLockfile {
@@ -13,13 +14,18 @@ interface BunLockfile {
   packages?: Record<string, unknown>;
 }
 
+interface AutoUpdateInstallContext {
+  installDir: string;
+  packageJsonPath: string;
+}
+
 /**
  * Removes a package from the bun.lock file if it's in JSON format.
  * Note: Newer Bun versions (1.1+) use a custom text format for bun.lock.
  * This function handles JSON-based lockfiles gracefully.
  */
-function removeFromBunLock(packageName: string): boolean {
-  const lockPath = path.join(CACHE_DIR, 'bun.lock');
+function removeFromBunLock(installDir: string, packageName: string): boolean {
+  const lockPath = path.join(installDir, 'bun.lock');
   if (!fs.existsSync(lockPath)) return false;
 
   try {
@@ -58,58 +64,125 @@ function removeFromBunLock(packageName: string): boolean {
   }
 }
 
-/**
- * Invalidates the current package by removing its directory and dependency entries.
- * This forces a clean state before running a fresh install.
- * @param packageName The name of the package to invalidate.
- */
-export function invalidatePackage(packageName: string = PACKAGE_NAME): boolean {
+function ensureDependencyVersion(
+  packageJsonPath: string,
+  packageName: string,
+  version: string,
+): boolean {
+  if (!fs.existsSync(packageJsonPath)) return false;
+
   try {
-    const pkgDir = path.join(CACHE_DIR, 'node_modules', packageName);
-    const pkgJsonPath = path.join(CACHE_DIR, 'package.json');
+    const content = fs.readFileSync(packageJsonPath, 'utf-8');
+    const pkgJson = JSON.parse(stripJsonComments(content)) as {
+      dependencies?: Record<string, string>;
+      [key: string]: unknown;
+    };
 
-    let packageRemoved = false;
-    let dependencyRemoved = false;
-    let lockRemoved = false;
-
-    if (fs.existsSync(pkgDir)) {
-      fs.rmSync(pkgDir, { recursive: true, force: true });
-      log(`[auto-update-checker] Package removed: ${pkgDir}`);
-      packageRemoved = true;
+    const dependencies = { ...(pkgJson.dependencies ?? {}) };
+    if (dependencies[packageName] === version) {
+      return true;
     }
 
-    if (fs.existsSync(pkgJsonPath)) {
-      try {
-        const content = fs.readFileSync(pkgJsonPath, 'utf-8');
-        const pkgJson = JSON.parse(stripJsonComments(content));
-        if (pkgJson.dependencies?.[packageName]) {
-          delete pkgJson.dependencies[packageName];
-          fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2));
-          log(
-            `[auto-update-checker] Dependency removed from package.json: ${packageName}`,
-          );
-          dependencyRemoved = true;
-        }
-      } catch (err) {
-        log(
-          `[auto-update-checker] Failed to update package.json for invalidation:`,
-          err,
-        );
+    dependencies[packageName] = version;
+    pkgJson.dependencies = dependencies;
+    fs.writeFileSync(packageJsonPath, JSON.stringify(pkgJson, null, 2));
+    log(
+      `[auto-update-checker] Updated dependency in package.json: ${packageName} → ${version}`,
+    );
+    return true;
+  } catch (err) {
+    log(
+      `[auto-update-checker] Failed to update package.json dependency for auto-update:`,
+      err,
+    );
+    return false;
+  }
+}
+
+function removeInstalledPackage(
+  installDir: string,
+  packageName: string,
+): boolean {
+  const pkgDir = path.join(installDir, 'node_modules', packageName);
+  if (!fs.existsSync(pkgDir)) return false;
+
+  fs.rmSync(pkgDir, { recursive: true, force: true });
+  log(`[auto-update-checker] Package removed: ${pkgDir}`);
+  return true;
+}
+
+export function resolveInstallContext(
+  runtimePackageJsonPath: string | null = getCurrentRuntimePackageJsonPath(),
+): AutoUpdateInstallContext | null {
+  if (runtimePackageJsonPath) {
+    const packageDir = path.dirname(runtimePackageJsonPath);
+    const nodeModulesDir = path.dirname(packageDir);
+
+    if (
+      path.basename(packageDir) === PACKAGE_NAME &&
+      path.basename(nodeModulesDir) === 'node_modules'
+    ) {
+      const installDir = path.dirname(nodeModulesDir);
+      const packageJsonPath = path.join(installDir, 'package.json');
+      if (fs.existsSync(packageJsonPath)) {
+        return { installDir, packageJsonPath };
       }
     }
 
-    lockRemoved = removeFromBunLock(packageName);
+    return null;
+  }
 
-    if (!packageRemoved && !dependencyRemoved && !lockRemoved) {
-      log(
-        `[auto-update-checker] Package not found, nothing to invalidate: ${packageName}`,
-      );
-      return false;
+  const legacyPackageJsonPath = path.join(CACHE_DIR, 'package.json');
+  if (fs.existsSync(legacyPackageJsonPath)) {
+    return { installDir: CACHE_DIR, packageJsonPath: legacyPackageJsonPath };
+  }
+
+  return null;
+}
+
+/**
+ * Prepares the current install root for a clean re-install of the target version.
+ * Returns the install directory to run `bun install` in.
+ */
+export function preparePackageUpdate(
+  version: string,
+  packageName: string = PACKAGE_NAME,
+  runtimePackageJsonPath: string | null = getCurrentRuntimePackageJsonPath(),
+): string | null {
+  try {
+    const installContext = resolveInstallContext(runtimePackageJsonPath);
+    if (!installContext) {
+      log('[auto-update-checker] No install context found for auto-update');
+      return null;
     }
 
-    return true;
+    const dependencyReady = ensureDependencyVersion(
+      installContext.packageJsonPath,
+      packageName,
+      version,
+    );
+    if (!dependencyReady) {
+      return null;
+    }
+
+    const packageRemoved = removeInstalledPackage(
+      installContext.installDir,
+      packageName,
+    );
+    const lockRemoved = removeFromBunLock(
+      installContext.installDir,
+      packageName,
+    );
+
+    if (!packageRemoved && !lockRemoved) {
+      log(
+        `[auto-update-checker] No cached package artifacts removed for ${packageName}; continuing with updated dependency spec`,
+      );
+    }
+
+    return installContext.installDir;
   } catch (err) {
-    log('[auto-update-checker] Failed to invalidate package:', err);
-    return false;
+    log('[auto-update-checker] Failed to prepare package update:', err);
+    return null;
   }
 }

--- a/src/hooks/auto-update-checker/checker.test.ts
+++ b/src/hooks/auto-update-checker/checker.test.ts
@@ -73,6 +73,12 @@ describe('auto-update-checker/checker', () => {
           return false;
         },
       );
+      const statSpy = spyOn(fs, 'statSync').mockImplementation(
+        () =>
+          ({
+            isDirectory: () => true,
+          }) as unknown as fs.Stats,
+      );
       const readSpy = spyOn(fs, 'readFileSync').mockImplementation(
         (p: string) => {
           if (p.includes('opencode.json')) {
@@ -97,6 +103,7 @@ describe('auto-update-checker/checker', () => {
       expect(getLocalDevVersion('/test')).toBe('1.2.3-dev');
 
       existsSpy.mockRestore();
+      statSpy.mockRestore();
       readSpy.mockRestore();
     });
   });

--- a/src/hooks/auto-update-checker/checker.ts
+++ b/src/hooks/auto-update-checker/checker.ts
@@ -139,6 +139,21 @@ export function getLocalDevVersion(directory: string): string | null {
 }
 
 /**
+ * Resolves the package.json for the currently running plugin bundle.
+ */
+export function getCurrentRuntimePackageJsonPath(
+  currentModuleUrl: string = import.meta.url,
+): string | null {
+  try {
+    const currentDir = path.dirname(fileURLToPath(currentModuleUrl));
+    return findPackageJsonUp(currentDir);
+  } catch (err) {
+    log('[auto-update-checker] Failed to resolve runtime package path:', err);
+    return null;
+  }
+}
+
+/**
  * Searches across all config locations to find the current installation entry for this plugin.
  */
 export function findPluginEntry(directory: string): PluginEntryInfo | null {
@@ -179,8 +194,9 @@ export function getCachedVersion(): string | null {
   if (cachedPackageVersion) return cachedPackageVersion;
 
   try {
-    if (fs.existsSync(INSTALLED_PACKAGE_JSON)) {
-      const content = fs.readFileSync(INSTALLED_PACKAGE_JSON, 'utf-8');
+    const runtimePackageJsonPath = getCurrentRuntimePackageJsonPath();
+    if (runtimePackageJsonPath && fs.existsSync(runtimePackageJsonPath)) {
+      const content = fs.readFileSync(runtimePackageJsonPath, 'utf-8');
       const pkg = JSON.parse(content) as PackageJson;
       if (pkg.version) {
         cachedPackageVersion = pkg.version;
@@ -192,10 +208,8 @@ export function getCachedVersion(): string | null {
   }
 
   try {
-    const currentDir = path.dirname(fileURLToPath(import.meta.url));
-    const pkgPath = findPackageJsonUp(currentDir);
-    if (pkgPath) {
-      const content = fs.readFileSync(pkgPath, 'utf-8');
+    if (fs.existsSync(INSTALLED_PACKAGE_JSON)) {
+      const content = fs.readFileSync(INSTALLED_PACKAGE_JSON, 'utf-8');
       const pkg = JSON.parse(content) as PackageJson;
       if (pkg.version) {
         cachedPackageVersion = pkg.version;

--- a/src/hooks/auto-update-checker/index.test.ts
+++ b/src/hooks/auto-update-checker/index.test.ts
@@ -14,7 +14,8 @@ mock.module('./checker', () => ({
 }));
 
 mock.module('./cache', () => ({
-  invalidatePackage: mock(() => false),
+  preparePackageUpdate: mock(() => '/tmp/opencode'),
+  resolveInstallContext: mock(() => ({ installDir: '/tmp/opencode' })),
 }));
 
 // Cache buster for dynamic imports

--- a/src/hooks/auto-update-checker/index.test.ts
+++ b/src/hooks/auto-update-checker/index.test.ts
@@ -1,32 +1,257 @@
-import { describe, expect, mock, test } from 'bun:test';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from 'bun:test';
 
-// Mock logger to avoid noise
-mock.module('../../utils/logger', () => ({
-  log: mock(() => {}),
-}));
+const logMock = mock(() => {});
 
-mock.module('./checker', () => ({
+const checkerMocks = {
   extractChannel: mock(() => 'latest'),
   findPluginEntry: mock(() => null),
   getCachedVersion: mock(() => null),
   getLatestVersion: mock(async () => null),
   getLocalDevVersion: mock(() => null),
-}));
+};
 
-mock.module('./cache', () => ({
+const cacheMocks = {
   preparePackageUpdate: mock(() => '/tmp/opencode'),
   resolveInstallContext: mock(() => ({ installDir: '/tmp/opencode' })),
+};
+
+mock.module('../../utils/logger', () => ({
+  log: logMock,
 }));
 
-// Cache buster for dynamic imports
+mock.module('./checker', () => checkerMocks);
+
+mock.module('./cache', () => cacheMocks);
+
 let importCounter = 0;
+let bunSpawnSpy: ReturnType<typeof spyOn> | undefined;
+
+function createCtx() {
+  const showToast = mock(() => Promise.resolve(undefined));
+
+  return {
+    ctx: {
+      directory: '/test',
+      client: {
+        tui: {
+          showToast,
+        },
+      },
+    },
+    showToast,
+  };
+}
+
+async function waitForCalls(
+  fn: { mock: { calls: unknown[] } },
+  minCalls = 1,
+): Promise<void> {
+  const deadline = Date.now() + 200;
+
+  while (fn.mock.calls.length < minCalls) {
+    if (Date.now() > deadline) {
+      throw new Error('Timed out waiting for async hook work');
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
 
 describe('auto-update-checker/index', () => {
-  test('uses OpenCode cache dir for auto-update installs', async () => {
+  beforeEach(() => {
+    logMock.mockClear();
+
+    checkerMocks.extractChannel.mockReset();
+    checkerMocks.extractChannel.mockImplementation(() => 'latest');
+    checkerMocks.findPluginEntry.mockReset();
+    checkerMocks.findPluginEntry.mockImplementation(() => null);
+    checkerMocks.getCachedVersion.mockReset();
+    checkerMocks.getCachedVersion.mockImplementation(() => null);
+    checkerMocks.getLatestVersion.mockReset();
+    checkerMocks.getLatestVersion.mockImplementation(async () => null);
+    checkerMocks.getLocalDevVersion.mockReset();
+    checkerMocks.getLocalDevVersion.mockImplementation(() => null);
+
+    cacheMocks.preparePackageUpdate.mockReset();
+    cacheMocks.preparePackageUpdate.mockImplementation(() => '/tmp/opencode');
+    cacheMocks.resolveInstallContext.mockReset();
+    cacheMocks.resolveInstallContext.mockImplementation(() => ({
+      installDir: '/tmp/opencode',
+    }));
+  });
+
+  afterEach(() => {
+    bunSpawnSpy?.mockRestore();
+    bunSpawnSpy = undefined;
+  });
+
+  test('uses resolved install root for auto-update installs', async () => {
     const { getAutoUpdateInstallDir } = await import(
       `./index?test=${importCounter++}`
     );
-    // The actual cache dir depends on the platform, but it should be a string
-    expect(typeof getAutoUpdateInstallDir()).toBe('string');
+
+    expect(getAutoUpdateInstallDir()).toBe('/tmp/opencode');
+  });
+
+  test('shows development toast and skips background update for local dev installs', async () => {
+    checkerMocks.getLocalDevVersion.mockImplementation(() => '0.9.11-dev');
+
+    const { createAutoUpdateCheckerHook } = await import(
+      `./index?test=${importCounter++}`
+    );
+    const { ctx, showToast } = createCtx();
+
+    const hook = createAutoUpdateCheckerHook(ctx as never);
+    hook.event({ event: { type: 'session.created', properties: {} } });
+    await waitForCalls(showToast);
+
+    expect(showToast).toHaveBeenCalledWith({
+      body: {
+        title: 'OMO-Slim 0.9.11-dev (dev)',
+        message: 'Running in local development mode.',
+        variant: 'info',
+        duration: 3000,
+      },
+    });
+    expect(checkerMocks.findPluginEntry).not.toHaveBeenCalled();
+    expect(checkerMocks.getLatestVersion).not.toHaveBeenCalled();
+  });
+
+  test('shows success toast after updating the active install root', async () => {
+    checkerMocks.findPluginEntry.mockImplementation(() => ({
+      pinnedVersion: null,
+      isPinned: false,
+    }));
+    checkerMocks.getCachedVersion.mockImplementation(() => '0.9.1');
+    checkerMocks.getLatestVersion.mockImplementation(async () => '0.9.11');
+
+    bunSpawnSpy = spyOn(Bun, 'spawn').mockImplementation(
+      () =>
+        ({
+          exited: Promise.resolve(0),
+          exitCode: 0,
+          kill: mock(() => {}),
+        }) as never,
+    );
+
+    const { createAutoUpdateCheckerHook } = await import(
+      `./index?test=${importCounter++}`
+    );
+    const { ctx, showToast } = createCtx();
+
+    const hook = createAutoUpdateCheckerHook(ctx as never, {
+      showStartupToast: false,
+    });
+    hook.event({ event: { type: 'session.created', properties: {} } });
+    await waitForCalls(showToast);
+
+    expect(cacheMocks.preparePackageUpdate).toHaveBeenCalledWith(
+      '0.9.11',
+      'oh-my-opencode-slim',
+    );
+    expect(bunSpawnSpy).toHaveBeenCalledWith(
+      ['bun', 'install'],
+      expect.objectContaining({ cwd: '/tmp/opencode' }),
+    );
+    expect(showToast).toHaveBeenCalledWith({
+      body: {
+        title: 'OMO-Slim Updated!',
+        message: 'v0.9.1 → v0.9.11\nRestart OpenCode to apply.',
+        variant: 'success',
+        duration: 8000,
+      },
+    });
+  });
+
+  test('shows prepare failure toast and skips installation when active install cannot be resolved', async () => {
+    checkerMocks.findPluginEntry.mockImplementation(() => ({
+      pinnedVersion: null,
+      isPinned: false,
+    }));
+    checkerMocks.getCachedVersion.mockImplementation(() => '0.9.1');
+    checkerMocks.getLatestVersion.mockImplementation(async () => '0.9.11');
+    cacheMocks.preparePackageUpdate.mockImplementation(() => null);
+
+    bunSpawnSpy = spyOn(Bun, 'spawn').mockImplementation(
+      () =>
+        ({
+          exited: Promise.resolve(0),
+          exitCode: 0,
+          kill: mock(() => {}),
+        }) as never,
+    );
+
+    const { createAutoUpdateCheckerHook } = await import(
+      `./index?test=${importCounter++}`
+    );
+    const { ctx, showToast } = createCtx();
+
+    const hook = createAutoUpdateCheckerHook(ctx as never, {
+      showStartupToast: false,
+    });
+    hook.event({ event: { type: 'session.created', properties: {} } });
+    await waitForCalls(showToast);
+
+    expect(bunSpawnSpy).not.toHaveBeenCalled();
+    expect(showToast).toHaveBeenCalledWith({
+      body: {
+        title: 'OMO-Slim 0.9.11',
+        message:
+          'v0.9.11 available. Auto-update could not prepare the active install.',
+        variant: 'info',
+        duration: 8000,
+      },
+    });
+  });
+
+  test('shows install failure toast without telling users to restart', async () => {
+    checkerMocks.findPluginEntry.mockImplementation(() => ({
+      pinnedVersion: null,
+      isPinned: false,
+    }));
+    checkerMocks.getCachedVersion.mockImplementation(() => '0.9.1');
+    checkerMocks.getLatestVersion.mockImplementation(async () => '0.9.11');
+
+    bunSpawnSpy = spyOn(Bun, 'spawn').mockImplementation(
+      () =>
+        ({
+          exited: Promise.resolve(1),
+          exitCode: 1,
+          kill: mock(() => {}),
+        }) as never,
+    );
+
+    const { createAutoUpdateCheckerHook } = await import(
+      `./index?test=${importCounter++}`
+    );
+    const { ctx, showToast } = createCtx();
+
+    const hook = createAutoUpdateCheckerHook(ctx as never, {
+      showStartupToast: false,
+    });
+    hook.event({ event: { type: 'session.created', properties: {} } });
+    await waitForCalls(showToast);
+
+    expect(bunSpawnSpy).toHaveBeenCalledWith(
+      ['bun', 'install'],
+      expect.objectContaining({ cwd: '/tmp/opencode' }),
+    );
+    expect(showToast).toHaveBeenCalledWith({
+      body: {
+        title: 'OMO-Slim 0.9.11',
+        message:
+          'v0.9.11 available, but auto-update failed to install it. Check logs or retry manually.',
+        variant: 'error',
+        duration: 8000,
+      },
+    });
   });
 });

--- a/src/hooks/auto-update-checker/index.ts
+++ b/src/hooks/auto-update-checker/index.ts
@@ -170,8 +170,8 @@ async function runBackgroundUpdateCheck(
     showToast(
       ctx,
       `OMO-Slim ${latestVersion}`,
-      `v${latestVersion} available. Restart to apply.`,
-      'info',
+      `v${latestVersion} available, but auto-update failed to install it. Check logs or retry manually.`,
+      'error',
       8000,
     );
     log('[auto-update-checker] bun install failed; update not installed');

--- a/src/hooks/auto-update-checker/index.ts
+++ b/src/hooks/auto-update-checker/index.ts
@@ -1,6 +1,6 @@
 import type { PluginInput } from '@opencode-ai/plugin';
 import { log } from '../../utils/logger';
-import { invalidatePackage } from './cache';
+import { preparePackageUpdate, resolveInstallContext } from './cache';
 import {
   extractChannel,
   findPluginEntry,
@@ -140,9 +140,20 @@ async function runBackgroundUpdateCheck(
     return;
   }
 
-  invalidatePackage(PACKAGE_NAME);
+  const installDir = preparePackageUpdate(latestVersion, PACKAGE_NAME);
+  if (!installDir) {
+    showToast(
+      ctx,
+      `OMO-Slim ${latestVersion}`,
+      `v${latestVersion} available. Auto-update could not prepare the active install.`,
+      'info',
+      8000,
+    );
+    log('[auto-update-checker] Failed to prepare install root for auto-update');
+    return;
+  }
 
-  const installSuccess = await runBunInstallSafe();
+  const installSuccess = await runBunInstallSafe(installDir);
 
   if (installSuccess) {
     showToast(
@@ -168,18 +179,17 @@ async function runBackgroundUpdateCheck(
 }
 
 export function getAutoUpdateInstallDir(): string {
-  return CACHE_DIR;
+  return resolveInstallContext()?.installDir ?? CACHE_DIR;
 }
 
 /**
  * Spawns a background process to run 'bun install'.
  * Includes a 60-second timeout to prevent stalling OpenCode.
- * @param ctx The plugin input context.
+ * @param installDir The directory whose package manager context should be refreshed.
  * @returns True if the installation succeeded within the timeout.
  */
-async function runBunInstallSafe(): Promise<boolean> {
+async function runBunInstallSafe(installDir: string): Promise<boolean> {
   try {
-    const installDir = getAutoUpdateInstallDir();
     const proc = Bun.spawn(['bun', 'install'], {
       cwd: installDir,
       stdout: 'pipe',


### PR DESCRIPTION
## Summary
- stop telling users to restart OpenCode when `bun install` fails, and report the failure as an install error instead
- add regression coverage for the auto-update flow across local-dev skip, install-root preparation failure, successful installs, and failed installs
- make the async hook test helper wait on observed calls instead of assuming a fixed number of event-loop ticks
## Validation
- bun test src/hooks/auto-update-checker
- bun run typecheck
- bun run build
## Context
Follow-up to #289.