### PR TITLE
Add ExceededBudget to rate_limit_patterns

### DIFF
--- a/src/hooks/foreground-fallback/index.ts
+++ b/src/hooks/foreground-fallback/index.ts
@@ -28,6 +28,7 @@ const RATE_LIMIT_PATTERNS = [
   /rate.?limit/i,
   /too many requests/i,
   /quota.?exceeded/i,
+  /ExceededBudget/i,  
   /usage.?exceeded/i,
   /usage limit/i,
   /overloaded/i,

--- a/src/hooks/foreground-fallback/index.ts
+++ b/src/hooks/foreground-fallback/index.ts
@@ -28,8 +28,9 @@ const RATE_LIMIT_PATTERNS = [
   /rate.?limit/i,
   /too many requests/i,
   /quota.?exceeded/i,
-  /ExceededBudget/i,  
   /usage.?exceeded/i,
+  /ExceededBudget/i,
+  /over.?budget/i,
   /usage limit/i,
   /overloaded/i,
   /resource.?exhausted/i,
@@ -163,6 +164,8 @@ export class ForegroundFallbackManager {
           msg.includes('usage limit') ||
           msg.includes('usage exceeded') ||
           msg.includes('quota exceeded') ||
+          msg.includes('exceededbudget') ||
+          msg.includes('over budget') ||
           msg.includes('high concurrency') ||
           msg.includes('reduce concurrency')
         ) {


### PR DESCRIPTION
Added ExceededBudget to the rate limit patterns, using a service which returns the following:
`API Error: 400 {"error":{"message":"ExceededBudget:`