### PR TITLE
docs: add optional /ulw command recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,19 @@ Session management is enabled by default even though it is not shown in the
 starter config. See **[Session Management](docs/session-management.md)** if you
 want to customize how many resumable child-agent sessions are remembered.
 
+### Optional `/ulw` Command Recipe
+
+OMO Slim includes an optional `/ulw` custom command recipe for autonomous
+implementation sessions. It uses the existing Todo Continuation mechanism
+instead of adding a separate loop engine or changing default runtime behavior.
+
+```text
+/ulw implement the requested change and run validation
+```
+
+See **[`/ulw` Command Recipe](docs/ulw-command.md)** and
+[`examples/commands/ulw.md`](examples/commands/ulw.md).
+
 ### For Alternative Providers
 
 To use Kimi, GitHub Copilot, ZAI Coding Plan, or a mixed-provider setup, use **[Configuration](docs/configuration.md)** for the full reference. If you want a ready-made starting point, check the **[Author's Preset](docs/authors-preset.md)** and **[$30 Preset](docs/thirty-dollars-preset.md)** - the `$30` preset is the best cheap setup.
@@ -478,6 +491,7 @@ Use this section as a map: start with installation, then jump to features, confi
 | **[Multiplexer Integration](docs/multiplexer-integration.md)** | Watch agents work live in Tmux or Zellij panes |
 | **[Session Management](docs/session-management.md)** | Reuse recent child-agent sessions with short aliases instead of starting over |
 | **[Todo Continuation](docs/todo-continuation.md)** | Auto-continue orchestrator sessions with cooldowns and safety checks |
+| **[`/ulw` Command Recipe](docs/ulw-command.md)** | Optional autonomous work command built on Todo Continuation |
 | **[Preset Switching](docs/preset-switching.md)** | Switch agent model presets at runtime with `/preset` |
 | **[Codemap](docs/codemap.md)** | Generate hierarchical codemaps to understand large codebases faster |
 

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -16,6 +16,7 @@
 | [Interview](interview.md) | `/interview` command, browser UI, dashboard mode, multi-session coordination |
 | [Multiplexer Integration](multiplexer-integration.md) | Real-time pane monitoring, layouts, troubleshooting |
 | [Todo Continuation](todo-continuation.md) | `auto_continue`, `/auto-continue`, cooldowns, safety gates |
+| [`/ulw` Command Recipe](ulw-command.md) | Optional autonomous work command built on Todo Continuation |
 | [Preset Switching](preset-switching.md) | `/preset` command for runtime agent model switching |
 | [Codemap Skill](codemap.md) | Hierarchical codemap generation |
 

--- a/docs/ulw-command.md
+++ b/docs/ulw-command.md
@@ -1,0 +1,109 @@
+# `/ulw` Command Recipe
+
+`/ulw` is an optional OpenCode custom command recipe for autonomous OMO Slim
+sessions.
+
+It is designed for long-running implementation work where you want the
+Orchestrator to:
+
+- enable Todo Continuation,
+- create structured todos,
+- delegate to specialists when useful,
+- keep working until validation passes,
+- stop only for real blockers or safety boundaries.
+
+`/ulw` is not installed or enabled by default. It is a recipe you can copy into
+OpenCode's custom command directory when you want this workflow.
+
+## Install
+
+Copy the example command into your OpenCode global commands directory:
+
+```bash
+mkdir -p ~/.config/opencode/commands
+cp examples/commands/ulw.md ~/.config/opencode/commands/ulw.md
+```
+
+You can also install it per project:
+
+```bash
+mkdir -p .opencode/commands
+cp examples/commands/ulw.md .opencode/commands/ulw.md
+```
+
+If you are not working from a clone of this repository, fetch the example from
+GitHub first:
+
+```bash
+mkdir -p ~/.config/opencode/commands
+curl -fsSL \
+  https://raw.githubusercontent.com/alvinunreal/oh-my-opencode-slim/master/examples/commands/ulw.md \
+  -o ~/.config/opencode/commands/ulw.md
+```
+
+## Usage
+
+```text
+/ulw fix the flaky checkout test and run the smallest relevant validation
+```
+
+```text
+/ulw implement the new config option end-to-end, update docs, and run typecheck
+```
+
+## When to Use
+
+Use `/ulw` for:
+
+- multi-step coding tasks,
+- bug fixing with validation,
+- refactors with tests,
+- implementation tasks where partial progress is not useful,
+- tasks where the Orchestrator should continue through incomplete todos.
+
+Do not use `/ulw` for:
+
+- pure Q&A,
+- plan-only requests,
+- tasks requiring review after each step,
+- destructive operations,
+- long or expensive experiments unless explicitly intended.
+
+## How It Works
+
+The command routes the request to the OMO Slim Orchestrator and tells it to:
+
+1. call `auto_continue` with `{ "enabled": true }`,
+2. create a real `todowrite` task list,
+3. understand the relevant codebase before editing,
+4. delegate only when a specialist creates clear net value,
+5. run the smallest relevant validation before claiming completion.
+
+Todo Continuation then handles safe resumption if the Orchestrator goes idle
+while incomplete todos remain. The normal Todo Continuation safety gates still
+apply, including the configured continuation limit and stop behavior.
+
+## Relationship to `/auto-continue`
+
+`/ulw` is not a separate loop engine. It is a command recipe that asks the
+Orchestrator to enable OMO Slim's existing Todo Continuation mechanism.
+
+If you want to stop continuation manually, use:
+
+```text
+/auto-continue off
+```
+
+You can also press Esc twice during the cooldown or after injection.
+
+## What It Does Not Do
+
+This recipe intentionally avoids full OMO-style loop behavior. It does not add:
+
+- hidden keyword detection,
+- per-message ultrawork prompt injection,
+- a separate Ralph-style loop,
+- `<promise>DONE</promise>` termination logic,
+- default runtime behavior changes.
+
+The workflow remains explicit, opt-in, and reversible.

--- a/examples/commands/ulw.md
+++ b/examples/commands/ulw.md
@@ -1,0 +1,62 @@
+---
+description: OMO Slim autonomous work mode: continue through todos until validated completion
+agent: orchestrator
+subtask: false
+---
+
+You are now in OMO Slim autonomous work mode.
+
+User task:
+$ARGUMENTS
+
+Activation:
+1. Immediately call the `auto_continue` tool with `{ "enabled": true }`.
+2. Immediately create a concrete task list using the `todowrite` tool before
+   making code changes.
+3. Keep todos small, verifiable, and tied to observable evidence.
+
+Operating rules:
+1. Understand the relevant codebase context before editing.
+2. Delegate to specialist agents only when it creates clear net value:
+   - use @explorer for broad codebase discovery
+   - use @librarian for current external library/API docs
+   - use @oracle for architecture, persistent bugs, risky trade-offs, or final
+     review
+   - use @fixer for bounded implementation/test edits
+   - use @designer only for user-facing UI/UX work
+3. Parallelize only independent branches. Do not parallelize sequential
+   dependencies.
+4. Keep final responsibility in the orchestrator. Integrate specialist results
+   before claiming completion.
+5. Continue working until all todos are complete and the relevant validation
+   passes.
+6. If validation fails, debug and retry.
+7. Do not stop after partial progress unless a safety boundary below applies.
+
+Safety boundaries:
+Stop and ask before:
+- destructive or irreversible actions
+- deleting large files/directories
+- force-pushing, rebasing shared branches, or rewriting git history
+- running very long or expensive jobs without clear user intent
+- changing public APIs or data formats beyond the requested scope
+- proceeding when the task is fundamentally ambiguous and multiple
+  interpretations would cause different code changes
+
+Blocked-state rule:
+Only claim you are blocked after showing the exact command, error, missing
+dependency, permission issue, or unavailable resource that proves the blocker.
+
+Validation:
+- Run the smallest relevant test, lint, typecheck, build, or smoke check.
+- If no validation command is obvious, infer one from the repo and explain why
+  it is the smallest relevant check.
+- Do not claim completion without validation evidence.
+- When complete, mark all todos complete and summarize:
+  - files changed
+  - validation command(s)
+  - validation result
+  - remaining caveats, if any
+
+If no task arguments were provided, ask the user for the concrete task instead
+of inventing one.

--- a/examples/commands/ulw.md
+++ b/examples/commands/ulw.md
@@ -9,6 +9,9 @@ You are now in OMO Slim autonomous work mode.
 User task:
 $ARGUMENTS
 
+If no task arguments were provided, ask the user for the concrete task instead
+of enabling auto-continue or creating todos.
+
 Activation:
 1. Immediately call the `auto_continue` tool with `{ "enabled": true }`.
 2. Immediately create a concrete task list using the `todowrite` tool before
@@ -37,6 +40,8 @@ Safety boundaries:
 Stop and ask before:
 - destructive or irreversible actions
 - deleting large files/directories
+- committing, pushing, opening pull requests, or publishing artifacts unless
+  explicitly requested
 - force-pushing, rebasing shared branches, or rewriting git history
 - running very long or expensive jobs without clear user intent
 - changing public APIs or data formats beyond the requested scope
@@ -57,6 +62,3 @@ Validation:
   - validation command(s)
   - validation result
   - remaining caveats, if any
-
-If no task arguments were provided, ask the user for the concrete task instead
-of inventing one.

--- a/examples/commands/ulw.md
+++ b/examples/commands/ulw.md
@@ -1,5 +1,5 @@
 ---
-description: OMO Slim autonomous work mode: continue through todos until validated completion
+description: "OMO Slim autonomous work mode: continue through todos until validated completion"
 agent: orchestrator
 subtask: false
 ---


### PR DESCRIPTION
## Summary

Add an optional `/ulw` custom command recipe for OMO Slim autonomous implementation sessions.

This PR documents and provides a copyable OpenCode command that routes a user task to the OMO Slim orchestrator, enables Todo Continuation, creates a concrete todo list, delegates to specialists when useful, and continues until the relevant validation passes or a real blocker/safety boundary is reached.

## What changed

- Added `examples/commands/ulw.md` as an optional OpenCode custom command recipe.
- Added `docs/ulw-command.md` with installation, usage, safety boundaries, and relationship to `/auto-continue`.
- Linked the new recipe from the README and quick reference.
- Kept the workflow explicit and opt-in: this does not change default runtime behavior or add a separate loop engine.

## Why

OMO Slim already has Todo Continuation and an orchestrator-driven multi-agent workflow. `/ulw` gives users a simple, reusable command for longer implementation tasks where they want the orchestrator to keep working through structured todos and validate before completion.

## Notes

This is intentionally lighter than full OMO-style loop behavior. It does not add hidden keyword detection, per-message ultrawork prompt injection, a separate loop engine, custom termination tokens, or default behavior changes.

## Validation

- Docs-only / recipe-only change.
- Checked command structure against OpenCode custom command support:
  - markdown command file
  - YAML frontmatter
  - `$ARGUMENTS`
  - `agent: orchestrator`
  - `subtask: false`