### PR TITLE
fix: replace Bun-only APIs for Node.js (Electron desktop) compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "build": "bun build src/index.ts --outdir dist --target bun --format esm && bun build src/cli/index.ts --outdir dist/cli --target bun --format esm && tsc --emitDeclarationOnly && bun run generate-schema",
+    "build": "bun build src/index.ts --outdir dist --target node --format esm && bun build src/cli/index.ts --outdir dist/cli --target node --format esm && tsc --emitDeclarationOnly && bun run generate-schema",
     "contributors:add": "all-contributors add",
     "contributors:check": "all-contributors check",
     "contributors:generate": "all-contributors generate",

--- a/src/cli/system.ts
+++ b/src/cli/system.ts
@@ -1,4 +1,5 @@
 import { statSync } from 'node:fs';
+import { crossSpawn } from '../utils/compat';
 
 let cachedOpenCodePath: string | null = null;
 
@@ -77,7 +78,7 @@ export async function isOpenCodeInstalled(): Promise<boolean> {
 
   for (const opencodePath of paths) {
     try {
-      const proc = Bun.spawn([opencodePath, '--version'], {
+      const proc = crossSpawn([opencodePath, '--version'], {
         stdout: 'pipe',
         stderr: 'pipe',
       });
@@ -95,7 +96,7 @@ export async function isOpenCodeInstalled(): Promise<boolean> {
 
 export async function isTmuxInstalled(): Promise<boolean> {
   try {
-    const proc = Bun.spawn(['tmux', '-V'], {
+    const proc = crossSpawn(['tmux', '-V'], {
       stdout: 'pipe',
       stderr: 'pipe',
     });
@@ -109,14 +110,14 @@ export async function isTmuxInstalled(): Promise<boolean> {
 export async function getOpenCodeVersion(): Promise<string | null> {
   const opencodePath = resolveOpenCodePath();
   try {
-    const proc = Bun.spawn([opencodePath, '--version'], {
+    const proc = crossSpawn([opencodePath, '--version'], {
       stdout: 'pipe',
       stderr: 'pipe',
     });
-    const output = await new Response(proc.stdout).text();
+    const outputPromise = proc.stdout();
     await proc.exited;
     if (proc.exitCode === 0) {
-      return output.trim();
+      return (await outputPromise).trim();
     }
   } catch {
     // Failed

--- a/src/hooks/auto-update-checker/index.ts
+++ b/src/hooks/auto-update-checker/index.ts
@@ -1,4 +1,5 @@
 import type { PluginInput } from '@opencode-ai/plugin';
+import { crossSpawn } from '../../utils/compat';
 import { log } from '../../utils/logger';
 import { invalidatePackage } from './cache';
 import {
@@ -176,7 +177,7 @@ async function runBackgroundUpdateCheck(
  */
 async function runBunInstallSafe(ctx: PluginInput): Promise<boolean> {
   try {
-    const proc = Bun.spawn(['bun', 'install'], {
+    const proc = crossSpawn(['bun', 'install'], {
       cwd: ctx.directory,
       stdout: 'pipe',
       stderr: 'pipe',

--- a/src/multiplexer/tmux/index.ts
+++ b/src/multiplexer/tmux/index.ts
@@ -2,7 +2,7 @@
  * Tmux multiplexer implementation
  */
 
-import { spawn } from 'bun';
+import { crossSpawn } from '../../utils/compat';
 import type { MultiplexerLayout } from '../../config/schema';
 import { log } from '../../utils/logger';
 import type { Multiplexer, PaneResult } from '../types';
@@ -62,14 +62,14 @@ export class TmuxMultiplexer implements Multiplexer {
 
       log('[tmux] spawnPane: executing', { tmux, args });
 
-      const proc = spawn([tmux, ...args], {
+      const proc = crossSpawn([tmux, ...args], {
         stdout: 'pipe',
         stderr: 'pipe',
       });
 
       const exitCode = await proc.exited;
-      const stdout = await new Response(proc.stdout).text();
-      const stderr = await new Response(proc.stderr).text();
+      const stdout = await proc.stdout();
+      const stderr = await proc.stderr();
       const paneId = stdout.trim();
 
       log('[tmux] spawnPane: result', {
@@ -80,7 +80,7 @@ export class TmuxMultiplexer implements Multiplexer {
 
       if (exitCode === 0 && paneId) {
         // Rename the pane for visibility
-        const renameProc = spawn(
+        const renameProc = crossSpawn(
           [tmux, 'select-pane', '-t', paneId, '-T', description.slice(0, 30)],
           { stdout: 'ignore', stderr: 'ignore' },
         );
@@ -115,7 +115,7 @@ export class TmuxMultiplexer implements Multiplexer {
     try {
       // Send Ctrl+C for graceful shutdown
       log('[tmux] closePane: sending Ctrl+C', { paneId });
-      const ctrlCProc = spawn([tmux, 'send-keys', '-t', paneId, 'C-c'], {
+      const ctrlCProc = crossSpawn([tmux, 'send-keys', '-t', paneId, 'C-c'], {
         stdout: 'pipe',
         stderr: 'pipe',
       });
@@ -126,13 +126,13 @@ export class TmuxMultiplexer implements Multiplexer {
 
       // Kill the pane
       log('[tmux] closePane: killing pane', { paneId });
-      const proc = spawn([tmux, 'kill-pane', '-t', paneId], {
+      const proc = crossSpawn([tmux, 'kill-pane', '-t', paneId], {
         stdout: 'pipe',
         stderr: 'pipe',
       });
 
       const exitCode = await proc.exited;
-      const stderr = await new Response(proc.stderr).text();
+      const stderr = await proc.stderr();
 
       log('[tmux] closePane: result', { exitCode, stderr: stderr.trim() });
 
@@ -164,7 +164,7 @@ export class TmuxMultiplexer implements Multiplexer {
 
     try {
       // Apply the layout
-      const layoutProc = spawn([tmux, 'select-layout', layout], {
+      const layoutProc = crossSpawn([tmux, 'select-layout', layout], {
         stdout: 'pipe',
         stderr: 'pipe',
       });
@@ -175,7 +175,7 @@ export class TmuxMultiplexer implements Multiplexer {
         const sizeOption =
           layout === 'main-horizontal' ? 'main-pane-height' : 'main-pane-width';
 
-        const sizeProc = spawn(
+        const sizeProc = crossSpawn(
           [tmux, 'set-window-option', sizeOption, `${mainPaneSize}%`],
           {
             stdout: 'pipe',
@@ -185,7 +185,7 @@ export class TmuxMultiplexer implements Multiplexer {
         await sizeProc.exited;
 
         // Reapply layout to use the new size
-        const reapplyProc = spawn([tmux, 'select-layout', layout], {
+        const reapplyProc = crossSpawn([tmux, 'select-layout', layout], {
           stdout: 'pipe',
           stderr: 'pipe',
         });
@@ -208,7 +208,7 @@ export class TmuxMultiplexer implements Multiplexer {
     const cmd = isWindows ? 'where' : 'which';
 
     try {
-      const proc = spawn([cmd, 'tmux'], {
+      const proc = crossSpawn([cmd, 'tmux'], {
         stdout: 'pipe',
         stderr: 'pipe',
       });
@@ -219,7 +219,7 @@ export class TmuxMultiplexer implements Multiplexer {
         return null;
       }
 
-      const stdout = await new Response(proc.stdout).text();
+      const stdout = await proc.stdout();
       const path = stdout.trim().split('\n')[0];
       if (!path) {
         log('[tmux] findBinary: no path in output');
@@ -227,7 +227,7 @@ export class TmuxMultiplexer implements Multiplexer {
       }
 
       // Verify it works
-      const verifyProc = spawn([path, '-V'], {
+      const verifyProc = crossSpawn([path, '-V'], {
         stdout: 'pipe',
         stderr: 'pipe',
       });

--- a/src/multiplexer/zellij/index.ts
+++ b/src/multiplexer/zellij/index.ts
@@ -7,7 +7,7 @@
  * - User stays in their original tab
  */
 
-import { spawn } from 'bun';
+import { crossSpawn } from '../../utils/compat';
 import type { MultiplexerLayout } from '../../config/schema';
 import type { Multiplexer, PaneResult } from '../types';
 
@@ -121,13 +121,13 @@ export class ZellijMultiplexer implements Multiplexer {
         opencodeCmd,
       ];
 
-      const proc = spawn([zellij, ...args], {
+      const proc = crossSpawn([zellij, ...args], {
         stdout: 'pipe',
         stderr: 'pipe',
       });
 
       const exitCode = await proc.exited;
-      const stdout = await new Response(proc.stdout).text();
+      const stdout = await proc.stdout();
       const paneId = stdout.trim();
 
       // Accept success if exit code is 0 and we got a valid pane ID
@@ -145,7 +145,7 @@ export class ZellijMultiplexer implements Multiplexer {
     const originalTab = await this.getCurrentTabId(zellij);
 
     // Switch to agent tab
-    await spawn([zellij, 'action', 'go-to-tab-by-id', this.agentTabId], {
+    await crossSpawn([zellij, 'action', 'go-to-tab-by-id', this.agentTabId], {
       stdout: 'ignore',
       stderr: 'ignore',
     }).exited;
@@ -163,18 +163,18 @@ export class ZellijMultiplexer implements Multiplexer {
       opencodeCmd,
     ];
 
-    const proc = spawn([zellij, ...args], {
+    const proc = crossSpawn([zellij, ...args], {
       stdout: 'pipe',
       stderr: 'pipe',
     });
 
     const exitCode = await proc.exited;
-    const stdout = await new Response(proc.stdout).text();
+    const stdout = await proc.stdout();
     const paneId = stdout.trim();
 
     // Switch back to original tab
     if (originalTab) {
-      await spawn([zellij, 'action', 'go-to-tab-by-id', String(originalTab)], {
+      await crossSpawn([zellij, 'action', 'go-to-tab-by-id', String(originalTab)], {
         stdout: 'ignore',
         stderr: 'ignore',
       }).exited;
@@ -197,22 +197,22 @@ export class ZellijMultiplexer implements Multiplexer {
     try {
       const opencodeCmd = `opencode attach ${serverUrl} --session ${sessionId}`;
 
-      await spawn([zellij, 'action', 'focus-pane', '--pane-id', paneId], {
+      await crossSpawn([zellij, 'action', 'focus-pane', '--pane-id', paneId], {
         stdout: 'ignore',
         stderr: 'ignore',
       }).exited;
 
-      await spawn(
+      await crossSpawn(
         [zellij, 'action', 'rename-pane', '--name', description.slice(0, 30)],
         { stdout: 'ignore', stderr: 'ignore' },
       ).exited;
 
-      await spawn([zellij, 'action', 'write-chars', opencodeCmd], {
+      await crossSpawn([zellij, 'action', 'write-chars', opencodeCmd], {
         stdout: 'ignore',
         stderr: 'ignore',
       }).exited;
 
-      await spawn([zellij, 'action', 'write-chars', '\n'], {
+      await crossSpawn([zellij, 'action', 'write-chars', '\n'], {
         stdout: 'ignore',
         stderr: 'ignore',
       }).exited;
@@ -244,7 +244,7 @@ export class ZellijMultiplexer implements Multiplexer {
       const beforePanes = await this.listPanes(zellij);
 
       // Create new tab
-      const createProc = spawn(
+      const createProc = crossSpawn(
         [zellij, 'action', 'new-tab', '--name', 'opencode-agents'],
         { stdout: 'pipe', stderr: 'pipe' },
       );
@@ -270,7 +270,7 @@ export class ZellijMultiplexer implements Multiplexer {
     tabId: string,
   ): Promise<string | null> {
     const originalTab = await this.getCurrentTabId(zellij);
-    await spawn([zellij, 'action', 'go-to-tab-by-id', tabId], {
+    await crossSpawn([zellij, 'action', 'go-to-tab-by-id', tabId], {
       stdout: 'ignore',
       stderr: 'ignore',
     }).exited;
@@ -279,7 +279,7 @@ export class ZellijMultiplexer implements Multiplexer {
 
     // Restore original tab
     if (originalTab) {
-      await spawn([zellij, 'action', 'go-to-tab-by-id', String(originalTab)], {
+      await crossSpawn([zellij, 'action', 'go-to-tab-by-id', String(originalTab)], {
         stdout: 'ignore',
         stderr: 'ignore',
       }).exited;
@@ -293,7 +293,7 @@ export class ZellijMultiplexer implements Multiplexer {
     name: string,
   ): Promise<{ tabId: string; name: string } | null> {
     try {
-      const proc = spawn([zellij, 'action', 'list-tabs', '--json'], {
+      const proc = crossSpawn([zellij, 'action', 'list-tabs', '--json'], {
         stdout: 'pipe',
         stderr: 'pipe',
       });
@@ -301,7 +301,7 @@ export class ZellijMultiplexer implements Multiplexer {
       const exitCode = await proc.exited;
       if (exitCode !== 0) return this.findTabByNameText(zellij, name);
 
-      const stdout = await new Response(proc.stdout).text();
+      const stdout = await proc.stdout();
 
       try {
         const tabs: ZellijTabInfo[] = JSON.parse(stdout);
@@ -324,7 +324,7 @@ export class ZellijMultiplexer implements Multiplexer {
     name: string,
   ): Promise<{ tabId: string; name: string } | null> {
     try {
-      const proc = spawn([zellij, 'action', 'list-tabs'], {
+      const proc = crossSpawn([zellij, 'action', 'list-tabs'], {
         stdout: 'pipe',
         stderr: 'pipe',
       });
@@ -332,7 +332,7 @@ export class ZellijMultiplexer implements Multiplexer {
       const exitCode = await proc.exited;
       if (exitCode !== 0) return null;
 
-      const stdout = await new Response(proc.stdout).text();
+      const stdout = await proc.stdout();
       const lines = stdout.split('\n');
 
       for (const line of lines) {
@@ -349,7 +349,7 @@ export class ZellijMultiplexer implements Multiplexer {
 
   private async getCurrentTabId(zellij: string): Promise<string | null> {
     try {
-      const proc = spawn([zellij, 'action', 'current-tab-info', '--json'], {
+      const proc = crossSpawn([zellij, 'action', 'current-tab-info', '--json'], {
         stdout: 'pipe',
         stderr: 'pipe',
       });
@@ -357,7 +357,7 @@ export class ZellijMultiplexer implements Multiplexer {
       const exitCode = await proc.exited;
       if (exitCode !== 0) return null;
 
-      const stdout = await new Response(proc.stdout).text();
+      const stdout = await proc.stdout();
       try {
         const info = JSON.parse(stdout);
         return String(info.tab_id);
@@ -371,7 +371,7 @@ export class ZellijMultiplexer implements Multiplexer {
 
   private async listPanes(zellij: string): Promise<string[]> {
     try {
-      const proc = spawn([zellij, 'action', 'list-panes'], {
+      const proc = crossSpawn([zellij, 'action', 'list-panes'], {
         stdout: 'pipe',
         stderr: 'pipe',
       });
@@ -379,7 +379,7 @@ export class ZellijMultiplexer implements Multiplexer {
       const exitCode = await proc.exited;
       if (exitCode !== 0) return [];
 
-      const stdout = await new Response(proc.stdout).text();
+      const stdout = await proc.stdout();
       return stdout
         .split('\n')
         .slice(1)
@@ -398,7 +398,7 @@ export class ZellijMultiplexer implements Multiplexer {
 
     try {
       // Send Ctrl+C for graceful shutdown
-      await spawn([zellij, 'action', 'write', '--pane-id', paneId, '\u0003'], {
+      await crossSpawn([zellij, 'action', 'write', '--pane-id', paneId, '\u0003'], {
         stdout: 'ignore',
         stderr: 'ignore',
       }).exited;
@@ -406,7 +406,7 @@ export class ZellijMultiplexer implements Multiplexer {
       await new Promise((r) => setTimeout(r, 250));
 
       // Close the pane
-      const proc = spawn(
+      const proc = crossSpawn(
         [zellij, 'action', 'close-pane', '--pane-id', paneId],
         { stdout: 'pipe', stderr: 'pipe' },
       );
@@ -434,12 +434,12 @@ export class ZellijMultiplexer implements Multiplexer {
   private async findBinary(): Promise<string | null> {
     const cmd = process.platform === 'win32' ? 'where' : 'which';
     try {
-      const proc = spawn([cmd, 'zellij'], {
+      const proc = crossSpawn([cmd, 'zellij'], {
         stdout: 'pipe',
         stderr: 'pipe',
       });
       if ((await proc.exited) !== 0) return null;
-      const stdout = await new Response(proc.stdout).text();
+      const stdout = await proc.stdout();
       return stdout.trim().split('\n')[0] || null;
     } catch {
       return null;

--- a/src/tools/ast-grep/cli.ts
+++ b/src/tools/ast-grep/cli.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs';
-import { spawn } from 'bun';
+import { crossSpawn } from '../../utils/compat';
 import {
   DEFAULT_MAX_MATCHES,
   DEFAULT_MAX_OUTPUT_BYTES,
@@ -107,7 +107,7 @@ export async function runSg(options: RunOptions): Promise<SgResult> {
 
   const timeout = DEFAULT_TIMEOUT_MS;
 
-  const proc = spawn([cliPath, ...args], {
+  const proc = crossSpawn([cliPath, ...args], {
     stdout: 'pipe',
     stderr: 'pipe',
   });
@@ -126,10 +126,10 @@ export async function runSg(options: RunOptions): Promise<SgResult> {
 
   try {
     stdout = await Promise.race([
-      new Response(proc.stdout).text(),
+      proc.stdout(),
       timeoutPromise,
     ]);
-    stderr = await new Response(proc.stderr).text();
+    stderr = await proc.stderr();
     exitCode = await proc.exited;
   } catch (e) {
     const error = e as Error;

--- a/src/tools/ast-grep/downloader.ts
+++ b/src/tools/ast-grep/downloader.ts
@@ -3,6 +3,7 @@ import { createRequire } from 'node:module';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { extractZip } from '../../utils';
+import { crossWrite } from '../../utils/compat';
 
 const REPO = 'ast-grep/ast-grep';
 
@@ -96,7 +97,7 @@ export async function downloadAstGrep(
 
     const archivePath = join(cacheDir, assetName);
     const arrayBuffer = await response.arrayBuffer();
-    await Bun.write(archivePath, arrayBuffer);
+    await crossWrite(archivePath, arrayBuffer);
 
     await extractZip(archivePath, cacheDir);
 

--- a/src/tools/lsp/client.ts
+++ b/src/tools/lsp/client.ts
@@ -2,9 +2,8 @@
 
 import { readFileSync } from 'node:fs';
 import { extname, resolve } from 'node:path';
-import { Readable, Writable } from 'node:stream';
 import { pathToFileURL } from 'node:url';
-import { type Subprocess, spawn } from 'bun';
+import { spawn as nodeSpawn, type ChildProcess } from 'node:child_process';
 import {
   createMessageConnection,
   type MessageConnection,
@@ -319,7 +318,7 @@ class LSPServerManager {
 export const lspManager = LSPServerManager.getInstance();
 
 export class LSPClient {
-  private proc: Subprocess<'pipe', 'pipe', 'pipe'> | null = null;
+  private proc: ChildProcess | null = null;
   private connection: MessageConnection | null = null;
   private openedFiles = new Set<string>();
   private stderrBuffer: string[] = [];
@@ -354,15 +353,10 @@ export class LSPClient {
       root: this.root,
     });
 
-    this.proc = spawn(command, {
-      stdin: 'pipe',
-      stdout: 'pipe',
-      stderr: 'pipe',
+    this.proc = nodeSpawn(command[0], command.slice(1), {
+      stdio: ['pipe', 'pipe', 'pipe'],
       cwd: this.root,
-      env: {
-        ...process.env,
-        ...this.server.env,
-      },
+      env: { ...process.env, ...this.server.env },
     });
 
     if (!this.proc) {
@@ -374,45 +368,9 @@ export class LSPClient {
     this.startStderrReading();
 
     // Create JSON-RPC connection
-    const stdoutReader = this.proc.stdout.getReader();
-    const nodeReadable = new Readable({
-      async read() {
-        try {
-          const { done, value } = await stdoutReader.read();
-          if (done) {
-            this.push(null);
-          } else {
-            this.push(value);
-          }
-        } catch (err) {
-          this.destroy(err as Error);
-        }
-      },
-    });
-
-    const stdin = this.proc.stdin;
-    const nodeWritable = new Writable({
-      write(chunk, _encoding, callback) {
-        try {
-          stdin.write(chunk);
-          callback();
-        } catch (err) {
-          callback(err as Error);
-        }
-      },
-      final(callback) {
-        try {
-          stdin.end();
-          callback();
-        } catch (err) {
-          callback(err as Error);
-        }
-      },
-    });
-
     this.connection = createMessageConnection(
-      new StreamMessageReader(nodeReadable),
-      new StreamMessageWriter(nodeWritable),
+      new StreamMessageReader(this.proc.stdout!),
+      new StreamMessageWriter(this.proc.stdin!),
     );
 
     this.connection.onNotification(
@@ -492,24 +450,13 @@ export class LSPClient {
   }
 
   private startStderrReading(): void {
-    if (!this.proc) return;
-
-    const reader = this.proc.stderr.getReader();
-    const read = async () => {
-      const decoder = new TextDecoder();
-      try {
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-          const text = decoder.decode(value);
-          this.stderrBuffer.push(text);
-          if (this.stderrBuffer.length > 100) {
-            this.stderrBuffer.shift();
-          }
-        }
-      } catch {}
-    };
-    read();
+    if (!this.proc?.stderr) return;
+    this.proc.stderr.on('data', (chunk: Buffer) => {
+      this.stderrBuffer.push(chunk.toString());
+      if (this.stderrBuffer.length > 100) {
+        this.stderrBuffer.shift();
+      }
+    });
   }
 
   async initialize(): Promise<void> {

--- a/src/utils/compat.ts
+++ b/src/utils/compat.ts
@@ -1,0 +1,83 @@
+import { spawn as nodeSpawn } from 'node:child_process';
+import { writeFile as fsWriteFile } from 'node:fs/promises';
+import type { ChildProcess } from 'node:child_process';
+
+export const isBun = typeof globalThis.Bun !== 'undefined';
+
+export interface CrossSpawnResult {
+  proc: ChildProcess;
+  /** Collects all stdout into a string */
+  stdout: () => Promise<string>;
+  /** Collects all stderr into a string */
+  stderr: () => Promise<string>;
+  /** Resolves when process exits with exit code */
+  exited: Promise<number>;
+  /** Kill the process */
+  kill: (signal?: NodeJS.Signals | number) => boolean;
+  /** Current exit code or null if running */
+  get exitCode(): number | null;
+}
+
+function collectStream(stream: NodeJS.ReadableStream | null): () => Promise<string> {
+  if (!stream) return () => Promise.resolve('');
+  const chunks: Buffer[] = [];
+  stream.on('data', (chunk: Buffer) => chunks.push(chunk));
+  return () => new Promise<string>((resolve, reject) => {
+    if (!stream.readable) {
+      resolve(Buffer.concat(chunks).toString('utf-8'));
+      return;
+    }
+    stream.on('end', () => resolve(Buffer.concat(chunks).toString('utf-8')));
+    stream.on('error', reject);
+  });
+}
+
+/**
+ * Cross-runtime spawn that works in both Bun and Node.js.
+ * API mimics Bun.spawn but uses node:child_process internally.
+ */
+export function crossSpawn(
+  command: string[],
+  options?: {
+    stdout?: 'pipe' | 'inherit' | 'ignore';
+    stderr?: 'pipe' | 'inherit' | 'ignore';
+    stdin?: 'pipe' | 'inherit' | 'ignore';
+    cwd?: string;
+    env?: Record<string, string | undefined>;
+  },
+): CrossSpawnResult {
+  const [cmd, ...args] = command;
+  const proc = nodeSpawn(cmd, args, {
+    stdio: [
+      options?.stdin ?? 'ignore',
+      options?.stdout ?? 'pipe',
+      options?.stderr ?? 'pipe',
+    ],
+    cwd: options?.cwd,
+    env: options?.env as NodeJS.ProcessEnv,
+  });
+
+  const stdoutCollector = collectStream(proc.stdout);
+  const stderrCollector = collectStream(proc.stderr);
+
+  const exited = new Promise<number>((resolve, reject) => {
+    proc.on('error', reject);
+    proc.on('close', (code) => resolve(code ?? 1));
+  });
+
+  return {
+    proc,
+    stdout: stdoutCollector,
+    stderr: stderrCollector,
+    exited,
+    kill: (signal) => proc.kill(signal as NodeJS.Signals),
+    get exitCode() { return proc.exitCode; },
+  };
+}
+
+/**
+ * Cross-runtime file write that works in both Bun and Node.js.
+ */
+export async function crossWrite(path: string, data: ArrayBuffer | Buffer | string): Promise<void> {
+  await fsWriteFile(path, Buffer.from(data as ArrayBuffer));
+}

--- a/src/utils/zip-extractor.ts
+++ b/src/utils/zip-extractor.ts
@@ -1,5 +1,6 @@
 import { release } from 'node:os';
-import { spawn, spawnSync } from 'bun';
+import { spawnSync } from 'node:child_process';
+import { crossSpawn } from './compat';
 
 const WINDOWS_BUILD_WITH_TAR = 17134;
 
@@ -16,11 +17,10 @@ function getWindowsBuildNumber(): number | null {
 
 function isPwshAvailable(): boolean {
   if (process.platform !== 'win32') return false;
-  const result = spawnSync(['where', 'pwsh'], {
-    stdout: 'pipe',
-    stderr: 'pipe',
+  const result = spawnSync('where', ['pwsh'], {
+    stdio: ['ignore', 'pipe', 'pipe'],
   });
-  return result.exitCode === 0;
+  return result.status === 0;
 }
 
 function escapePowerShellPath(path: string): string {
@@ -47,20 +47,20 @@ export async function extractZip(
   archivePath: string,
   destDir: string,
 ): Promise<void> {
-  let proc: ReturnType<typeof spawn>;
+  let proc: ReturnType<typeof crossSpawn>;
 
   if (process.platform === 'win32') {
     const extractor = getWindowsZipExtractor();
 
     switch (extractor) {
       case 'tar':
-        proc = spawn(['tar', '-xf', archivePath, '-C', destDir], {
+        proc = crossSpawn(['tar', '-xf', archivePath, '-C', destDir], {
           stdout: 'ignore',
           stderr: 'pipe',
         });
         break;
       case 'pwsh':
-        proc = spawn(
+        proc = crossSpawn(
           [
             'pwsh',
             '-Command',
@@ -73,7 +73,7 @@ export async function extractZip(
         );
         break;
       default:
-        proc = spawn(
+        proc = crossSpawn(
           [
             'powershell',
             '-Command',
@@ -87,7 +87,7 @@ export async function extractZip(
         break;
     }
   } else {
-    proc = spawn(['unzip', '-o', archivePath, '-d', destDir], {
+    proc = crossSpawn(['unzip', '-o', archivePath, '-d', destDir], {
       stdout: 'ignore',
       stderr: 'pipe',
     });
@@ -96,7 +96,7 @@ export async function extractZip(
   const exitCode = await proc.exited;
 
   if (exitCode !== 0) {
-    const stderr = await new Response(proc.stderr as ReadableStream).text();
+    const stderr = await proc.stderr();
     throw new Error(`zip extraction failed (exit ${exitCode}): ${stderr}`);
   }
 }


### PR DESCRIPTION
## Summary

- Replace all Bun-specific APIs (`import { spawn } from 'bun'`, `Bun.write()`, `Bun.spawn()`) with cross-runtime alternatives (`node:child_process`, `node:fs/promises`)
- Add `src/utils/compat.ts` with `crossSpawn()` and `crossWrite()` utilities
- Change build target from `--target bun` to `--target node` to avoid Bun-specific `__require` shim

## Problem

The OpenCode desktop app (Electron) runs the server **in-process using Node.js**, not Bun. When the plugin is loaded via `import()`, the bundled `from 'bun'` imports fail immediately because the `bun` module doesn't exist in Node.js. Additionally, `--target bun` produces a `__require` helper that is Bun-specific and throws `__require is not a function` in Node.js.

The plugin works fine in CLI mode because the CLI uses a Bun binary.

## Changes

| File | Change |
|------|--------|
| `src/utils/compat.ts` | **New** — `crossSpawn()`, `crossWrite()` using `node:child_process` + `node:fs/promises` |
| `src/tools/ast-grep/cli.ts` | `spawn` from `bun` → `crossSpawn` |
| `src/tools/ast-grep/downloader.ts` | `Bun.write()` → `crossWrite()` |
| `src/tools/lsp/client.ts` | `spawn` from `bun` → `node:child_process`, removed redundant stream wrappers |
| `src/multiplexer/tmux/index.ts` | `spawn` from `bun` → `crossSpawn` |
| `src/multiplexer/zellij/index.ts` | `spawn` from `bun` → `crossSpawn` |
| `src/utils/zip-extractor.ts` | `spawn`/`spawnSync` from `bun` → `node:child_process` |
| `src/cli/system.ts` | `Bun.spawn()` → `crossSpawn` |
| `src/hooks/auto-update-checker/index.ts` | `Bun.spawn()` → `crossSpawn` |
| `package.json` | build target `--target bun` → `--target node` |

## Why this is safe

`node:child_process` and `node:fs/promises` are **fully supported in both Bun and Node.js**. CLI mode (Bun) continues to work exactly as before — verified with all 532 tests passing.

## Test plan

- [x] `bun run typecheck` — passes
- [x] `bun test` — 532 tests pass, 0 failures
- [x] `bun run build` — 248 modules bundled successfully
- [x] Built `dist/index.js` contains zero `from "bun"` imports
- [x] Tested in OpenCode desktop app (Electron) — plugin loads successfully

Fixes #298