### PR TITLE
feat: auto-scroll to top when submitting interview answers

### DIFF
--- a/src/interview/interview.test.ts
+++ b/src/interview/interview.test.ts
@@ -1610,6 +1610,17 @@ describe('renderInterviewPage', () => {
     expect(html).toContain('<svg');
     expect(html).not.toContain('https://ohmyopencodeslim.com');
   });
+
+  test('includes smooth scroll-to-top behavior in the submit handler', () => {
+    const html = renderInterviewPage('scroll-test', 'scroll-test');
+
+    expect(html).toContain('function scrollToTop()');
+    expect(html).toContain(
+      "window.scrollTo({ top: 0, left: 0, behavior: 'smooth' });",
+    );
+    expect(html).toContain('overlayText.textContent = "Submitting Answers...";');
+    expect(html).toContain('scrollToTop();');
+  });
 });
 
 /** Discover a free port by briefly binding to port 0, then closing. */

--- a/src/interview/ui.ts
+++ b/src/interview/ui.ts
@@ -1390,6 +1390,10 @@ export function renderInterviewPage(
         render(data);
       }
 
+      function scrollToTop() {
+        window.scrollTo({ top: 0, left: 0, behavior: 'smooth' });
+      }
+
       document.getElementById('submitButton').addEventListener('click', async () => {
         if (!state.data) return;
         const answers = (state.data.questions || []).map((question) => {
@@ -1403,6 +1407,7 @@ export function renderInterviewPage(
         const overlayText = document.getElementById('loadingText');
         overlay.classList.add('active');
         overlayText.textContent = "Submitting Answers...";
+        scrollToTop();
 
         try {
           const response = await fetch('/api/interviews/' + encodeURIComponent(interviewId) + '/answers', {


### PR DESCRIPTION
## Summary

Adds smooth scroll-to-top behavior in the Interview web page when the Submit Answer button is clicked. This improves UX by automatically bringing the user back to the top of the page to see new questions without manual scrolling.

## Changes

- Added `scrollToTop()` helper function in `src/interview/ui.ts` that uses `window.scrollTo()` with smooth behavior
- Called `scrollToTop()` immediately after showing the loading overlay when submitting answers
- Added regression test in `src/interview/interview.test.ts` to verify the scroll behavior is included in the rendered page

## Testing

The implementation adds a smooth scroll to the top of the page (coordinates 0,0) triggered right after the user clicks Submit Answers, before the POST request begins.

Fixes #371
