### PR TITLE
Remember task context summaries

### DIFF
--- a/docs/session-management.md
+++ b/docs/session-management.md
@@ -47,13 +47,13 @@ On a related follow-up, the orchestrator can reuse that session instead of
 launching a fresh one. If the remembered child session no longer exists, the
 plugin drops the stale entry and falls back to a new session automatically.
 
-Child agents are asked to return a short `<context_summary>` metadata block at
-the end of delegated task results. The context summary should capture the
-concrete context now present in that child session, such as files inspected,
-findings, decisions, or state it can recall if resumed. It can be a short
-paragraph when one sentence would lose useful context. The plugin stores that
-summary when present, strips the metadata from the visible result, and falls
-back to the original task label if the agent omits it.
+Child agents are asked to return a short `<context_summary>` metadata block as
+the final standalone block in delegated task results. The context summary should
+capture the concrete context now present in that child session, such as files
+inspected, findings, decisions, or state it can recall if resumed. It is capped
+to keep prompt usage bounded. The plugin stores that summary when present,
+strips the metadata from the visible result, and falls back to the original task
+label if the agent omits it.
 
 ---
 

--- a/docs/session-management.md
+++ b/docs/session-management.md
@@ -39,13 +39,21 @@ The orchestrator sees a compact reminder in its system context, for example:
 
 ```text
 ### Resumable Sessions
-explorer: exp-1 Search routing files
-oracle: ora-1 Review auth architecture
+- explorer: exp-1 Search routing files — Found route handlers and middleware entry points.
+- oracle: ora-1 Review auth architecture — Reviewed auth flow and token refresh trade-offs.
 ```
 
 On a related follow-up, the orchestrator can reuse that session instead of
 launching a fresh one. If the remembered child session no longer exists, the
 plugin drops the stale entry and falls back to a new session automatically.
+
+Child agents are asked to return a short `<context_summary>` metadata block at
+the end of delegated task results. The context summary should capture the
+concrete context now present in that child session, such as files inspected,
+findings, decisions, or state it can recall if resumed. It can be a short
+paragraph when one sentence would lose useful context. The plugin stores that
+summary when present, strips the metadata from the visible result, and falls
+back to the original task label if the agent omits it.
 
 ---
 

--- a/src/agents/orchestrator.ts
+++ b/src/agents/orchestrator.ts
@@ -187,6 +187,7 @@ Balance: respect dependencies, avoid parallelizing what must be sequential.
 
 ### Session Reuse
 - Reuse an available specialist session only for clear follow-up work on the same thread.
+- Prefer sessions whose summaries match the intended follow-up context.
 - Prefer a fresh session for unrelated work, even with the same specialist.
 - If multiple remembered sessions fit, prefer the most recently used matching session.
 - If reuse is unclear, start a fresh session.

