### PR TITLE
fix(agent-permissions): restrict council_session access

### DIFF
--- a/src/agents/index.test.ts
+++ b/src/agents/index.test.ts
@@ -129,11 +129,11 @@ describe('orchestrator agent', () => {
     expect((orchestrator?.config.permission as any).question).toBe('allow');
   });
 
-  test('orchestrator is allowed to invoke council_session', () => {
+  test('orchestrator is denied access to council_session', () => {
     const agents = createAgents();
     const orchestrator = agents.find((a) => a.name === 'orchestrator');
     expect((orchestrator?.config.permission as any).council_session).toBe(
-      'allow',
+      'deny',
     );
   });
 

--- a/src/agents/index.test.ts
+++ b/src/agents/index.test.ts
@@ -286,6 +286,12 @@ describe('tool permissions', () => {
     const explorer = agents.find((a) => a.name === 'explorer');
     expect((explorer?.config.permission as any).council_session).toBe('deny');
   });
+
+  test('councillor is denied access to council_session', () => {
+    const agents = createAgents();
+    const councillor = agents.find((a) => a.name === 'councillor');
+    expect((councillor?.config.permission as any).council_session).toBe('deny');
+  });
 });
 
 describe('isSubagent type guard', () => {

--- a/src/agents/index.test.ts
+++ b/src/agents/index.test.ts
@@ -129,6 +129,14 @@ describe('orchestrator agent', () => {
     expect((orchestrator?.config.permission as any).question).toBe('allow');
   });
 
+  test('orchestrator is allowed to invoke council_session', () => {
+    const agents = createAgents();
+    const orchestrator = agents.find((a) => a.name === 'orchestrator');
+    expect((orchestrator?.config.permission as any).council_session).toBe(
+      'allow',
+    );
+  });
+
   test('orchestrator accepts overrides', () => {
     const config: PluginConfig = {
       agents: {
@@ -257,6 +265,26 @@ describe('skill permissions', () => {
     const skillPerm = (oracle?.config.permission as Record<string, unknown>)
       ?.skill as Record<string, string>;
     expect(skillPerm?.simplify).toBe('allow');
+  });
+});
+
+describe('tool permissions', () => {
+  test('council agent is allowed to invoke council_session', () => {
+    const agents = createAgents();
+    const council = agents.find((a) => a.name === 'council');
+    expect((council?.config.permission as any).council_session).toBe('allow');
+  });
+
+  test('oracle is denied access to council_session', () => {
+    const agents = createAgents();
+    const oracle = agents.find((a) => a.name === 'oracle');
+    expect((oracle?.config.permission as any).council_session).toBe('deny');
+  });
+
+  test('explorer is denied access to council_session', () => {
+    const agents = createAgents();
+    const explorer = agents.find((a) => a.name === 'explorer');
+    expect((explorer?.config.permission as any).council_session).toBe('deny');
   });
 });
 

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -117,9 +117,9 @@ function applyDefaultPermissions(
 
   // Respect explicit deny on question (councillor)
   const questionPerm = existing.question === 'deny' ? 'deny' : 'allow';
-  const councilSessionPerm =
-    existing.council_session ??
-    (COUNCIL_TOOL_ALLOWED_AGENTS.has(agent.name) ? 'allow' : 'deny');
+  const councilSessionPerm = COUNCIL_TOOL_ALLOWED_AGENTS.has(agent.name)
+    ? (existing.council_session ?? 'allow')
+    : 'deny';
 
   agent.config.permission = {
     ...existing,

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -31,7 +31,7 @@ type AgentFactory = (
   customAppendPrompt?: string,
 ) => AgentDefinition;
 
-const COUNCIL_TOOL_ALLOWED_AGENTS = new Set(['orchestrator', 'council']);
+const COUNCIL_TOOL_ALLOWED_AGENTS = new Set(['council']);
 
 function normalizeDisplayName(displayName: string): string {
   const trimmed = displayName.trim();

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -31,6 +31,8 @@ type AgentFactory = (
   customAppendPrompt?: string,
 ) => AgentDefinition;
 
+const COUNCIL_TOOL_ALLOWED_AGENTS = new Set(['orchestrator', 'council']);
+
 function normalizeDisplayName(displayName: string): string {
   const trimmed = displayName.trim();
   return trimmed.startsWith('@') ? trimmed.slice(1) : trimmed;
@@ -115,10 +117,14 @@ function applyDefaultPermissions(
 
   // Respect explicit deny on question (councillor)
   const questionPerm = existing.question === 'deny' ? 'deny' : 'allow';
+  const councilSessionPerm =
+    existing.council_session ??
+    (COUNCIL_TOOL_ALLOWED_AGENTS.has(agent.name) ? 'allow' : 'deny');
 
   agent.config.permission = {
     ...existing,
     question: questionPerm,
+    council_session: councilSessionPerm,
     // Apply skill permissions as nested object under 'skill' key
     skill: {
       ...(typeof existing.skill === 'object' ? existing.skill : {}),

--- a/src/tools/council.test.ts
+++ b/src/tools/council.test.ts
@@ -359,23 +359,20 @@ describe('council_session tool', () => {
       expect(councilManager.runCouncil).toHaveBeenCalledTimes(1);
     });
 
-    test('allows orchestrator agent to invoke council session', async () => {
+    test('blocks orchestrator agent from invoking council session', async () => {
       const ctx = createMockPluginContext();
-      const councilManager = createMockCouncilManager({
-        success: true,
-        result: 'Synthesised answer',
-        councillorResults: [
-          { name: 'alpha', status: 'completed', result: 'A' },
-        ],
-      });
+      const councilManager = createMockCouncilManager();
       const tools = createCouncilTool(ctx, councilManager);
 
-      const result = await tools.council_session.execute({ prompt: 'Test' }, {
-        sessionID: 'test',
-        agent: 'orchestrator',
-      } as any);
-
-      expect(result).toContain('Synthesised answer');
+      expect(
+        tools.council_session.execute({ prompt: 'Test' }, {
+          sessionID: 'test',
+          agent: 'orchestrator',
+        } as any),
+      ).rejects.toThrow(
+        'Council sessions can only be invoked by the council agent',
+      );
+      expect(councilManager.runCouncil).not.toHaveBeenCalled();
     });
 
     test('blocks disallowed agents from invoking council session', async () => {
@@ -389,7 +386,7 @@ describe('council_session tool', () => {
           agent: 'explorer',
         } as any),
       ).rejects.toThrow(
-        'Council sessions can only be invoked by council or orchestrator agents',
+        'Council sessions can only be invoked by the council agent',
       );
       expect(councilManager.runCouncil).not.toHaveBeenCalled();
     });

--- a/src/tools/council.ts
+++ b/src/tools/council.ts
@@ -58,13 +58,13 @@ Returns the councillor responses with a summary footer.`,
         throw new Error('Invalid toolContext: missing sessionID');
       }
 
-      // Guard: Only council and orchestrator agents can invoke council sessions.
+      // Guard: Only the council agent can invoke council sessions.
       // If agent is missing from context, allow through (backward compatible).
-      const allowedAgents = ['council', 'orchestrator'];
+      const allowedAgents = ['council'];
       const callingAgent = (toolContext as { agent?: string }).agent;
       if (callingAgent && !allowedAgents.includes(callingAgent)) {
         throw new Error(
-          `Council sessions can only be invoked by council or orchestrator agents. Current agent: ${callingAgent}`,
+          `Council sessions can only be invoked by the council agent. Current agent: ${callingAgent}`,
         );
       }
 


### PR DESCRIPTION
```
⚙ council_session [prompt=Review the agent model fallback feature in this repo for bugs/edge cases/design issues. Focus on src/index.ts (runtimeChains/modelArrayMap + config hook model resolution + event hook), src/hooks/foreground-fallback/index.ts, src/agents/index.ts, src/agents/orchestrator.ts, src/config/schema.ts, and tests in src/hooks/foreground-fallback/index.test.ts, src/config/model-resolution.test.ts, src/agents/index.test.ts. Prioritize correctness gaps between startup-time model resolution and runtime fallback, variant handling, session/agent mapping, dedupe/exhaustion logic, and config merge behavior. Return concise findings with file:line refs and why they matter., preset=code-review]
Council sessions can only be invoked by council or orchestrator agents. Current agent: oracle
```