### PR TITLE
fix: cleanup all session image dirs, not just current session

### DIFF
--- a/src/hooks/image-hook.ts
+++ b/src/hooks/image-hook.ts
@@ -96,8 +96,10 @@ function cleanupAllSessions(saveDir: string): void {
 
   for (const dir of dirsToScan) {
     try {
+      let isEmpty = true;
       let allRemoved = true;
       for (const f of readdirSync(dir)) {
+        isEmpty = false;
         const fp = join(dir, f);
         try {
           if (now - statSync(fp).mtimeMs > maxAge) {
@@ -109,8 +111,8 @@ function cleanupAllSessions(saveDir: string): void {
           allRemoved = false;
         }
       }
-      // Remove empty session subdirectory
-      if (allRemoved) {
+      // Remove session subdirectory only if it had files and all were expired
+      if (!isEmpty && allRemoved) {
         try {
           rmdirSync(dir);
         } catch {}

--- a/src/hooks/image-hook.ts
+++ b/src/hooks/image-hook.ts
@@ -71,31 +71,52 @@ function sanitizeFilename(name: string): string {
   return name.replace(/[^a-zA-Z0-9._-]/g, '_');
 }
 
-function cleanupOldImages(dir: string, saveDir: string): void {
+function cleanupAllSessions(saveDir: string): void {
   const now = Date.now();
-  if (!lastCleanupByDir.has(dir) && existsSync(dir)) {
-    lastCleanupByDir.set(dir, now);
-  }
-  const lastCleanup = lastCleanupByDir.get(dir) ?? 0;
+  const lastCleanup = lastCleanupByDir.get(saveDir) ?? 0;
   if (now - lastCleanup < CLEANUP_INTERVAL) return;
-  lastCleanupByDir.set(dir, now);
+  lastCleanupByDir.set(saveDir, now);
 
+  const maxAge = 60 * 60 * 1000;
+  const dirsToScan: string[] = [];
+
+  // Collect saveDir itself (for non-session images) + all session subdirs
   try {
-    const maxAge = 60 * 60 * 1000;
-    for (const f of readdirSync(dir)) {
-      const fp = join(dir, f);
-      try {
-        if (now - statSync(fp).mtimeMs > maxAge) unlinkSync(fp);
-      } catch {}
-    }
-    // Remove empty session subdirectory and prune its debounce entry
-    if (dir !== saveDir) {
-      try {
-        rmdirSync(dir);
-        lastCleanupByDir.delete(dir);
-      } catch {}
+    for (const entry of readdirSync(saveDir, { withFileTypes: true })) {
+      const fp = join(saveDir, entry.name);
+      if (entry.isDirectory()) {
+        dirsToScan.push(fp);
+      } else {
+        try {
+          if (now - statSync(fp).mtimeMs > maxAge) unlinkSync(fp);
+        } catch {}
+      }
     }
   } catch {}
+
+  for (const dir of dirsToScan) {
+    try {
+      let allRemoved = true;
+      for (const f of readdirSync(dir)) {
+        const fp = join(dir, f);
+        try {
+          if (now - statSync(fp).mtimeMs > maxAge) {
+            unlinkSync(fp);
+          } else {
+            allRemoved = false;
+          }
+        } catch {
+          allRemoved = false;
+        }
+      }
+      // Remove empty session subdirectory
+      if (allRemoved) {
+        try {
+          rmdirSync(dir);
+        } catch {}
+      }
+    } catch {}
+  }
 }
 
 function writeUniqueFile(
@@ -160,6 +181,8 @@ export function processImageAttachments(args: {
     log(`[image-hook] failed to create image directory: ${e}`);
   }
 
+  cleanupAllSessions(saveDir);
+
   for (const msg of messages) {
     if (msg.info.role !== 'user') continue;
     const imageParts = msg.parts.filter(isImagePart);
@@ -174,8 +197,6 @@ export function processImageAttachments(args: {
     } catch (e) {
       log(`[image-hook] failed to create target image directory: ${e}`);
     }
-
-    cleanupOldImages(targetDir, saveDir);
 
     // Save each image to .opencode/images/ and collect paths
     const savedPaths: string[] = [];


### PR DESCRIPTION
## Summary

- Replace per-session `cleanupOldImages(targetDir)` with `cleanupAllSessions(saveDir)` that scans **all** session subdirectories under `.opencode/images/`
- Prevents legacy session images from accumulating indefinitely when those sessions never upload again

## Problem

PR #314 scoped cleanup to the current session's subdirectory only. This means:

```
.opencode/images/
├── session-abc/    ← Session A ended, never uploads again
│   └── old.png     ← 3 hours old, never cleaned up
├── session-xyz/    ← Session B is active
│   └── new.png     ← only this dir gets cleaned
```

Any session that stops uploading images leaves behind files that are never evicted.

## Fix

`cleanupAllSessions(saveDir)` now:
1. Scans `saveDir` for all session subdirectories
2. Deletes files older than 1 hour in **every** subdirectory
3. Removes empty session subdirectories via `rmdirSync`
4. Debounced once per 10 minutes (keyed on `saveDir`, not per-subdirectory)

Any active session triggering `processImageAttachments` will clean up all stale sessions.

## Test Plan

- [x] `bun run check:ci` passes
- [x] `bun run typecheck` passes
- [x] `bun test` — 882 tests pass
- [ ] Manual: create images in multiple session dirs, verify all are cleaned after 1 hour

Follow-up to #314