### PR TITLE
fix(agents): use council master model for councillor agent registration

### DIFF
--- a/src/agents/index.test.ts
+++ b/src/agents/index.test.ts
@@ -374,6 +374,31 @@ describe('council agent model resolution', () => {
     const councilMaster = agents.find((a) => a.name === 'council-master');
     expect(councilMaster?.config.model).toBe(DEFAULT_MODELS['council-master']);
   });
+
+  test('councillor agent uses config.council.master.model', () => {
+    const config = {
+      council: {
+        master: { model: 'anthropic/claude-sonnet-4-6' },
+        presets: {
+          default: {
+            councillors: {
+              alpha: { model: 'test/alpha-model' },
+            },
+            master: undefined,
+          },
+        },
+      },
+    } as unknown as PluginConfig;
+    const agents = createAgents(config);
+    const councillor = agents.find((a) => a.name === 'councillor');
+    expect(councillor?.config.model).toBe('anthropic/claude-sonnet-4-6');
+  });
+
+  test('councillor agent falls back to default without council config', () => {
+    const agents = createAgents();
+    const councillor = agents.find((a) => a.name === 'councillor');
+    expect(councillor?.config.model).toBe(DEFAULT_MODELS.councillor);
+  });
 });
 
 describe('options passthrough', () => {

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -147,7 +147,9 @@ export function createAgents(config?: PluginConfig): AgentDefinition[] {
     // config.council.master.model so the TUI validates the user's
     // actual model, not the hardcoded default
     if (
-      (name === 'council' || name === 'council-master') &&
+      (name === 'council' ||
+        name === 'council-master' ||
+        name === 'councillor') &&
       config?.council?.master?.model
     ) {
       return config.council.master.model;


### PR DESCRIPTION
## Summary

- Fix councillor agent always using hardcoded `openai/gpt-5.4-mini` default model instead of the configured council master model
- Councillor was missing from the special-case check in `getModelForAgent()` that `council` and `council-master` already had

## Changes

- Added `'councillor'` to the model resolution condition in `src/agents/index.ts` so the agent definition uses `config.council.master.model` instead of falling through to `DEFAULT_MODELS.councillor`

This caused `ProviderModelNotFoundError` when the hardcoded default provider wasn't available, and used the wrong model even when it was. The council manager correctly passes per-councillor models at prompt time, but OpenCode needs a valid registered model to create the session in the first place.