### PR TITLE
fix: #345

### DIFF
--- a/src/hooks/image-hook.ts
+++ b/src/hooks/image-hook.ts
@@ -73,6 +73,9 @@ function sanitizeFilename(name: string): string {
 
 function cleanupOldImages(dir: string, saveDir: string): void {
   const now = Date.now();
+  if (!lastCleanupByDir.has(dir) && existsSync(dir)) {
+    lastCleanupByDir.set(dir, now);
+  }
   const lastCleanup = lastCleanupByDir.get(dir) ?? 0;
   if (now - lastCleanup < CLEANUP_INTERVAL) return;
   lastCleanupByDir.set(dir, now);

--- a/src/hooks/image-hook.ts
+++ b/src/hooks/image-hook.ts
@@ -107,6 +107,9 @@ function writeUniqueFile(
   const ext = extname(name);
   const base = basename(name, ext) || name;
   let candidate = join(dir, name);
+  if (existsSync(candidate)) {
+    return null;
+  }
   let counter = 0;
 
   const MAX_ATTEMPTS = 1000;


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does. 1-3 bullet points. -->

Fixes #123

## Changes

<!-- What was changed and how. List specific modifications. -->

The directory for storing images in session ID is given a default timeout upon initial creation to avoid the 10-minute timer being ineffective. The `if (now - lastCleanup < CLEANUP_INTERVAL) return;` statement will then directly trigger the deletion process after the first creation.