### PR TITLE
fix: prevent duplicate tmux pane spawns

### DIFF
--- a/src/multiplexer/session-manager.test.ts
+++ b/src/multiplexer/session-manager.test.ts
@@ -46,6 +46,16 @@ const defaultMultiplexerConfig = {
   main_pane_size: 60,
 };
 
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 describe('MultiplexerSessionManager', () => {
   beforeEach(() => {
     mockMultiplexer.spawnPane.mockReset();
@@ -160,6 +170,41 @@ describe('MultiplexerSessionManager', () => {
       });
 
       expect(mockMultiplexer.spawnPane).not.toHaveBeenCalled();
+    });
+
+    test('does not spawn twice for duplicate create events while spawning', async () => {
+      const ctx = createMockContext();
+      const manager = new MultiplexerSessionManager(
+        ctx,
+        defaultMultiplexerConfig,
+      );
+      const deferred = createDeferred<{ success: true; paneId: string }>();
+
+      mockMultiplexer.spawnPane.mockImplementationOnce(() => deferred.promise);
+
+      const event = {
+        type: 'session.created',
+        properties: {
+          info: {
+            id: 'child-race',
+            parentID: 'parent-race',
+            title: 'Race Worker',
+          },
+        },
+      };
+
+      const firstCreate = manager.onSessionCreated(event);
+      const secondCreate = manager.onSessionCreated(event);
+
+      await Promise.resolve();
+
+      expect(mockMultiplexer.spawnPane).toHaveBeenCalledTimes(1);
+
+      deferred.resolve({ success: true, paneId: 'p-race' });
+
+      await Promise.all([firstCreate, secondCreate]);
+
+      expect(mockMultiplexer.spawnPane).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -330,6 +375,45 @@ describe('MultiplexerSessionManager', () => {
       expect((manager as any).sessions.get('child-999')?.paneId).toBe(
         'p-existing',
       );
+    });
+
+    test('does not respawn while initial pane spawn is still in progress', async () => {
+      const ctx = createMockContext();
+      const manager = new MultiplexerSessionManager(
+        ctx,
+        defaultMultiplexerConfig,
+      );
+      const deferred = createDeferred<{ success: true; paneId: string }>();
+
+      mockMultiplexer.spawnPane.mockImplementationOnce(() => deferred.promise);
+
+      const createPromise = manager.onSessionCreated({
+        type: 'session.created',
+        properties: {
+          info: {
+            id: 'child-busy-race',
+            parentID: 'parent-busy-race',
+            title: 'Busy Worker',
+            directory: '/task/dir',
+          },
+        },
+      });
+
+      await manager.onSessionStatus({
+        type: 'session.status',
+        properties: {
+          sessionID: 'child-busy-race',
+          status: { type: 'busy' },
+        },
+      });
+
+      expect(mockMultiplexer.spawnPane).toHaveBeenCalledTimes(1);
+
+      deferred.resolve({ success: true, paneId: 'p-busy-race' });
+
+      await createPromise;
+
+      expect(mockMultiplexer.spawnPane).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/multiplexer/session-manager.test.ts
+++ b/src/multiplexer/session-manager.test.ts
@@ -444,6 +444,40 @@ describe('MultiplexerSessionManager', () => {
       expect(mockMultiplexer.closePane).toHaveBeenCalledWith('p1');
       expect(mockMultiplexer.closePane).toHaveBeenCalledWith('p2');
     });
+
+    test('clears spawning sessions during cleanup', async () => {
+      const ctx = createMockContext();
+      const manager = new MultiplexerSessionManager(
+        ctx,
+        defaultMultiplexerConfig,
+      );
+
+      const deferred = createDeferred<{ success: true; paneId: string }>();
+      mockMultiplexer.spawnPane.mockImplementationOnce(() => deferred.promise);
+      const event = {
+        type: 'session.created',
+        properties: {
+          info: {
+            id: 'cleanup-spawn',
+            parentID: 'parent-cleanup',
+            title: 'Cleanup Worker',
+          },
+        },
+      };
+
+      const createPromise = manager.onSessionCreated(event);
+
+      await Promise.resolve();
+
+      await manager.cleanup();
+
+      await manager.onSessionCreated(event);
+
+      deferred.resolve({ success: true, paneId: 'p-cleanup' });
+      await createPromise;
+
+      expect(mockMultiplexer.spawnPane).toHaveBeenCalledTimes(2);
+    });
   });
 });
 

--- a/src/multiplexer/session-manager.ts
+++ b/src/multiplexer/session-manager.ts
@@ -57,6 +57,7 @@ export class MultiplexerSessionManager {
   private multiplexer: Multiplexer | null = null;
   private sessions = new Map<string, TrackedSession>();
   private knownSessions = new Map<string, KnownSession>();
+  private spawningSessions = new Set<string>();
   private pollInterval?: ReturnType<typeof setInterval>;
   private enabled = false;
 
@@ -100,54 +101,67 @@ export class MultiplexerSessionManager {
       directory,
     });
 
-    if (this.sessions.has(sessionId)) {
-      log('[multiplexer-session-manager] session already tracked', {
+    if (this.isTrackedOrSpawning(sessionId)) {
+      log('[multiplexer-session-manager] session already tracked or spawning', {
         sessionId,
       });
       return;
     }
 
-    const serverRunning = await isServerRunning(this.serverUrl);
-    if (!serverRunning) {
-      log('[multiplexer-session-manager] server not running, skipping', {
-        serverUrl: this.serverUrl,
-      });
-      return;
-    }
+    this.spawningSessions.add(sessionId);
 
-    log('[multiplexer-session-manager] child session created, spawning pane', {
-      sessionId,
-      parentId,
-      title,
-    });
-
-    const paneResult = await this.multiplexer
-      .spawnPane(sessionId, title, this.serverUrl, directory)
-      .catch((err) => {
-        log('[multiplexer-session-manager] failed to spawn pane', {
-          error: String(err),
+    try {
+      const serverRunning = await isServerRunning(this.serverUrl);
+      if (!serverRunning) {
+        log('[multiplexer-session-manager] server not running, skipping', {
+          serverUrl: this.serverUrl,
         });
-        return { success: false, paneId: undefined };
-      });
+        return;
+      }
 
-    if (paneResult.success && paneResult.paneId) {
-      const now = Date.now();
-      this.sessions.set(sessionId, {
-        sessionId,
-        paneId: paneResult.paneId,
-        parentId,
-        title,
-        directory,
-        createdAt: now,
-        lastSeenAt: now,
-      });
+      if (this.sessions.has(sessionId)) {
+        return;
+      }
 
-      log('[multiplexer-session-manager] pane spawned', {
-        sessionId,
-        paneId: paneResult.paneId,
-      });
+      log(
+        '[multiplexer-session-manager] child session created, spawning pane',
+        {
+          sessionId,
+          parentId,
+          title,
+        },
+      );
 
-      this.startPolling();
+      const paneResult = await this.multiplexer
+        .spawnPane(sessionId, title, this.serverUrl, directory)
+        .catch((err) => {
+          log('[multiplexer-session-manager] failed to spawn pane', {
+            error: String(err),
+          });
+          return { success: false, paneId: undefined };
+        });
+
+      if (paneResult.success && paneResult.paneId) {
+        const now = Date.now();
+        this.sessions.set(sessionId, {
+          sessionId,
+          paneId: paneResult.paneId,
+          parentId,
+          title,
+          directory,
+          createdAt: now,
+          lastSeenAt: now,
+        });
+
+        log('[multiplexer-session-manager] pane spawned', {
+          sessionId,
+          paneId: paneResult.paneId,
+        });
+
+        this.startPolling();
+      }
+    } finally {
+      this.spawningSessions.delete(sessionId);
     }
   }
 
@@ -265,62 +279,72 @@ export class MultiplexerSessionManager {
 
   private async respawnIfKnown(sessionId: string): Promise<void> {
     if (!this.enabled || !this.multiplexer) return;
-    if (this.sessions.has(sessionId)) return;
+    if (this.isTrackedOrSpawning(sessionId)) return;
 
     const known = this.knownSessions.get(sessionId);
     if (!known) return;
 
-    const serverRunning = await isServerRunning(this.serverUrl);
-    if (!serverRunning) {
+    this.spawningSessions.add(sessionId);
+
+    try {
+      const serverRunning = await isServerRunning(this.serverUrl);
+      if (!serverRunning) {
+        log(
+          '[multiplexer-session-manager] server not running, skipping busy respawn',
+          {
+            serverUrl: this.serverUrl,
+            sessionId,
+          },
+        );
+        return;
+      }
+
+      if (this.sessions.has(sessionId)) return;
+
       log(
-        '[multiplexer-session-manager] server not running, skipping busy respawn',
+        '[multiplexer-session-manager] child session busy again, respawning pane',
         {
-          serverUrl: this.serverUrl,
           sessionId,
+          parentId: known.parentId,
+          title: known.title,
         },
       );
-      return;
-    }
 
-    if (this.sessions.has(sessionId)) return;
+      const paneResult = await this.multiplexer
+        .spawnPane(sessionId, known.title, this.serverUrl, known.directory)
+        .catch((err) => {
+          log('[multiplexer-session-manager] failed to respawn pane', {
+            error: String(err),
+          });
+          return { success: false, paneId: undefined };
+        });
 
-    log(
-      '[multiplexer-session-manager] child session busy again, respawning pane',
-      {
+      if (!paneResult.success || !paneResult.paneId) return;
+
+      const now = Date.now();
+      this.sessions.set(sessionId, {
         sessionId,
+        paneId: paneResult.paneId,
         parentId: known.parentId,
         title: known.title,
-      },
-    );
-
-    const paneResult = await this.multiplexer
-      .spawnPane(sessionId, known.title, this.serverUrl, known.directory)
-      .catch((err) => {
-        log('[multiplexer-session-manager] failed to respawn pane', {
-          error: String(err),
-        });
-        return { success: false, paneId: undefined };
+        directory: known.directory,
+        createdAt: now,
+        lastSeenAt: now,
       });
 
-    if (!paneResult.success || !paneResult.paneId) return;
+      log('[multiplexer-session-manager] pane respawned on busy', {
+        sessionId,
+        paneId: paneResult.paneId,
+      });
 
-    const now = Date.now();
-    this.sessions.set(sessionId, {
-      sessionId,
-      paneId: paneResult.paneId,
-      parentId: known.parentId,
-      title: known.title,
-      directory: known.directory,
-      createdAt: now,
-      lastSeenAt: now,
-    });
+      this.startPolling();
+    } finally {
+      this.spawningSessions.delete(sessionId);
+    }
+  }
 
-    log('[multiplexer-session-manager] pane respawned on busy', {
-      sessionId,
-      paneId: paneResult.paneId,
-    });
-
-    this.startPolling();
+  private isTrackedOrSpawning(sessionId: string): boolean {
+    return this.sessions.has(sessionId) || this.spawningSessions.has(sessionId);
   }
 
   async cleanup(): Promise<void> {

--- a/src/multiplexer/session-manager.ts
+++ b/src/multiplexer/session-manager.ts
@@ -368,6 +368,7 @@ export class MultiplexerSessionManager {
     }
 
     this.knownSessions.clear();
+    this.spawningSessions.clear();
 
     log('[multiplexer-session-manager] cleanup complete');
   }


### PR DESCRIPTION
## Summary
- add an in-flight session spawn guard so create/busy events cannot open two tmux panes for one child session
- apply the same protection to busy-triggered respawns while a pane spawn is already pending
- add regression tests covering duplicate create events and create-plus-busy race conditions