### PR TITLE
fix: use package name instead of temp path when running via bunx/npx

### DIFF
--- a/src/cli/config-io.ts
+++ b/src/cli/config-io.ts
@@ -31,10 +31,35 @@ function isPluginEntry(entry: string): boolean {
   );
 }
 
+function isRunningFromTempDir(cliEntryPath: string): boolean {
+  // Detect bunx temporary directories (e.g., /tmp/bunx-...)
+  const bunxPatterns = [
+    /[\\/]tmp[\\/]bunx-[^\\/]+[\\/]/,
+    /[\\/]tmp[\\/]\.bunx[\\/]/,
+  ];
+
+  // Detect npx temporary directories
+  const npxPatterns = [
+    /[\\/]\.npm[\\/]_npx[\\/]/,
+    /[\\/]tmp[\\/]npx[\\/]/,
+    /[\\/]npx-cache[\\/]/,
+  ];
+
+  return [...bunxPatterns, ...npxPatterns].some((pattern) =>
+    pattern.test(cliEntryPath),
+  );
+}
+
 function getPluginEntry(): string {
   const cliEntryPath = process.argv[1];
 
   if (!cliEntryPath) {
+    return PACKAGE_NAME;
+  }
+
+  // When running via bunx/npx, the package is in a temp directory that gets cleaned up
+  // Use the package name instead so it resolves from the actual installed location
+  if (isRunningFromTempDir(cliEntryPath)) {
     return PACKAGE_NAME;
   }
 


### PR DESCRIPTION
## Problem

When running `bunx oh-my-opencode-slim@latest install`, the plugin entry in opencode.json gets set to a file:// URL pointing to a temporary directory like `/tmp/bunx-1000-oh-my-opencode-slim@latest/node_modules/oh-my-opencode-slim/dist/index.js`.

Since /tmp gets cleared on reboot, the plugin stops working after a system restart and users have to run install again.

## Solution

Detect when the CLI is running from a temporary directory (bunx or npx) and use the package name `oh-my-opencode-slim` instead of a file path. This lets OpenCode resolve the plugin from wherever it's actually installed (global node_modules, local project, etc.).

## Changes

- Added `isRunningFromTempDir()` function to detect bunx/npx temp directories
- Modified `getPluginEntry()` to return package name when running from temp dir
- Patterns cover: bunx (/tmp/bunx-*, /tmp/.bunx), npx (.npm/_npx, /tmp/npx, npx-cache)

## Testing

- All existing tests pass
- The fix handles both bunx and npx temporary directory patterns

Fixes #293