### PR TITLE
Let native apply_patch handle external paths

### DIFF
--- a/src/hooks/apply-patch/hook.test.ts
+++ b/src/hooks/apply-patch/hook.test.ts
@@ -623,7 +623,7 @@ garbage
     );
   });
 
-  test('passes through relative targets outside root/worktree before native execution', async () => {
+  test('passes through sibling-directory targets outside root/worktree before native execution', async () => {
     const root = await createTempDir('apply-patch-hook-');
     const outside = path.join(path.dirname(root), 'outside.txt');
     await writeFile(outside, 'outside\n', 'utf-8');

--- a/src/hooks/apply-patch/hook.test.ts
+++ b/src/hooks/apply-patch/hook.test.ts
@@ -115,6 +115,74 @@ PATCH`,
     });
   });
 
+  test('passes through an absolute target outside root/worktree before native execution', async () => {
+    const root = await createTempDir('apply-patch-hook-');
+    const outsideDir = await createTempDir('apply-patch-hook-outside-');
+    const outsidePath = path.join(outsideDir, 'outside.txt');
+    await writeFile(outsidePath, 'outside\n', 'utf-8');
+    const hook = createApplyPatchHook({
+      client: {} as never,
+      directory: root,
+      worktree: root,
+    } as never);
+    const patchText = `*** Begin Patch
+*** Update File: ${outsidePath}
+@@
+-outside
++changed
+*** End Patch`;
+    const output = { args: { patchText } };
+
+    await expect(
+      hook['tool.execute.before'](
+        { tool: 'apply_patch', directory: root },
+        output,
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(output.args.patchText).toBe(patchText);
+    expect(await readFile(outsidePath, 'utf-8')).toBe('outside\n');
+  });
+
+  test('passes through mixed stale inside and absolute outside patch without partial rewrite', async () => {
+    const root = await createTempDir('apply-patch-hook-');
+    const outsideDir = await createTempDir('apply-patch-hook-outside-');
+    const outsidePath = path.join(outsideDir, 'outside.txt');
+    await writeFixture(root, 'sample.txt', 'prefix\nstale-value\nsuffix\n');
+    await writeFile(outsidePath, 'outside\n', 'utf-8');
+    const hook = createApplyPatchHook({
+      client: {} as never,
+      directory: root,
+      worktree: root,
+    } as never);
+    const patchText = `*** Begin Patch
+*** Update File: sample.txt
+@@
+ prefix
+-old-value
++new-value
+ suffix
+*** Update File: ${outsidePath}
+@@
+-outside
++changed
+*** End Patch`;
+    const output = { args: { patchText } };
+
+    await expect(
+      hook['tool.execute.before'](
+        { tool: 'apply_patch', directory: root },
+        output,
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(output.args.patchText).toBe(patchText);
+    expect(await readFile(path.join(root, 'sample.txt'), 'utf-8')).toBe(
+      'prefix\nstale-value\nsuffix\n',
+    );
+    expect(await readFile(outsidePath, 'utf-8')).toBe('outside\n');
+  });
+
   test('rewrites a stale prefix patch and remains applicable', async () => {
     const root = await createTempDir('apply-patch-hook-');
     await writeFixture(
@@ -555,7 +623,7 @@ garbage
     );
   });
 
-  test('aborts early when the patch only targets outside root/worktree', async () => {
+  test('passes through relative targets outside root/worktree before native execution', async () => {
     const root = await createTempDir('apply-patch-hook-');
     const outside = path.join(path.dirname(root), 'outside.txt');
     await writeFile(outside, 'outside\n', 'utf-8');
@@ -573,9 +641,7 @@ garbage
         { tool: 'apply_patch', directory: root },
         output,
       ),
-    ).rejects.toThrow(
-      `apply_patch blocked: patch contains path outside workspace root: ${outside}`,
-    );
+    ).resolves.toBeUndefined();
 
     expect(output.args.patchText).toBe(patchText);
     expect(await readFile(outside, 'utf-8')).toBe('outside\n');
@@ -611,7 +677,7 @@ garbage
     });
   });
 
-  test('aborts early and applies nothing when a mixed patch has outside paths', async () => {
+  test('passes through mixed patches with outside paths without partial rewrite', async () => {
     const root = await createTempDir('apply-patch-hook-');
     const outsideDir = await createTempDir('apply-patch-hook-outside-');
     await writeFixture(root, 'sample.txt', 'prefix\nstale-value\nsuffix\n');
@@ -636,9 +702,7 @@ garbage
         { tool: 'apply_patch', directory: root },
         output,
       ),
-    ).rejects.toThrow(
-      `apply_patch blocked: patch contains path outside workspace root: ${outsideAdded}`,
-    );
+    ).resolves.toBeUndefined();
 
     expect(output.args.patchText).toBe(patchText);
     expect(await readFile(path.join(root, 'sample.txt'), 'utf-8')).toBe(

--- a/src/hooks/apply-patch/index.ts
+++ b/src/hooks/apply-patch/index.ts
@@ -86,6 +86,9 @@ export function createApplyPatchHook(ctx: PluginInput) {
 
         if (
           normalizedError.kind === 'blocked' &&
+          // Only the plugin-side outside-workspace preflight should fail open.
+          // Keep the code check explicit so any future blocked error remains
+          // fail-closed by default.
           details?.code === 'outside_workspace'
         ) {
           logHookStatus('skipped', {

--- a/src/hooks/apply-patch/index.ts
+++ b/src/hooks/apply-patch/index.ts
@@ -32,6 +32,7 @@ export function createApplyPatchHook(ctx: PluginInput) {
     state:
       | 'rewrite'
       | 'unchanged'
+      | 'skipped'
       | 'blocked'
       | 'validation'
       | 'verification'
@@ -82,6 +83,21 @@ export function createApplyPatchHook(ctx: PluginInput) {
               error,
             );
         const details = getApplyPatchErrorDetails(normalizedError);
+
+        if (
+          normalizedError.kind === 'blocked' &&
+          details?.code === 'outside_workspace'
+        ) {
+          logHookStatus('skipped', {
+            kind: details.kind,
+            code: details.code,
+            reason: normalizedError.message,
+            failOpen: true,
+            rescueOptions: APPLY_PATCH_RESCUE_OPTIONS,
+            rewriteStage: 'before-native',
+          });
+          return;
+        }
 
         logHookStatus(
           isApplyPatchVerificationError(normalizedError)


### PR DESCRIPTION
## Summary
- Make the plugin-side apply_patch rescue hook skip rewriting when a patch target is outside the root/worktree it can safely reason about.
- Leave external patches unchanged so native OpenCode apply_patch can handle its normal external_directory permission flow.
- Avoid partial rewrites for mixed inside/outside patches and keep strict behavior for malformed or unrecoverable in-workspace patches.

## Why
This addresses #414. The apply_patch rescue layer is useful for stale/tolerant rewrites inside the workspace, but it should not become stricter than native OpenCode for sibling or external project paths. When the hook cannot validate a target as inside its safe root/worktree, it now fails open only for the rescue layer: it logs the skip, preserves the original patch text, and lets native apply_patch enforce the final permission policy.

This keeps the improvements from #406 for normal in-workspace patches while avoiding premature plugin-side blocking for multi-repo workflows.

## Validation
- bun test src/hooks/apply-patch/hook.test.ts
- bun run typecheck