### PR TITLE
fix: custom orchestrator prompt gets appended instead of replacing default

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -569,10 +569,12 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
         );
         if (!alreadyInjected) {
           // Prepend the orchestrator prompt to the system array.
-          // agentDefs[0] is always the orchestrator — use its resolved prompt
+          // Use the resolved prompt from the orchestrator agent definition
           // (which includes any custom replacement or append from orchestrator.md / orchestrator_append.md)
           // Fall back to buildOrchestratorPrompt only if the resolved prompt is missing.
-          const orchestratorDef = agentDefs[0];
+          const orchestratorDef = agentDefs.find(
+            (a) => a.name === 'orchestrator',
+          );
           const orchestratorPrompt =
             typeof orchestratorDef?.config?.prompt === 'string'
               ? orchestratorDef.config.prompt

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import type { Plugin } from '@opencode-ai/plugin';
 import { createAgents, getAgentConfigs, getDisabledAgents } from './agents';
+import { buildOrchestratorPrompt } from './agents/orchestrator';
 import { BackgroundTaskManager, MultiplexerSessionManager } from './background';
 import { loadPluginConfig, type MultiplexerConfig } from './config';
 import { parseList } from './config/agent-mcps';
@@ -550,6 +551,8 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
     // Inject orchestrator system prompt for serve-mode sessions.
     // In serve mode, the agent's prompt field may be absent from the agents registry
     // (built before plugin config hooks run). This hook injects it at LLM call time.
+    // Uses the already-resolved prompt from agentDefs (which has custom replacement
+    // or append prompts applied) instead of rebuilding the default.
     'experimental.chat.system.transform': async (
       input: { sessionID?: string },
       output: { system: string[] },
@@ -565,14 +568,15 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
             s.includes('orchestrator'),
         );
         if (!alreadyInjected) {
-          // Prepend the orchestrator prompt to the system array
-          // Use buildOrchestratorPrompt with disabledAgents so the
-          // serve-mode prompt matches the interactive-mode prompt
-          const { buildOrchestratorPrompt } = await import(
-            './agents/orchestrator'
-          );
-          const disabledAgents = getDisabledAgents(config);
-          const orchestratorPrompt = buildOrchestratorPrompt(disabledAgents);
+          // Prepend the orchestrator prompt to the system array.
+          // agentDefs[0] is always the orchestrator — use its resolved prompt
+          // (which includes any custom replacement or append from orchestrator.md / orchestrator_append.md)
+          // Fall back to buildOrchestratorPrompt only if the resolved prompt is missing.
+          const orchestratorDef = agentDefs[0];
+          const orchestratorPrompt =
+            typeof orchestratorDef?.config?.prompt === 'string'
+              ? orchestratorDef.config.prompt
+              : buildOrchestratorPrompt(getDisabledAgents(config));
           output.system[0] =
             orchestratorPrompt +
             (output.system[0] ? `\n\n${output.system[0]}` : '');


### PR DESCRIPTION
Fixes #295

## Summary

A custom `orchestrator.md` replacement prompt was being **appended** to the default prompt instead of replacing it. The `experimental.chat.system.transform` hook always rebuilt the default prompt via `buildOrchestratorPrompt()`, ignoring the custom prompt already resolved during agent creation.

## Root Cause

The hook unconditionally called `buildOrchestratorPrompt(disabledAgents)` to construct the orchestrator prompt, even when a custom prompt had already been resolved via `resolvePrompt()` at agent creation time and stored in `agentDefs[].config.prompt`.

## Fix

The hook now reads the already-resolved prompt from the orchestrator agent definition (which includes any custom replacement or append from `orchestrator.md` / `orchestrator_append.md`). Falls back to `buildOrchestratorPrompt()` only if the resolved prompt is missing. Also uses name-based `.find()` lookup instead of positional index (thanks @greptile-apps[bot]).

## Testing

- All 1008 tests pass
- Static import of `buildOrchestratorPrompt` replaces dynamic import (module already loaded at plugin init)