### PR TITLE
fix: improve image-hook naming and session-scoped cleanup

### DIFF
--- a/src/hooks/image-hook.ts
+++ b/src/hooks/image-hook.ts
@@ -7,10 +7,10 @@ import {
   unlinkSync,
   writeFileSync,
 } from 'node:fs';
-import { join } from 'node:path';
+import { basename, extname, join } from 'node:path';
 
-// Debounce: only run cleanup every 10 minutes
-let lastCleanup = 0;
+// Debounce: only run cleanup every 10 minutes per directory
+const lastCleanupByDir = new Map<string, number>();
 const CLEANUP_INTERVAL = 10 * 60 * 1000; // 10 minutes
 
 interface ImagePart {
@@ -66,6 +66,58 @@ function extFromMime(mime: string): string {
   return map[mime] ?? '.png';
 }
 
+function sanitizeFilename(name: string): string {
+  return name.replace(/[^a-zA-Z0-9._-]/g, '_');
+}
+
+function cleanupOldImages(dir: string): void {
+  const now = Date.now();
+  const lastCleanup = lastCleanupByDir.get(dir) ?? 0;
+  if (now - lastCleanup < CLEANUP_INTERVAL) return;
+  lastCleanupByDir.set(dir, now);
+
+  try {
+    const maxAge = 60 * 60 * 1000;
+    for (const f of readdirSync(dir)) {
+      const fp = join(dir, f);
+      try {
+        if (now - statSync(fp).mtimeMs > maxAge) unlinkSync(fp);
+      } catch {}
+    }
+  } catch {}
+}
+
+function writeUniqueFile(
+  dir: string,
+  name: string,
+  data: Buffer,
+  log: (msg: string) => void,
+): string | null {
+  const ext = extname(name);
+  const base = basename(name, ext) || name;
+  let candidate = join(dir, name);
+  let counter = 0;
+
+  while (true) {
+    try {
+      writeFileSync(candidate, data, { flag: 'wx' });
+      return candidate;
+    } catch (e) {
+      if (
+        e instanceof Error &&
+        (e as NodeJS.ErrnoException).code === 'EEXIST'
+      ) {
+        counter += 1;
+        candidate = join(dir, `${base}-${counter}${ext}`);
+        continue;
+      }
+
+      log(`[image-hook] failed to save image: ${e}`);
+      return null;
+    }
+  }
+}
+
 export function processImageAttachments(args: {
   messages: MessageWithParts[];
   workDir: string;
@@ -88,25 +140,22 @@ export function processImageAttachments(args: {
     log(`[image-hook] failed to create image directory: ${e}`);
   }
 
-  // Clean up images older than 1 hour (debounced: only check every 10 minutes)
-  const now = Date.now();
-  if (now - lastCleanup > CLEANUP_INTERVAL) {
-    lastCleanup = now;
-    try {
-      const maxAge = 60 * 60 * 1000;
-      for (const f of readdirSync(saveDir)) {
-        const fp = join(saveDir, f);
-        try {
-          if (now - statSync(fp).mtimeMs > maxAge) unlinkSync(fp);
-        } catch {}
-      }
-    } catch {}
-  }
-
   for (const msg of messages) {
     if (msg.info.role !== 'user') continue;
     const imageParts = msg.parts.filter(isImagePart);
     if (imageParts.length === 0) continue;
+
+    const sessionSubdir = msg.info.sessionID
+      ? sanitizeFilename(msg.info.sessionID)
+      : undefined;
+    const targetDir = sessionSubdir ? join(saveDir, sessionSubdir) : saveDir;
+    try {
+      mkdirSync(targetDir, { recursive: true });
+    } catch (e) {
+      log(`[image-hook] failed to create target image directory: ${e}`);
+    }
+
+    cleanupOldImages(targetDir);
 
     // Save each image to .opencode/images/ and collect paths
     const savedPaths: string[] = [];
@@ -121,14 +170,18 @@ export function processImageAttachments(args: {
             .update(decoded.data)
             .digest('hex')
             .slice(0, 8);
-          const name = filename ?? `image-${hash}${extFromMime(decoded.mime)}`;
-          const filePath = join(saveDir, name);
-          try {
-            writeFileSync(filePath, decoded.data);
-            savedPaths.push(filePath);
-          } catch (e) {
-            log(`[image-hook] failed to save image: ${e}`);
-          }
+          const sanitizedFilename = filename
+            ? sanitizeFilename(filename)
+            : undefined;
+          const baseName = sanitizedFilename
+            ? sanitizedFilename.replace(/\.[^.]+$/, '')
+            : 'image';
+          const ext = sanitizedFilename
+            ? extname(sanitizedFilename) || extFromMime(decoded.mime)
+            : extFromMime(decoded.mime);
+          const name = `${baseName}-${hash}${ext}`;
+          const filePath = writeUniqueFile(targetDir, name, decoded.data, log);
+          if (filePath) savedPaths.push(filePath);
         }
       }
     }

--- a/src/hooks/image-hook.ts
+++ b/src/hooks/image-hook.ts
@@ -3,6 +3,7 @@ import {
   existsSync,
   mkdirSync,
   readdirSync,
+  rmdirSync,
   statSync,
   unlinkSync,
   writeFileSync,
@@ -70,7 +71,7 @@ function sanitizeFilename(name: string): string {
   return name.replace(/[^a-zA-Z0-9._-]/g, '_');
 }
 
-function cleanupOldImages(dir: string): void {
+function cleanupOldImages(dir: string, saveDir: string): void {
   const now = Date.now();
   const lastCleanup = lastCleanupByDir.get(dir) ?? 0;
   if (now - lastCleanup < CLEANUP_INTERVAL) return;
@@ -82,6 +83,13 @@ function cleanupOldImages(dir: string): void {
       const fp = join(dir, f);
       try {
         if (now - statSync(fp).mtimeMs > maxAge) unlinkSync(fp);
+      } catch {}
+    }
+    // Remove empty session subdirectory and prune its debounce entry
+    if (dir !== saveDir) {
+      try {
+        rmdirSync(dir);
+        lastCleanupByDir.delete(dir);
       } catch {}
     }
   } catch {}
@@ -161,7 +169,7 @@ export function processImageAttachments(args: {
       log(`[image-hook] failed to create target image directory: ${e}`);
     }
 
-    cleanupOldImages(targetDir);
+    cleanupOldImages(targetDir, saveDir);
 
     // Save each image to .opencode/images/ and collect paths
     const savedPaths: string[] = [];
@@ -180,7 +188,7 @@ export function processImageAttachments(args: {
             ? sanitizeFilename(filename)
             : undefined;
           const baseName = sanitizedFilename
-            ? sanitizedFilename.replace(/\.[^.]+$/, '')
+            ? sanitizedFilename.replace(/\.[^.]+$/, '') || 'image'
             : 'image';
           const ext = sanitizedFilename
             ? extname(sanitizedFilename) || extFromMime(decoded.mime)

--- a/src/hooks/image-hook.ts
+++ b/src/hooks/image-hook.ts
@@ -98,7 +98,8 @@ function writeUniqueFile(
   let candidate = join(dir, name);
   let counter = 0;
 
-  while (true) {
+  const MAX_ATTEMPTS = 1000;
+  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
     try {
       writeFileSync(candidate, data, { flag: 'wx' });
       return candidate;
@@ -116,6 +117,11 @@ function writeUniqueFile(
       return null;
     }
   }
+
+  log(
+    `[image-hook] failed to save image: max attempts (${MAX_ATTEMPTS}) reached`,
+  );
+  return null;
 }
 
 export function processImageAttachments(args: {


### PR DESCRIPTION
## Summary

- Fix image filename collisions by including content hash in all generated names (`{basename}-{hash}.{ext}`)
- Add atomic file writes via `writeFileSync` with `{ flag: 'wx' }` and collision retry (`-1`, `-2`, ...) in new `writeUniqueFile()` helper
- Scope images and cleanup per session using `sessionID`-based subdirectories under `.opencode/images/`
- Replace global `lastCleanup` with per-directory debounce via `lastCleanupByDir` Map

## Why

- Screenshots often share the same default filename (e.g. `image.png`), causing different images to overwrite each other
- Without atomic writes, concurrent sessions or multiple images uploaded simultaneously could race on the same filepath
- A global cleanup timestamp meant one session's cleanup could skip or delete another session's images prematurely

## Details

| Before | After |
|--------|-------|
| Same-name screenshots overwrite (`image.png`) | Names include content hash (`image-a1b2c3d4.png`) |
| No write collision handling | `wx` (exclusive) flag + retry with suffixed names |
| All sessions share one cleanup timer | Per-directory debounce via `Map<string, number>` |
| All images in flat `.opencode/images/` | Session-scoped `.opencode/images/<sessionID>/` |

## Test Plan

- [x] `bun run check:ci` passes
- [x] `bun run typecheck` passes
- [x] `bun test` — 973 tests pass
- [x] Manual: upload multiple screenshots with same filename in one message → verify each gets unique name
- [x] Manual: run two concurrent sessions uploading images → verify no overwrites
- [x] Manual: verify cleanup still runs per-session after 1 hour

Related #307