### PR TITLE
fix: collapse system messages for Qwen3.5 compatibility

### DIFF
--- a/src/hooks/todo-continuation/todo-hygiene.test.ts
+++ b/src/hooks/todo-continuation/todo-hygiene.test.ts
@@ -86,7 +86,7 @@ describe('todo hygiene', () => {
     await hook.handleChatSystemTransform({ sessionID: 's1' }, system);
 
     expect(
-      system.system.filter((item) => item === TODO_HYGIENE_REMINDER),
+      system.system.filter((item) => item.includes(TODO_HYGIENE_REMINDER)),
     ).toHaveLength(1);
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -590,6 +590,12 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
         input,
         output,
       );
+
+      // Collapse to single system message for provider compatibility.
+      // Some providers (e.g. Qwen3.5 via DashScope) reject multiple system
+      // messages. Sub-hooks above may push additional entries; join them
+      // back into one element so OpenCode emits a single system message.
+      output.system = [output.system.join('\n\n')];
     },
 
     // Inject phase reminder and filter available skills before sending to API (doesn't show in UI)

--- a/src/index.ts
+++ b/src/index.ts
@@ -595,7 +595,8 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
       // Some providers (e.g. Qwen3.5 via DashScope) reject multiple system
       // messages. Sub-hooks above may push additional entries; join them
       // back into one element so OpenCode emits a single system message.
-      output.system = [output.system.join('\n\n')];
+      const joined = output.system.join('\n\n');
+      output.system = joined ? [joined] : [];
     },
 
     // Inject phase reminder and filter available skills before sending to API (doesn't show in UI)


### PR DESCRIPTION
## Summary

Qwen3.5 models throw `"System message must be at the beginning"` error because the plugin's hooks push multiple entries into `output.system[]`, which OpenCode converts to separate `{"role": "system"}` messages in the API call. Qwen rejects multiple system messages.

Closes #315

## Root Cause

Two-part chain:

1. **slim hooks** - `todo-hygiene.ts` and `post-file-tool-nudge/index.ts` push additional entries via `output.system.push(...)`
2. **OpenCode core** (`session/llm.ts`) converts each array element to a separate system message: `system.map(x => ({role: "system", content: x}))`

Before hooks run, OpenCode joins everything into one string. After hooks push new entries, the array has 3 elements, producing 3 system messages. Most providers tolerate this; Qwen3.5 does not.

## Fix

Collapse `output.system` back to a single element after all sub-hooks run:

```typescript
output.system = [output.system.join('\n\n')];
```

This ensures OpenCode always emits exactly one system message, regardless of how many entries the hooks add.

## Changes

- `src/index.ts` ,  add collapse after sub-hook calls in `system.transform`
- `src/hooks/todo-continuation/todo-hygiene.test.ts`,  update one assertion from exact element match (`===`) to substring match (`.includes()`). Would have still worked, but  is more defensive for future integration tests.

## Testing

- All 30 hygiene tests pass
- Typecheck clean
- No new lint issues