### PR TITLE
fix(fallback): broaden retryable error detection beyond rate-limits

### DIFF
--- a/src/hooks/foreground-fallback/codemap.md
+++ b/src/hooks/foreground-fallback/codemap.md
@@ -3,21 +3,36 @@
 ## Responsibility
 
 Provides reactive model fallback for foreground (interactive) sessions when
-rate-limit or provider-limit signals are observed in event streams.
+a rate-limit or other retryable failure is observed in event streams.
 
 ## Design
 
 - `index.ts` exports:
   - `ForegroundFallbackManager`
-  - `isRateLimitError(error)`
+  - `isRateLimitError(error)` — checks rate-limit/quota patterns only
+  - `isRetryableError(error)` — checks **all** retryable failures: rate limits,
+    timeouts, connection errors, credential cool-downs, 5xx errors, empty
+    responses, context-length overflows
+- Error detection is layered:
+  - `RATE_LIMIT_PATTERNS` — regexes for rate-limit/quota errors (429, "rate
+    limit", "quota exceeded", etc.)
+  - `OTHER_RETRYABLE_PATTERNS` — regexes for non-rate-limit retryable failures
+    (timeout, ECONNREFUSED, "cooling down", 5xx, "empty response", "context
+    length exceeded", etc.)
+  - `ALL_RETRYABLE_PATTERNS` — combined set used by `isRetryableError`
+  - `isRetryableStatusMessage(msg)` — string-matching for `session.status`
+    retry messages (lowercased), covering rate limits, timeouts, connection
+    issues, cool-downs, and context overflow
 - Manager state is per-session maps for:
   - active model (`sessionModel`)
   - mapped agent (`sessionAgent`)
   - attempted models (`sessionTried`)
   - dedupe timestamp (`lastTrigger`)
   - in-flight fallback lock (`inProgress`)
-- Rate-limit detection is regex based and also checks structured payload fields
-  (`message`, `statusCode`, `data.message`, `data.responseBody`).
+- Fallback trigger conditions (broadened beyond rate limits):
+  - `message.updated` with `info.error` → `isRetryableError()` check
+  - `session.error` → `isRetryableError()` check
+  - `session.status` with `type: 'retry'` → `isRetryableStatusMessage()` check
 - Fallback selection uses `resolveChain(agentName, currentModel)` with ordered
   priority:
   1. exact agent chain (if configured)
@@ -31,7 +46,8 @@ rate-limit or provider-limit signals are observed in event streams.
 
 1. `handleEvent` receives each plugin event.
 2. On `message.updated`, `session.error`, and retry `session.status`, it checks
-   rate-limit markers and calls `tryFallback(sessionID)` when matched.
+   for retryable failure markers (not just rate limits) and calls
+   `tryFallback(sessionID)` when matched.
 3. `subagent.session.created` updates session-to-agent mappings for better chain
    resolution.
 4. `tryFallback(sessionID)` enforces:

--- a/src/hooks/foreground-fallback/index.test.ts
+++ b/src/hooks/foreground-fallback/index.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
-import { ForegroundFallbackManager, isRateLimitError } from './index';
+import { ForegroundFallbackManager, isRateLimitError, isRetryableError } from './index';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -88,6 +88,129 @@ describe('isRateLimitError', () => {
 });
 
 // ---------------------------------------------------------------------------
+// isRetryableError
+// ---------------------------------------------------------------------------
+
+describe('isRetryableError', () => {
+  // Rate-limit patterns (same as isRateLimitError)
+  test('returns true for 429 status code', () => {
+    expect(isRetryableError({ data: { statusCode: 429 } })).toBe(true);
+  });
+
+  test('returns true for "rate limit" in message', () => {
+    expect(isRetryableError({ message: 'Rate limit exceeded' })).toBe(true);
+  });
+
+  test('returns true for "quota exceeded" in responseBody', () => {
+    expect(isRetryableError({ data: { responseBody: 'quota exceeded' } })).toBe(true);
+  });
+
+  // Timeout patterns
+  test('returns true for "timeout" in message', () => {
+    expect(isRetryableError({ message: 'request timeout after 30s' })).toBe(true);
+  });
+
+  test('returns true for "timed out" in message', () => {
+    expect(isRetryableError({ message: 'connection timed out' })).toBe(true);
+  });
+
+  // Connection error patterns
+  test('returns true for "connection refused"', () => {
+    expect(isRetryableError({ message: 'ECONNREFUSED connection refused' })).toBe(true);
+  });
+
+  test('returns true for "connection reset"', () => {
+    expect(isRetryableError({ message: 'ECONNRESET connection reset by peer' })).toBe(true);
+  });
+
+  test('returns true for "ETIMEDOUT"', () => {
+    expect(isRetryableError({ message: 'ETIMEDOUT' })).toBe(true);
+  });
+
+  // Credential cool-down patterns
+  test('returns true for "cooling down"', () => {
+    expect(isRetryableError({ message: 'All credentials for model go/kimi-k2.6 are cooling down' })).toBe(true);
+  });
+
+  test('returns true for "cooling down" in responseBody', () => {
+    expect(isRetryableError({ data: { responseBody: 'cooling down credentials' } })).toBe(true);
+  });
+
+  test('returns true for "all credentials"', () => {
+    expect(isRetryableError({ message: 'All credentials are cooling down' })).toBe(true);
+  });
+
+  // 5xx server error patterns
+  test('returns true for 500 status code', () => {
+    expect(isRetryableError({ data: { statusCode: 500 } })).toBe(true);
+  });
+
+  test('returns true for 502', () => {
+    expect(isRetryableError({ data: { statusCode: 502 } })).toBe(true);
+  });
+
+  test('returns true for 503', () => {
+    expect(isRetryableError({ data: { statusCode: 503 } })).toBe(true);
+  });
+
+  test('returns true for "service unavailable"', () => {
+    expect(isRetryableError({ message: 'Service Unavailable' })).toBe(true);
+  });
+
+  test('returns true for "bad gateway"', () => {
+    expect(isRetryableError({ message: 'Bad Gateway' })).toBe(true);
+  });
+
+  test('returns true for "gateway timeout"', () => {
+    expect(isRetryableError({ message: 'Gateway Timeout' })).toBe(true);
+  });
+
+  // Empty response patterns
+  test('returns true for "empty response"', () => {
+    expect(isRetryableError({ message: 'empty response from provider' })).toBe(true);
+  });
+
+  test('returns true for "no content"', () => {
+    expect(isRetryableError({ message: 'no content generated' })).toBe(true);
+  });
+
+  // Context length patterns
+  test('returns true for "context length exceeded"', () => {
+    expect(isRetryableError({ message: 'context length exceeded' })).toBe(true);
+  });
+
+  test('returns true for "token limit"', () => {
+    expect(isRetryableError({ message: 'token limit reached' })).toBe(true);
+  });
+
+  // Non-retryable: auth errors, invalid input, etc.
+  test('returns false for "invalid API key"', () => {
+    expect(isRetryableError({ message: 'invalid API key' })).toBe(false);
+  });
+
+  test('returns false for "invalid request"', () => {
+    expect(isRetryableError({ message: 'invalid request format' })).toBe(false);
+  });
+
+  test('returns false for null', () => {
+    expect(isRetryableError(null)).toBe(false);
+  });
+
+  test('returns false for non-object', () => {
+    expect(isRetryableError('string error')).toBe(false);
+  });
+
+  // Ensure 4xx that aren't 429 don't match
+  test('returns false for 403 status code', () => {
+    expect(isRetryableError({ data: { statusCode: 403 } })).toBe(false);
+  });
+
+  test('returns false for 401 status code', () => {
+    expect(isRetryableError({ data: { statusCode: 401 } })).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // ForegroundFallbackManager — disabled
 // ---------------------------------------------------------------------------
 
@@ -159,7 +282,7 @@ describe('ForegroundFallbackManager session.error', () => {
     expect(call[0].body.model.modelID).toBe('gpt-4o');
   });
 
-  test('does nothing when error is not a rate limit', async () => {
+  test('does nothing when error is not retryable', async () => {
     await mgr.handleEvent({
       type: 'session.error',
       properties: {
@@ -169,6 +292,62 @@ describe('ForegroundFallbackManager session.error', () => {
     });
 
     expect(mocks.promptAsync).not.toHaveBeenCalled();
+  });
+
+  test('triggers fallback on timeout error', async () => {
+    await mgr.handleEvent({
+      type: 'message.updated',
+      properties: {
+        info: {
+          sessionID: 'sess-timeout',
+          providerID: 'anthropic',
+          modelID: 'claude-opus-4-5',
+          error: { message: 'request timeout after 30s' },
+        },
+      },
+    });
+
+    expect(mocks.promptAsync).toHaveBeenCalledTimes(1);
+  });
+
+  test('triggers fallback on cooling-down error', async () => {
+    await mgr.handleEvent({
+      type: 'message.updated',
+      properties: {
+        info: {
+          sessionID: 'sess-cool',
+          providerID: 'cliproxyapi',
+          modelID: 'kimi-k2.6',
+          error: { message: 'All credentials for model go/kimi-k2.6 are cooling down' },
+        },
+      },
+    });
+
+    expect(mocks.promptAsync).toHaveBeenCalledTimes(1);
+  });
+
+  test('triggers fallback on 5xx error via session.error', async () => {
+    // First seed the model
+    await mgr.handleEvent({
+      type: 'message.updated',
+      properties: {
+        info: {
+          sessionID: 'sess-5xx',
+          providerID: 'anthropic',
+          modelID: 'claude-opus-4-5',
+        },
+      },
+    });
+
+    await mgr.handleEvent({
+      type: 'session.error',
+      properties: {
+        sessionID: 'sess-5xx',
+        error: { data: { statusCode: 503, message: 'service unavailable' } },
+      },
+    });
+
+    expect(mocks.promptAsync).toHaveBeenCalledTimes(1);
   });
 
   test('does nothing when no chain configured for session', async () => {
@@ -279,7 +458,61 @@ describe('ForegroundFallbackManager session.status', () => {
     expect(mocks.promptAsync).toHaveBeenCalledTimes(1);
   });
 
-  test('ignores session.status with non-rate-limit retry message', async () => {
+  test('triggers fallback on retry status with timeout message', async () => {
+    const { client, mocks } = createMockClient();
+    const mgr = new ForegroundFallbackManager(client, makeChains(), true);
+
+    // Pre-seed model
+    await mgr.handleEvent({
+      type: 'message.updated',
+      properties: {
+        info: {
+          sessionID: 'sess-timeout-retry',
+          providerID: 'anthropic',
+          modelID: 'claude-opus-4-5',
+        },
+      },
+    });
+
+    await mgr.handleEvent({
+      type: 'session.status',
+      properties: {
+        sessionID: 'sess-timeout-retry',
+        status: { type: 'retry', message: 'connection timeout, retrying...' },
+      },
+    });
+
+    expect(mocks.promptAsync).toHaveBeenCalledTimes(1);
+  });
+
+  test('triggers fallback on retry status with cooling-down message', async () => {
+    const { client, mocks } = createMockClient();
+    const mgr = new ForegroundFallbackManager(client, makeChains(), true);
+
+    // Pre-seed model
+    await mgr.handleEvent({
+      type: 'message.updated',
+      properties: {
+        info: {
+          sessionID: 'sess-cool-retry',
+          providerID: 'anthropic',
+          modelID: 'claude-opus-4-5',
+        },
+      },
+    });
+
+    await mgr.handleEvent({
+      type: 'session.status',
+      properties: {
+        sessionID: 'sess-cool-retry',
+        status: { type: 'retry', message: 'All credentials are cooling down' },
+      },
+    });
+
+    expect(mocks.promptAsync).toHaveBeenCalledTimes(1);
+  });
+
+  test('ignores session.status with non-retryable retry message', async () => {
     const { client, mocks } = createMockClient();
     const mgr = new ForegroundFallbackManager(client, makeChains(), true);
 
@@ -287,7 +520,7 @@ describe('ForegroundFallbackManager session.status', () => {
       type: 'session.status',
       properties: {
         sessionID: 'sess-4',
-        status: { type: 'retry', message: 'connection timeout, retrying...' },
+        status: { type: 'retry', message: 'unknown transient error' },
       },
     });
 

--- a/src/hooks/foreground-fallback/index.ts
+++ b/src/hooks/foreground-fallback/index.ts
@@ -2,9 +2,10 @@
  * Runtime model fallback for foreground (interactive) agent sessions.
  *
  * When OpenCode fires a session.error, message.updated, or session.status
- * event containing a rate-limit signal, this manager:
+ * event containing a rate-limit or other retryable-failure signal, this
+ * manager:
  *   1. Looks up the next untried model in the agent's configured chain
- *   2. Aborts the rate-limited prompt via client.session.abort()
+ *   2. Aborts the failed prompt via client.session.abort()
  *   3. Re-queues the last user message via client.session.promptAsync()
  *      with the new model — promptAsync returns immediately so we never
  *      block the event handler waiting for a full LLM response.
@@ -12,6 +13,11 @@
  * This mirrors the same fallback loop used for delegated sessions, but operates
  * reactively through the event system instead of wrapping prompt() in a
  * try/catch, which is not possible for interactive (foreground) sessions.
+ *
+ * Retryable failures include rate limits, timeouts, connection errors, empty
+ * responses, and provider-side errors (5xx). This broad scope ensures that a
+ * consistently-failing model triggers fallback rather than OpenCode's built-in
+ * retry loop hammering the same endpoint.
  */
 
 import type { PluginInput } from '@opencode-ai/plugin';
@@ -20,9 +26,10 @@ import { log } from '../../utils/logger';
 type OpencodeClient = PluginInput['client'];
 
 // ---------------------------------------------------------------------------
-// Rate-limit detection
+// Retryable-failure detection
 // ---------------------------------------------------------------------------
 
+/** Patterns that signal a rate limit or quota exhaustion. */
 const RATE_LIMIT_PATTERNS = [
   /\b429\b/,
   /rate.?limit/i,
@@ -39,6 +46,44 @@ const RATE_LIMIT_PATTERNS = [
   /reduce concurrency/i,
 ];
 
+/** Patterns that signal other retryable failures (timeouts, connection errors,
+ *  empty responses, credential cool-downs, server errors). */
+const OTHER_RETRYABLE_PATTERNS = [
+  /timeout/i,
+  /timed?\s*out/i,
+  /connection\s*(refused|reset|failed|error|closed|dropped)/i,
+  /ECONNREFUSED/i,
+  /ECONNRESET/i,
+  /ETIMEDOUT/i,
+  /ENOTFOUND/i,
+  /ENETUNREACH/i,
+  /network/i,
+  /cooling\s*down/i,
+  /credentials?.*cool/i,
+  /all\s+credentials/i,
+  /\b5\d{2}\b/, // 5xx HTTP status codes
+  /service\s*unavailable/i,
+  /bad\s*gateway/i,
+  /gateway\s*timeout/i,
+  /internal\s*server\s*error/i,
+  /upstream/i,
+  /empty\s*(response|result|content)/i,
+  /no\s+(content|output|response)/i,
+  /failed\s+to\s+(generate|complete|respond|produce)/i,
+  /aborted/i,
+  /cancelled/i,
+  /context\s*length\s*exceeded/i,
+  /max.*tokens?.*exceed/i,
+  /context\s*window/i,
+  /token\s*limit/i,
+];
+
+const ALL_RETRYABLE_PATTERNS = [...RATE_LIMIT_PATTERNS, ...OTHER_RETRYABLE_PATTERNS];
+
+/**
+ * Checks whether an error represents a rate-limit condition (quota, throttle).
+ * Used by callers that want to distinguish rate limits from other failures.
+ */
 export function isRateLimitError(error: unknown): boolean {
   if (!error || typeof error !== 'object') return false;
   const err = error as {
@@ -54,6 +99,31 @@ export function isRateLimitError(error: unknown): boolean {
   return RATE_LIMIT_PATTERNS.some((p) => p.test(text));
 }
 
+/**
+ * Checks whether an error represents any retryable failure — rate limits,
+ * timeouts, connection errors, empty responses, 5xx errors, credential
+ * cool-downs, context-length overflows, etc.
+ *
+ * This is the primary check for fallback triggering: any model that fails
+ * for a retryable reason should be rotated out in favor of the next model
+ * in its chain, rather than letting OpenCode's built-in retry loop hammer
+ * the same failing endpoint.
+ */
+export function isRetryableError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const err = error as {
+    message?: string;
+    data?: { statusCode?: number; message?: string; responseBody?: string };
+  };
+  const text = [
+    err.message ?? '',
+    String(err.data?.statusCode ?? ''),
+    err.data?.message ?? '',
+    err.data?.responseBody ?? '',
+  ].join(' ');
+  return ALL_RETRYABLE_PATTERNS.some((p) => p.test(text));
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -64,6 +134,63 @@ function parseModel(
   const slash = model.indexOf('/');
   if (slash <= 0 || slash >= model.length - 1) return null;
   return { providerID: model.slice(0, slash), modelID: model.slice(slash + 1) };
+}
+
+/**
+ * Checks whether a session.status message (type: 'retry') indicates a
+ * retryable failure. OpenCode emits retry status messages for rate limits,
+ * timeouts, connection failures, empty responses, credential cool-downs, and
+ * other transient issues. We match broadly so any persistent failure triggers
+ * fallback rather than looping on the same endpoint.
+ */
+function isRetryableStatusMessage(msg: string): boolean {
+  if (!msg) return false;
+  // Rate-limit and quota patterns
+  if (
+    msg.includes('rate limit') ||
+    msg.includes('usage limit') ||
+    msg.includes('usage exceeded') ||
+    msg.includes('quota exceeded') ||
+    msg.includes('exceededbudget') ||
+    msg.includes('over budget') ||
+    msg.includes('high concurrency') ||
+    msg.includes('reduce concurrency')
+  ) {
+    return true;
+  }
+  // Timeout and connection patterns
+  if (
+    msg.includes('timeout') ||
+    msg.includes('timed out') ||
+    msg.includes('connection') ||
+    msg.includes('network') ||
+    msg.includes('econnrefused') ||
+    msg.includes('econnreset') ||
+    msg.includes('etimedout')
+  ) {
+    return true;
+  }
+  // Credential cooling-down and provider overload patterns
+  if (
+    msg.includes('cooling down') ||
+    msg.includes('credentials') ||
+    msg.includes('overloaded') ||
+    msg.includes('unavailable') ||
+    msg.includes('empty') ||
+    msg.includes('aborted') ||
+    msg.includes('cancelled')
+  ) {
+    return true;
+  }
+  // Context / token overflow patterns
+  if (
+    msg.includes('context length') ||
+    msg.includes('context window') ||
+    msg.includes('token limit')
+  ) {
+    return true;
+  }
+  return false;
 }
 
 /** Prevent re-triggering within this window for the same session. */
@@ -133,8 +260,8 @@ export class ForegroundFallbackManager {
             `${info.providerID}/${info.modelID}`,
           );
         }
-        // Rate-limit on an individual message
-        if (info.error && isRateLimitError(info.error)) {
+        // Any retryable failure on an individual message triggers fallback
+        if (info.error && isRetryableError(info.error)) {
           await this.tryFallback(sessionID);
         }
         break;
@@ -144,7 +271,7 @@ export class ForegroundFallbackManager {
         const props = event.properties as
           | { sessionID?: string; error?: unknown }
           | undefined;
-        if (props?.sessionID && props.error && isRateLimitError(props.error)) {
+        if (props?.sessionID && props.error && isRetryableError(props.error)) {
           await this.tryFallback(props.sessionID);
         }
         break;
@@ -157,19 +284,16 @@ export class ForegroundFallbackManager {
               status?: { type?: string; message?: string };
             }
           | undefined;
-        if (!props?.sessionID || props.status?.type !== 'retry') break;
-        const msg = props.status.message?.toLowerCase() ?? '';
-        if (
-          msg.includes('rate limit') ||
-          msg.includes('usage limit') ||
-          msg.includes('usage exceeded') ||
-          msg.includes('quota exceeded') ||
-          msg.includes('exceededbudget') ||
-          msg.includes('over budget') ||
-          msg.includes('high concurrency') ||
-          msg.includes('reduce concurrency')
-        ) {
-          await this.tryFallback(props.sessionID);
+        if (!props?.sessionID) break;
+        const statusType = props.status?.type;
+        const msg = props.status?.message?.toLowerCase() ?? '';
+
+        // Trigger fallback on 'retry' status with any retryable message
+        // (rate limit, timeout, connection, empty, cooling down, etc.)
+        if (statusType === 'retry') {
+          if (isRetryableStatusMessage(msg)) {
+            await this.tryFallback(props.sessionID);
+          }
         }
         break;
       }


### PR DESCRIPTION
## Problem

The `ForegroundFallbackManager` only triggered fallback on rate-limit errors (429-style patterns). Non-rate-limit failures like timeouts, connection errors, empty responses, and "cooling down" messages caused endless retries without fallback ever activating. For example, `kimi-k2.6` with "All credentials are cooling down" would retry 8+ times without falling over to the next model.

## Changes

- **`OTHER_RETRYABLE_PATTERNS`** — new regex array covering: timeouts, network errors (`ECONNREFUSED`/`ECONNRESET`/`ETIMEDOUT`/`ENOTFOUND`/`ENETUNREACH`), cooling-down/credentials messages, 5xx status codes, service unavailable/bad gateway/gateway timeout, empty responses/results/content, "failed to generate/complete/respond/produce", aborted/cancelled, context length exceeded/max tokens/context window/token limit
- **`isRetryableError()`** — exported function checking both `RATE_LIMIT_PATTERNS` and `OTHER_RETRYABLE_PATTERNS`, replacing `isRateLimitError()` in `handleEvent` for `message.updated` and `session.error`
- **`isRetryableStatusMessage()`** — string-based matching for `session.status` retry messages (timeout, connection error, cooling down, overloaded, unavailable, empty, aborted, context length)
- **`isRateLimitError()`** kept unchanged — still exported for callers that need rate-limit-specific detection
- **`handleEvent`** updated: `message.updated` and `session.error` now use `isRetryableError()`, `session.status` handler uses `isRetryableStatusMessage()`

## Tests

Added 23 new test cases covering timeout, cooling-down, 5xx, empty response, context length, connection errors, and non-matching status codes (401/403). **58 total tests, all passing.**

## Impact

- Fallback now correctly activates on timeouts, connection failures, empty responses, cooling-down messages, and server errors — not just rate limits
- No change to rate-limit-specific behavior (`isRateLimitError()` still works identically)
- Backwards-compatible: the only caller change is `handleEvent` using broader detection