### PR TITLE
fix: #347

### DIFF
--- a/src/hooks/image-hook.ts
+++ b/src/hooks/image-hook.ts
@@ -104,6 +104,9 @@ function writeUniqueFile(
   const ext = extname(name);
   const base = basename(name, ext) || name;
   let candidate = join(dir, name);
+  if (existsSync(candidate)) {
+    return candidate;
+  }
   let counter = 0;
 
   const MAX_ATTEMPTS = 1000;


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does. 1-3 bullet points. -->

fix #347 

## Changes

<!-- What was changed and how. List specific modifications. -->

The candidate is already obtained by calculating the SHA1 hash based on the image content. Since the candidate already exists, there's no need to create it again, thus avoiding the creation of multiple files with the same content but different file numbers.