--- a/src/hooks/task-session-manager/index.test.ts
+++ b/src/hooks/task-session-manager/index.test.ts
@@ -80,9 +80,9 @@ describe('task-session-manager hook', () => {
     );
 
     expect(beforeOutput.args.prompt).toContain('<context_summary>');
-    expect(beforeOutput.args.prompt).toContain('short paragraph');
+    expect(beforeOutput.args.prompt).toContain('under 280 characters');
     expect(beforeOutput.args.prompt).toContain(
-      'final child inside your <results> block',
+      'outside any other XML/result tags',
     );
     expect(beforeOutput.args.prompt).toContain(
       'Do not omit the closing </context_summary> tag',
@@ -139,11 +139,9 @@ describe('task-session-manager hook', () => {
       beforeOutput,
     );
 
+    expect(beforeOutput.args.prompt).toContain('After your final answer');
     expect(beforeOutput.args.prompt).toContain(
-      'At the end of your final answer',
-    );
-    expect(beforeOutput.args.prompt).toContain(
-      '<context_summary>List the specific files',
+      '<context_summary>Briefly list the specific reusable context',
     );
   });
 

--- a/src/hooks/task-session-manager/index.test.ts
+++ b/src/hooks/task-session-manager/index.test.ts
@@ -60,6 +60,93 @@ describe('task-session-manager hook', () => {
     expect(system.system.join('\n')).toContain('explorer: exp-1 config schema');
   });
 
+  test('appends context instructions and stores returned summaries', async () => {
+    const { hook } = createHook();
+    const beforeOutput = {
+      args: {
+        subagent_type: 'oracle',
+        description: 'session lifecycle review',
+        prompt: 'review session lifecycle',
+      },
+    };
+
+    await hook['tool.execute.before'](
+      {
+        tool: 'task',
+        sessionID: 'parent-1',
+        callID: 'call-1',
+      },
+      beforeOutput,
+    );
+
+    expect(beforeOutput.args.prompt).toContain('<context_summary>');
+    expect(beforeOutput.args.prompt).toContain('short paragraph');
+    expect(beforeOutput.args.prompt).toContain(
+      'final child inside your <results> block',
+    );
+    expect(beforeOutput.args.prompt).toContain(
+      'Do not omit the closing </context_summary> tag',
+    );
+
+    const afterOutput = {
+      output: [
+        'task_id: child-1 (for resuming to continue this task if needed)',
+        '<task_result>',
+        'Reviewed cleanup behavior.',
+        '</task_result>',
+        '<context_summary>Contains index.ts hook wiring, task.ts parser behavior, and session-manager rendering details.</context_summary>',
+      ].join('\n'),
+    };
+
+    await hook['tool.execute.after'](
+      {
+        tool: 'task',
+        sessionID: 'parent-1',
+        callID: 'call-1',
+      },
+      afterOutput,
+    );
+
+    expect(afterOutput.output).not.toContain('<context_summary>');
+
+    const system = { system: ['base'] };
+    await hook['experimental.chat.system.transform'](
+      { sessionID: 'parent-1' },
+      system,
+    );
+
+    expect(system.system.join('\n')).toContain(
+      'oracle: ora-1 session lifecycle review — Contains index.ts hook wiring, task.ts parser behavior, and session-manager rendering details.',
+    );
+  });
+
+  test('still appends instructions when prompt mentions context summary tags', async () => {
+    const { hook } = createHook();
+    const beforeOutput = {
+      args: {
+        subagent_type: 'explorer',
+        description: 'inspect parser',
+        prompt: 'Find code that parses <context_summary> blocks.',
+      },
+    };
+
+    await hook['tool.execute.before'](
+      {
+        tool: 'task',
+        sessionID: 'parent-1',
+        callID: 'call-1',
+      },
+      beforeOutput,
+    );
+
+    expect(beforeOutput.args.prompt).toContain(
+      'At the end of your final answer',
+    );
+    expect(beforeOutput.args.prompt).toContain(
+      '<context_summary>List the specific files',
+    );
+  });
+
   test('resolves remembered aliases to real task ids before execution', async () => {
     const { hook } = createHook();
 

--- a/src/hooks/task-session-manager/index.ts
+++ b/src/hooks/task-session-manager/index.ts
@@ -43,8 +43,8 @@ const CONTEXT_SUMMARY_INSTRUCTION_MARKER =
 const CONTEXT_SUMMARY_INSTRUCTION = [
   '',
   CONTEXT_SUMMARY_INSTRUCTION_MARKER,
-  'At the end of your final answer, include a brief metadata block for future session reuse. Include it as the final child inside your <results> block when you return structured results. Focus on the concrete context/knowledge now present in this child session, not a generic description of the task. A short paragraph is fine if needed. Do not omit the closing </context_summary> tag:',
-  '<context_summary>List the specific files, decisions, findings, and state this child session can recall if resumed.</context_summary>',
+  'After your final answer, append exactly one standalone metadata block for future session reuse. It must be the very last thing in your response, outside any other XML/result tags. Keep it concise: 1-2 sentences, under 280 characters, focused on concrete files, decisions, findings, and state this child session can recall if resumed. Do not omit the closing </context_summary> tag:',
+  '<context_summary>Briefly list the specific reusable context this child session can recall if resumed.</context_summary>',
 ].join('\n');
 
 function isAgentName(value: unknown): value is AgentName {

--- a/src/hooks/task-session-manager/index.ts
+++ b/src/hooks/task-session-manager/index.ts
@@ -2,8 +2,10 @@ import type { PluginInput } from '@opencode-ai/plugin';
 import type { AgentName } from '../../config';
 import {
   deriveTaskSessionLabel,
+  parseContextSummaryFromTaskOutput,
   parseTaskIdFromTaskOutput,
   SessionManager,
+  stripContextSummaryFromTaskOutput,
 } from '../../utils';
 
 interface TaskArgs {
@@ -35,12 +37,30 @@ const AGENT_NAME_SET = new Set<AgentName>([
 
 const MAX_PENDING_TASK_CALLS = 100;
 
+const CONTEXT_SUMMARY_INSTRUCTION_MARKER =
+  '<!-- oh-my-opencode-slim-context-summary-instruction -->';
+
+const CONTEXT_SUMMARY_INSTRUCTION = [
+  '',
+  CONTEXT_SUMMARY_INSTRUCTION_MARKER,
+  'At the end of your final answer, include a brief metadata block for future session reuse. Include it as the final child inside your <results> block when you return structured results. Focus on the concrete context/knowledge now present in this child session, not a generic description of the task. A short paragraph is fine if needed. Do not omit the closing </context_summary> tag:',
+  '<context_summary>List the specific files, decisions, findings, and state this child session can recall if resumed.</context_summary>',
+].join('\n');
+
 function isAgentName(value: unknown): value is AgentName {
   return typeof value === 'string' && AGENT_NAME_SET.has(value as AgentName);
 }
 
 function isObjectRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
+}
+
+function appendContextSummaryInstruction(prompt: string): string {
+  if (prompt.includes(CONTEXT_SUMMARY_INSTRUCTION_MARKER)) {
+    return prompt;
+  }
+
+  return `${prompt.trimEnd()}${CONTEXT_SUMMARY_INSTRUCTION}`;
 }
 
 export function createTaskSessionManagerHook(
@@ -115,6 +135,10 @@ export function createTaskSessionManagerHook(
         agentType: args.subagent_type,
       });
 
+      if (typeof args.prompt === 'string') {
+        args.prompt = appendContextSummaryInstruction(args.prompt);
+      }
+
       if (input.callID) {
         rememberPendingCall({
           callId: input.callID,
@@ -166,11 +190,16 @@ export function createTaskSessionManagerHook(
       const pending = takePendingCall(input.callID);
 
       if (!pending || typeof output.output !== 'string') return;
-      const taskId = parseTaskIdFromTaskOutput(output.output);
+
+      const rawOutput = output.output;
+      const contextSummary = parseContextSummaryFromTaskOutput(rawOutput);
+      const strippedOutput = stripContextSummaryFromTaskOutput(rawOutput);
+      output.output = strippedOutput;
+      const taskId = parseTaskIdFromTaskOutput(strippedOutput);
       if (!taskId) {
         if (
           pending.resumedTaskId &&
-          isMissingRememberedSessionError(output.output)
+          isMissingRememberedSessionError(strippedOutput)
         ) {
           sessionManager.drop(
             pending.parentSessionId,
@@ -194,6 +223,7 @@ export function createTaskSessionManagerHook(
         taskId,
         agentType: pending.agentType,
         label: pending.label,
+        contextSummary,
       });
     },
 

--- a/src/utils/session-manager.test.ts
+++ b/src/utils/session-manager.test.ts
@@ -45,6 +45,22 @@ describe('SessionManager', () => {
 
     expect(manager.formatForPrompt('parent-1')).toBeUndefined();
   });
+
+  test('renders session summaries when available', () => {
+    const manager = new SessionManager(2);
+
+    manager.remember({
+      parentSessionId: 'parent-1',
+      taskId: 'task-1',
+      agentType: 'oracle',
+      label: 'architecture',
+      contextSummary: 'Reviewed session lifecycle and cleanup behavior.',
+    });
+
+    expect(manager.formatForPrompt('parent-1')).toContain(
+      'ora-1 architecture — Reviewed session lifecycle and cleanup behavior.',
+    );
+  });
 });
 
 describe('deriveTaskSessionLabel', () => {

--- a/src/utils/session-manager.test.ts
+++ b/src/utils/session-manager.test.ts
@@ -61,6 +61,23 @@ describe('SessionManager', () => {
       'ora-1 architecture — Reviewed session lifecycle and cleanup behavior.',
     );
   });
+
+  test('normalizes and truncates session summaries', () => {
+    const manager = new SessionManager(2);
+
+    manager.remember({
+      parentSessionId: 'parent-1',
+      taskId: 'task-1',
+      agentType: 'oracle',
+      label: 'architecture',
+      contextSummary: ` ${'a'.repeat(320)} `,
+    });
+
+    const prompt = manager.formatForPrompt('parent-1');
+
+    expect(prompt).toContain(`ora-1 architecture — ${'a'.repeat(280)}`);
+    expect(prompt).not.toContain('a'.repeat(281));
+  });
 });
 
 describe('deriveTaskSessionLabel', () => {

--- a/src/utils/session-manager.ts
+++ b/src/utils/session-manager.ts
@@ -5,6 +5,7 @@ export interface RememberedTaskSession {
   taskId: string;
   agentType: AgentName;
   label: string;
+  contextSummary?: string;
   createdAt: number;
   lastUsedAt: number;
 }
@@ -78,6 +79,7 @@ export class SessionManager {
     taskId: string;
     agentType: AgentName;
     label: string;
+    contextSummary?: string;
   }): RememberedTaskSession {
     const now = this.nextOrder();
     const group = this.getAgentGroup(
@@ -92,6 +94,9 @@ export class SessionManager {
 
     if (existing) {
       existing.label = input.label;
+      if (input.contextSummary) {
+        existing.contextSummary = input.contextSummary;
+      }
       existing.lastUsedAt = this.nextOrder();
       return existing;
     }
@@ -101,6 +106,7 @@ export class SessionManager {
       taskId: input.taskId,
       agentType: input.agentType,
       label: input.label,
+      contextSummary: input.contextSummary,
       createdAt: now,
       lastUsedAt: now,
     };
@@ -167,7 +173,12 @@ export class SessionManager {
       .map(
         ([agentType, entries]) =>
           `- ${agentType}: ${entries
-            .map((entry) => `${entry.alias} ${entry.label}`)
+            .map((entry) => {
+              const base = `${entry.alias} ${entry.label}`;
+              return entry.contextSummary
+                ? `${base} — ${entry.contextSummary}`
+                : base;
+            })
             .join('; ')}`,
       );
 

--- a/src/utils/session-manager.ts
+++ b/src/utils/session-manager.ts
@@ -12,6 +12,15 @@ export interface RememberedTaskSession {
 
 type SessionGroupMap = Map<AgentName, RememberedTaskSession[]>;
 
+const MAX_CONTEXT_SUMMARY_LENGTH = 280;
+
+function normalizeContextSummary(value?: string): string | undefined {
+  const normalized = normalizeWhitespace(value ?? '');
+  if (!normalized) return undefined;
+
+  return normalized.slice(0, MAX_CONTEXT_SUMMARY_LENGTH);
+}
+
 function aliasPrefix(agentType: AgentName): string {
   switch (agentType) {
     case 'explorer':
@@ -82,6 +91,7 @@ export class SessionManager {
     contextSummary?: string;
   }): RememberedTaskSession {
     const now = this.nextOrder();
+    const contextSummary = normalizeContextSummary(input.contextSummary);
     const group = this.getAgentGroup(
       input.parentSessionId,
       input.agentType,
@@ -94,8 +104,8 @@ export class SessionManager {
 
     if (existing) {
       existing.label = input.label;
-      if (input.contextSummary) {
-        existing.contextSummary = input.contextSummary;
+      if (contextSummary) {
+        existing.contextSummary = contextSummary;
       }
       existing.lastUsedAt = this.nextOrder();
       return existing;
@@ -106,7 +116,7 @@ export class SessionManager {
       taskId: input.taskId,
       agentType: input.agentType,
       label: input.label,
-      contextSummary: input.contextSummary,
+      contextSummary,
       createdAt: now,
       lastUsedAt: now,
     };

--- a/src/utils/task.test.ts
+++ b/src/utils/task.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from 'bun:test';
-import { parseTaskIdFromTaskOutput } from './task';
+import {
+  parseContextSummaryFromTaskOutput,
+  parseTaskIdFromTaskOutput,
+  stripContextSummaryFromTaskOutput,
+} from './task';
 
 describe('parseTaskIdFromTaskOutput', () => {
   test('parses task_id line from successful task tool output', () => {
@@ -20,5 +24,89 @@ describe('parseTaskIdFromTaskOutput', () => {
     );
 
     expect(parseTaskIdFromTaskOutput(output)).toBeUndefined();
+  });
+});
+
+describe('parseContextSummaryFromTaskOutput', () => {
+  test('parses and normalizes the last context summary block', () => {
+    const output = [
+      '<context_summary>old summary</context_summary>',
+      '<task_result>',
+      'done',
+      '</task_result>',
+      '<context_summary>',
+      '  Reviewed   session management\n and found implementation points. ',
+      '</context_summary>',
+    ].join('\n');
+
+    expect(parseContextSummaryFromTaskOutput(output)).toBe(
+      'Reviewed session management and found implementation points.',
+    );
+  });
+
+  test('returns undefined when context block is absent or empty', () => {
+    expect(parseContextSummaryFromTaskOutput('plain output')).toBeUndefined();
+    expect(
+      parseContextSummaryFromTaskOutput(
+        '<context_summary>   \n </context_summary>',
+      ),
+    ).toBeUndefined();
+  });
+
+  test('parses malformed trailing context summary blocks', () => {
+    const output = [
+      '<task_result>',
+      '<results>',
+      '<answer>done</answer>',
+      '<context_summary>Remember inspected session code.',
+      '</task_result>',
+    ].join('\n');
+
+    expect(parseContextSummaryFromTaskOutput(output)).toBe(
+      'Remember inspected session code.',
+    );
+  });
+});
+
+describe('stripContextSummaryFromTaskOutput', () => {
+  test('removes context summary metadata blocks', () => {
+    const output = [
+      'task_id: session-abc-123',
+      '',
+      '<task_result>',
+      'done',
+      '</task_result>',
+      '<context_summary>metadata only</context_summary>',
+    ].join('\n');
+
+    expect(stripContextSummaryFromTaskOutput(output)).toBe(
+      [
+        'task_id: session-abc-123',
+        '',
+        '<task_result>',
+        'done',
+        '</task_result>',
+      ].join('\n'),
+    );
+  });
+
+  test('removes malformed trailing context summary metadata blocks', () => {
+    const output = [
+      'task_id: session-abc-123',
+      '<task_result>',
+      '<results>',
+      '<answer>done</answer>',
+      '<context_summary>metadata only',
+      '</task_result>',
+    ].join('\n');
+
+    expect(stripContextSummaryFromTaskOutput(output)).toBe(
+      [
+        'task_id: session-abc-123',
+        '<task_result>',
+        '<results>',
+        '<answer>done</answer>',
+      ].join('\n'),
+    );
   });
 });

--- a/src/utils/task.test.ts
+++ b/src/utils/task.test.ts
@@ -28,7 +28,7 @@ describe('parseTaskIdFromTaskOutput', () => {
 });
 
 describe('parseContextSummaryFromTaskOutput', () => {
-  test('parses and normalizes the last context summary block', () => {
+  test('parses and normalizes the final context summary block', () => {
     const output = [
       '<context_summary>old summary</context_summary>',
       '<task_result>',
@@ -44,6 +44,31 @@ describe('parseContextSummaryFromTaskOutput', () => {
     );
   });
 
+  test('ignores context summary mentions that are not final metadata', () => {
+    const output = [
+      '<task_result>',
+      '<results>',
+      '<answer>Discusses <context_summary> syntax only.</answer>',
+      '</results>',
+      '</task_result>',
+    ].join('\n');
+
+    expect(parseContextSummaryFromTaskOutput(output)).toBeUndefined();
+  });
+
+  test('ignores context summary blocks nested inside task results', () => {
+    const output = [
+      '<task_result>',
+      '<results>',
+      '<answer>done</answer>',
+      '<context_summary>Nested summary should not parse.</context_summary>',
+      '</results>',
+      '</task_result>',
+    ].join('\n');
+
+    expect(parseContextSummaryFromTaskOutput(output)).toBeUndefined();
+  });
+
   test('returns undefined when context block is absent or empty', () => {
     expect(parseContextSummaryFromTaskOutput('plain output')).toBeUndefined();
     expect(
@@ -53,18 +78,28 @@ describe('parseContextSummaryFromTaskOutput', () => {
     ).toBeUndefined();
   });
 
-  test('parses malformed trailing context summary blocks', () => {
+  test('parses malformed final context summary blocks', () => {
     const output = [
       '<task_result>',
       '<results>',
       '<answer>done</answer>',
-      '<context_summary>Remember inspected session code.',
       '</task_result>',
+      '<context_summary>Remember inspected session code.',
     ].join('\n');
 
     expect(parseContextSummaryFromTaskOutput(output)).toBe(
       'Remember inspected session code.',
     );
+  });
+
+  test('truncates long context summaries', () => {
+    const longSummary = 'a'.repeat(320);
+
+    expect(
+      parseContextSummaryFromTaskOutput(
+        `<context_summary>${longSummary}</context_summary>`,
+      ),
+    ).toHaveLength(280);
   });
 });
 
@@ -90,14 +125,26 @@ describe('stripContextSummaryFromTaskOutput', () => {
     );
   });
 
-  test('removes malformed trailing context summary metadata blocks', () => {
+  test('does not remove context summary mentions inside task results', () => {
+    const output = [
+      '<task_result>',
+      '<results>',
+      '<answer>Discusses <context_summary> syntax only.</answer>',
+      '</results>',
+      '</task_result>',
+    ].join('\n');
+
+    expect(stripContextSummaryFromTaskOutput(output)).toBe(output);
+  });
+
+  test('removes malformed final context summary metadata blocks', () => {
     const output = [
       'task_id: session-abc-123',
       '<task_result>',
       '<results>',
       '<answer>done</answer>',
-      '<context_summary>metadata only',
       '</task_result>',
+      '<context_summary>metadata only',
     ].join('\n');
 
     expect(stripContextSummaryFromTaskOutput(output)).toBe(
@@ -106,6 +153,7 @@ describe('stripContextSummaryFromTaskOutput', () => {
         '<task_result>',
         '<results>',
         '<answer>done</answer>',
+        '</task_result>',
       ].join('\n'),
     );
   });

--- a/src/utils/task.ts
+++ b/src/utils/task.ts
@@ -19,7 +19,13 @@ export function parseTaskIdFromTaskOutput(output: string): string | undefined {
   return undefined;
 }
 
-const MAX_CONTEXT_SUMMARY_LENGTH = 600;
+const MAX_CONTEXT_SUMMARY_LENGTH = 280;
+
+const FINAL_CONTEXT_SUMMARY_PATTERN =
+  /(?:^|\n)\s*<context_summary>((?:(?!<context_summary>)[\s\S])*?)<\/context_summary>\s*$/i;
+
+const FINAL_MALFORMED_CONTEXT_SUMMARY_PATTERN =
+  /(?:^|\n)\s*<context_summary>((?:(?!<context_summary>|<\/context_summary>)[\s\S])*?)\s*$/i;
 
 function normalizeContextSummary(value: string): string | undefined {
   const normalized = value.replace(/\s+/g, ' ').trim();
@@ -29,34 +35,27 @@ function normalizeContextSummary(value: string): string | undefined {
 }
 
 /**
- * Parse the last context summary metadata block from Task tool output.
+ * Parse the final standalone context summary metadata block from Task output.
  */
 export function parseContextSummaryFromTaskOutput(
   output: string,
 ): string | undefined {
-  const matches = [
-    ...output.matchAll(/<context_summary>([\s\S]*?)<\/context_summary>/gi),
-  ];
-  const lastMatch = matches.at(-1);
-  if (!lastMatch) {
-    const fallbackMatch =
-      /<context_summary>([\s\S]*?)(?:<\/task_result>|$)/i.exec(output);
+  const match = FINAL_CONTEXT_SUMMARY_PATTERN.exec(output);
+  if (match) return normalizeContextSummary(match[1]);
 
-    return fallbackMatch
-      ? normalizeContextSummary(fallbackMatch[1])
-      : undefined;
-  }
+  const fallbackMatch = FINAL_MALFORMED_CONTEXT_SUMMARY_PATTERN.exec(output);
 
-  return normalizeContextSummary(lastMatch[1]);
+  return fallbackMatch ? normalizeContextSummary(fallbackMatch[1]) : undefined;
 }
 
 /**
- * Remove context summary metadata blocks before the parent model sees output.
+ * Remove the final standalone context summary metadata block before the parent
+ * model sees output.
  */
 export function stripContextSummaryFromTaskOutput(output: string): string {
   return output
-    .replace(/\n?\s*<context_summary>[\s\S]*?<\/context_summary>\s*/gi, '\n')
-    .replace(/\n?\s*<context_summary>[\s\S]*?(?:<\/task_result>|$)/i, '\n')
+    .replace(FINAL_CONTEXT_SUMMARY_PATTERN, '')
+    .replace(FINAL_MALFORMED_CONTEXT_SUMMARY_PATTERN, '')
     .replace(/\n{3,}/g, '\n\n')
     .trimEnd();
 }

--- a/src/utils/task.ts
+++ b/src/utils/task.ts
@@ -18,3 +18,45 @@ export function parseTaskIdFromTaskOutput(output: string): string | undefined {
 
   return undefined;
 }
+
+const MAX_CONTEXT_SUMMARY_LENGTH = 600;
+
+function normalizeContextSummary(value: string): string | undefined {
+  const normalized = value.replace(/\s+/g, ' ').trim();
+  if (!normalized) return undefined;
+
+  return normalized.slice(0, MAX_CONTEXT_SUMMARY_LENGTH);
+}
+
+/**
+ * Parse the last context summary metadata block from Task tool output.
+ */
+export function parseContextSummaryFromTaskOutput(
+  output: string,
+): string | undefined {
+  const matches = [
+    ...output.matchAll(/<context_summary>([\s\S]*?)<\/context_summary>/gi),
+  ];
+  const lastMatch = matches.at(-1);
+  if (!lastMatch) {
+    const fallbackMatch =
+      /<context_summary>([\s\S]*?)(?:<\/task_result>|$)/i.exec(output);
+
+    return fallbackMatch
+      ? normalizeContextSummary(fallbackMatch[1])
+      : undefined;
+  }
+
+  return normalizeContextSummary(lastMatch[1]);
+}
+
+/**
+ * Remove context summary metadata blocks before the parent model sees output.
+ */
+export function stripContextSummaryFromTaskOutput(output: string): string {
+  return output
+    .replace(/\n?\s*<context_summary>[\s\S]*?<\/context_summary>\s*/gi, '\n')
+    .replace(/\n?\s*<context_summary>[\s\S]*?(?:<\/task_result>|$)/i, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trimEnd();
+}


### PR DESCRIPTION
## Summary
- capture `<context_summary>` metadata from delegated task results and store it with resumable task sessions
- inject stronger child-agent instructions and render saved summaries in the resumable-session prompt
- add parser/stripper coverage for well-formed and malformed context-summary blocks

## Validation
- `bun test`
- `bun run typecheck`
- `bunx biome check docs/session-management.md src/agents/orchestrator.ts src/hooks/task-session-manager/index.test.ts src/hooks/task-session-manager/index.ts src/utils/session-manager.test.ts src/utils/session-manager.ts src/utils/task.test.ts src/utils/task.ts`

Note: full `bun run check:ci` still reports unrelated pre-existing formatting issues outside this change set.