### PR TITLE
feat: add read context to resumable sessions

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -109,6 +109,8 @@ Presets can also be switched at runtime without restarting using the `/preset` c
 | `tmux.layout` | string | `"main-vertical"` | Legacy alias for `multiplexer.layout` |
 | `tmux.main_pane_size` | number | `60` | Legacy alias for `multiplexer.main_pane_size` |
 | `sessionManager.maxSessionsPerAgent` | integer | `2` | Maximum remembered resumable child sessions per specialist type in the current orchestrator session (1–10). See [Session Management](session-management.md) |
+| `sessionManager.readContextMinLines` | integer | `10` | Minimum number of lines read from a file before it appears in resumable-session context (0–1000) |
+| `sessionManager.readContextMaxFiles` | integer | `8` | Maximum number of recent read-context files shown per remembered child session (0–50) |
 | `disabled_mcps` | string[] | `[]` | MCP server IDs to disable globally |
 | `fallback.enabled` | boolean | `false` | Enable model failover on timeout/error |
 | `fallback.timeoutMs` | number | `15000` | Time before aborting and trying next model |
@@ -175,8 +177,9 @@ automatically.
 
 Session management is enabled by default and does not need to be present in the
 starter config. Add `sessionManager` only if you want to tune how many resumable
-child-agent sessions are remembered. See [Session Management](session-management.md)
-for the concept, defaults, and examples.
+child-agent sessions are remembered or how much read context is shown. See
+[Session Management](session-management.md) for the concept, defaults, and
+examples.
 
 ### Agent Display Names
 

--- a/docs/session-management.md
+++ b/docs/session-management.md
@@ -39,9 +39,18 @@ The orchestrator sees a compact reminder in its system context, for example:
 
 ```text
 ### Resumable Sessions
-explorer: exp-1 Search routing files
-oracle: ora-1 Review auth architecture
+- explorer: exp-1 Search routing files
+  Context read by exp-1: src/router.ts (120 lines), src/routes/api.ts (74 lines)
+- oracle: ora-1 Review auth architecture
 ```
+
+When a child session reads files through OpenCode's `read` tool, the reminder can
+include a compact list of files that session has already inspected. This helps the
+orchestrator choose the right session to resume for related follow-up work.
+
+To keep the prompt small, read context only shows files where at least 10 lines
+were read, includes line counts, and caps each remembered session to the most
+recent 8 files.
 
 On a related follow-up, the orchestrator can reuse that session instead of
 launching a fresh one. If the remembered child session no longer exists, the
@@ -59,6 +68,8 @@ Session management is intentionally narrow:
 - It does not change manual `@agent` calls.
 - It keeps only a small number of recent sessions per specialist type.
 - Missing or deleted child sessions are cleaned up automatically.
+- Read context is best-effort and tracks normal OpenCode `read` tool usage, not
+  arbitrary filesystem access through shell commands or external MCP tools.
 
 This keeps the feature useful for continuity without turning child sessions into
 long-lived global state.

--- a/docs/session-management.md
+++ b/docs/session-management.md
@@ -50,7 +50,7 @@ orchestrator choose the right session to resume for related follow-up work.
 
 To keep the prompt small, read context only shows files where at least 10 lines
 were read, includes line counts, and caps each remembered session to the most
-recent 8 files.
+recent 8 files by default. Both thresholds are configurable.
 
 On a related follow-up, the orchestrator can reuse that session instead of
 launching a fresh one. If the remembered child session no longer exists, the
@@ -102,12 +102,14 @@ default.
 
 ## Configuration
 
-Only add `sessionManager` if you want to change the default limit:
+Only add `sessionManager` if you want to change the default limits:
 
 ```jsonc
 {
   "sessionManager": {
-    "maxSessionsPerAgent": 2
+    "maxSessionsPerAgent": 2,
+    "readContextMinLines": 10,
+    "readContextMaxFiles": 8
   }
 }
 ```
@@ -117,6 +119,23 @@ Only add `sessionManager` if you want to change the default limit:
 | Type | Default | Range | Meaning |
 |------|---------|-------|---------|
 | integer | `2` | `1`–`10` | Number of recent resumable child sessions remembered per specialist type in the current parent session |
+
+### `sessionManager.readContextMinLines`
+
+| Type | Default | Range | Meaning |
+|------|---------|-------|---------|
+| integer | `10` | `0`–`1000` | Minimum number of lines read from a file before it appears in resumable-session context |
+
+Set this lower if you want short config files to appear. Set it higher to keep
+the prompt focused on substantial file reads.
+
+### `sessionManager.readContextMaxFiles`
+
+| Type | Default | Range | Meaning |
+|------|---------|-------|---------|
+| integer | `8` | `0`–`50` | Maximum number of recent read-context files shown per remembered child session |
+
+Set this to `0` to keep session aliases but hide read-context file lists.
 
 Use a higher value if you often run several parallel threads per specialist. Use
 a lower value if you want fewer aliases in the orchestrator context.
@@ -140,7 +159,8 @@ Example with a smaller memory window:
 ```jsonc
 {
   "sessionManager": {
-    "maxSessionsPerAgent": 1
+    "maxSessionsPerAgent": 1,
+    "readContextMaxFiles": 4
   }
 }
 ```
@@ -150,7 +170,8 @@ Example with a larger memory window:
 ```jsonc
 {
   "sessionManager": {
-    "maxSessionsPerAgent": 4
+    "maxSessionsPerAgent": 4,
+    "readContextMinLines": 5
   }
 }
 ```

--- a/oh-my-opencode-slim.schema.json
+++ b/oh-my-opencode-slim.schema.json
@@ -498,6 +498,18 @@
           "type": "integer",
           "minimum": 1,
           "maximum": 10
