### PR TITLE
fix(build): externalize zod from plugin bundle to prevent dual-instance crash

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,6 @@
         "vscode-jsonrpc": "^8.2.1",
         "vscode-languageserver-protocol": "^3.17.5",
         "which": "^6.0.1",
-        "zod": "^4.3.6",
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.11",
@@ -27,6 +26,10 @@
         "all-contributors-cli": "^6.26.1",
         "bun-types": "1.3.12",
         "typescript": "^5.9.3",
+        "zod": "^4.3.6",
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0",
       },
     },
   },

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "LICENSE"
   ],
   "scripts": {
-    "build:plugin": "bun build src/index.ts --outdir dist --target node --format esm --external @ast-grep/napi --external @opencode-ai/plugin --external @opencode-ai/sdk --external jsdom",
-    "build:cli": "bun build src/cli/index.ts --outdir dist/cli --target node --format esm --external @ast-grep/napi --external @opencode-ai/plugin --external @opencode-ai/sdk --external jsdom",
+    "build:plugin": "bun build src/index.ts --outdir dist --target node --format esm --external @ast-grep/napi --external @opencode-ai/plugin --external @opencode-ai/sdk --external jsdom --external zod",
+    "build:cli": "bun build src/cli/index.ts --outdir dist/cli --target node --format esm --external @ast-grep/napi --external @opencode-ai/plugin --external @opencode-ai/sdk --external jsdom --external zod",
     "build": "bun run build:plugin && bun run build:cli && tsc --emitDeclarationOnly && bun run generate-schema",
     "prepare": "bun run build",
     "contributors:add": "all-contributors add",
@@ -69,8 +69,7 @@
     "turndown": "^7.2.4",
     "vscode-jsonrpc": "^8.2.1",
     "vscode-languageserver-protocol": "^3.17.5",
-    "which": "^6.0.1",
-    "zod": "^4.3.6"
+    "which": "^6.0.1"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.11",
@@ -80,7 +79,11 @@
     "@types/which": "^3.0.4",
     "all-contributors-cli": "^6.26.1",
     "bun-types": "1.3.12",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "zod": "^4.3.6"
+  },
+  "peerDependencies": {
+    "zod": "^4.0.0"
   },
   "trustedDependencies": [
     "@ast-grep/cli"


### PR DESCRIPTION
## Summary

Fixes #342

**Root cause:** Both OpenCode and the plugin bundle their own copy of zod v4. Zod v4 uses instance-identity checks (`schema._zod.def`) that fail when schemas cross the plugin/host boundary.

Same class of bug as [code-yeongyu/oh-my-openagent#3480](https://github.com/code-yeongyu/oh-my-openagent/pull/3480), which applied the same fix in the oh-my-openagent framework.

**Fix:**
- Add `--external zod` to both `build:plugin` and `build:cli` so the plugin resolves zod at runtime from OpenCode's copy
- Move `zod` from `dependencies` to `peerDependencies` (`^4.0.0`) so package managers deduplicate on a single instance
- Keep `zod` in `devDependencies` for local builds and tests

## Verification

- `_zod` internals: 0 occurrences in the built bundle
- 1032 tests pass, 0 fail
- TypeScript: clean
- Biome: clean (1 pre-existing warning)
- `verify:host-smoke`: plugin loads cleanly inside a fresh OpenCode host

## Files changed

- `package.json` - build scripts + dependency reshuffling
- `bun.lock` - lockfile update