### PR TITLE
fix: mark jsdom as external to prevent worker path resolution error (#311)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "LICENSE"
   ],
   "scripts": {
-    "build:plugin": "bun build src/index.ts --outdir dist --target node --format esm --external @ast-grep/napi --external @opencode-ai/plugin --external @opencode-ai/sdk",
-    "build:cli": "bun build src/cli/index.ts --outdir dist/cli --target node --format esm --external @ast-grep/napi --external @opencode-ai/plugin --external @opencode-ai/sdk",
+    "build:plugin": "bun build src/index.ts --outdir dist --target node --format esm --external @ast-grep/napi --external @opencode-ai/plugin --external @opencode-ai/sdk --external jsdom",
+    "build:cli": "bun build src/cli/index.ts --outdir dist/cli --target node --format esm --external @ast-grep/napi --external @opencode-ai/plugin --external @opencode-ai/sdk --external jsdom",
     "build": "bun run build:plugin && bun run build:cli && tsc --emitDeclarationOnly && bun run generate-schema",
     "prepare": "bun run build",
     "contributors:add": "all-contributors add",


### PR DESCRIPTION
## Problem

When the plugin is loaded from OpenCode's cache after being built, it fails with:



## Root Cause

Bun was bundling  and hardcoding an absolute path to  into . This breaks when the plugin is loaded from OpenCode's cache on a different machine with a different path structure.

## Solution

Mark  as external in both Bun build commands ( and ). This prevents Bun from bundling jsdom and instead keeps it as a normal dependency that gets resolved at runtime from the installed .

## Changes

- Added  to both  and  scripts in 

## Verification

-  and  both succeed
-  passes
- The built  no longer contains the broken absolute  reference

Fixes #311