+        },
+        "readContextMinLines": {
+          "default": 10,
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 1000
+        },
+        "readContextMaxFiles": {
+          "default": 8,
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 50
         }
       }
     },

--- a/src/agents/index.test.ts
+++ b/src/agents/index.test.ts
@@ -730,6 +730,8 @@ describe("PluginConfigSchema custom-agent-only prompt fields", () => {
     const result = PluginConfigSchema.safeParse({
       sessionManager: {
         maxSessionsPerAgent: 2,
+        readContextMinLines: 10,
+        readContextMaxFiles: 8,
       },
     });
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -183,6 +183,8 @@ export type InterviewConfig = z.infer<typeof InterviewConfigSchema>;
 
 export const SessionManagerConfigSchema = z.object({
   maxSessionsPerAgent: z.number().int().min(1).max(10).default(2),
+  readContextMinLines: z.number().int().min(0).max(1000).default(10),
+  readContextMaxFiles: z.number().int().min(0).max(50).default(8),
 });
 
 export type SessionManagerConfig = z.infer<typeof SessionManagerConfigSchema>;

--- a/src/hooks/task-session-manager/index.test.ts
+++ b/src/hooks/task-session-manager/index.test.ts
@@ -111,6 +111,13 @@ describe('task-session-manager hook', () => {
   test('tracks files read by child sessions in resumable prompt context', async () => {
     const { hook } = createHook();
 
+    await hook.event({
+      event: {
+        type: 'session.created',
+        properties: { info: { id: 'child-1', parentID: 'parent-1' } },
+      },
+    });
+
     await hook['tool.execute.after'](
       {
         tool: 'read',
@@ -171,6 +178,13 @@ describe('task-session-manager hook', () => {
   test('accumulates multiple reads and hides tiny read context', async () => {
     const { hook } = createHook();
 
+    await hook.event({
+      event: {
+        type: 'session.created',
+        properties: { info: { id: 'child-1', parentID: 'parent-1' } },
+      },
+    });
+
     await hook['tool.execute.after'](
       { tool: 'read', sessionID: 'child-1', callID: 'read-1' },
       {
@@ -226,6 +240,102 @@ describe('task-session-manager hook', () => {
     const prompt = system.system.join('\n');
     expect(prompt).not.toContain('small.ts');
     expect(prompt).toContain('src/large.ts (12 lines)');
+  });
+
+  test('ignores reads from unmanaged child sessions', async () => {
+    const { hook } = createHook({
+      shouldManageSession: (sessionID) => sessionID === 'parent-1',
+    });
+
+    await hook.event({
+      event: {
+        type: 'session.created',
+        properties: { info: { id: 'child-1', parentID: 'other-parent' } },
+      },
+    });
+    await hook['tool.execute.after'](
+      { tool: 'read', sessionID: 'child-1', callID: 'read-1' },
+      {
+        output: [
+          '<path>/tmp/src/index.ts</path>',
+          '<content>',
+          ...Array.from({ length: 12 }, (_, index) => `${index + 1}: line`),
+          '</content>',
+        ].join('\n'),
+      },
+    );
+
+    await hook['tool.execute.before'](
+      { tool: 'task', sessionID: 'parent-1', callID: 'call-1' },
+      { args: { subagent_type: 'explorer', description: 'unmanaged read' } },
+    );
+    await hook['tool.execute.after'](
+      { tool: 'task', sessionID: 'parent-1', callID: 'call-1' },
+      {
+        output:
+          'task_id: child-1 (for resuming to continue this task if needed)',
+      },
+    );
+
+    const system = { system: ['base'] };
+    await hook['experimental.chat.system.transform'](
+      { sessionID: 'parent-1' },
+      system,
+    );
+
+    const prompt = system.system.join('\n');
+    expect(prompt).toContain('exp-1 unmanaged read');
+    expect(prompt).not.toContain('Context read by exp-1');
+  });
+
+  test('prunes read context when remembered sessions are evicted', async () => {
+    const { hook } = createHook();
+
+    for (const index of [1, 2, 3]) {
+      await hook.event({
+        event: {
+          type: 'session.created',
+          properties: {
+            info: { id: `child-${index}`, parentID: 'parent-1' },
+          },
+        },
+      });
+      await hook['tool.execute.after'](
+        { tool: 'read', sessionID: `child-${index}`, callID: `read-${index}` },
+        {
+          output: [
+            `<path>/tmp/src/file-${index}.ts</path>`,
+            '<content>',
+            ...Array.from({ length: 12 }, (_, line) => `${line + 1}: line`),
+            '</content>',
+          ].join('\n'),
+        },
+      );
+      await hook['tool.execute.before'](
+        { tool: 'task', sessionID: 'parent-1', callID: `call-${index}` },
+        { args: { subagent_type: 'explorer', description: `thread ${index}` } },
+      );
+      await hook['tool.execute.after'](
+        { tool: 'task', sessionID: 'parent-1', callID: `call-${index}` },
+        {
+          output: `task_id: child-${index} (for resuming to continue this task if needed)`,
+        },
+      );
+    }
+
+    const system = { system: ['base'] };
+    await hook['experimental.chat.system.transform'](
+      { sessionID: 'parent-1' },
+      system,
+    );
+
+    const prompt = system.system.join('\n');
+    expect(prompt).not.toContain('exp-1 thread 1');
+    expect(prompt).not.toContain('file-1.ts');
+    expect(prompt).toContain('exp-2 thread 2');
+    expect(prompt).toContain('file-2.ts (12 lines)');
+    expect(prompt).toContain('exp-3 thread 3');
+    expect(prompt).toContain('file-3.ts (12 lines)');
   });
 
   test('drops stale remembered sessions and falls back to fresh', async () => {

--- a/src/hooks/task-session-manager/index.test.ts
+++ b/src/hooks/task-session-manager/index.test.ts
@@ -108,6 +108,126 @@ describe('task-session-manager hook', () => {
     expect(next.args.task_id).toBe('child-1');
   });
 
+  test('tracks files read by child sessions in resumable prompt context', async () => {
+    const { hook } = createHook();
+
+    await hook['tool.execute.after'](
+      {
+        tool: 'read',
+        sessionID: 'child-1',
+        callID: 'read-1',
+      },
+      {
+        output: [
+          '<path>/tmp/src/index.ts</path>',
+          '<type>file</type>',
+          '<content>',
+          ...Array.from({ length: 12 }, (_, index) => `${index + 1}: line`),
+          '</content>',
+        ].join('\n'),
+        metadata: {
+          loaded: ['/tmp/AGENTS.md'],
+        },
+      },
+    );
+
+    await hook['tool.execute.before'](
+      {
+        tool: 'task',
+        sessionID: 'parent-1',
+        callID: 'call-1',
+      },
+      {
+        args: {
+          subagent_type: 'explorer',
+          description: 'session files',
+        },
+      },
+    );
+    await hook['tool.execute.after'](
+      {
+        tool: 'task',
+        sessionID: 'parent-1',
+        callID: 'call-1',
+      },
+      {
+        output:
+          'task_id: child-1 (for resuming to continue this task if needed)',
+      },
+    );
+
+    const system = { system: ['base'] };
+    await hook['experimental.chat.system.transform'](
+      { sessionID: 'parent-1' },
+      system,
+    );
+
+    expect(system.system.join('\n')).toContain('exp-1 session files');
+    expect(system.system.join('\n')).toContain(
+      'Context read by exp-1: src/index.ts (12 lines)',
+    );
+  });
+
+  test('accumulates multiple reads and hides tiny read context', async () => {
+    const { hook } = createHook();
+
+    await hook['tool.execute.after'](
+      { tool: 'read', sessionID: 'child-1', callID: 'read-1' },
+      {
+        output: [
+          '<path>/tmp/src/small.ts</path>',
+          '<content>',
+          ...Array.from({ length: 4 }, (_, index) => `${index + 1}: line`),
+          '</content>',
+        ].join('\n'),
+      },
+    );
+    await hook['tool.execute.after'](
+      { tool: 'read', sessionID: 'child-1', callID: 'read-2' },
+      {
+        output: [
+          '<path>/tmp/src/large.ts</path>',
+          '<content>',
+          ...Array.from({ length: 7 }, (_, index) => `${index + 1}: line`),
+          '</content>',
+        ].join('\n'),
+      },
+    );
+    await hook['tool.execute.after'](
+      { tool: 'read', sessionID: 'child-1', callID: 'read-3' },
+      {
+        output: [
+          '<path>/tmp/src/large.ts</path>',
+          '<content>',
+          ...Array.from({ length: 5 }, (_, index) => `${index + 8}: line`),
+          '</content>',
+        ].join('\n'),
+      },
+    );
+
+    await hook['tool.execute.before'](
+      { tool: 'task', sessionID: 'parent-1', callID: 'call-1' },
+      { args: { subagent_type: 'explorer', description: 'line counts' } },
+    );
+    await hook['tool.execute.after'](
+      { tool: 'task', sessionID: 'parent-1', callID: 'call-1' },
+      {
+        output:
+          'task_id: child-1 (for resuming to continue this task if needed)',
+      },
+    );
+
+    const system = { system: ['base'] };
+    await hook['experimental.chat.system.transform'](
+      { sessionID: 'parent-1' },
+      system,
+    );
+
+    const prompt = system.system.join('\n');
+    expect(prompt).not.toContain('small.ts');
+    expect(prompt).toContain('src/large.ts (12 lines)');
+  });
+
   test('drops stale remembered sessions and falls back to fresh', async () => {
     const { hook } = createHook();
 

--- a/src/hooks/task-session-manager/index.test.ts
+++ b/src/hooks/task-session-manager/index.test.ts
@@ -3,6 +3,8 @@ import { createTaskSessionManagerHook } from './index';
 
 function createHook(options?: {
   shouldManageSession?: (sessionID: string) => boolean;
+  readContextMinLines?: number;
+  readContextMaxFiles?: number;
 }) {
   const hook = createTaskSessionManagerHook(
     {
@@ -12,6 +14,8 @@ function createHook(options?: {
     } as never,
     {
       maxSessionsPerAgent: 2,
+      readContextMinLines: options?.readContextMinLines,
+      readContextMaxFiles: options?.readContextMaxFiles,
       shouldManageSession: options?.shouldManageSession ?? (() => true),
     },
   );
@@ -240,6 +244,60 @@ describe('task-session-manager hook', () => {
     const prompt = system.system.join('\n');
     expect(prompt).not.toContain('small.ts');
     expect(prompt).toContain('src/large.ts (12 lines)');
+  });
+
+  test('uses configured read context thresholds', async () => {
+    const { hook } = createHook({
+      readContextMinLines: 5,
+      readContextMaxFiles: 1,
+    });
+
+    await hook.event({
+      event: {
+        type: 'session.created',
+        properties: { info: { id: 'child-1', parentID: 'parent-1' } },
+      },
+    });
+    for (const [file, lines] of [
+      ['small.ts', 4],
+      ['medium.ts', 5],
+      ['large.ts', 12],
+    ] as const) {
+      await hook['tool.execute.after'](
+        { tool: 'read', sessionID: 'child-1', callID: `read-${file}` },
+        {
+          output: [
+            `<path>/tmp/src/${file}</path>`,
+            '<content>',
+            ...Array.from({ length: lines }, (_, line) => `${line + 1}: line`),
+            '</content>',
+          ].join('\n'),
+        },
+      );
+    }
+
+    await hook['tool.execute.before'](
+      { tool: 'task', sessionID: 'parent-1', callID: 'call-1' },
+      { args: { subagent_type: 'explorer', description: 'configured caps' } },
+    );
+    await hook['tool.execute.after'](
+      { tool: 'task', sessionID: 'parent-1', callID: 'call-1' },
+      {
+        output:
+          'task_id: child-1 (for resuming to continue this task if needed)',
+      },
+    );
+
+    const system = { system: ['base'] };
+    await hook['experimental.chat.system.transform'](
+      { sessionID: 'parent-1' },
+      system,
+    );
+
+    const prompt = system.system.join('\n');
+    expect(prompt).not.toContain('small.ts');
+    expect(prompt).toContain('Context read by exp-1:');
+    expect(prompt).toContain('(+1 more)');
   });
 
   test('ignores reads from unmanaged child sessions', async () => {

--- a/src/hooks/task-session-manager/index.test.ts
+++ b/src/hooks/task-session-manager/index.test.ts
@@ -246,6 +246,51 @@ describe('task-session-manager hook', () => {
     expect(prompt).toContain('src/large.ts (12 lines)');
   });
 
+  test('counts overlapping repeated reads once per unique line', async () => {
+    const { hook } = createHook();
+
+    await hook.event({
+      event: {
+        type: 'session.created',
+        properties: { info: { id: 'child-1', parentID: 'parent-1' } },
+      },
+    });
+    for (const call of ['read-1', 'read-2']) {
+      await hook['tool.execute.after'](
+        { tool: 'read', sessionID: 'child-1', callID: call },
+        {
+          output: [
+            '<path>/tmp/src/repeat.ts</path>',
+            '<content>',
+            ...Array.from({ length: 12 }, (_, index) => `${index + 1}: line`),
+            '</content>',
+          ].join('\n'),
+        },
+      );
+    }
+
+    await hook['tool.execute.before'](
+      { tool: 'task', sessionID: 'parent-1', callID: 'call-1' },
+      { args: { subagent_type: 'explorer', description: 'repeat reads' } },
+    );
+    await hook['tool.execute.after'](
+      { tool: 'task', sessionID: 'parent-1', callID: 'call-1' },
+      {
+        output:
+          'task_id: child-1 (for resuming to continue this task if needed)',
+      },
+    );
+
+    const system = { system: ['base'] };
+    await hook['experimental.chat.system.transform'](
+      { sessionID: 'parent-1' },
+      system,
+    );
+
+    expect(system.system.join('\n')).toContain('src/repeat.ts (12 lines)');
+    expect(system.system.join('\n')).not.toContain('src/repeat.ts (24 lines)');
+  });
+
   test('uses configured read context thresholds', async () => {
     const { hook } = createHook({
       readContextMinLines: 5,

--- a/src/hooks/task-session-manager/index.ts
+++ b/src/hooks/task-session-manager/index.ts
@@ -100,6 +100,7 @@ export function createTaskSessionManagerHook(
   const pendingCalls = new Map<string, PendingTaskCall>();
   const pendingCallOrder: string[] = [];
   const contextByTask = new Map<string, Map<string, PendingContextFile>>();
+  const pendingManagedTaskIds = new Set<string>();
 
   function addTaskContext(taskId: string, files: ContextFile[]): void {
     if (files.length === 0) return;
@@ -132,6 +133,21 @@ export function createTaskSessionManagerHook(
       lineCount: file.lineCount,
       lastReadAt: file.lastReadAt,
     }));
+  }
+
+  function canTrackTaskContext(taskId: string): boolean {
+    return (
+      pendingManagedTaskIds.has(taskId) || sessionManager.taskIds().has(taskId)
+    );
+  }
+
+  function pruneContext(): void {
+    const remembered = sessionManager.taskIds();
+    for (const taskId of contextByTask.keys()) {
+      if (!pendingManagedTaskIds.has(taskId) && !remembered.has(taskId)) {
+        contextByTask.delete(taskId);
+      }
+    }
   }
 
   function isMissingRememberedSessionError(output: string): boolean {
@@ -221,6 +237,7 @@ export function createTaskSessionManagerHook(
       }
 
       args.task_id = remembered.taskId;
+      pendingManagedTaskIds.add(remembered.taskId);
       sessionManager.markUsed(
         input.sessionID,
         args.subagent_type,
@@ -242,7 +259,7 @@ export function createTaskSessionManagerHook(
       output: { output: unknown; metadata?: unknown },
     ): Promise<void> => {
       if (input.tool.toLowerCase() === 'read') {
-        if (input.sessionID) {
+        if (input.sessionID && canTrackTaskContext(input.sessionID)) {
           addTaskContext(
             input.sessionID,
             extractReadFiles(_ctx.directory, output),
@@ -285,8 +302,10 @@ export function createTaskSessionManagerHook(
         agentType: pending.agentType,
         label: pending.label,
       });
+      pendingManagedTaskIds.delete(taskId);
       const contextFiles = contextFilesForPrompt(contextByTask.get(taskId));
       sessionManager.addContext(taskId, contextFiles);
+      pruneContext();
     },
 
     'experimental.chat.system.transform': async (
@@ -305,9 +324,24 @@ export function createTaskSessionManagerHook(
     event: async (input: {
       event: {
         type: string;
-        properties?: { info?: { id?: string }; sessionID?: string };
+        properties?: {
+          info?: { id?: string; parentID?: string };
+          sessionID?: string;
+        };
       };
     }): Promise<void> => {
+      if (input.event.type === 'session.created') {
+        const info = input.event.properties?.info;
+        if (
+          info?.id &&
+          info.parentID &&
+          options.shouldManageSession(info.parentID)
+        ) {
+          pendingManagedTaskIds.add(info.id);
+        }
+        return;
+      }
+
       if (input.event.type !== 'session.deleted') return;
       const sessionId =
         input.event.properties?.info?.id ?? input.event.properties?.sessionID;
@@ -316,6 +350,8 @@ export function createTaskSessionManagerHook(
       sessionManager.clearParent(sessionId);
       sessionManager.dropTask(sessionId);
       contextByTask.delete(sessionId);
+      pendingManagedTaskIds.delete(sessionId);
+      pruneContext();
 
       for (const [callId, pending] of pendingCalls.entries()) {
         if (pending.parentSessionId !== sessionId) {

--- a/src/hooks/task-session-manager/index.ts
+++ b/src/hooks/task-session-manager/index.ts
@@ -1,6 +1,8 @@
+import path from 'node:path';
 import type { PluginInput } from '@opencode-ai/plugin';
 import type { AgentName } from '../../config';
 import {
+  type ContextFile,
   deriveTaskSessionLabel,
   parseTaskIdFromTaskOutput,
   SessionManager,
@@ -35,12 +37,56 @@ const AGENT_NAME_SET = new Set<AgentName>([
 
 const MAX_PENDING_TASK_CALLS = 100;
 
+interface PendingContextFile {
+  path: string;
+  lineCount: number;
+  lastReadAt: number;
+}
+
 function isAgentName(value: unknown): value is AgentName {
   return typeof value === 'string' && AGENT_NAME_SET.has(value as AgentName);
 }
 
 function isObjectRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
+}
+
+function extractPath(output: string): string | undefined {
+  return /<path>([^<]+)<\/path>/.exec(output)?.[1];
+}
+
+function normalizePath(root: string, file: string): string {
+  const relative = path.relative(root, file);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) {
+    return file;
+  }
+  return relative;
+}
+
+function extractReadFiles(
+  root: string,
+  output: { output: unknown; metadata?: unknown },
+): ContextFile[] {
+  if (typeof output.output !== 'string') return [];
+
+  const file = extractPath(output.output);
+  if (!file) return [];
+
+  return [
+    {
+      path: normalizePath(root, file),
+      lineCount: countReadLines(output.output),
+      lastReadAt: Date.now(),
+    },
+  ];
+}
+
+function countReadLines(output: string): number {
+  const lines = new Set<number>();
+  for (const match of output.matchAll(/^([0-9]+):/gm)) {
+    lines.add(Number(match[1]));
+  }
+  return lines.size;
 }
 
 export function createTaskSessionManagerHook(
@@ -53,6 +99,40 @@ export function createTaskSessionManagerHook(
   const sessionManager = new SessionManager(options.maxSessionsPerAgent);
   const pendingCalls = new Map<string, PendingTaskCall>();
   const pendingCallOrder: string[] = [];
+  const contextByTask = new Map<string, Map<string, PendingContextFile>>();
+
+  function addTaskContext(taskId: string, files: ContextFile[]): void {
+    if (files.length === 0) return;
+
+    let context = contextByTask.get(taskId);
+    if (!context) {
+      context = new Map();
+      contextByTask.set(taskId, context);
+    }
+    for (const file of files) {
+      const pending = context.get(file.path) ?? {
+        path: file.path,
+        lineCount: 0,
+        lastReadAt: file.lastReadAt,
+      };
+      pending.lineCount += file.lineCount;
+      pending.lastReadAt = Math.max(pending.lastReadAt, file.lastReadAt);
+      context.set(file.path, pending);
+    }
+
+    sessionManager.addContext(taskId, contextFilesForPrompt(context));
+  }
+
+  function contextFilesForPrompt(
+    context: Map<string, PendingContextFile> | undefined,
+  ): ContextFile[] {
+    if (!context) return [];
+    return [...context.values()].map((file) => ({
+      path: file.path,
+      lineCount: file.lineCount,
+      lastReadAt: file.lastReadAt,
+    }));
+  }
 
   function isMissingRememberedSessionError(output: string): boolean {
     const firstLine = output.split(/\r?\n/, 1)[0]?.trim().toLowerCase() ?? '';
@@ -159,8 +239,18 @@ export function createTaskSessionManagerHook(
 
     'tool.execute.after': async (
       input: { tool: string; sessionID?: string; callID?: string },
-      output: { output: unknown },
+      output: { output: unknown; metadata?: unknown },
     ): Promise<void> => {
+      if (input.tool.toLowerCase() === 'read') {
+        if (input.sessionID) {
+          addTaskContext(
+            input.sessionID,
+            extractReadFiles(_ctx.directory, output),
+          );
+        }
+        return;
+      }
+
       if (input.tool.toLowerCase() !== 'task') return;
 
       const pending = takePendingCall(input.callID);
@@ -195,6 +285,8 @@ export function createTaskSessionManagerHook(
         agentType: pending.agentType,
         label: pending.label,
       });
+      const contextFiles = contextFilesForPrompt(contextByTask.get(taskId));
+      sessionManager.addContext(taskId, contextFiles);
     },
 
     'experimental.chat.system.transform': async (
@@ -223,6 +315,7 @@ export function createTaskSessionManagerHook(
 
       sessionManager.clearParent(sessionId);
       sessionManager.dropTask(sessionId);
+      contextByTask.delete(sessionId);
 
       for (const [callId, pending] of pendingCalls.entries()) {
         if (pending.parentSessionId !== sessionId) {

--- a/src/hooks/task-session-manager/index.ts
+++ b/src/hooks/task-session-manager/index.ts
@@ -39,7 +39,7 @@ const MAX_PENDING_TASK_CALLS = 100;
 
 interface PendingContextFile {
   path: string;
-  lineCount: number;
+  lines: Set<number>;
   lastReadAt: number;
 }
 
@@ -75,18 +75,19 @@ function extractReadFiles(
   return [
     {
       path: normalizePath(root, file),
-      lineCount: countReadLines(output.output),
+      lineCount: countReadLines(output.output).length,
+      lineNumbers: countReadLines(output.output),
       lastReadAt: Date.now(),
     },
   ];
 }
 
-function countReadLines(output: string): number {
+function countReadLines(output: string): number[] {
   const lines = new Set<number>();
   for (const match of output.matchAll(/^([0-9]+):/gm)) {
     lines.add(Number(match[1]));
   }
-  return lines.size;
+  return [...lines];
 }
 
 export function createTaskSessionManagerHook(
@@ -118,10 +119,12 @@ export function createTaskSessionManagerHook(
     for (const file of files) {
       const pending = context.get(file.path) ?? {
         path: file.path,
-        lineCount: 0,
+        lines: new Set<number>(),
         lastReadAt: file.lastReadAt,
       };
-      pending.lineCount += file.lineCount;
+      for (const line of file.lineNumbers ?? []) {
+        pending.lines.add(line);
+      }
       pending.lastReadAt = Math.max(pending.lastReadAt, file.lastReadAt);
       context.set(file.path, pending);
     }
@@ -135,7 +138,7 @@ export function createTaskSessionManagerHook(
     if (!context) return [];
     return [...context.values()].map((file) => ({
       path: file.path,
-      lineCount: file.lineCount,
+      lineCount: file.lines.size,
       lastReadAt: file.lastReadAt,
     }));
   }

--- a/src/hooks/task-session-manager/index.ts
+++ b/src/hooks/task-session-manager/index.ts
@@ -93,10 +93,15 @@ export function createTaskSessionManagerHook(
   _ctx: PluginInput,
   options: {
     maxSessionsPerAgent: number;
+    readContextMinLines?: number;
+    readContextMaxFiles?: number;
     shouldManageSession: (sessionID: string) => boolean;
   },
 ) {
-  const sessionManager = new SessionManager(options.maxSessionsPerAgent);
+  const sessionManager = new SessionManager(options.maxSessionsPerAgent, {
+    readContextMinLines: options.readContextMinLines,
+    readContextMaxFiles: options.readContextMaxFiles,
+  });
   const pendingCalls = new Map<string, PendingTaskCall>();
   const pendingCallOrder: string[] = [];
   const contextByTask = new Map<string, Map<string, PendingContextFile>>();

--- a/src/index.ts
+++ b/src/index.ts
@@ -266,6 +266,8 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
     });
     taskSessionManagerHook = createTaskSessionManagerHook(ctx, {
       maxSessionsPerAgent: config.sessionManager?.maxSessionsPerAgent ?? 2,
+      readContextMinLines: config.sessionManager?.readContextMinLines ?? 10,
+      readContextMaxFiles: config.sessionManager?.readContextMaxFiles ?? 8,
       shouldManageSession: (sessionID) =>
         sessionAgentMap.get(sessionID) === 'orchestrator',
     });

--- a/src/utils/session-manager.test.ts
+++ b/src/utils/session-manager.test.ts
@@ -45,6 +45,55 @@ describe('SessionManager', () => {
 
     expect(manager.formatForPrompt('parent-1')).toBeUndefined();
   });
+
+  test('includes read context for remembered sessions', () => {
+    const manager = new SessionManager(2);
+
+    manager.remember({
+      parentSessionId: 'parent-1',
+      taskId: 'task-1',
+      agentType: 'explorer',
+      label: 'session manager',
+    });
+    manager.addContext('task-1', [
+      { path: 'src/index.ts', lineCount: 42, lastReadAt: 1 },
+      {
+        path: 'src/multiplexer/session-manager.ts',
+        lineCount: 24,
+        lastReadAt: 2,
+      },
+    ]);
+
+    const prompt = manager.formatForPrompt('parent-1');
+    expect(prompt).toContain('exp-1 session manager');
+    expect(prompt).toContain(
+      'Context read by exp-1: src/multiplexer/session-manager.ts (24 lines), src/index.ts (42 lines)',
+    );
+  });
+
+  test('filters tiny reads and caps read context files', () => {
+    const manager = new SessionManager(2);
+
+    manager.remember({
+      parentSessionId: 'parent-1',
+      taskId: 'task-1',
+      agentType: 'explorer',
+      label: 'large context',
+    });
+    manager.addContext(
+      'task-1',
+      Array.from({ length: 10 }, (_, index) => ({
+        path: `file-${index}.ts`,
+        lineCount: index === 0 ? 9 : 20 + index,
+        lastReadAt: index,
+      })),
+    );
+
+    const prompt = manager.formatForPrompt('parent-1') ?? '';
+    expect(prompt).not.toContain('file-0.ts');
+    expect(prompt).toContain('file-9.ts (29 lines)');
+    expect(prompt).toContain('(+1 more)');
+  });
 });
 
 describe('deriveTaskSessionLabel', () => {

--- a/src/utils/session-manager.test.ts
+++ b/src/utils/session-manager.test.ts
@@ -94,6 +94,31 @@ describe('SessionManager', () => {
     expect(prompt).toContain('file-9.ts (29 lines)');
     expect(prompt).toContain('(+1 more)');
   });
+
+  test('uses configurable read context thresholds', () => {
+    const manager = new SessionManager(2, {
+      readContextMinLines: 5,
+      readContextMaxFiles: 1,
+    });
+
+    manager.remember({
+      parentSessionId: 'parent-1',
+      taskId: 'task-1',
+      agentType: 'explorer',
+      label: 'custom thresholds',
+    });
+    manager.addContext('task-1', [
+      { path: 'small.ts', lineCount: 4, lastReadAt: 1 },
+      { path: 'medium.ts', lineCount: 5, lastReadAt: 2 },
+      { path: 'large.ts', lineCount: 12, lastReadAt: 3 },
+    ]);
+
+    const prompt = manager.formatForPrompt('parent-1') ?? '';
+    expect(prompt).not.toContain('small.ts');
+    expect(prompt).toContain('large.ts (12 lines)');
+    expect(prompt).not.toContain('medium.ts');
+    expect(prompt).toContain('(+1 more)');
+  });
 });
 
 describe('deriveTaskSessionLabel', () => {

--- a/src/utils/session-manager.test.ts
+++ b/src/utils/session-manager.test.ts
@@ -119,6 +119,35 @@ describe('SessionManager', () => {
     expect(prompt).not.toContain('medium.ts');
     expect(prompt).toContain('(+1 more)');
   });
+
+  test('bounds stored read context files to the render cap plus overflow marker', () => {
+    const manager = new SessionManager(2, {
+      readContextMinLines: 1,
+      readContextMaxFiles: 2,
+    });
+
+    const remembered = manager.remember({
+      parentSessionId: 'parent-1',
+      taskId: 'task-1',
+      agentType: 'explorer',
+      label: 'bounded context',
+    });
+    manager.addContext(
+      'task-1',
+      Array.from({ length: 10 }, (_, index) => ({
+        path: `file-${index}.ts`,
+        lineCount: 10,
+        lastReadAt: index,
+      })),
+    );
+
+    expect(remembered.contextFiles).toHaveLength(3);
+    const prompt = manager.formatForPrompt('parent-1') ?? '';
+    expect(prompt).toContain('file-9.ts (10 lines)');
+    expect(prompt).toContain('file-8.ts (10 lines)');
+    expect(prompt).toContain('(+1 more)');
+    expect(prompt).not.toContain('file-0.ts');
+  });
 });
 
 describe('deriveTaskSessionLabel', () => {

--- a/src/utils/session-manager.ts
+++ b/src/utils/session-manager.ts
@@ -156,6 +156,18 @@ export class SessionManager {
     }
   }
 
+  taskIds(): Set<string> {
+    const ids = new Set<string>();
+    for (const groups of this.sessionsByParent.values()) {
+      for (const group of groups.values()) {
+        for (const entry of group) {
+          ids.add(entry.taskId);
+        }
+      }
+    }
+    return ids;
+  }
+
   addContext(taskId: string, files: ContextFile[]): void {
     if (files.length === 0) return;
 

--- a/src/utils/session-manager.ts
+++ b/src/utils/session-manager.ts
@@ -1,15 +1,25 @@
 import type { AgentName } from '../config';
 
+export interface ContextFile {
+  path: string;
+  lineCount: number;
+  lastReadAt: number;
+}
+
 export interface RememberedTaskSession {
   alias: string;
   taskId: string;
   agentType: AgentName;
   label: string;
+  contextFiles: ContextFile[];
   createdAt: number;
   lastUsedAt: number;
 }
 
 type SessionGroupMap = Map<AgentName, RememberedTaskSession[]>;
+
+const MIN_CONTEXT_FILE_LINES = 10;
+const MAX_CONTEXT_FILES_PER_SESSION = 8;
 
 function aliasPrefix(agentType: AgentName): string {
   switch (agentType) {
@@ -101,6 +111,7 @@ export class SessionManager {
       taskId: input.taskId,
       agentType: input.agentType,
       label: input.label,
+      contextFiles: [],
       createdAt: now,
       lastUsedAt: now,
     };
@@ -145,6 +156,33 @@ export class SessionManager {
     }
   }
 
+  addContext(taskId: string, files: ContextFile[]): void {
+    if (files.length === 0) return;
+
+    for (const groups of this.sessionsByParent.values()) {
+      for (const group of groups.values()) {
+        const match = group.find((entry) => entry.taskId === taskId);
+        if (!match) continue;
+
+        const existing = new Map(
+          match.contextFiles.map((file) => [file.path, file]),
+        );
+        for (const file of files) {
+          const previous = existing.get(file.path);
+          if (previous) {
+            previous.lineCount = Math.max(previous.lineCount, file.lineCount);
+            previous.lastReadAt = Math.max(
+              previous.lastReadAt,
+              file.lastReadAt,
+            );
+            continue;
+          }
+          match.contextFiles.push({ ...file });
+        }
+      }
+    }
+  }
+
   clearParent(parentSessionId: string): void {
     this.sessionsByParent.delete(parentSessionId);
     this.nextAliasIndexByParent.delete(parentSessionId);
@@ -164,11 +202,22 @@ export class SessionManager {
       )
       .filter(([, entries]) => entries.length > 0)
       .sort((a, b) => b[1][0].lastUsedAt - a[1][0].lastUsedAt)
-      .map(
-        ([agentType, entries]) =>
+      .map(([agentType, entries]) =>
+        [
           `- ${agentType}: ${entries
             .map((entry) => `${entry.alias} ${entry.label}`)
             .join('; ')}`,
+          ...entries
+            .map(
+              (entry) =>
+                [entry, formatContextFiles(entry.contextFiles)] as const,
+            )
+            .filter(([, context]) => context.length > 0)
+            .map(
+              ([entry, context]) =>
+                `  Context read by ${entry.alias}: ${context}`,
+            ),
+        ].join('\n'),
       );
 
     if (lines.length === 0) return undefined;
@@ -244,4 +293,16 @@ export class SessionManager {
     this.orderCounter += 1;
     return this.orderCounter;
   }
+}
+
+function formatContextFiles(files: ContextFile[]): string {
+  const eligible = files
+    .filter((file) => file.lineCount >= MIN_CONTEXT_FILE_LINES)
+    .sort((a, b) => b.lastReadAt - a.lastReadAt);
+  const shown = eligible.slice(0, MAX_CONTEXT_FILES_PER_SESSION);
+  const rest = eligible.length - shown.length;
+  const rendered = shown.map(
+    (file) => `${file.path} (${file.lineCount} lines)`,
+  );
+  return `${rendered.join(', ')}${rest > 0 ? ` (+${rest} more)` : ''}`;
 }

--- a/src/utils/session-manager.ts
+++ b/src/utils/session-manager.ts
@@ -21,6 +21,11 @@ type SessionGroupMap = Map<AgentName, RememberedTaskSession[]>;
 const MIN_CONTEXT_FILE_LINES = 10;
 const MAX_CONTEXT_FILES_PER_SESSION = 8;
 
+interface SessionManagerOptions {
+  readContextMinLines?: number;
+  readContextMaxFiles?: number;
+}
+
 function aliasPrefix(agentType: AgentName): string {
   switch (agentType) {
     case 'explorer':
@@ -72,6 +77,8 @@ export function deriveTaskSessionLabel(input: {
 
 export class SessionManager {
   private readonly maxSessionsPerAgent: number;
+  private readonly readContextMinLines: number;
+  private readonly readContextMaxFiles: number;
   private readonly sessionsByParent = new Map<string, SessionGroupMap>();
   private readonly nextAliasIndexByParent = new Map<
     string,
@@ -79,8 +86,15 @@ export class SessionManager {
   >();
   private orderCounter = 0;
 
-  constructor(maxSessionsPerAgent: number) {
+  constructor(
+    maxSessionsPerAgent: number,
+    options: SessionManagerOptions = {},
+  ) {
     this.maxSessionsPerAgent = maxSessionsPerAgent;
+    this.readContextMinLines =
+      options.readContextMinLines ?? MIN_CONTEXT_FILE_LINES;
+    this.readContextMaxFiles =
+      options.readContextMaxFiles ?? MAX_CONTEXT_FILES_PER_SESSION;
   }
 
   remember(input: {
@@ -222,7 +236,13 @@ export class SessionManager {
           ...entries
             .map(
               (entry) =>
-                [entry, formatContextFiles(entry.contextFiles)] as const,
+                [
+                  entry,
+                  formatContextFiles(entry.contextFiles, {
+                    minLines: this.readContextMinLines,
+                    maxFiles: this.readContextMaxFiles,
+                  }),
+                ] as const,
             )
             .filter(([, context]) => context.length > 0)
             .map(
@@ -307,11 +327,14 @@ export class SessionManager {
   }
 }
 
-function formatContextFiles(files: ContextFile[]): string {
+function formatContextFiles(
+  files: ContextFile[],
+  options: { minLines: number; maxFiles: number },
+): string {
   const eligible = files
-    .filter((file) => file.lineCount >= MIN_CONTEXT_FILE_LINES)
+    .filter((file) => file.lineCount >= options.minLines)
     .sort((a, b) => b.lastReadAt - a.lastReadAt);
-  const shown = eligible.slice(0, MAX_CONTEXT_FILES_PER_SESSION);
+  const shown = eligible.slice(0, options.maxFiles);
   const rest = eligible.length - shown.length;
   const rendered = shown.map(
     (file) => `${file.path} (${file.lineCount} lines)`,

--- a/src/utils/session-manager.ts
+++ b/src/utils/session-manager.ts
@@ -3,6 +3,7 @@ import type { AgentName } from '../config';
 export interface ContextFile {
   path: string;
   lineCount: number;
+  lineNumbers?: number[];
   lastReadAt: number;
 }
 
@@ -205,6 +206,7 @@ export class SessionManager {
           }
           match.contextFiles.push({ ...file });
         }
+        this.trimContextFiles(match);
       }
     }
   }
@@ -319,6 +321,18 @@ export class SessionManager {
     if (group.length > this.maxSessionsPerAgent) {
       group.length = this.maxSessionsPerAgent;
     }
+  }
+
+  private trimContextFiles(entry: RememberedTaskSession): void {
+    if (this.readContextMaxFiles === 0) {
+      entry.contextFiles = [];
+      return;
+    }
+
+    entry.contextFiles = entry.contextFiles
+      .filter((file) => file.lineCount >= this.readContextMinLines)
+      .sort((a, b) => b.lastReadAt - a.lastReadAt)
+      .slice(0, this.readContextMaxFiles + 1);
   }
 
   private nextOrder(): number {


### PR DESCRIPTION
## Summary
- Track files read by delegated task sessions and surface them in the orchestrator's resumable session prompt
- Include line counts, filter tiny reads, and cap rendered context to recent substantial files
- Update session-management docs and tests for read-context rendering

## Verification
- bun test src/hooks/task-session-manager/index.test.ts src/utils/session-manager.test.ts
- bun test
- bun run typecheck
- bun run build
- bunx biome check docs/session-management.md src/hooks/task-session-manager/index.test.ts src/hooks/task-session-manager/index.ts src/utils/session-manager.test.ts src/utils/session-manager.ts

Note: `bun run check:ci` currently reports pre-existing formatting diagnostics in unrelated files.