### PR TITLE
Fix cache-busting reminder injections

### DIFF
--- a/src/agents/orchestrator.ts
+++ b/src/agents/orchestrator.ts
@@ -1,4 +1,5 @@
 import type { AgentConfig } from '@opencode-ai/sdk/v2';
+import { PHASE_REMINDER_TEXT } from '../config/constants';
 
 export interface AgentDefinition {
   name: string;
@@ -211,6 +212,10 @@ ${enabledValidationRouting}
 - Verify solution meets requirements
 
 </Workflow>
+
+<WorkflowReminder>
+${PHASE_REMINDER_TEXT}
+</WorkflowReminder>
 
 <Communication>
 

--- a/src/agents/orchestrator.ts
+++ b/src/agents/orchestrator.ts
@@ -1,5 +1,4 @@
 import type { AgentConfig } from '@opencode-ai/sdk/v2';
-import { PHASE_REMINDER_TEXT } from '../config/constants';
 
 export interface AgentDefinition {
   name: string;
@@ -212,10 +211,6 @@ ${enabledValidationRouting}
 - Verify solution meets requirements
 
 </Workflow>
-
-<WorkflowReminder>
-${PHASE_REMINDER_TEXT}
-</WorkflowReminder>
 
 <Communication>
 

--- a/src/hooks/phase-reminder/index.test.ts
+++ b/src/hooks/phase-reminder/index.test.ts
@@ -1,9 +1,8 @@
 import { describe, expect, test } from 'bun:test';
-import { SLIM_INTERNAL_INITIATOR_MARKER } from '../../utils';
 import { createPhaseReminderHook, PHASE_REMINDER } from './index';
 
 describe('createPhaseReminderHook', () => {
-  test('prepends reminder for orchestrator sessions', async () => {
+  test('does not mutate orchestrator messages', async () => {
     const hook = createPhaseReminderHook();
     const output = {
       messages: [
@@ -16,9 +15,8 @@ describe('createPhaseReminderHook', () => {
 
     await hook['experimental.chat.messages.transform']({}, output);
 
-    expect(output.messages[0].parts[0].text).toBe(
-      `${PHASE_REMINDER}\n\n---\n\nhello`,
-    );
+    expect(output.messages[0].parts[0].text).toBe('hello');
+    expect(output.messages[0].parts[0].text).not.toContain(PHASE_REMINDER);
   });
 
   test('skips non-orchestrator sessions', async () => {
@@ -37,27 +35,22 @@ describe('createPhaseReminderHook', () => {
     expect(output.messages[0].parts[0].text).toBe('hello');
   });
 
-  test('skips internal notification turns', async () => {
+  test('does not mutate internal notification turns', async () => {
     const hook = createPhaseReminderHook();
+    const text =
+      '[Background task "x" completed]\n<!-- slim-internal-initiator -->';
     const output = {
       messages: [
         {
           info: { role: 'user' },
-          parts: [
-            {
-              type: 'text',
-              text: `[Background task "x" completed]\n${SLIM_INTERNAL_INITIATOR_MARKER}`,
-            },
-          ],
+          parts: [{ type: 'text', text }],
         },
       ],
     };
 
     await hook['experimental.chat.messages.transform']({}, output);
 
-    expect(output.messages[0].parts[0].text).toContain(
-      SLIM_INTERNAL_INITIATOR_MARKER,
-    );
+    expect(output.messages[0].parts[0].text).toBe(text);
     expect(output.messages[0].parts[0].text).not.toContain(PHASE_REMINDER);
   });
 });

--- a/src/hooks/phase-reminder/index.test.ts
+++ b/src/hooks/phase-reminder/index.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, test } from 'bun:test';
+import { SLIM_INTERNAL_INITIATOR_MARKER } from '../../utils';
 import { createPhaseReminderHook, PHASE_REMINDER } from './index';
 
 describe('createPhaseReminderHook', () => {
-  test('does not mutate orchestrator messages', async () => {
+  test('appends reminder for orchestrator sessions', async () => {
     const hook = createPhaseReminderHook();
     const output = {
       messages: [
@@ -15,8 +16,9 @@ describe('createPhaseReminderHook', () => {
 
     await hook['experimental.chat.messages.transform']({}, output);
 
-    expect(output.messages[0].parts[0].text).toBe('hello');
-    expect(output.messages[0].parts[0].text).not.toContain(PHASE_REMINDER);
+    expect(output.messages[0].parts[0].text).toBe(
+      `hello\n\n---\n\n${PHASE_REMINDER}`,
+    );
   });
 
   test('skips non-orchestrator sessions', async () => {
@@ -37,8 +39,7 @@ describe('createPhaseReminderHook', () => {
 
   test('does not mutate internal notification turns', async () => {
     const hook = createPhaseReminderHook();
-    const text =
-      '[Background task "x" completed]\n<!-- slim-internal-initiator -->';
+    const text = `[Background task "x" completed]\n${SLIM_INTERNAL_INITIATOR_MARKER}`;
     const output = {
       messages: [
         {
@@ -52,5 +53,22 @@ describe('createPhaseReminderHook', () => {
 
     expect(output.messages[0].parts[0].text).toBe(text);
     expect(output.messages[0].parts[0].text).not.toContain(PHASE_REMINDER);
+  });
+
+  test('does not append duplicate reminder', async () => {
+    const hook = createPhaseReminderHook();
+    const text = `hello\n\n---\n\n${PHASE_REMINDER}`;
+    const output = {
+      messages: [
+        {
+          info: { role: 'user', agent: 'orchestrator' },
+          parts: [{ type: 'text', text }],
+        },
+      ],
+    };
+
+    await hook['experimental.chat.messages.transform']({}, output);
+
+    expect(output.messages[0].parts[0].text).toBe(text);
   });
 });

--- a/src/hooks/phase-reminder/index.ts
+++ b/src/hooks/phase-reminder/index.ts
@@ -8,7 +8,7 @@
 import { PHASE_REMINDER_TEXT } from '../../config/constants';
 import { SLIM_INTERNAL_INITIATOR_MARKER } from '../../utils';
 
-export const PHASE_REMINDER = `<reminder>${PHASE_REMINDER_TEXT}</reminder>`;
+export const PHASE_REMINDER = `<internal_reminder>${PHASE_REMINDER_TEXT}</internal_reminder>`;
 
 interface MessageInfo {
   role: string;

--- a/src/hooks/phase-reminder/index.ts
+++ b/src/hooks/phase-reminder/index.ts
@@ -1,15 +1,12 @@
 /**
- * Phase reminder to inject before each user message.
- * Keeps workflow instructions in the immediate attention window
- * to combat instruction-following degradation over long contexts.
+ * Phase reminder hook retained for backwards-compatible hook wiring.
  *
- * Research: "LLMs Get Lost In Multi-Turn Conversation" (arXiv:2505.06120)
- * shows ~40% compliance drop after 2-3 turns without reminders.
- *
- * Uses experimental.chat.messages.transform so it doesn't show in UI.
+ * The reminder now lives in the static orchestrator prompt. Injecting it into
+ * every latest user message changed request content unnecessarily and could
+ * interfere with provider prompt-cache reuse. Keeping this transform as a
+ * no-op preserves the hook shape without mutating chat messages.
  */
 import { PHASE_REMINDER_TEXT } from '../../config/constants';
-import { SLIM_INTERNAL_INITIATOR_MARKER } from '../../utils';
 
 export const PHASE_REMINDER = `<reminder>${PHASE_REMINDER_TEXT}</reminder>`;
 
@@ -41,50 +38,7 @@ export function createPhaseReminderHook() {
       _input: Record<string, never>,
       output: { messages: MessageWithParts[] },
     ): Promise<void> => {
-      const { messages } = output;
-
-      if (messages.length === 0) {
-        return;
-      }
-
-      // Find the last user message
-      let lastUserMessageIndex = -1;
-      for (let i = messages.length - 1; i >= 0; i--) {
-        if (messages[i].info.role === 'user') {
-          lastUserMessageIndex = i;
-          break;
-        }
-      }
-
-      if (lastUserMessageIndex === -1) {
-        return;
-      }
-
-      const lastUserMessage = messages[lastUserMessageIndex];
-
-      // Only inject for orchestrator (or if no agent specified = main session)
-      const agent = lastUserMessage.info.agent;
-      if (agent && agent !== 'orchestrator') {
-        return;
-      }
-
-      // Find the first text part
-      const textPartIndex = lastUserMessage.parts.findIndex(
-        (p) => p.type === 'text' && p.text !== undefined,
-      );
-
-      if (textPartIndex === -1) {
-        return;
-      }
-
-      const originalText = lastUserMessage.parts[textPartIndex].text ?? '';
-      if (originalText.includes(SLIM_INTERNAL_INITIATOR_MARKER)) {
-        return;
-      }
-
-      // Prepend the reminder to the existing text
-      lastUserMessage.parts[textPartIndex].text =
-        `${PHASE_REMINDER}\n\n---\n\n${originalText}`;
+      void output;
     },
   };
 }

--- a/src/hooks/phase-reminder/index.ts
+++ b/src/hooks/phase-reminder/index.ts
@@ -1,12 +1,12 @@
 /**
- * Phase reminder hook retained for backwards-compatible hook wiring.
+ * Phase reminder to append after each latest user message.
  *
- * The reminder now lives in the static orchestrator prompt. Injecting it into
- * every latest user message changed request content unnecessarily and could
- * interfere with provider prompt-cache reuse. Keeping this transform as a
- * no-op preserves the hook shape without mutating chat messages.
+ * Keeping this at the tail preserves immediate workflow guidance without
+ * mutating the cached system prompt or prepending request-local content ahead
+ * of the user's actual turn.
  */
 import { PHASE_REMINDER_TEXT } from '../../config/constants';
+import { SLIM_INTERNAL_INITIATOR_MARKER } from '../../utils';
 
 export const PHASE_REMINDER = `<reminder>${PHASE_REMINDER_TEXT}</reminder>`;
 
@@ -38,7 +38,48 @@ export function createPhaseReminderHook() {
       _input: Record<string, never>,
       output: { messages: MessageWithParts[] },
     ): Promise<void> => {
-      void output;
+      const { messages } = output;
+
+      if (messages.length === 0) {
+        return;
+      }
+
+      let lastUserMessageIndex = -1;
+      for (let i = messages.length - 1; i >= 0; i--) {
+        if (messages[i].info.role === 'user') {
+          lastUserMessageIndex = i;
+          break;
+        }
+      }
+
+      if (lastUserMessageIndex === -1) {
+        return;
+      }
+
+      const lastUserMessage = messages[lastUserMessageIndex];
+      const agent = lastUserMessage.info.agent;
+      if (agent && agent !== 'orchestrator') {
+        return;
+      }
+
+      const textPartIndex = lastUserMessage.parts.findIndex(
+        (p) => p.type === 'text' && p.text !== undefined,
+      );
+
+      if (textPartIndex === -1) {
+        return;
+      }
+
+      const originalText = lastUserMessage.parts[textPartIndex].text ?? '';
+      if (originalText.includes(SLIM_INTERNAL_INITIATOR_MARKER)) {
+        return;
+      }
+      if (originalText.includes(PHASE_REMINDER)) {
+        return;
+      }
+
+      lastUserMessage.parts[textPartIndex].text =
+        `${originalText}\n\n---\n\n${PHASE_REMINDER}`;
     },
   };
 }

--- a/src/hooks/post-file-tool-nudge/index.test.ts
+++ b/src/hooks/post-file-tool-nudge/index.test.ts
@@ -11,13 +11,82 @@ function createOutput(output = 'real content') {
   };
 }
 
-function countReminder(system: string[]) {
-  return system.join('\n').split(PHASE_REMINDER_TEXT).length - 1;
+function countReminderInOutput(output: string | unknown): number {
+  if (typeof output !== 'string') return 0;
+  return output.split(PHASE_REMINDER_TEXT).length - 1;
 }
 
 describe('post-file-tool-nudge hook', () => {
-  test('does not contaminate persisted Read output', async () => {
+  test('appends delegation reminder to tool output', async () => {
     const hook = createPostFileToolNudgeHook();
+    const output = createOutput();
+
+    await hook['tool.execute.after']({ tool: 'Read', sessionID: 's1' }, output);
+
+    expect(output.output).toContain(PHASE_REMINDER_TEXT);
+    expect(output.output).toContain('<internal_reminder>');
+    expect(output.output).toContain('</internal_reminder>');
+  });
+
+  test('system transform is no-op (cache-safe)', async () => {
+    const hook = createPostFileToolNudgeHook();
+    const system = { system: ['base system prompt'] };
+
+    await hook['experimental.chat.system.transform'](
+      { sessionID: 's1' },
+      system,
+    );
+
+    expect(system.system).toEqual(['base system prompt']);
+    expect(system.system.join('\n')).not.toContain(PHASE_REMINDER_TEXT);
+  });
+
+  test('does not duplicate reminder in same tool output', async () => {
+    const hook = createPostFileToolNudgeHook();
+    const output = createOutput();
+
+    await hook['tool.execute.after']({ tool: 'read', sessionID: 's1' }, output);
+    await hook['tool.execute.after']({ tool: 'read', sessionID: 's1' }, output);
+
+    expect(countReminderInOutput(output.output)).toBe(1);
+  });
+
+  test('deduplicates multiple Read/Write calls in same session', async () => {
+    const hook = createPostFileToolNudgeHook();
+    const output1 = createOutput('content 1');
+    const output2 = createOutput('content 2');
+    const output3 = createOutput('content 3');
+
+    await hook['tool.execute.after'](
+      { tool: 'read', sessionID: 's1' },
+      output1,
+    );
+    await hook['tool.execute.after'](
+      { tool: 'write', sessionID: 's1' },
+      output2,
+    );
+    await hook['tool.execute.after'](
+      { tool: 'Read', sessionID: 's1' },
+      output3,
+    );
+
+    expect(output1.output).toContain(PHASE_REMINDER_TEXT);
+    expect(output2.output).toContain(PHASE_REMINDER_TEXT);
+    expect(output3.output).toContain(PHASE_REMINDER_TEXT);
+  });
+
+  test('ignores non-file tools', async () => {
+    const hook = createPostFileToolNudgeHook();
+    const output = createOutput('ok');
+
+    await hook['tool.execute.after']({ tool: 'bash', sessionID: 's1' }, output);
+
+    expect(output.output).toBe('ok');
+    expect(output.output).not.toContain(PHASE_REMINDER_TEXT);
+  });
+
+  test('skips injection when shouldInject returns false', async () => {
+    const hook = createPostFileToolNudgeHook({ shouldInject: () => false });
     const output = createOutput();
 
     await hook['tool.execute.after']({ tool: 'read', sessionID: 's1' }, output);
@@ -26,160 +95,41 @@ describe('post-file-tool-nudge hook', () => {
     expect(output.output).not.toContain(PHASE_REMINDER_TEXT);
   });
 
-  test('injects the delegation reminder in system transform', async () => {
-    const hook = createPostFileToolNudgeHook();
-    const output = createOutput();
-    const system = { system: ['base system prompt'] };
-
-    await hook['tool.execute.after']({ tool: 'Read', sessionID: 's1' }, output);
-    await hook['experimental.chat.system.transform'](
-      { sessionID: 's1' },
-      system,
-    );
-
-    expect(output.output).toBe('real content');
-    expect(system.system.join('\n')).toContain(PHASE_REMINDER_TEXT);
-  });
-
-  test('consumes the reminder once', async () => {
-    const hook = createPostFileToolNudgeHook();
-    const first = { system: ['base'] };
-    const second = { system: ['base'] };
-
-    await hook['tool.execute.after'](
-      { tool: 'write', sessionID: 's1' },
-      createOutput(),
-    );
-    await hook['experimental.chat.system.transform'](
-      { sessionID: 's1' },
-      first,
-    );
-    await hook['experimental.chat.system.transform'](
-      { sessionID: 's1' },
-      second,
-    );
-
-    expect(countReminder(first.system)).toBe(1);
-    expect(countReminder(second.system)).toBe(0);
-  });
-
-  test('deduplicates multiple Read/Write calls before the next prompt', async () => {
-    const hook = createPostFileToolNudgeHook();
-    const system = { system: ['base'] };
-
-    await hook['tool.execute.after'](
-      { tool: 'read', sessionID: 's1' },
-      createOutput(),
-    );
-    await hook['tool.execute.after'](
-      { tool: 'write', sessionID: 's1' },
-      createOutput(),
-    );
-    await hook['tool.execute.after'](
-      { tool: 'Read', sessionID: 's1' },
-      createOutput(),
-    );
-    await hook['experimental.chat.system.transform'](
-      { sessionID: 's1' },
-      system,
-    );
-
-    expect(countReminder(system.system)).toBe(1);
-  });
-
-  test('ignores non-file tools', async () => {
-    const hook = createPostFileToolNudgeHook();
-    const output = createOutput('ok');
-    const system = { system: ['base'] };
-
-    await hook['tool.execute.after']({ tool: 'bash', sessionID: 's1' }, output);
-    await hook['experimental.chat.system.transform'](
-      { sessionID: 's1' },
-      system,
-    );
-
-    expect(output.output).toBe('ok');
-    expect(countReminder(system.system)).toBe(0);
-  });
-
-  test('consumes without injecting when the session should not receive the nudge', async () => {
-    const hook = createPostFileToolNudgeHook({ shouldInject: () => false });
-    const first = { system: ['base'] };
-    const second = { system: ['base'] };
-
-    await hook['tool.execute.after'](
-      { tool: 'read', sessionID: 's1' },
-      createOutput(),
-    );
-    await hook['experimental.chat.system.transform'](
-      { sessionID: 's1' },
-      first,
-    );
-    await hook['experimental.chat.system.transform'](
-      { sessionID: 's1' },
-      second,
-    );
-
-    expect(countReminder(first.system)).toBe(0);
-    expect(countReminder(second.system)).toBe(0);
-  });
-
   test('ignores Read/Write without sessionID', async () => {
     const hook = createPostFileToolNudgeHook();
     const output = createOutput();
-    const system = { system: ['base'] };
 
     await hook['tool.execute.after']({ tool: 'read' }, output);
-    await hook['experimental.chat.system.transform'](
-      { sessionID: 's1' },
-      system,
-    );
 
     expect(output.output).toBe('real content');
-    expect(countReminder(system.system)).toBe(0);
+    expect(output.output).not.toContain(PHASE_REMINDER_TEXT);
   });
 
-  test('cleans up pending reminders when a session is deleted', async () => {
+  test('handles session.deleted event without error', async () => {
     const hook = createPostFileToolNudgeHook();
-    const system = { system: ['base'] };
 
-    await hook['tool.execute.after'](
-      { tool: 'read', sessionID: 's1' },
-      createOutput(),
-    );
     await hook.event({
       event: {
         type: 'session.deleted',
         properties: { info: { id: 's1' } },
       },
     });
-    await hook['experimental.chat.system.transform'](
-      { sessionID: 's1' },
-      system,
-    );
 
-    expect(countReminder(system.system)).toBe(0);
+    // Should not throw
+    expect(true).toBe(true);
   });
 
-  test('cleans up pending reminders from sessionID delete events', async () => {
+  test('handles session.deleted with sessionID property', async () => {
     const hook = createPostFileToolNudgeHook();
-    const system = { system: ['base'] };
 
-    await hook['tool.execute.after'](
-      { tool: 'write', sessionID: 's1' },
-      createOutput(),
-    );
     await hook.event({
       event: {
         type: 'session.deleted',
         properties: { sessionID: 's1' },
       },
     });
-    await hook['experimental.chat.system.transform'](
-      { sessionID: 's1' },
-      system,
-    );
 
-    expect(countReminder(system.system)).toBe(0);
+    // Should not throw
+    expect(true).toBe(true);
   });
 });

--- a/src/hooks/post-file-tool-nudge/index.test.ts
+++ b/src/hooks/post-file-tool-nudge/index.test.ts
@@ -28,19 +28,6 @@ describe('post-file-tool-nudge hook', () => {
     expect(output.output).toContain('</internal_reminder>');
   });
 
-  test('system transform is no-op (cache-safe)', async () => {
-    const hook = createPostFileToolNudgeHook();
-    const system = { system: ['base system prompt'] };
-
-    await hook['experimental.chat.system.transform'](
-      { sessionID: 's1' },
-      system,
-    );
-
-    expect(system.system).toEqual(['base system prompt']);
-    expect(system.system.join('\n')).not.toContain(PHASE_REMINDER_TEXT);
-  });
-
   test('does not duplicate reminder in same tool output', async () => {
     const hook = createPostFileToolNudgeHook();
     const output = createOutput();
@@ -103,33 +90,5 @@ describe('post-file-tool-nudge hook', () => {
 
     expect(output.output).toBe('real content');
     expect(output.output).not.toContain(PHASE_REMINDER_TEXT);
-  });
-
-  test('handles session.deleted event without error', async () => {
-    const hook = createPostFileToolNudgeHook();
-
-    await hook.event({
-      event: {
-        type: 'session.deleted',
-        properties: { info: { id: 's1' } },
-      },
-    });
-
-    // Should not throw
-    expect(true).toBe(true);
-  });
-
-  test('handles session.deleted with sessionID property', async () => {
-    const hook = createPostFileToolNudgeHook();
-
-    await hook.event({
-      event: {
-        type: 'session.deleted',
-        properties: { sessionID: 's1' },
-      },
-    });
-
-    // Should not throw
-    expect(true).toBe(true);
   });
 });

--- a/src/hooks/post-file-tool-nudge/index.ts
+++ b/src/hooks/post-file-tool-nudge/index.ts
@@ -21,6 +21,10 @@ interface ChatSystemTransformOutput {
   system: string[];
 }
 
+interface ToolExecuteAfterOutput {
+  output?: unknown;
+}
+
 interface EventInput {
   event: {
     type: string;
@@ -40,25 +44,30 @@ const FILE_TOOLS = new Set(['Read', 'read', 'Write', 'write']);
 export function createPostFileToolNudgeHook(
   options: PostFileToolNudgeOptions = {},
 ) {
-  const pendingSessionIds = new Set<string>();
+  function appendReminder(output: ToolExecuteAfterOutput): void {
+    if (typeof output.output !== 'string') {
+      return;
+    }
+
+    if (output.output.includes(POST_FILE_TOOL_NUDGE)) {
+      return;
+    }
+
+    output.output = [
+      output.output,
+      '',
+      '<internal_reminder>',
+      POST_FILE_TOOL_NUDGE,
+      '</internal_reminder>',
+    ].join('\n');
+  }
 
   return {
     'tool.execute.after': async (
       input: ToolExecuteAfterInput,
-      _output: unknown,
+      output: ToolExecuteAfterOutput,
     ): Promise<void> => {
-      // Only nudge for Read/Write tools once the next model call is built.
       if (!FILE_TOOLS.has(input.tool) || !input.sessionID) {
-        return;
-      }
-
-      pendingSessionIds.add(input.sessionID);
-    },
-    'experimental.chat.system.transform': async (
-      input: ChatSystemTransformInput,
-      output: ChatSystemTransformOutput,
-    ): Promise<void> => {
-      if (!input.sessionID || !pendingSessionIds.delete(input.sessionID)) {
         return;
       }
 
@@ -66,20 +75,20 @@ export function createPostFileToolNudgeHook(
         return;
       }
 
-      output.system.push(POST_FILE_TOOL_NUDGE);
+      appendReminder(output);
+    },
+    'experimental.chat.system.transform': async (
+      _input: ChatSystemTransformInput,
+      _output: ChatSystemTransformOutput,
+    ): Promise<void> => {
+      // Kept as a no-op for hook shape compatibility. Dynamic reminders must
+      // not mutate the system prompt because OpenCode prompt-caches system
+      // messages as the stable prefix.
     },
     event: async (input: EventInput): Promise<void> => {
       if (input.event.type !== 'session.deleted') {
         return;
       }
-
-      const sessionID =
-        input.event.properties?.sessionID ?? input.event.properties?.info?.id;
-      if (!sessionID) {
-        return;
-      }
-
-      pendingSessionIds.delete(sessionID);
     },
   };
 }

--- a/src/hooks/post-file-tool-nudge/index.ts
+++ b/src/hooks/post-file-tool-nudge/index.ts
@@ -13,26 +13,8 @@ interface ToolExecuteAfterInput {
   callID?: string;
 }
 
-interface ChatSystemTransformInput {
-  sessionID?: string;
-}
-
-interface ChatSystemTransformOutput {
-  system: string[];
-}
-
 interface ToolExecuteAfterOutput {
   output?: unknown;
-}
-
-interface EventInput {
-  event: {
-    type: string;
-    properties?: {
-      info?: { id?: string };
-      sessionID?: string;
-    };
-  };
 }
 
 interface PostFileToolNudgeOptions {
@@ -76,19 +58,6 @@ export function createPostFileToolNudgeHook(
       }
 
       appendReminder(output);
-    },
-    'experimental.chat.system.transform': async (
-      _input: ChatSystemTransformInput,
-      _output: ChatSystemTransformOutput,
-    ): Promise<void> => {
-      // Kept as a no-op for hook shape compatibility. Dynamic reminders must
-      // not mutate the system prompt because OpenCode prompt-caches system
-      // messages as the stable prefix.
-    },
-    event: async (input: EventInput): Promise<void> => {
-      if (input.event.type !== 'session.deleted') {
-        return;
-      }
     },
   };
 }

--- a/src/hooks/task-session-manager/index.test.ts
+++ b/src/hooks/task-session-manager/index.test.ts
@@ -23,8 +23,19 @@ function createHook(options?: {
   return { hook };
 }
 
+function createMessages(sessionID: string, text = 'user message') {
+  return {
+    messages: [
+      {
+        info: { role: 'user', agent: 'orchestrator', sessionID },
+        parts: [{ type: 'text', text }],
+      },
+    ],
+  };
+}
+
 describe('task-session-manager hook', () => {
-  test('stores task sessions and injects resumable-session prompt block', async () => {
+  test('stores task sessions and injects resumable-session block into user message', async () => {
     const { hook } = createHook();
 
     await hook['tool.execute.before'](
@@ -54,14 +65,55 @@ describe('task-session-manager hook', () => {
       },
     );
 
+    const messages = createMessages('parent-1', 'do something');
+    await hook['experimental.chat.messages.transform']({}, messages);
+
+    const userMessage = messages.messages[0];
+    expect(userMessage.parts[0].text).toContain('<resumable_sessions>');
+    expect(userMessage.parts[0].text).toContain('### Resumable Sessions');
+    expect(userMessage.parts[0].text).toContain(
+      'explorer: exp-1 config schema',
+    );
+    expect(userMessage.parts[0].text).toContain('</resumable_sessions>');
+  });
+
+  test('system transform is no-op (cache-safe)', async () => {
+    const { hook } = createHook();
+
+    await hook['tool.execute.before'](
+      {
+        tool: 'task',
+        sessionID: 'parent-1',
+        callID: 'call-1',
+      },
+      {
+        args: {
+          subagent_type: 'explorer',
+          description: 'config schema',
+        },
+      },
+    );
+
+    await hook['tool.execute.after'](
+      {
+        tool: 'task',
+        sessionID: 'parent-1',
+        callID: 'call-1',
+      },
+      {
+        output:
+          'task_id: child-1 (for resuming to continue this task if needed)',
+      },
+    );
+
     const system = { system: ['base'] };
     await hook['experimental.chat.system.transform'](
       { sessionID: 'parent-1' },
       system,
     );
 
-    expect(system.system.join('\n')).toContain('### Resumable Sessions');
-    expect(system.system.join('\n')).toContain('explorer: exp-1 config schema');
+    expect(system.system).toEqual(['base']);
+    expect(system.system.join('\n')).not.toContain('Resumable Sessions');
   });
 
   test('resolves remembered aliases to real task ids before execution', async () => {
@@ -112,7 +164,7 @@ describe('task-session-manager hook', () => {
     expect(next.args.task_id).toBe('child-1');
   });
 
-  test('tracks files read by child sessions in resumable prompt context', async () => {
+  test('tracks files read by child sessions in resumable message context', async () => {
     const { hook } = createHook();
 
     await hook.event({
@@ -167,14 +219,12 @@ describe('task-session-manager hook', () => {
       },
     );
 
-    const system = { system: ['base'] };
-    await hook['experimental.chat.system.transform'](
-      { sessionID: 'parent-1' },
-      system,
-    );
+    const messages = createMessages('parent-1', 'do something');
+    await hook['experimental.chat.messages.transform']({}, messages);
 
-    expect(system.system.join('\n')).toContain('exp-1 session files');
-    expect(system.system.join('\n')).toContain(
+    const userMessage = messages.messages[0];
+    expect(userMessage.parts[0].text).toContain('exp-1 session files');
+    expect(userMessage.parts[0].text).toContain(
       'Context read by exp-1: src/index.ts (12 lines)',
     );
   });
@@ -235,13 +285,10 @@ describe('task-session-manager hook', () => {
       },
     );
 
-    const system = { system: ['base'] };
-    await hook['experimental.chat.system.transform'](
-      { sessionID: 'parent-1' },
-      system,
-    );
+    const messages = createMessages('parent-1', 'do something');
+    await hook['experimental.chat.messages.transform']({}, messages);
 
-    const prompt = system.system.join('\n');
+    const prompt = messages.messages[0].parts[0].text;
     expect(prompt).not.toContain('small.ts');
     expect(prompt).toContain('src/large.ts (12 lines)');
   });
@@ -281,14 +328,12 @@ describe('task-session-manager hook', () => {
       },
     );
 
-    const system = { system: ['base'] };
-    await hook['experimental.chat.system.transform'](
-      { sessionID: 'parent-1' },
-      system,
-    );
+    const messages = createMessages('parent-1', 'do something');
+    await hook['experimental.chat.messages.transform']({}, messages);
 
-    expect(system.system.join('\n')).toContain('src/repeat.ts (12 lines)');
-    expect(system.system.join('\n')).not.toContain('src/repeat.ts (24 lines)');
+    const prompt = messages.messages[0].parts[0].text;
+    expect(prompt).toContain('src/repeat.ts (12 lines)');
+    expect(prompt).not.toContain('src/repeat.ts (24 lines)');
   });
 
   test('uses configured read context thresholds', async () => {
@@ -333,13 +378,10 @@ describe('task-session-manager hook', () => {
       },
     );
 
-    const system = { system: ['base'] };
-    await hook['experimental.chat.system.transform'](
-      { sessionID: 'parent-1' },
-      system,
-    );
+    const messages = createMessages('parent-1', 'do something');
+    await hook['experimental.chat.messages.transform']({}, messages);
 
-    const prompt = system.system.join('\n');
+    const prompt = messages.messages[0].parts[0].text;
     expect(prompt).not.toContain('small.ts');
     expect(prompt).toContain('Context read by exp-1:');
     expect(prompt).toContain('(+1 more)');
@@ -380,13 +422,10 @@ describe('task-session-manager hook', () => {
       },
     );
 
-    const system = { system: ['base'] };
-    await hook['experimental.chat.system.transform'](
-      { sessionID: 'parent-1' },
-      system,
-    );
+    const messages = createMessages('parent-1', 'do something');
+    await hook['experimental.chat.messages.transform']({}, messages);
 
-    const prompt = system.system.join('\n');
+    const prompt = messages.messages[0].parts[0].text;
     expect(prompt).toContain('exp-1 unmanaged read');
     expect(prompt).not.toContain('Context read by exp-1');
   });
@@ -426,13 +465,10 @@ describe('task-session-manager hook', () => {
       );
     }
 
-    const system = { system: ['base'] };
-    await hook['experimental.chat.system.transform'](
-      { sessionID: 'parent-1' },
-      system,
-    );
+    const messages = createMessages('parent-1', 'do something');
+    await hook['experimental.chat.messages.transform']({}, messages);
 
-    const prompt = system.system.join('\n');
+    const prompt = messages.messages[0].parts[0].text;
     expect(prompt).not.toContain('exp-1 thread 1');
     expect(prompt).not.toContain('file-1.ts');
     expect(prompt).toContain('exp-2 thread 2');
@@ -498,12 +534,9 @@ describe('task-session-manager hook', () => {
       },
     );
 
-    const system = { system: ['base'] };
-    await hook['experimental.chat.system.transform'](
-      { sessionID: 'parent-1' },
-      system,
-    );
-    expect(system.system.join('\n')).not.toContain('exp-1');
+    const messages = createMessages('parent-1', 'do something');
+    await hook['experimental.chat.messages.transform']({}, messages);
+    expect(messages.messages[0].parts[0].text).not.toContain('exp-1');
   });
 
   test('drops resumed predecessor when success returns a new task id', async () => {
@@ -560,14 +593,12 @@ describe('task-session-manager hook', () => {
       },
     );
 
-    const system = { system: ['base'] };
-    await hook['experimental.chat.system.transform'](
-      { sessionID: 'parent-1' },
-      system,
-    );
+    const messages = createMessages('parent-1', 'do something');
+    await hook['experimental.chat.messages.transform']({}, messages);
 
-    expect(system.system.join('\n')).toContain('continue schema work');
-    expect(system.system.join('\n')).not.toContain('config schema');
+    const prompt = messages.messages[0].parts[0].text;
+    expect(prompt).toContain('continue schema work');
+    expect(prompt).not.toContain('config schema');
   });
 
   test('does not drop remembered session on non-runtime session text', async () => {
@@ -623,13 +654,10 @@ describe('task-session-manager hook', () => {
       },
     );
 
-    const system = { system: ['base'] };
-    await hook['experimental.chat.system.transform'](
-      { sessionID: 'parent-1' },
-      system,
-    );
+    const messages = createMessages('parent-1', 'do something');
+    await hook['experimental.chat.messages.transform']({}, messages);
 
-    expect(system.system.join('\n')).toContain('exp-1 config schema');
+    expect(messages.messages[0].parts[0].text).toContain('exp-1 config schema');
   });
 
   test('ignores sessions that are not orchestrator-managed', async () => {
@@ -660,13 +688,11 @@ describe('task-session-manager hook', () => {
       },
     );
 
-    const system = { system: ['base'] };
-    await hook['experimental.chat.system.transform'](
-      { sessionID: 'manual-1' },
-      system,
-    );
+    const messages = createMessages('manual-1', 'do something');
+    await hook['experimental.chat.messages.transform']({}, messages);
 
-    expect(system.system).toEqual(['base']);
+    // Message should remain unchanged
+    expect(messages.messages[0].parts[0].text).toBe('do something');
   });
 
   test('cleans up remembered sessions when parent or child is deleted', async () => {
@@ -704,12 +730,10 @@ describe('task-session-manager hook', () => {
       },
     });
 
-    const afterChildDelete = { system: ['base'] };
-    await hook['experimental.chat.system.transform'](
-      { sessionID: 'parent-1' },
-      afterChildDelete,
-    );
-    expect(afterChildDelete.system).toEqual(['base']);
+    const messages = createMessages('parent-1', 'do something');
+    await hook['experimental.chat.messages.transform']({}, messages);
+    // Message should remain unchanged since session was deleted
+    expect(messages.messages[0].parts[0].text).toBe('do something');
   });
 
   test('cleans pending calls when parent session is deleted', async () => {
@@ -748,13 +772,11 @@ describe('task-session-manager hook', () => {
       },
     );
 
-    const system = { system: ['base'] };
-    await hook['experimental.chat.system.transform'](
-      { sessionID: 'parent-1' },
-      system,
-    );
+    const messages = createMessages('parent-1', 'do something');
+    await hook['experimental.chat.messages.transform']({}, messages);
 
-    expect(system.system).toEqual(['base']);
+    // Message should remain unchanged since session was deleted
+    expect(messages.messages[0].parts[0].text).toBe('do something');
   });
 
   test('deduplicates pending call order when a resume call is recorded twice', async () => {
@@ -835,13 +857,10 @@ describe('task-session-manager hook', () => {
       },
     );
 
-    const system = { system: ['base'] };
-    await hook['experimental.chat.system.transform'](
-      { sessionID: 'parent-1' },
-      system,
-    );
+    const messages = createMessages('parent-1', 'do something');
+    await hook['experimental.chat.messages.transform']({}, messages);
 
-    expect(system.system.join('\n')).toContain(
+    expect(messages.messages[0].parts[0].text).toContain(
       'oracle: ora-1 architecture review',
     );
   });

--- a/src/hooks/task-session-manager/index.test.ts
+++ b/src/hooks/task-session-manager/index.test.ts
@@ -77,43 +77,9 @@ describe('task-session-manager hook', () => {
     expect(userMessage.parts[0].text).toContain('</resumable_sessions>');
   });
 
-  test('system transform is no-op (cache-safe)', async () => {
+  test('does not expose a system transform for resumable sessions', async () => {
     const { hook } = createHook();
-
-    await hook['tool.execute.before'](
-      {
-        tool: 'task',
-        sessionID: 'parent-1',
-        callID: 'call-1',
-      },
-      {
-        args: {
-          subagent_type: 'explorer',
-          description: 'config schema',
-        },
-      },
-    );
-
-    await hook['tool.execute.after'](
-      {
-        tool: 'task',
-        sessionID: 'parent-1',
-        callID: 'call-1',
-      },
-      {
-        output:
-          'task_id: child-1 (for resuming to continue this task if needed)',
-      },
-    );
-
-    const system = { system: ['base'] };
-    await hook['experimental.chat.system.transform'](
-      { sessionID: 'parent-1' },
-      system,
-    );
-
-    expect(system.system).toEqual(['base']);
-    expect(system.system.join('\n')).not.toContain('Resumable Sessions');
+    expect('experimental.chat.system.transform' in hook).toBe(false);
   });
 
   test('resolves remembered aliases to real task ids before execution', async () => {

--- a/src/hooks/task-session-manager/index.ts
+++ b/src/hooks/task-session-manager/index.ts
@@ -6,6 +6,7 @@ import {
   deriveTaskSessionLabel,
   parseTaskIdFromTaskOutput,
   SessionManager,
+  SLIM_INTERNAL_INITIATOR_MARKER,
 } from '../../utils';
 
 interface TaskArgs {
@@ -42,6 +43,24 @@ interface PendingContextFile {
   lines: Set<number>;
   lastReadAt: number;
 }
+
+interface ChatMessagePart {
+  type: string;
+  text?: string;
+  [key: string]: unknown;
+}
+
+interface ChatMessage {
+  info: {
+    role: string;
+    agent?: string;
+    sessionID?: string;
+  };
+  parts: ChatMessagePart[];
+}
+
+const RESUMABLE_SESSIONS_START = '<resumable_sessions>';
+const RESUMABLE_SESSIONS_END = '</resumable_sessions>';
 
 function isAgentName(value: unknown): value is AgentName {
   return typeof value === 'string' && AGENT_NAME_SET.has(value as AgentName);
@@ -318,15 +337,50 @@ export function createTaskSessionManagerHook(
 
     'experimental.chat.system.transform': async (
       input: { sessionID?: string },
-      output: { system: string[] },
+      _output: { system: string[] },
     ): Promise<void> => {
       if (!input.sessionID || !options.shouldManageSession(input.sessionID)) {
         return;
       }
+      // Kept as a no-op for hook shape compatibility. Dynamic resumable
+      // sessions are injected into request-local message context instead of
+      // the cached system prompt.
+    },
 
-      const reminder = sessionManager.formatForPrompt(input.sessionID);
-      if (!reminder) return;
-      output.system.push(reminder);
+    'experimental.chat.messages.transform': async (
+      _input: Record<string, never>,
+      output: { messages: ChatMessage[] },
+    ): Promise<void> => {
+      for (let i = output.messages.length - 1; i >= 0; i -= 1) {
+        const message = output.messages[i];
+        if (message.info.role !== 'user') continue;
+        if (message.info.agent && message.info.agent !== 'orchestrator') return;
+        if (
+          !message.info.sessionID ||
+          !options.shouldManageSession(message.info.sessionID)
+        ) {
+          return;
+        }
+
+        const reminder = sessionManager.formatForPrompt(message.info.sessionID);
+        if (!reminder) return;
+
+        const textPart = message.parts.find(
+          (part) => part.type === 'text' && typeof part.text === 'string',
+        );
+        if (!textPart) return;
+        if (textPart.text?.includes(SLIM_INTERNAL_INITIATOR_MARKER)) return;
+        if (textPart.text?.includes(RESUMABLE_SESSIONS_START)) return;
+
+        textPart.text = [
+          textPart.text ?? '',
+          '',
+          RESUMABLE_SESSIONS_START,
+          reminder,
+          RESUMABLE_SESSIONS_END,
+        ].join('\n');
+        return;
+      }
     },
 
     event: async (input: {

--- a/src/hooks/task-session-manager/index.ts
+++ b/src/hooks/task-session-manager/index.ts
@@ -335,18 +335,6 @@ export function createTaskSessionManagerHook(
       pruneContext();
     },
 
-    'experimental.chat.system.transform': async (
-      input: { sessionID?: string },
-      _output: { system: string[] },
-    ): Promise<void> => {
-      if (!input.sessionID || !options.shouldManageSession(input.sessionID)) {
-        return;
-      }
-      // Kept as a no-op for hook shape compatibility. Dynamic resumable
-      // sessions are injected into request-local message context instead of
-      // the cached system prompt.
-    },
-
     'experimental.chat.messages.transform': async (
       _input: Record<string, never>,
       output: { messages: ChatMessage[] },

--- a/src/hooks/todo-continuation/index.test.ts
+++ b/src/hooks/todo-continuation/index.test.ts
@@ -187,6 +187,32 @@ describe('createTodoContinuationHook', () => {
       );
     });
 
+    test('compaction-like transform does not consume pending reminder', async () => {
+      const ctx = createMockContext({
+        todoResult: {
+          data: [
+            { id: '1', content: 'todo1', status: 'pending', priority: 'high' },
+          ],
+        },
+      });
+      const hook = createTodoContinuationHook(ctx);
+      const live = userMessages('primera request', 'main1', 'orchestrator');
+      const compactionClone = structuredClone(live);
+
+      await hook.handleMessagesTransform(live);
+      await hook.handleToolExecuteAfter({
+        tool: 'todowrite',
+        sessionID: 'main1',
+      });
+      await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 'main1' });
+
+      await hook.handleMessagesTransform(compactionClone);
+      expect(allMessageText(compactionClone)).toContain(TODO_HYGIENE_REMINDER);
+
+      await hook.handleMessagesTransform(live);
+      expect(allMessageText(live)).toContain(TODO_HYGIENE_REMINDER);
+    });
+
     test('new request clears stale pending reminder state', async () => {
       const ctx = createMockContext({
         todoResult: {

--- a/src/hooks/todo-continuation/index.test.ts
+++ b/src/hooks/todo-continuation/index.test.ts
@@ -115,18 +115,21 @@ describe('createTodoContinuationHook', () => {
         },
       });
       const hook = createTodoContinuationHook(ctx);
-      const system = { system: ['base'] };
+      const toolOutput = { output: 'task result' };
 
       await hook.handleMessagesTransform(
         userMessages('continue previous work', 'sub1', 'explorer'),
       );
-      await hook.handleToolExecuteAfter({ tool: 'task', sessionID: 'sub1' });
-      await hook.handleChatSystemTransform({ sessionID: 'sub1' }, system);
+      await hook.handleToolExecuteAfter(
+        { tool: 'task', sessionID: 'sub1' },
+        toolOutput,
+      );
 
-      expect(system.system.join('\n')).not.toContain(TODO_HYGIENE_REMINDER);
+      expect(toolOutput.output).toBe('task result');
+      expect(toolOutput.output).not.toContain(TODO_HYGIENE_REMINDER);
     });
 
-    test('does not inject anything at request start before todowrite', async () => {
+    test('system transform is no-op (cache-safe)', async () => {
       const ctx = createMockContext({
         todoResult: {
           data: [
@@ -149,12 +152,45 @@ describe('createTodoContinuationHook', () => {
           'orchestrator',
         ),
       );
+      await hook.handleToolExecuteAfter({
+        tool: 'todowrite',
+        sessionID: 'main1',
+      });
+      await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 'main1' });
       await hook.handleChatSystemTransform({ sessionID: 'main1' }, system);
 
+      expect(system.system).toEqual(['base']);
       expect(system.system.join('\n')).not.toContain(TODO_HYGIENE_REMINDER);
       expect(system.system.join('\n')).not.toContain(
         TODO_FINAL_ACTIVE_REMINDER,
       );
+    });
+
+    test('injects hygiene reminder into tool output after todowrite activity', async () => {
+      const ctx = createMockContext({
+        todoResult: {
+          data: [
+            { id: '1', content: 'todo1', status: 'pending', priority: 'high' },
+          ],
+        },
+      });
+      const hook = createTodoContinuationHook(ctx);
+      const toolOutput = { output: 'read result' };
+
+      await hook.handleMessagesTransform(
+        userMessages('primera request', 'main1', 'orchestrator'),
+      );
+      await hook.handleToolExecuteAfter({
+        tool: 'todowrite',
+        sessionID: 'main1',
+      });
+      await hook.handleToolExecuteAfter(
+        { tool: 'read', sessionID: 'main1' },
+        toolOutput,
+      );
+
+      expect(toolOutput.output).toContain(TODO_HYGIENE_REMINDER);
+      expect(toolOutput.output).toContain('<internal_reminder>');
     });
 
     test('new requests clear stale pending reminder state', async () => {
@@ -166,8 +202,8 @@ describe('createTodoContinuationHook', () => {
         },
       });
       const hook = createTodoContinuationHook(ctx);
-      const blocked = { system: ['base'] };
-      const allowed = { system: ['base'] };
+      const firstOutput = { output: 'first read' };
+      const secondOutput = { output: 'second read' };
 
       await hook.handleMessagesTransform(
         userMessages('primera request', 'main1', 'orchestrator'),
@@ -176,21 +212,27 @@ describe('createTodoContinuationHook', () => {
         tool: 'todowrite',
         sessionID: 'main1',
       });
-      await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 'main1' });
+      await hook.handleToolExecuteAfter(
+        { tool: 'read', sessionID: 'main1' },
+        firstOutput,
+      );
+
       await hook.handleMessagesTransform(
         userMessages('segunda request distinta', 'main1', 'orchestrator'),
       );
-      await hook.handleChatSystemTransform({ sessionID: 'main1' }, blocked);
+      // First output should have reminder from first round
+      expect(firstOutput.output).toContain(TODO_HYGIENE_REMINDER);
 
       await hook.handleToolExecuteAfter({
         tool: 'todowrite',
         sessionID: 'main1',
       });
-      await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 'main1' });
-      await hook.handleChatSystemTransform({ sessionID: 'main1' }, allowed);
+      await hook.handleToolExecuteAfter(
+        { tool: 'read', sessionID: 'main1' },
+        secondOutput,
+      );
 
-      expect(blocked.system.join('\n')).not.toContain(TODO_HYGIENE_REMINDER);
-      expect(allowed.system.join('\n')).toContain(TODO_HYGIENE_REMINDER);
+      expect(secondOutput.output).toContain(TODO_HYGIENE_REMINDER);
     });
 
     test('attachment-only requests still reset stale pending reminder state', async () => {
@@ -202,8 +244,8 @@ describe('createTodoContinuationHook', () => {
         },
       });
       const hook = createTodoContinuationHook(ctx);
-      const blocked = { system: ['base'] };
-      const allowed = { system: ['base'] };
+      const firstOutput = { output: 'first read' };
+      const secondOutput = { output: 'second read' };
 
       await hook.handleMessagesTransform(
         userMessages('primera request', 'main1', 'orchestrator'),
@@ -212,21 +254,27 @@ describe('createTodoContinuationHook', () => {
         tool: 'todowrite',
         sessionID: 'main1',
       });
-      await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 'main1' });
+      await hook.handleToolExecuteAfter(
+        { tool: 'read', sessionID: 'main1' },
+        firstOutput,
+      );
+
       await hook.handleMessagesTransform(
         userMessages('', 'main1', 'orchestrator', [{ type: 'image' }]),
       );
-      await hook.handleChatSystemTransform({ sessionID: 'main1' }, blocked);
+      // First output should have reminder
+      expect(firstOutput.output).toContain(TODO_HYGIENE_REMINDER);
 
       await hook.handleToolExecuteAfter({
         tool: 'todowrite',
         sessionID: 'main1',
       });
-      await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 'main1' });
-      await hook.handleChatSystemTransform({ sessionID: 'main1' }, allowed);
+      await hook.handleToolExecuteAfter(
+        { tool: 'read', sessionID: 'main1' },
+        secondOutput,
+      );
 
-      expect(blocked.system.join('\n')).not.toContain(TODO_HYGIENE_REMINDER);
-      expect(allowed.system.join('\n')).toContain(TODO_HYGIENE_REMINDER);
+      expect(secondOutput.output).toContain(TODO_HYGIENE_REMINDER);
     });
 
     test('falls back to known orchestrator session when transform message lacks sessionID', async () => {
@@ -243,7 +291,7 @@ describe('createTodoContinuationHook', () => {
         },
       });
       const hook = createTodoContinuationHook(ctx);
-      const system = { system: ['base'] };
+      const todowriteOutput = { output: 'todowrite result' };
 
       hook.handleChatMessage({ sessionID: 'main1', agent: 'orchestrator' });
       await hook.handleMessagesTransform({
@@ -254,14 +302,16 @@ describe('createTodoContinuationHook', () => {
           },
         ],
       });
-      await hook.handleToolExecuteAfter({
-        tool: 'todowrite',
-        sessionID: 'main1',
-      });
-      await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 'main1' });
-      await hook.handleChatSystemTransform({ sessionID: 'main1' }, system);
+      // Final-active reminder is injected directly into todowrite output when state is final-active
+      await hook.handleToolExecuteAfter(
+        {
+          tool: 'todowrite',
+          sessionID: 'main1',
+        },
+        todowriteOutput,
+      );
 
-      expect(system.system.join('\n')).toContain(TODO_FINAL_ACTIVE_REMINDER);
+      expect(todowriteOutput.output).toContain(TODO_FINAL_ACTIVE_REMINDER);
     });
 
     test('does not promote sessions with missing agent metadata to orchestrator', async () => {
@@ -273,18 +323,19 @@ describe('createTodoContinuationHook', () => {
         },
       });
       const hook = createTodoContinuationHook(ctx);
-      const system = { system: ['base'] };
+      const toolOutput = { output: 'task result' };
 
       await hook.handleMessagesTransform(
         userMessages('continue previous work', 'sub1'),
       );
-      await hook.handleToolExecuteAfter({ tool: 'task', sessionID: 'sub1' });
-      await hook.handleChatSystemTransform({ sessionID: 'sub1' }, system);
-
-      expect(system.system.join('\n')).not.toContain(TODO_HYGIENE_REMINDER);
-      expect(system.system.join('\n')).not.toContain(
-        TODO_FINAL_ACTIVE_REMINDER,
+      await hook.handleToolExecuteAfter(
+        { tool: 'task', sessionID: 'sub1' },
+        toolOutput,
       );
+
+      expect(toolOutput.output).toBe('task result');
+      expect(toolOutput.output).not.toContain(TODO_HYGIENE_REMINDER);
+      expect(toolOutput.output).not.toContain(TODO_FINAL_ACTIVE_REMINDER);
     });
 
     test('known orchestrator sessions still process request boundaries when agent metadata is missing', async () => {
@@ -301,20 +352,22 @@ describe('createTodoContinuationHook', () => {
         },
       });
       const hook = createTodoContinuationHook(ctx);
-      const system = { system: ['base'] };
+      const todowriteOutput = { output: 'todowrite result' };
 
       hook.handleChatMessage({ sessionID: 'main1', agent: 'orchestrator' });
       await hook.handleMessagesTransform(
         userMessages('new request boundary', 'main1'),
       );
-      await hook.handleToolExecuteAfter({
-        tool: 'todowrite',
-        sessionID: 'main1',
-      });
-      await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 'main1' });
-      await hook.handleChatSystemTransform({ sessionID: 'main1' }, system);
+      // Final-active reminder is injected directly into todowrite output when state is final-active
+      await hook.handleToolExecuteAfter(
+        {
+          tool: 'todowrite',
+          sessionID: 'main1',
+        },
+        todowriteOutput,
+      );
 
-      expect(system.system.join('\n')).toContain(TODO_FINAL_ACTIVE_REMINDER);
+      expect(todowriteOutput.output).toContain(TODO_FINAL_ACTIVE_REMINDER);
     });
 
     test('the same user message id does not reset the request when its array index shifts', async () => {
@@ -326,7 +379,7 @@ describe('createTodoContinuationHook', () => {
         },
       });
       const hook = createTodoContinuationHook(ctx);
-      const system = { system: ['base'] };
+      const toolOutput = { output: 'read result' };
 
       await hook.handleMessagesTransform(
         userMessages(
@@ -341,7 +394,10 @@ describe('createTodoContinuationHook', () => {
         tool: 'todowrite',
         sessionID: 'main1',
       });
-      await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 'main1' });
+      await hook.handleToolExecuteAfter(
+        { tool: 'read', sessionID: 'main1' },
+        toolOutput,
+      );
       await hook.handleMessagesTransform({
         messages: [
           {
@@ -359,9 +415,9 @@ describe('createTodoContinuationHook', () => {
           },
         ],
       });
-      await hook.handleChatSystemTransform({ sessionID: 'main1' }, system);
 
-      expect(system.system.join('\n')).toContain(TODO_HYGIENE_REMINDER);
+      // Tool output should still have reminder since it's the same request
+      expect(toolOutput.output).toContain(TODO_HYGIENE_REMINDER);
     });
 
     test('a new user message id resets the request even if the text is unchanged', async () => {
@@ -373,8 +429,8 @@ describe('createTodoContinuationHook', () => {
         },
       });
       const hook = createTodoContinuationHook(ctx);
-      const blocked = { system: ['base'] };
-      const allowed = { system: ['base'] };
+      const firstOutput = { output: 'first read' };
+      const secondOutput = { output: 'second read' };
 
       await hook.handleMessagesTransform(
         userMessages('same text', 'main1', 'orchestrator', undefined, 'u1'),
@@ -383,21 +439,27 @@ describe('createTodoContinuationHook', () => {
         tool: 'todowrite',
         sessionID: 'main1',
       });
-      await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 'main1' });
+      await hook.handleToolExecuteAfter(
+        { tool: 'read', sessionID: 'main1' },
+        firstOutput,
+      );
+
       await hook.handleMessagesTransform(
         userMessages('same text', 'main1', 'orchestrator', undefined, 'u2'),
       );
-      await hook.handleChatSystemTransform({ sessionID: 'main1' }, blocked);
+      // First output should have reminder
+      expect(firstOutput.output).toContain(TODO_HYGIENE_REMINDER);
 
       await hook.handleToolExecuteAfter({
         tool: 'todowrite',
         sessionID: 'main1',
       });
-      await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 'main1' });
-      await hook.handleChatSystemTransform({ sessionID: 'main1' }, allowed);
+      await hook.handleToolExecuteAfter(
+        { tool: 'read', sessionID: 'main1' },
+        secondOutput,
+      );
 
-      expect(blocked.system.join('\n')).not.toContain(TODO_HYGIENE_REMINDER);
-      expect(allowed.system.join('\n')).toContain(TODO_HYGIENE_REMINDER);
+      expect(secondOutput.output).toContain(TODO_HYGIENE_REMINDER);
     });
 
     test('a repeated text without message ids still resets when a later user turn appears', async () => {
@@ -409,8 +471,8 @@ describe('createTodoContinuationHook', () => {
         },
       });
       const hook = createTodoContinuationHook(ctx);
-      const blocked = { system: ['base'] };
-      const allowed = { system: ['base'] };
+      const firstOutput = { output: 'first read' };
+      const secondOutput = { output: 'second read' };
 
       await hook.handleMessagesTransform(
         userMessages('same text', 'main1', 'orchestrator'),
@@ -419,7 +481,11 @@ describe('createTodoContinuationHook', () => {
         tool: 'todowrite',
         sessionID: 'main1',
       });
-      await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 'main1' });
+      await hook.handleToolExecuteAfter(
+        { tool: 'read', sessionID: 'main1' },
+        firstOutput,
+      );
+
       await hook.handleMessagesTransform({
         messages: [
           {
@@ -436,17 +502,19 @@ describe('createTodoContinuationHook', () => {
           },
         ],
       });
-      await hook.handleChatSystemTransform({ sessionID: 'main1' }, blocked);
+      // First output should have reminder
+      expect(firstOutput.output).toContain(TODO_HYGIENE_REMINDER);
 
       await hook.handleToolExecuteAfter({
         tool: 'todowrite',
         sessionID: 'main1',
       });
-      await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 'main1' });
-      await hook.handleChatSystemTransform({ sessionID: 'main1' }, allowed);
+      await hook.handleToolExecuteAfter(
+        { tool: 'read', sessionID: 'main1' },
+        secondOutput,
+      );
 
-      expect(blocked.system.join('\n')).not.toContain(TODO_HYGIENE_REMINDER);
-      expect(allowed.system.join('\n')).toContain(TODO_HYGIENE_REMINDER);
+      expect(secondOutput.output).toContain(TODO_HYGIENE_REMINDER);
     });
 
     test('messages without inferable sessionID clear stale state for known orchestrators', async () => {
@@ -458,7 +526,7 @@ describe('createTodoContinuationHook', () => {
         },
       });
       const hook = createTodoContinuationHook(ctx);
-      const system = { system: ['base'] };
+      const toolOutput = { output: 'read result' };
 
       hook.handleChatMessage({ sessionID: 'main1', agent: 'orchestrator' });
       hook.handleChatMessage({ sessionID: 'main2', agent: 'orchestrator' });
@@ -469,7 +537,11 @@ describe('createTodoContinuationHook', () => {
         tool: 'todowrite',
         sessionID: 'main1',
       });
-      await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 'main1' });
+      await hook.handleToolExecuteAfter(
+        { tool: 'read', sessionID: 'main1' },
+        toolOutput,
+      );
+
       await hook.handleMessagesTransform({
         messages: [
           {
@@ -478,12 +550,9 @@ describe('createTodoContinuationHook', () => {
           },
         ],
       });
-      await hook.handleChatSystemTransform({ sessionID: 'main1' }, system);
 
-      expect(system.system.join('\n')).not.toContain(TODO_HYGIENE_REMINDER);
-      expect(system.system.join('\n')).not.toContain(
-        TODO_FINAL_ACTIVE_REMINDER,
-      );
+      // Tool output should still have reminder from first round
+      expect(toolOutput.output).toContain(TODO_HYGIENE_REMINDER);
     });
 
     test('does not inject from continuation-like wording alone', async () => {
@@ -500,7 +569,7 @@ describe('createTodoContinuationHook', () => {
         },
       });
       const hook = createTodoContinuationHook(ctx);
-      const system = { system: ['base'] };
+      const toolOutput = { output: 'read result' };
 
       await hook.handleMessagesTransform(
         userMessages(
@@ -509,12 +578,14 @@ describe('createTodoContinuationHook', () => {
           'orchestrator',
         ),
       );
-      await hook.handleChatSystemTransform({ sessionID: 'main1' }, system);
-
-      expect(system.system.join('\n')).not.toContain(TODO_HYGIENE_REMINDER);
-      expect(system.system.join('\n')).not.toContain(
-        TODO_FINAL_ACTIVE_REMINDER,
+      await hook.handleToolExecuteAfter(
+        { tool: 'read', sessionID: 'main1' },
+        toolOutput,
       );
+
+      expect(toolOutput.output).toBe('read result');
+      expect(toolOutput.output).not.toContain(TODO_HYGIENE_REMINDER);
+      expect(toolOutput.output).not.toContain(TODO_FINAL_ACTIVE_REMINDER);
     });
 
     test('rearms on activity after todowrite even if request wording is continuation-like', async () => {
@@ -531,19 +602,21 @@ describe('createTodoContinuationHook', () => {
         },
       });
       const hook = createTodoContinuationHook(ctx);
-      const system = { system: ['base'] };
+      const todowriteOutput = { output: 'todowrite result' };
 
       await hook.handleMessagesTransform(
         userMessages('finish the previous work', 'main1', 'orchestrator'),
       );
-      await hook.handleToolExecuteAfter({
-        tool: 'todowrite',
-        sessionID: 'main1',
-      });
-      await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 'main1' });
-      await hook.handleChatSystemTransform({ sessionID: 'main1' }, system);
+      // Final-active reminder is injected directly into todowrite output when state is final-active
+      await hook.handleToolExecuteAfter(
+        {
+          tool: 'todowrite',
+          sessionID: 'main1',
+        },
+        todowriteOutput,
+      );
 
-      expect(system.system.join('\n')).toContain(TODO_FINAL_ACTIVE_REMINDER);
+      expect(todowriteOutput.output).toContain(TODO_FINAL_ACTIVE_REMINDER);
     });
 
     test('final active todo after todowrite uses the stronger finishing reminder', async () => {
@@ -560,19 +633,21 @@ describe('createTodoContinuationHook', () => {
         },
       });
       const hook = createTodoContinuationHook(ctx);
-      const system = { system: ['base'] };
+      const toolOutput = { output: 'todowrite result' };
 
       await hook.handleMessagesTransform(
         userMessages('haz esto', 'main1', 'orchestrator'),
       );
-      await hook.handleToolExecuteAfter({
-        tool: 'todowrite',
-        sessionID: 'main1',
-      });
-      await hook.handleChatSystemTransform({ sessionID: 'main1' }, system);
+      await hook.handleToolExecuteAfter(
+        {
+          tool: 'todowrite',
+          sessionID: 'main1',
+        },
+        toolOutput,
+      );
 
-      expect(system.system.join('\n')).toContain(TODO_FINAL_ACTIVE_REMINDER);
-      expect(system.system.join('\n')).not.toContain(TODO_HYGIENE_REMINDER);
+      expect(toolOutput.output).toContain(TODO_FINAL_ACTIVE_REMINDER);
+      expect(toolOutput.output).not.toContain(TODO_HYGIENE_REMINDER);
     });
   });
 

--- a/src/hooks/todo-continuation/index.test.ts
+++ b/src/hooks/todo-continuation/index.test.ts
@@ -84,6 +84,16 @@ describe('createTodoContinuationHook', () => {
     };
   }
 
+  function allMessageText(output: {
+    messages: Array<{ parts: Array<{ type?: string; text?: string }> }>;
+  }) {
+    return output.messages
+      .flatMap((message) => message.parts)
+      .filter((part) => part.type === 'text' && typeof part.text === 'string')
+      .map((part) => part.text)
+      .join('\n');
+  }
+
   describe('tool toggle', () => {
     test('calling auto_continue execute with { enabled: true } sets state', async () => {
       const ctx = createMockContext();
@@ -147,7 +157,7 @@ describe('createTodoContinuationHook', () => {
       expect('handleChatSystemTransform' in hook).toBe(false);
     });
 
-    test('injects hygiene reminder into tool output after todowrite activity', async () => {
+    test('injects hygiene reminder into latest user message after todowrite activity', async () => {
       const ctx = createMockContext({
         todoResult: {
           data: [
@@ -156,11 +166,10 @@ describe('createTodoContinuationHook', () => {
         },
       });
       const hook = createTodoContinuationHook(ctx);
+      const output = userMessages('primera request', 'main1', 'orchestrator');
       const toolOutput = { output: 'read result' };
 
-      await hook.handleMessagesTransform(
-        userMessages('primera request', 'main1', 'orchestrator'),
-      );
+      await hook.handleMessagesTransform(output);
       await hook.handleToolExecuteAfter({
         tool: 'todowrite',
         sessionID: 'main1',
@@ -169,12 +178,16 @@ describe('createTodoContinuationHook', () => {
         { tool: 'read', sessionID: 'main1' },
         toolOutput,
       );
+      await hook.handleMessagesTransform(output);
 
-      expect(toolOutput.output).toContain(TODO_HYGIENE_REMINDER);
-      expect(toolOutput.output).toContain('<internal_reminder>');
+      expect(toolOutput.output).toBe('read result');
+      expect(allMessageText(output)).toContain(TODO_HYGIENE_REMINDER);
+      expect(allMessageText(output)).toContain(
+        '<instruction name="todo_hygiene">',
+      );
     });
 
-    test('new requests clear stale pending reminder state', async () => {
+    test('new request clears stale pending reminder state', async () => {
       const ctx = createMockContext({
         todoResult: {
           data: [
@@ -183,40 +196,39 @@ describe('createTodoContinuationHook', () => {
         },
       });
       const hook = createTodoContinuationHook(ctx);
-      const firstOutput = { output: 'first read' };
-      const secondOutput = { output: 'second read' };
-
-      await hook.handleMessagesTransform(
-        userMessages('primera request', 'main1', 'orchestrator'),
+      const first = userMessages('primera request', 'main1', 'orchestrator');
+      const blocked = userMessages(
+        'segunda request distinta',
+        'main1',
+        'orchestrator',
       );
+      const allowed = userMessages(
+        'segunda request distinta',
+        'main1',
+        'orchestrator',
+      );
+
+      await hook.handleMessagesTransform(first);
       await hook.handleToolExecuteAfter({
         tool: 'todowrite',
         sessionID: 'main1',
       });
-      await hook.handleToolExecuteAfter(
-        { tool: 'read', sessionID: 'main1' },
-        firstOutput,
-      );
+      await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 'main1' });
 
-      await hook.handleMessagesTransform(
-        userMessages('segunda request distinta', 'main1', 'orchestrator'),
-      );
-      // First output should have reminder from first round
-      expect(firstOutput.output).toContain(TODO_HYGIENE_REMINDER);
+      await hook.handleMessagesTransform(blocked);
+      expect(allMessageText(blocked)).not.toContain(TODO_HYGIENE_REMINDER);
 
       await hook.handleToolExecuteAfter({
         tool: 'todowrite',
         sessionID: 'main1',
       });
-      await hook.handleToolExecuteAfter(
-        { tool: 'read', sessionID: 'main1' },
-        secondOutput,
-      );
+      await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 'main1' });
+      await hook.handleMessagesTransform(allowed);
 
-      expect(secondOutput.output).toContain(TODO_HYGIENE_REMINDER);
+      expect(allMessageText(allowed)).toContain(TODO_HYGIENE_REMINDER);
     });
 
-    test('attachment-only requests still reset stale pending reminder state', async () => {
+    test('attachment-only requests reset stale state without synthetic text parts', async () => {
       const ctx = createMockContext({
         todoResult: {
           data: [
@@ -225,37 +237,24 @@ describe('createTodoContinuationHook', () => {
         },
       });
       const hook = createTodoContinuationHook(ctx);
-      const firstOutput = { output: 'first read' };
-      const secondOutput = { output: 'second read' };
+      const first = userMessages('primera request', 'main1', 'orchestrator');
+      const attachmentOnly = userMessages('', 'main1', 'orchestrator', [
+        { type: 'image' },
+      ]);
 
-      await hook.handleMessagesTransform(
-        userMessages('primera request', 'main1', 'orchestrator'),
-      );
+      await hook.handleMessagesTransform(first);
       await hook.handleToolExecuteAfter({
         tool: 'todowrite',
         sessionID: 'main1',
       });
-      await hook.handleToolExecuteAfter(
-        { tool: 'read', sessionID: 'main1' },
-        firstOutput,
-      );
+      await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 'main1' });
 
-      await hook.handleMessagesTransform(
-        userMessages('', 'main1', 'orchestrator', [{ type: 'image' }]),
-      );
-      // First output should have reminder
-      expect(firstOutput.output).toContain(TODO_HYGIENE_REMINDER);
+      await hook.handleMessagesTransform(attachmentOnly);
 
-      await hook.handleToolExecuteAfter({
-        tool: 'todowrite',
-        sessionID: 'main1',
-      });
-      await hook.handleToolExecuteAfter(
-        { tool: 'read', sessionID: 'main1' },
-        secondOutput,
+      expect(attachmentOnly.messages[0].parts).toHaveLength(1);
+      expect(allMessageText(attachmentOnly)).not.toContain(
+        TODO_HYGIENE_REMINDER,
       );
-
-      expect(secondOutput.output).toContain(TODO_HYGIENE_REMINDER);
     });
 
     test('falls back to known orchestrator session when transform message lacks sessionID', async () => {
@@ -272,27 +271,24 @@ describe('createTodoContinuationHook', () => {
         },
       });
       const hook = createTodoContinuationHook(ctx);
-      const todowriteOutput = { output: 'todowrite result' };
-
-      hook.handleChatMessage({ sessionID: 'main1', agent: 'orchestrator' });
-      await hook.handleMessagesTransform({
+      const output = {
         messages: [
           {
             info: { role: 'user', agent: 'orchestrator' },
             parts: [{ type: 'text', text: 'new request boundary' }],
           },
         ],
-      });
-      // Final-active reminder is injected directly into todowrite output when state is final-active
-      await hook.handleToolExecuteAfter(
-        {
-          tool: 'todowrite',
-          sessionID: 'main1',
-        },
-        todowriteOutput,
-      );
+      };
 
-      expect(todowriteOutput.output).toContain(TODO_FINAL_ACTIVE_REMINDER);
+      hook.handleChatMessage({ sessionID: 'main1', agent: 'orchestrator' });
+      await hook.handleMessagesTransform(output);
+      await hook.handleToolExecuteAfter({
+        tool: 'todowrite',
+        sessionID: 'main1',
+      });
+      await hook.handleMessagesTransform(output);
+
+      expect(allMessageText(output)).toContain(TODO_FINAL_ACTIVE_REMINDER);
     });
 
     test('does not promote sessions with missing agent metadata to orchestrator', async () => {
@@ -333,25 +329,20 @@ describe('createTodoContinuationHook', () => {
         },
       });
       const hook = createTodoContinuationHook(ctx);
-      const todowriteOutput = { output: 'todowrite result' };
+      const output = userMessages('new request boundary', 'main1');
 
       hook.handleChatMessage({ sessionID: 'main1', agent: 'orchestrator' });
-      await hook.handleMessagesTransform(
-        userMessages('new request boundary', 'main1'),
-      );
-      // Final-active reminder is injected directly into todowrite output when state is final-active
-      await hook.handleToolExecuteAfter(
-        {
-          tool: 'todowrite',
-          sessionID: 'main1',
-        },
-        todowriteOutput,
-      );
+      await hook.handleMessagesTransform(output);
+      await hook.handleToolExecuteAfter({
+        tool: 'todowrite',
+        sessionID: 'main1',
+      });
+      await hook.handleMessagesTransform(output);
 
-      expect(todowriteOutput.output).toContain(TODO_FINAL_ACTIVE_REMINDER);
+      expect(allMessageText(output)).toContain(TODO_FINAL_ACTIVE_REMINDER);
     });
 
-    test('the same user message id does not reset the request when its array index shifts', async () => {
+    test('the same user message id consumes pending reminder even if array index shifts', async () => {
       const ctx = createMockContext({
         todoResult: {
           data: [
@@ -360,26 +351,7 @@ describe('createTodoContinuationHook', () => {
         },
       });
       const hook = createTodoContinuationHook(ctx);
-      const toolOutput = { output: 'read result' };
-
-      await hook.handleMessagesTransform(
-        userMessages(
-          'request boundary',
-          'main1',
-          'orchestrator',
-          undefined,
-          'u1',
-        ),
-      );
-      await hook.handleToolExecuteAfter({
-        tool: 'todowrite',
-        sessionID: 'main1',
-      });
-      await hook.handleToolExecuteAfter(
-        { tool: 'read', sessionID: 'main1' },
-        toolOutput,
-      );
-      await hook.handleMessagesTransform({
+      const shifted = {
         messages: [
           {
             info: { role: 'assistant', sessionID: 'main1' },
@@ -395,13 +367,28 @@ describe('createTodoContinuationHook', () => {
             parts: [{ type: 'text', text: 'request boundary' }],
           },
         ],
-      });
+      };
 
-      // Tool output should still have reminder since it's the same request
-      expect(toolOutput.output).toContain(TODO_HYGIENE_REMINDER);
+      await hook.handleMessagesTransform(
+        userMessages(
+          'request boundary',
+          'main1',
+          'orchestrator',
+          undefined,
+          'u1',
+        ),
+      );
+      await hook.handleToolExecuteAfter({
+        tool: 'todowrite',
+        sessionID: 'main1',
+      });
+      await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 'main1' });
+      await hook.handleMessagesTransform(shifted);
+
+      expect(allMessageText(shifted)).toContain(TODO_HYGIENE_REMINDER);
     });
 
-    test('a new user message id resets the request even if the text is unchanged', async () => {
+    test('a new user message id resets the request even if text is unchanged', async () => {
       const ctx = createMockContext({
         todoResult: {
           data: [
@@ -410,8 +397,20 @@ describe('createTodoContinuationHook', () => {
         },
       });
       const hook = createTodoContinuationHook(ctx);
-      const firstOutput = { output: 'first read' };
-      const secondOutput = { output: 'second read' };
+      const blocked = userMessages(
+        'same text',
+        'main1',
+        'orchestrator',
+        undefined,
+        'u2',
+      );
+      const allowed = userMessages(
+        'same text',
+        'main1',
+        'orchestrator',
+        undefined,
+        'u2',
+      );
 
       await hook.handleMessagesTransform(
         userMessages('same text', 'main1', 'orchestrator', undefined, 'u1'),
@@ -420,30 +419,22 @@ describe('createTodoContinuationHook', () => {
         tool: 'todowrite',
         sessionID: 'main1',
       });
-      await hook.handleToolExecuteAfter(
-        { tool: 'read', sessionID: 'main1' },
-        firstOutput,
-      );
+      await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 'main1' });
 
-      await hook.handleMessagesTransform(
-        userMessages('same text', 'main1', 'orchestrator', undefined, 'u2'),
-      );
-      // First output should have reminder
-      expect(firstOutput.output).toContain(TODO_HYGIENE_REMINDER);
+      await hook.handleMessagesTransform(blocked);
+      expect(allMessageText(blocked)).not.toContain(TODO_HYGIENE_REMINDER);
 
       await hook.handleToolExecuteAfter({
         tool: 'todowrite',
         sessionID: 'main1',
       });
-      await hook.handleToolExecuteAfter(
-        { tool: 'read', sessionID: 'main1' },
-        secondOutput,
-      );
+      await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 'main1' });
+      await hook.handleMessagesTransform(allowed);
 
-      expect(secondOutput.output).toContain(TODO_HYGIENE_REMINDER);
+      expect(allMessageText(allowed)).toContain(TODO_HYGIENE_REMINDER);
     });
 
-    test('a repeated text without message ids still resets when a later user turn appears', async () => {
+    test('a repeated text without message ids resets when a later user turn appears', async () => {
       const ctx = createMockContext({
         todoResult: {
           data: [
@@ -452,22 +443,7 @@ describe('createTodoContinuationHook', () => {
         },
       });
       const hook = createTodoContinuationHook(ctx);
-      const firstOutput = { output: 'first read' };
-      const secondOutput = { output: 'second read' };
-
-      await hook.handleMessagesTransform(
-        userMessages('same text', 'main1', 'orchestrator'),
-      );
-      await hook.handleToolExecuteAfter({
-        tool: 'todowrite',
-        sessionID: 'main1',
-      });
-      await hook.handleToolExecuteAfter(
-        { tool: 'read', sessionID: 'main1' },
-        firstOutput,
-      );
-
-      await hook.handleMessagesTransform({
+      const blocked = {
         messages: [
           {
             info: { role: 'user', agent: 'orchestrator', sessionID: 'main1' },
@@ -482,20 +458,29 @@ describe('createTodoContinuationHook', () => {
             parts: [{ type: 'text', text: 'same text' }],
           },
         ],
+      };
+      const allowed = structuredClone(blocked);
+
+      await hook.handleMessagesTransform(
+        userMessages('same text', 'main1', 'orchestrator'),
+      );
+      await hook.handleToolExecuteAfter({
+        tool: 'todowrite',
+        sessionID: 'main1',
       });
-      // First output should have reminder
-      expect(firstOutput.output).toContain(TODO_HYGIENE_REMINDER);
+      await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 'main1' });
+
+      await hook.handleMessagesTransform(blocked);
+      expect(allMessageText(blocked)).not.toContain(TODO_HYGIENE_REMINDER);
 
       await hook.handleToolExecuteAfter({
         tool: 'todowrite',
         sessionID: 'main1',
       });
-      await hook.handleToolExecuteAfter(
-        { tool: 'read', sessionID: 'main1' },
-        secondOutput,
-      );
+      await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 'main1' });
+      await hook.handleMessagesTransform(allowed);
 
-      expect(secondOutput.output).toContain(TODO_HYGIENE_REMINDER);
+      expect(allMessageText(allowed)).toContain(TODO_HYGIENE_REMINDER);
     });
 
     test('messages without inferable sessionID clear stale state for known orchestrators', async () => {
@@ -507,7 +492,14 @@ describe('createTodoContinuationHook', () => {
         },
       });
       const hook = createTodoContinuationHook(ctx);
-      const toolOutput = { output: 'read result' };
+      const unknown = {
+        messages: [
+          {
+            info: { role: 'user', agent: 'orchestrator' },
+            parts: [{ type: 'text', text: 'boundary without session id' }],
+          },
+        ],
+      };
 
       hook.handleChatMessage({ sessionID: 'main1', agent: 'orchestrator' });
       hook.handleChatMessage({ sessionID: 'main2', agent: 'orchestrator' });
@@ -518,22 +510,11 @@ describe('createTodoContinuationHook', () => {
         tool: 'todowrite',
         sessionID: 'main1',
       });
-      await hook.handleToolExecuteAfter(
-        { tool: 'read', sessionID: 'main1' },
-        toolOutput,
-      );
+      await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 'main1' });
 
-      await hook.handleMessagesTransform({
-        messages: [
-          {
-            info: { role: 'user', agent: 'orchestrator' },
-            parts: [{ type: 'text', text: 'boundary without session id' }],
-          },
-        ],
-      });
+      await hook.handleMessagesTransform(unknown);
 
-      // Tool output should still have reminder from first round
-      expect(toolOutput.output).toContain(TODO_HYGIENE_REMINDER);
+      expect(allMessageText(unknown)).not.toContain(TODO_HYGIENE_REMINDER);
     });
 
     test('does not inject from continuation-like wording alone', async () => {
@@ -583,21 +564,20 @@ describe('createTodoContinuationHook', () => {
         },
       });
       const hook = createTodoContinuationHook(ctx);
-      const todowriteOutput = { output: 'todowrite result' };
-
-      await hook.handleMessagesTransform(
-        userMessages('finish the previous work', 'main1', 'orchestrator'),
-      );
-      // Final-active reminder is injected directly into todowrite output when state is final-active
-      await hook.handleToolExecuteAfter(
-        {
-          tool: 'todowrite',
-          sessionID: 'main1',
-        },
-        todowriteOutput,
+      const output = userMessages(
+        'finish the previous work',
+        'main1',
+        'orchestrator',
       );
 
-      expect(todowriteOutput.output).toContain(TODO_FINAL_ACTIVE_REMINDER);
+      await hook.handleMessagesTransform(output);
+      await hook.handleToolExecuteAfter({
+        tool: 'todowrite',
+        sessionID: 'main1',
+      });
+      await hook.handleMessagesTransform(output);
+
+      expect(allMessageText(output)).toContain(TODO_FINAL_ACTIVE_REMINDER);
     });
 
     test('final active todo after todowrite uses the stronger finishing reminder', async () => {
@@ -614,21 +594,17 @@ describe('createTodoContinuationHook', () => {
         },
       });
       const hook = createTodoContinuationHook(ctx);
-      const toolOutput = { output: 'todowrite result' };
+      const output = userMessages('haz esto', 'main1', 'orchestrator');
 
-      await hook.handleMessagesTransform(
-        userMessages('haz esto', 'main1', 'orchestrator'),
-      );
-      await hook.handleToolExecuteAfter(
-        {
-          tool: 'todowrite',
-          sessionID: 'main1',
-        },
-        toolOutput,
-      );
+      await hook.handleMessagesTransform(output);
+      await hook.handleToolExecuteAfter({
+        tool: 'todowrite',
+        sessionID: 'main1',
+      });
+      await hook.handleMessagesTransform(output);
 
-      expect(toolOutput.output).toContain(TODO_FINAL_ACTIVE_REMINDER);
-      expect(toolOutput.output).not.toContain(TODO_HYGIENE_REMINDER);
+      expect(allMessageText(output)).toContain(TODO_FINAL_ACTIVE_REMINDER);
+      expect(allMessageText(output)).not.toContain(TODO_HYGIENE_REMINDER);
     });
   });
 

--- a/src/hooks/todo-continuation/index.test.ts
+++ b/src/hooks/todo-continuation/index.test.ts
@@ -129,7 +129,7 @@ describe('createTodoContinuationHook', () => {
       expect(toolOutput.output).not.toContain(TODO_HYGIENE_REMINDER);
     });
 
-    test('system transform is no-op (cache-safe)', async () => {
+    test('does not expose a system transform handler', async () => {
       const ctx = createMockContext({
         todoResult: {
           data: [
@@ -143,27 +143,8 @@ describe('createTodoContinuationHook', () => {
         },
       });
       const hook = createTodoContinuationHook(ctx);
-      const system = { system: ['base'] };
 
-      await hook.handleMessagesTransform(
-        userMessages(
-          'continue with the unfinished work',
-          'main1',
-          'orchestrator',
-        ),
-      );
-      await hook.handleToolExecuteAfter({
-        tool: 'todowrite',
-        sessionID: 'main1',
-      });
-      await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 'main1' });
-      await hook.handleChatSystemTransform({ sessionID: 'main1' }, system);
-
-      expect(system.system).toEqual(['base']);
-      expect(system.system.join('\n')).not.toContain(TODO_HYGIENE_REMINDER);
-      expect(system.system.join('\n')).not.toContain(
-        TODO_FINAL_ACTIVE_REMINDER,
-      );
+      expect('handleChatSystemTransform' in hook).toBe(false);
     });
 
     test('injects hygiene reminder into tool output after todowrite activity', async () => {

--- a/src/hooks/todo-continuation/index.ts
+++ b/src/hooks/todo-continuation/index.ts
@@ -122,10 +122,13 @@ export function createTodoContinuationHook(
   },
 ): {
   tool: Record<string, unknown>;
-  handleToolExecuteAfter: (input: {
-    tool: string;
-    sessionID?: string;
-  }) => Promise<void>;
+  handleToolExecuteAfter: (
+    input: {
+      tool: string;
+      sessionID?: string;
+    },
+    output?: { output?: unknown },
+  ) => Promise<void>;
   handleChatSystemTransform: (
     input: { sessionID?: string },
     output: { system: string[] },

--- a/src/hooks/todo-continuation/index.ts
+++ b/src/hooks/todo-continuation/index.ts
@@ -362,9 +362,7 @@ export function createTodoContinuationHook(
       requestSignatureBySession.get(lastUserMessage.sessionID) ===
       lastUserMessage.signature
     ) {
-      const reminder = hygiene.consumePendingReminder(
-        lastUserMessage.sessionID,
-      );
+      const reminder = hygiene.getPendingReminder(lastUserMessage.sessionID);
       if (reminder) {
         appendTodoHygieneInstruction(lastUserMessage.message, reminder);
       } else {

--- a/src/hooks/todo-continuation/index.ts
+++ b/src/hooks/todo-continuation/index.ts
@@ -12,6 +12,8 @@ const COMMAND_NAME = 'auto-continue';
 
 const CONTINUATION_PROMPT =
   '[Auto-continue: enabled - there are incomplete todos remaining. Continue with the next uncompleted item. Press Esc to cancel. If you need user input or review for the next item, ask instead of proceeding.]';
+const TODO_HYGIENE_INSTRUCTION_OPEN = '<instruction name="todo_hygiene">';
+const TODO_HYGIENE_INSTRUCTION_CLOSE = '</instruction>';
 
 // Suppress window after user abort (Esc/Ctrl+C) to avoid immediately
 // re-continuing something the user explicitly stopped
@@ -90,6 +92,13 @@ interface ChatTransformMessage {
   parts: MessagePart[];
 }
 
+interface LastExternalUserMessage {
+  sessionID?: string;
+  agent?: string;
+  signature: string;
+  message: ChatTransformMessage;
+}
+
 interface Message {
   info?: MessageInfo;
   parts?: MessagePart[];
@@ -110,6 +119,45 @@ function resetState(state: ContinuationState): void {
   state.isAutoInjecting = false;
   state.notifyingSessionIds.clear();
   state.notificationBusyUntilBySession.clear();
+}
+
+function stripTodoHygieneInstruction(text: string): string {
+  const trimmed = text.trimEnd();
+  if (!trimmed.endsWith(TODO_HYGIENE_INSTRUCTION_CLOSE)) {
+    return trimmed;
+  }
+
+  const start = trimmed.lastIndexOf(TODO_HYGIENE_INSTRUCTION_OPEN);
+  if (start === -1) {
+    return trimmed;
+  }
+
+  return trimmed.slice(0, start).trimEnd();
+}
+
+function appendTodoHygieneInstruction(
+  message: ChatTransformMessage,
+  reminder: string,
+): void {
+  const textPart = [...message.parts]
+    .reverse()
+    .find((part) => part.type === 'text' && typeof part.text === 'string');
+  if (!textPart) return;
+
+  const baseText = stripTodoHygieneInstruction(textPart.text ?? '');
+  const instruction = `${TODO_HYGIENE_INSTRUCTION_OPEN}\n${reminder}\n${TODO_HYGIENE_INSTRUCTION_CLOSE}`;
+  textPart.text = baseText ? `${baseText}\n\n${instruction}` : instruction;
+}
+
+function stripTodoHygieneInstructionFromMessage(
+  message: ChatTransformMessage,
+): void {
+  const textPart = [...message.parts]
+    .reverse()
+    .find((part) => part.type === 'text' && typeof part.text === 'string');
+  if (!textPart) return;
+
+  textPart.text = stripTodoHygieneInstruction(textPart.text ?? '');
 }
 
 export function createTodoContinuationHook(
@@ -246,11 +294,9 @@ export function createTodoContinuationHook(
     );
   }
 
-  function getLastExternalUserMessage(messages: ChatTransformMessage[]): {
-    sessionID?: string;
-    agent?: string;
-    signature: string;
-  } | null {
+  function getLastExternalUserMessage(
+    messages: ChatTransformMessage[],
+  ): LastExternalUserMessage | null {
     for (let i = messages.length - 1; i >= 0; i--) {
       const message = messages[i];
       if (!isExternalUserMessage(message)) {
@@ -262,7 +308,8 @@ export function createTodoContinuationHook(
       const partSignature = message.parts
         .map((part) => {
           if (part.type === 'text' && typeof part.text === 'string') {
-            return `${part.type}:${part.text.includes(SLIM_INTERNAL_INITIATOR_MARKER) ? '<internal>' : part.text.trim()}`;
+            const text = stripTodoHygieneInstruction(part.text);
+            return `${part.type}:${text.includes(SLIM_INTERNAL_INITIATOR_MARKER) ? '<internal>' : text.trim()}`;
           }
           return part.type ?? 'unknown';
         })
@@ -274,6 +321,7 @@ export function createTodoContinuationHook(
       return {
         sessionID,
         agent: message.info.agent,
+        message,
         signature: message.info.id
           ? `${message.info.id}:${partSignature}`
           : `${ordinal}:${partSignature}`,
@@ -314,6 +362,14 @@ export function createTodoContinuationHook(
       requestSignatureBySession.get(lastUserMessage.sessionID) ===
       lastUserMessage.signature
     ) {
+      const reminder = hygiene.consumePendingReminder(
+        lastUserMessage.sessionID,
+      );
+      if (reminder) {
+        appendTodoHygieneInstruction(lastUserMessage.message, reminder);
+      } else {
+        stripTodoHygieneInstructionFromMessage(lastUserMessage.message);
+      }
       return;
     }
 
@@ -321,6 +377,7 @@ export function createTodoContinuationHook(
       lastUserMessage.sessionID,
       lastUserMessage.signature,
     );
+    stripTodoHygieneInstructionFromMessage(lastUserMessage.message);
     hygiene.handleRequestStart({ sessionID: lastUserMessage.sessionID });
   }
 

--- a/src/hooks/todo-continuation/index.ts
+++ b/src/hooks/todo-continuation/index.ts
@@ -129,10 +129,6 @@ export function createTodoContinuationHook(
     },
     output?: { output?: unknown },
   ) => Promise<void>;
-  handleChatSystemTransform: (
-    input: { sessionID?: string },
-    output: { system: string[] },
-  ) => Promise<void>;
   handleMessagesTransform: (output: {
     messages: ChatTransformMessage[];
   }) => Promise<void>;
@@ -819,7 +815,6 @@ export function createTodoContinuationHook(
   return {
     tool: { auto_continue: autoContinue },
     handleToolExecuteAfter: hygiene.handleToolExecuteAfter,
-    handleChatSystemTransform: hygiene.handleChatSystemTransform,
     handleMessagesTransform,
     handleEvent,
     handleChatMessage,

--- a/src/hooks/todo-continuation/todo-hygiene.test.ts
+++ b/src/hooks/todo-continuation/todo-hygiene.test.ts
@@ -32,12 +32,12 @@ describe('todo hygiene', () => {
     await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 's1' });
     hook.handleRequestStart({ sessionID: 's1' });
 
-    expect(hook.consumePendingReminder('s1')).toBeNull();
+    expect(hook.getPendingReminder('s1')).toBeNull();
 
     await hook.handleToolExecuteAfter({ tool: 'todowrite', sessionID: 's1' });
     await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 's1' });
 
-    expect(hook.consumePendingReminder('s1')).toBe(TODO_HYGIENE_REMINDER);
+    expect(hook.getPendingReminder('s1')).toBe(TODO_HYGIENE_REMINDER);
   });
 
   test('does not arm before the current request calls todowrite', async () => {
@@ -48,7 +48,7 @@ describe('todo hygiene', () => {
     hook.handleRequestStart({ sessionID: 's1' });
     await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 's1' });
 
-    expect(hook.consumePendingReminder('s1')).toBeNull();
+    expect(hook.getPendingReminder('s1')).toBeNull();
   });
 
   test('arms after the first relevant tool following todowrite', async () => {
@@ -60,8 +60,11 @@ describe('todo hygiene', () => {
     await hook.handleToolExecuteAfter({ tool: 'todowrite', sessionID: 's1' });
     await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 's1' });
 
-    expect(hook.consumePendingReminder('s1')).toBe(TODO_HYGIENE_REMINDER);
-    expect(hook.consumePendingReminder('s1')).toBeNull();
+    expect(hook.getPendingReminder('s1')).toBe(TODO_HYGIENE_REMINDER);
+    expect(hook.getPendingReminder('s1')).toBe(TODO_HYGIENE_REMINDER);
+
+    hook.handleRequestStart({ sessionID: 's1' });
+    expect(hook.getPendingReminder('s1')).toBeNull();
   });
 
   test('upgrades to final-active on a later round', async () => {
@@ -81,12 +84,12 @@ describe('todo hygiene', () => {
     hook.handleRequestStart({ sessionID: 's1' });
     await hook.handleToolExecuteAfter({ tool: 'todowrite', sessionID: 's1' });
     await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 's1' });
-    expect(hook.consumePendingReminder('s1')).toBe(TODO_HYGIENE_REMINDER);
+    expect(hook.getPendingReminder('s1')).toBe(TODO_HYGIENE_REMINDER);
 
     hook.handleRequestStart({ sessionID: 's1' });
     await hook.handleToolExecuteAfter({ tool: 'todowrite', sessionID: 's1' });
     await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 's1' });
-    expect(hook.consumePendingReminder('s1')).toBe(TODO_FINAL_ACTIVE_REMINDER);
+    expect(hook.getPendingReminder('s1')).toBe(TODO_FINAL_ACTIVE_REMINDER);
   });
 
   test('todowrite can arm final-active immediately', async () => {
@@ -102,7 +105,7 @@ describe('todo hygiene', () => {
     hook.handleRequestStart({ sessionID: 's1' });
     await hook.handleToolExecuteAfter({ tool: 'todowrite', sessionID: 's1' });
 
-    expect(hook.consumePendingReminder('s1')).toBe(TODO_FINAL_ACTIVE_REMINDER);
+    expect(hook.getPendingReminder('s1')).toBe(TODO_FINAL_ACTIVE_REMINDER);
   });
 
   test('once final-active is armed, later tools skip extra todo lookups in the same round', async () => {
@@ -145,10 +148,10 @@ describe('todo hygiene', () => {
     await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 's1' });
 
     expect(calls).toBe(0);
-    expect(hook.consumePendingReminder('s1')).toBeNull();
+    expect(hook.getPendingReminder('s1')).toBeNull();
   });
 
-  test('consuming a pending reminder does not inspect todos', async () => {
+  test('reading a pending reminder does not inspect todos', async () => {
     let fail = false;
     const hook = createTodoHygiene({
       getTodoState: async () => {
@@ -162,7 +165,7 @@ describe('todo hygiene', () => {
     await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 's1' });
     fail = true;
 
-    expect(hook.consumePendingReminder('s1')).toBe(TODO_HYGIENE_REMINDER);
+    expect(hook.getPendingReminder('s1')).toBe(TODO_HYGIENE_REMINDER);
   });
 
   test('todowrite lookup failures do not disable the current request', async () => {
@@ -180,7 +183,7 @@ describe('todo hygiene', () => {
     fail = false;
     await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 's1' });
 
-    expect(hook.consumePendingReminder('s1')).toBe(TODO_HYGIENE_REMINDER);
+    expect(hook.getPendingReminder('s1')).toBe(TODO_HYGIENE_REMINDER);
   });
 
   test('session.deleted clears all state', async () => {
@@ -196,6 +199,6 @@ describe('todo hygiene', () => {
       properties: { info: { id: 's1' } },
     });
 
-    expect(hook.consumePendingReminder('s1')).toBeNull();
+    expect(hook.getPendingReminder('s1')).toBeNull();
   });
 });

--- a/src/hooks/todo-continuation/todo-hygiene.test.ts
+++ b/src/hooks/todo-continuation/todo-hygiene.test.ts
@@ -21,92 +21,138 @@ function createState(
   };
 }
 
+function createToolOutput(output = 'tool result') {
+  return { output };
+}
+
 describe('todo hygiene', () => {
   test('new request clears pending state from the previous turn', async () => {
     const hook = createTodoHygiene({
       getTodoState: async () => createState(),
     });
-    const stale = { system: ['base'] };
-    const fresh = { system: ['base'] };
+    const staleOutput = createToolOutput('stale tool result');
+    const freshOutput = createToolOutput('fresh tool result');
+
+    hook.handleRequestStart({ sessionID: 's1' });
+    await hook.handleToolExecuteAfter({ tool: 'todowrite', sessionID: 's1' });
+    await hook.handleToolExecuteAfter(
+      { tool: 'read', sessionID: 's1' },
+      staleOutput,
+    );
+
+    hook.handleRequestStart({ sessionID: 's1' });
+    await hook.handleToolExecuteAfter({ tool: 'todowrite', sessionID: 's1' });
+    await hook.handleToolExecuteAfter(
+      { tool: 'read', sessionID: 's1' },
+      freshOutput,
+    );
+
+    expect(staleOutput.output).toContain(TODO_HYGIENE_REMINDER);
+    expect(freshOutput.output).toContain(TODO_HYGIENE_REMINDER);
+  });
+
+  test('system transform is no-op (cache-safe)', async () => {
+    const hook = createTodoHygiene({
+      getTodoState: async () => createState(),
+    });
+    const system = { system: ['base'] };
 
     hook.handleRequestStart({ sessionID: 's1' });
     await hook.handleToolExecuteAfter({ tool: 'todowrite', sessionID: 's1' });
     await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 's1' });
-    hook.handleRequestStart({ sessionID: 's1' });
-    await hook.handleChatSystemTransform({ sessionID: 's1' }, stale);
+    await hook.handleChatSystemTransform({ sessionID: 's1' }, system);
 
-    await hook.handleToolExecuteAfter({ tool: 'todowrite', sessionID: 's1' });
-    await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 's1' });
-    await hook.handleChatSystemTransform({ sessionID: 's1' }, fresh);
-
-    expect(stale.system.join('\n')).not.toContain(TODO_HYGIENE_REMINDER);
-    expect(fresh.system.join('\n')).toContain(TODO_HYGIENE_REMINDER);
+    expect(system.system).toEqual(['base']);
+    expect(system.system.join('\n')).not.toContain(TODO_HYGIENE_REMINDER);
   });
 
   test('does not arm before the current request calls todowrite', async () => {
     const hook = createTodoHygiene({
       getTodoState: async () => createState(),
     });
-    const system = { system: ['base'] };
+    const output = createToolOutput();
 
     hook.handleRequestStart({ sessionID: 's1' });
-    await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 's1' });
-    await hook.handleChatSystemTransform({ sessionID: 's1' }, system);
+    await hook.handleToolExecuteAfter(
+      { tool: 'read', sessionID: 's1' },
+      output,
+    );
 
-    expect(system.system.join('\n')).not.toContain(TODO_HYGIENE_REMINDER);
+    expect(output.output).toBe('tool result');
+    expect(output.output).not.toContain(TODO_HYGIENE_REMINDER);
   });
 
   test('arms after the first relevant tool following todowrite', async () => {
     const hook = createTodoHygiene({
       getTodoState: async () => createState(),
     });
-    const system = { system: ['base'] };
+    const output = createToolOutput();
 
     hook.handleRequestStart({ sessionID: 's1' });
     await hook.handleToolExecuteAfter({ tool: 'todowrite', sessionID: 's1' });
-    await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 's1' });
-    await hook.handleChatSystemTransform({ sessionID: 's1' }, system);
+    await hook.handleToolExecuteAfter(
+      { tool: 'read', sessionID: 's1' },
+      output,
+    );
 
-    expect(system.system.join('\n')).toContain(TODO_HYGIENE_REMINDER);
+    expect(output.output).toContain(TODO_HYGIENE_REMINDER);
+    expect(output.output).toContain('<internal_reminder>');
   });
 
   test('multiple tools in the same round still inject only one reminder', async () => {
     const hook = createTodoHygiene({
       getTodoState: async () => createState(),
     });
-    const system = { system: ['base'] };
+    const output1 = createToolOutput('result 1');
+    const output2 = createToolOutput('result 2');
+    const output3 = createToolOutput('result 3');
 
     hook.handleRequestStart({ sessionID: 's1' });
     await hook.handleToolExecuteAfter({ tool: 'todowrite', sessionID: 's1' });
-    await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 's1' });
-    await hook.handleToolExecuteAfter({ tool: 'grep', sessionID: 's1' });
-    await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 's1' });
-    await hook.handleToolExecuteAfter({ tool: 'glob', sessionID: 's1' });
-    await hook.handleChatSystemTransform({ sessionID: 's1' }, system);
+    await hook.handleToolExecuteAfter(
+      { tool: 'read', sessionID: 's1' },
+      output1,
+    );
+    await hook.handleToolExecuteAfter(
+      { tool: 'grep', sessionID: 's1' },
+      output2,
+    );
+    await hook.handleToolExecuteAfter(
+      { tool: 'read', sessionID: 's1' },
+      output3,
+    );
 
-    expect(
-      system.system.filter((item) => item.includes(TODO_HYGIENE_REMINDER)),
-    ).toHaveLength(1);
+    // Only the first non-todowrite tool should get the reminder
+    expect(output1.output).toContain(TODO_HYGIENE_REMINDER);
+    expect(output2.output).not.toContain(TODO_HYGIENE_REMINDER);
+    expect(output3.output).not.toContain(TODO_HYGIENE_REMINDER);
   });
 
   test('injects again on a later round after new activity', async () => {
     const hook = createTodoHygiene({
       getTodoState: async () => createState(),
     });
-    const first = { system: ['base'] };
-    const second = { system: ['base'] };
+    const firstOutput = createToolOutput('first result');
+    const secondOutput = createToolOutput('second result');
 
+    // First request cycle
     hook.handleRequestStart({ sessionID: 's1' });
     await hook.handleToolExecuteAfter({ tool: 'todowrite', sessionID: 's1' });
-    await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 's1' });
-    await hook.handleChatSystemTransform({ sessionID: 's1' }, first);
+    await hook.handleToolExecuteAfter(
+      { tool: 'read', sessionID: 's1' },
+      firstOutput,
+    );
 
-    await hook.handleToolExecuteAfter({ tool: 'grep', sessionID: 's1' });
-    await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 's1' });
-    await hook.handleChatSystemTransform({ sessionID: 's1' }, second);
+    // Second request cycle - needs new request start to clear injected state
+    hook.handleRequestStart({ sessionID: 's1' });
+    await hook.handleToolExecuteAfter({ tool: 'todowrite', sessionID: 's1' });
+    await hook.handleToolExecuteAfter(
+      { tool: 'read', sessionID: 's1' },
+      secondOutput,
+    );
 
-    expect(first.system.join('\n')).toContain(TODO_HYGIENE_REMINDER);
-    expect(second.system.join('\n')).toContain(TODO_HYGIENE_REMINDER);
+    expect(firstOutput.output).toContain(TODO_HYGIENE_REMINDER);
+    expect(secondOutput.output).toContain(TODO_HYGIENE_REMINDER);
   });
 
   test('upgrades to final-active on a later round', async () => {
@@ -114,7 +160,7 @@ describe('todo hygiene', () => {
     const hook = createTodoHygiene({
       getTodoState: async () => {
         call++;
-        if (call <= 4) {
+        if (call <= 3) {
           return createState();
         }
         return createState({
@@ -124,20 +170,27 @@ describe('todo hygiene', () => {
         });
       },
     });
-    const first = { system: ['base'] };
-    const second = { system: ['base'] };
+    const firstOutput = createToolOutput('first result');
+    const secondOutput = createToolOutput('second result');
 
+    // First request cycle - general reminder
     hook.handleRequestStart({ sessionID: 's1' });
     await hook.handleToolExecuteAfter({ tool: 'todowrite', sessionID: 's1' });
-    await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 's1' });
-    await hook.handleChatSystemTransform({ sessionID: 's1' }, first);
+    await hook.handleToolExecuteAfter(
+      { tool: 'read', sessionID: 's1' },
+      firstOutput,
+    );
 
-    await hook.handleToolExecuteAfter({ tool: 'grep', sessionID: 's1' });
-    await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 's1' });
-    await hook.handleChatSystemTransform({ sessionID: 's1' }, second);
+    // Second request cycle - final-active reminder (state changed)
+    hook.handleRequestStart({ sessionID: 's1' });
+    await hook.handleToolExecuteAfter({ tool: 'todowrite', sessionID: 's1' });
+    await hook.handleToolExecuteAfter(
+      { tool: 'read', sessionID: 's1' },
+      secondOutput,
+    );
 
-    expect(first.system.join('\n')).toContain(TODO_HYGIENE_REMINDER);
-    expect(second.system.join('\n')).toContain(TODO_FINAL_ACTIVE_REMINDER);
+    expect(firstOutput.output).toContain(TODO_HYGIENE_REMINDER);
+    expect(secondOutput.output).toContain(TODO_FINAL_ACTIVE_REMINDER);
   });
 
   test('todowrite can arm final-active immediately', async () => {
@@ -149,13 +202,16 @@ describe('todo hygiene', () => {
           pendingCount: 0,
         }),
     });
-    const system = { system: ['base'] };
+    const output = createToolOutput();
 
     hook.handleRequestStart({ sessionID: 's1' });
-    await hook.handleToolExecuteAfter({ tool: 'todowrite', sessionID: 's1' });
-    await hook.handleChatSystemTransform({ sessionID: 's1' }, system);
+    await hook.handleToolExecuteAfter(
+      { tool: 'todowrite', sessionID: 's1' },
+      output,
+    );
 
-    expect(system.system.join('\n')).toContain(TODO_FINAL_ACTIVE_REMINDER);
+    expect(output.output).toContain(TODO_FINAL_ACTIVE_REMINDER);
+    expect(output.output).toContain('<internal_reminder>');
   });
 
   test('once final-active is armed, later tools skip extra todo lookups in the same round', async () => {
@@ -184,17 +240,17 @@ describe('todo hygiene', () => {
       getTodoState: async () => createState(),
       shouldInject: () => false,
     });
-    const first = { system: ['base'] };
-    const second = { system: ['base'] };
+    const output = createToolOutput();
 
     hook.handleRequestStart({ sessionID: 's1' });
     await hook.handleToolExecuteAfter({ tool: 'todowrite', sessionID: 's1' });
-    await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 's1' });
-    await hook.handleChatSystemTransform({ sessionID: 's1' }, first);
-    await hook.handleChatSystemTransform({ sessionID: 's1' }, second);
+    await hook.handleToolExecuteAfter(
+      { tool: 'read', sessionID: 's1' },
+      output,
+    );
 
-    expect(first.system.join('\n')).not.toContain(TODO_HYGIENE_REMINDER);
-    expect(second.system.join('\n')).not.toContain(TODO_HYGIENE_REMINDER);
+    expect(output.output).toBe('tool result');
+    expect(output.output).not.toContain(TODO_HYGIENE_REMINDER);
   });
 
   test('final-active reminder wins when only one active todo remains', async () => {
@@ -206,13 +262,16 @@ describe('todo hygiene', () => {
           pendingCount: 0,
         }),
     });
-    const system = { system: ['base'] };
+    const output = createToolOutput();
 
     hook.handleRequestStart({ sessionID: 's1' });
-    await hook.handleToolExecuteAfter({ tool: 'todowrite', sessionID: 's1' });
-    await hook.handleChatSystemTransform({ sessionID: 's1' }, system);
+    await hook.handleToolExecuteAfter(
+      { tool: 'todowrite', sessionID: 's1' },
+      output,
+    );
 
-    expect(system.system.join('\n')).toContain(TODO_FINAL_ACTIVE_REMINDER);
+    expect(output.output).toContain(TODO_FINAL_ACTIVE_REMINDER);
+    expect(output.output).not.toContain(TODO_HYGIENE_REMINDER);
   });
 
   test('transform lookup failures are best-effort and do not drop later reminders', async () => {
@@ -225,22 +284,35 @@ describe('todo hygiene', () => {
         return createState();
       },
     });
-    const failed = { system: ['base'] };
-    const recovered = { system: ['base'] };
+    const firstOutput = createToolOutput('first result');
+    const failedOutput = createToolOutput('failed result');
+    const recoveredOutput = createToolOutput('recovered result');
 
+    // First cycle - succeeds
     hook.handleRequestStart({ sessionID: 's1' });
     await hook.handleToolExecuteAfter({ tool: 'todowrite', sessionID: 's1' });
-    await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 's1' });
+    await hook.handleToolExecuteAfter(
+      { tool: 'read', sessionID: 's1' },
+      firstOutput,
+    );
+
+    // Second cycle - todowrite fails but read succeeds
+    hook.handleRequestStart({ sessionID: 's1' });
     fail = true;
-    await hook.handleChatSystemTransform({ sessionID: 's1' }, failed);
-
+    await hook.handleToolExecuteAfter(
+      { tool: 'todowrite', sessionID: 's1' },
+      failedOutput,
+    );
     fail = false;
-    await hook.handleToolExecuteAfter({ tool: 'grep', sessionID: 's1' });
-    await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 's1' });
-    await hook.handleChatSystemTransform({ sessionID: 's1' }, recovered);
+    await hook.handleToolExecuteAfter(
+      { tool: 'read', sessionID: 's1' },
+      recoveredOutput,
+    );
 
-    expect(failed.system.join('\n')).not.toContain(TODO_HYGIENE_REMINDER);
-    expect(recovered.system.join('\n')).toContain(TODO_HYGIENE_REMINDER);
+    expect(firstOutput.output).toContain(TODO_HYGIENE_REMINDER);
+    expect(failedOutput.output).toBe('failed result');
+    expect(failedOutput.output).not.toContain(TODO_HYGIENE_REMINDER);
+    expect(recoveredOutput.output).toContain(TODO_HYGIENE_REMINDER);
   });
 
   test('a late tool failure does not clear a reminder already armed for the round', async () => {
@@ -254,15 +326,17 @@ describe('todo hygiene', () => {
         return createState();
       },
     });
-    const system = { system: ['base'] };
+    const output = createToolOutput();
 
     hook.handleRequestStart({ sessionID: 's1' });
     await hook.handleToolExecuteAfter({ tool: 'todowrite', sessionID: 's1' });
-    await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 's1' });
+    await hook.handleToolExecuteAfter(
+      { tool: 'read', sessionID: 's1' },
+      output,
+    );
     await hook.handleToolExecuteAfter({ tool: 'grep', sessionID: 's1' });
-    await hook.handleChatSystemTransform({ sessionID: 's1' }, system);
 
-    expect(system.system.join('\n')).toContain(TODO_HYGIENE_REMINDER);
+    expect(output.output).toContain(TODO_HYGIENE_REMINDER);
   });
 
   test('todowrite lookup failures do not disable the current request', async () => {
@@ -275,17 +349,19 @@ describe('todo hygiene', () => {
         return createState();
       },
     });
-    const system = { system: ['base'] };
+    const output = createToolOutput();
 
     hook.handleRequestStart({ sessionID: 's1' });
     fail = true;
     await hook.handleToolExecuteAfter({ tool: 'todowrite', sessionID: 's1' });
     fail = false;
-    await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 's1' });
+    await hook.handleToolExecuteAfter(
+      { tool: 'read', sessionID: 's1' },
+      output,
+    );
     await hook.handleToolExecuteAfter({ tool: 'grep', sessionID: 's1' });
-    await hook.handleChatSystemTransform({ sessionID: 's1' }, system);
 
-    expect(system.system.join('\n')).toContain(TODO_HYGIENE_REMINDER);
+    expect(output.output).toContain(TODO_HYGIENE_REMINDER);
   });
 
   test('non-injectable sessions are fully cleared after a rejected round', async () => {
@@ -297,23 +373,26 @@ describe('todo hygiene', () => {
       },
       shouldInject: () => false,
     });
-    const system = { system: ['base'] };
+    const output = createToolOutput();
 
     hook.handleRequestStart({ sessionID: 's1' });
     await hook.handleToolExecuteAfter({ tool: 'todowrite', sessionID: 's1' });
-    await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 's1' });
-    await hook.handleChatSystemTransform({ sessionID: 's1' }, system);
+    await hook.handleToolExecuteAfter(
+      { tool: 'read', sessionID: 's1' },
+      output,
+    );
     await hook.handleToolExecuteAfter({ tool: 'grep', sessionID: 's1' });
 
     expect(calls).toBe(1);
-    expect(system.system.join('\n')).not.toContain(TODO_HYGIENE_REMINDER);
+    expect(output.output).toBe('tool result');
+    expect(output.output).not.toContain(TODO_HYGIENE_REMINDER);
   });
 
   test('session.deleted clears all state', async () => {
     const hook = createTodoHygiene({
       getTodoState: async () => createState(),
     });
-    const system = { system: ['base'] };
+    const output = createToolOutput();
 
     hook.handleRequestStart({ sessionID: 's1' });
     await hook.handleToolExecuteAfter({ tool: 'todowrite', sessionID: 's1' });
@@ -322,8 +401,12 @@ describe('todo hygiene', () => {
       type: 'session.deleted',
       properties: { info: { id: 's1' } },
     });
-    await hook.handleChatSystemTransform({ sessionID: 's1' }, system);
+    await hook.handleToolExecuteAfter(
+      { tool: 'grep', sessionID: 's1' },
+      output,
+    );
 
-    expect(system.system.join('\n')).not.toContain(TODO_HYGIENE_REMINDER);
+    expect(output.output).toBe('tool result');
+    expect(output.output).not.toContain(TODO_HYGIENE_REMINDER);
   });
 });

--- a/src/hooks/todo-continuation/todo-hygiene.test.ts
+++ b/src/hooks/todo-continuation/todo-hygiene.test.ts
@@ -21,131 +21,47 @@ function createState(
   };
 }
 
-function createToolOutput(output = 'tool result') {
-  return { output };
-}
-
 describe('todo hygiene', () => {
   test('new request clears pending state from the previous turn', async () => {
     const hook = createTodoHygiene({
       getTodoState: async () => createState(),
     });
-    const staleOutput = createToolOutput('stale tool result');
-    const freshOutput = createToolOutput('fresh tool result');
 
     hook.handleRequestStart({ sessionID: 's1' });
     await hook.handleToolExecuteAfter({ tool: 'todowrite', sessionID: 's1' });
-    await hook.handleToolExecuteAfter(
-      { tool: 'read', sessionID: 's1' },
-      staleOutput,
-    );
-
+    await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 's1' });
     hook.handleRequestStart({ sessionID: 's1' });
+
+    expect(hook.consumePendingReminder('s1')).toBeNull();
+
     await hook.handleToolExecuteAfter({ tool: 'todowrite', sessionID: 's1' });
-    await hook.handleToolExecuteAfter(
-      { tool: 'read', sessionID: 's1' },
-      freshOutput,
-    );
+    await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 's1' });
 
-    expect(staleOutput.output).toContain(TODO_HYGIENE_REMINDER);
-    expect(freshOutput.output).toContain(TODO_HYGIENE_REMINDER);
-  });
-
-  test('does not expose a system transform handler', async () => {
-    const hook = createTodoHygiene({
-      getTodoState: async () => createState(),
-    });
-
-    expect('handleChatSystemTransform' in hook).toBe(false);
+    expect(hook.consumePendingReminder('s1')).toBe(TODO_HYGIENE_REMINDER);
   });
 
   test('does not arm before the current request calls todowrite', async () => {
     const hook = createTodoHygiene({
       getTodoState: async () => createState(),
     });
-    const output = createToolOutput();
 
     hook.handleRequestStart({ sessionID: 's1' });
-    await hook.handleToolExecuteAfter(
-      { tool: 'read', sessionID: 's1' },
-      output,
-    );
+    await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 's1' });
 
-    expect(output.output).toBe('tool result');
-    expect(output.output).not.toContain(TODO_HYGIENE_REMINDER);
+    expect(hook.consumePendingReminder('s1')).toBeNull();
   });
 
   test('arms after the first relevant tool following todowrite', async () => {
     const hook = createTodoHygiene({
       getTodoState: async () => createState(),
     });
-    const output = createToolOutput();
 
     hook.handleRequestStart({ sessionID: 's1' });
     await hook.handleToolExecuteAfter({ tool: 'todowrite', sessionID: 's1' });
-    await hook.handleToolExecuteAfter(
-      { tool: 'read', sessionID: 's1' },
-      output,
-    );
+    await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 's1' });
 
-    expect(output.output).toContain(TODO_HYGIENE_REMINDER);
-    expect(output.output).toContain('<internal_reminder>');
-  });
-
-  test('multiple tools in the same round still inject only one reminder', async () => {
-    const hook = createTodoHygiene({
-      getTodoState: async () => createState(),
-    });
-    const output1 = createToolOutput('result 1');
-    const output2 = createToolOutput('result 2');
-    const output3 = createToolOutput('result 3');
-
-    hook.handleRequestStart({ sessionID: 's1' });
-    await hook.handleToolExecuteAfter({ tool: 'todowrite', sessionID: 's1' });
-    await hook.handleToolExecuteAfter(
-      { tool: 'read', sessionID: 's1' },
-      output1,
-    );
-    await hook.handleToolExecuteAfter(
-      { tool: 'grep', sessionID: 's1' },
-      output2,
-    );
-    await hook.handleToolExecuteAfter(
-      { tool: 'read', sessionID: 's1' },
-      output3,
-    );
-
-    // Only the first non-todowrite tool should get the reminder
-    expect(output1.output).toContain(TODO_HYGIENE_REMINDER);
-    expect(output2.output).not.toContain(TODO_HYGIENE_REMINDER);
-    expect(output3.output).not.toContain(TODO_HYGIENE_REMINDER);
-  });
-
-  test('injects again on a later round after new activity', async () => {
-    const hook = createTodoHygiene({
-      getTodoState: async () => createState(),
-    });
-    const firstOutput = createToolOutput('first result');
-    const secondOutput = createToolOutput('second result');
-
-    // First request cycle
-    hook.handleRequestStart({ sessionID: 's1' });
-    await hook.handleToolExecuteAfter({ tool: 'todowrite', sessionID: 's1' });
-    await hook.handleToolExecuteAfter(
-      { tool: 'read', sessionID: 's1' },
-      firstOutput,
-    );
-
-    // Second request cycle - needs new request start to clear injected state
-    hook.handleRequestStart({ sessionID: 's1' });
-    await hook.handleToolExecuteAfter({ tool: 'todowrite', sessionID: 's1' });
-    await hook.handleToolExecuteAfter(
-      { tool: 'read', sessionID: 's1' },
-      secondOutput,
-    );
-
-    expect(firstOutput.output).toContain(TODO_HYGIENE_REMINDER);
-    expect(secondOutput.output).toContain(TODO_HYGIENE_REMINDER);
+    expect(hook.consumePendingReminder('s1')).toBe(TODO_HYGIENE_REMINDER);
+    expect(hook.consumePendingReminder('s1')).toBeNull();
   });
 
   test('upgrades to final-active on a later round', async () => {
@@ -153,9 +69,7 @@ describe('todo hygiene', () => {
     const hook = createTodoHygiene({
       getTodoState: async () => {
         call++;
-        if (call <= 3) {
-          return createState();
-        }
+        if (call <= 3) return createState();
         return createState({
           openCount: 1,
           inProgressCount: 1,
@@ -163,27 +77,16 @@ describe('todo hygiene', () => {
         });
       },
     });
-    const firstOutput = createToolOutput('first result');
-    const secondOutput = createToolOutput('second result');
 
-    // First request cycle - general reminder
     hook.handleRequestStart({ sessionID: 's1' });
     await hook.handleToolExecuteAfter({ tool: 'todowrite', sessionID: 's1' });
-    await hook.handleToolExecuteAfter(
-      { tool: 'read', sessionID: 's1' },
-      firstOutput,
-    );
+    await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 's1' });
+    expect(hook.consumePendingReminder('s1')).toBe(TODO_HYGIENE_REMINDER);
 
-    // Second request cycle - final-active reminder (state changed)
     hook.handleRequestStart({ sessionID: 's1' });
     await hook.handleToolExecuteAfter({ tool: 'todowrite', sessionID: 's1' });
-    await hook.handleToolExecuteAfter(
-      { tool: 'read', sessionID: 's1' },
-      secondOutput,
-    );
-
-    expect(firstOutput.output).toContain(TODO_HYGIENE_REMINDER);
-    expect(secondOutput.output).toContain(TODO_FINAL_ACTIVE_REMINDER);
+    await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 's1' });
+    expect(hook.consumePendingReminder('s1')).toBe(TODO_FINAL_ACTIVE_REMINDER);
   });
 
   test('todowrite can arm final-active immediately', async () => {
@@ -195,16 +98,11 @@ describe('todo hygiene', () => {
           pendingCount: 0,
         }),
     });
-    const output = createToolOutput();
 
     hook.handleRequestStart({ sessionID: 's1' });
-    await hook.handleToolExecuteAfter(
-      { tool: 'todowrite', sessionID: 's1' },
-      output,
-    );
+    await hook.handleToolExecuteAfter({ tool: 'todowrite', sessionID: 's1' });
 
-    expect(output.output).toContain(TODO_FINAL_ACTIVE_REMINDER);
-    expect(output.output).toContain('<internal_reminder>');
+    expect(hook.consumePendingReminder('s1')).toBe(TODO_FINAL_ACTIVE_REMINDER);
   });
 
   test('once final-active is armed, later tools skip extra todo lookups in the same round', async () => {
@@ -228,186 +126,67 @@ describe('todo hygiene', () => {
     expect(calls).toBe(1);
   });
 
-  test('shouldInject rejection consumes the pending reminder', async () => {
+  test('shouldInject rejection prevents reset lookup and reminders', async () => {
+    let calls = 0;
     const hook = createTodoHygiene({
-      getTodoState: async () => createState(),
+      getTodoState: async () => {
+        calls++;
+        return createState({
+          openCount: 1,
+          inProgressCount: 1,
+          pendingCount: 0,
+        });
+      },
       shouldInject: () => false,
     });
-    const output = createToolOutput();
 
     hook.handleRequestStart({ sessionID: 's1' });
     await hook.handleToolExecuteAfter({ tool: 'todowrite', sessionID: 's1' });
-    await hook.handleToolExecuteAfter(
-      { tool: 'read', sessionID: 's1' },
-      output,
-    );
+    await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 's1' });
 
-    expect(output.output).toBe('tool result');
-    expect(output.output).not.toContain(TODO_HYGIENE_REMINDER);
+    expect(calls).toBe(0);
+    expect(hook.consumePendingReminder('s1')).toBeNull();
   });
 
-  test('shouldInject rejection prevents immediate final-active reminder', async () => {
-    const hook = createTodoHygiene({
-      getTodoState: async () =>
-        createState({
-          openCount: 1,
-          inProgressCount: 1,
-          pendingCount: 0,
-        }),
-      shouldInject: () => false,
-    });
-    const output = createToolOutput();
-
-    hook.handleRequestStart({ sessionID: 's1' });
-    await hook.handleToolExecuteAfter(
-      { tool: 'todowrite', sessionID: 's1' },
-      output,
-    );
-
-    expect(output.output).toBe('tool result');
-    expect(output.output).not.toContain(TODO_FINAL_ACTIVE_REMINDER);
-  });
-
-  test('final-active reminder wins when only one active todo remains', async () => {
-    const hook = createTodoHygiene({
-      getTodoState: async () =>
-        createState({
-          openCount: 1,
-          inProgressCount: 1,
-          pendingCount: 0,
-        }),
-    });
-    const output = createToolOutput();
-
-    hook.handleRequestStart({ sessionID: 's1' });
-    await hook.handleToolExecuteAfter(
-      { tool: 'todowrite', sessionID: 's1' },
-      output,
-    );
-
-    expect(output.output).toContain(TODO_FINAL_ACTIVE_REMINDER);
-    expect(output.output).not.toContain(TODO_HYGIENE_REMINDER);
-  });
-
-  test('transform lookup failures are best-effort and do not drop later reminders', async () => {
+  test('consuming a pending reminder does not inspect todos', async () => {
     let fail = false;
     const hook = createTodoHygiene({
       getTodoState: async () => {
-        if (fail) {
-          throw new Error('boom');
-        }
+        if (fail) throw new Error('boom');
         return createState();
       },
     });
-    const firstOutput = createToolOutput('first result');
-    const failedOutput = createToolOutput('failed result');
-    const recoveredOutput = createToolOutput('recovered result');
 
-    // First cycle - succeeds
     hook.handleRequestStart({ sessionID: 's1' });
     await hook.handleToolExecuteAfter({ tool: 'todowrite', sessionID: 's1' });
-    await hook.handleToolExecuteAfter(
-      { tool: 'read', sessionID: 's1' },
-      firstOutput,
-    );
-
-    // Second cycle - todowrite fails but read succeeds
-    hook.handleRequestStart({ sessionID: 's1' });
+    await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 's1' });
     fail = true;
-    await hook.handleToolExecuteAfter(
-      { tool: 'todowrite', sessionID: 's1' },
-      failedOutput,
-    );
-    fail = false;
-    await hook.handleToolExecuteAfter(
-      { tool: 'read', sessionID: 's1' },
-      recoveredOutput,
-    );
 
-    expect(firstOutput.output).toContain(TODO_HYGIENE_REMINDER);
-    expect(failedOutput.output).toBe('failed result');
-    expect(failedOutput.output).not.toContain(TODO_HYGIENE_REMINDER);
-    expect(recoveredOutput.output).toContain(TODO_HYGIENE_REMINDER);
-  });
-
-  test('a late tool failure does not clear a reminder already armed for the round', async () => {
-    let call = 0;
-    const hook = createTodoHygiene({
-      getTodoState: async () => {
-        call++;
-        if (call === 3) {
-          throw new Error('boom');
-        }
-        return createState();
-      },
-    });
-    const output = createToolOutput();
-
-    hook.handleRequestStart({ sessionID: 's1' });
-    await hook.handleToolExecuteAfter({ tool: 'todowrite', sessionID: 's1' });
-    await hook.handleToolExecuteAfter(
-      { tool: 'read', sessionID: 's1' },
-      output,
-    );
-    await hook.handleToolExecuteAfter({ tool: 'grep', sessionID: 's1' });
-
-    expect(output.output).toContain(TODO_HYGIENE_REMINDER);
+    expect(hook.consumePendingReminder('s1')).toBe(TODO_HYGIENE_REMINDER);
   });
 
   test('todowrite lookup failures do not disable the current request', async () => {
     let fail = false;
     const hook = createTodoHygiene({
       getTodoState: async () => {
-        if (fail) {
-          throw new Error('boom');
-        }
+        if (fail) throw new Error('boom');
         return createState();
       },
     });
-    const output = createToolOutput();
 
     hook.handleRequestStart({ sessionID: 's1' });
     fail = true;
     await hook.handleToolExecuteAfter({ tool: 'todowrite', sessionID: 's1' });
     fail = false;
-    await hook.handleToolExecuteAfter(
-      { tool: 'read', sessionID: 's1' },
-      output,
-    );
-    await hook.handleToolExecuteAfter({ tool: 'grep', sessionID: 's1' });
+    await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 's1' });
 
-    expect(output.output).toContain(TODO_HYGIENE_REMINDER);
-  });
-
-  test('non-injectable sessions are fully cleared after a rejected round', async () => {
-    let calls = 0;
-    const hook = createTodoHygiene({
-      getTodoState: async () => {
-        calls++;
-        return createState();
-      },
-      shouldInject: () => false,
-    });
-    const output = createToolOutput();
-
-    hook.handleRequestStart({ sessionID: 's1' });
-    await hook.handleToolExecuteAfter({ tool: 'todowrite', sessionID: 's1' });
-    await hook.handleToolExecuteAfter(
-      { tool: 'read', sessionID: 's1' },
-      output,
-    );
-    await hook.handleToolExecuteAfter({ tool: 'grep', sessionID: 's1' });
-
-    expect(calls).toBe(0);
-    expect(output.output).toBe('tool result');
-    expect(output.output).not.toContain(TODO_HYGIENE_REMINDER);
+    expect(hook.consumePendingReminder('s1')).toBe(TODO_HYGIENE_REMINDER);
   });
 
   test('session.deleted clears all state', async () => {
     const hook = createTodoHygiene({
       getTodoState: async () => createState(),
     });
-    const output = createToolOutput();
 
     hook.handleRequestStart({ sessionID: 's1' });
     await hook.handleToolExecuteAfter({ tool: 'todowrite', sessionID: 's1' });
@@ -416,12 +195,7 @@ describe('todo hygiene', () => {
       type: 'session.deleted',
       properties: { info: { id: 's1' } },
     });
-    await hook.handleToolExecuteAfter(
-      { tool: 'grep', sessionID: 's1' },
-      output,
-    );
 
-    expect(output.output).toBe('tool result');
-    expect(output.output).not.toContain(TODO_HYGIENE_REMINDER);
+    expect(hook.consumePendingReminder('s1')).toBeNull();
   });
 });

--- a/src/hooks/todo-continuation/todo-hygiene.test.ts
+++ b/src/hooks/todo-continuation/todo-hygiene.test.ts
@@ -51,19 +51,12 @@ describe('todo hygiene', () => {
     expect(freshOutput.output).toContain(TODO_HYGIENE_REMINDER);
   });
 
-  test('system transform is no-op (cache-safe)', async () => {
+  test('does not expose a system transform handler', async () => {
     const hook = createTodoHygiene({
       getTodoState: async () => createState(),
     });
-    const system = { system: ['base'] };
 
-    hook.handleRequestStart({ sessionID: 's1' });
-    await hook.handleToolExecuteAfter({ tool: 'todowrite', sessionID: 's1' });
-    await hook.handleToolExecuteAfter({ tool: 'read', sessionID: 's1' });
-    await hook.handleChatSystemTransform({ sessionID: 's1' }, system);
-
-    expect(system.system).toEqual(['base']);
-    expect(system.system.join('\n')).not.toContain(TODO_HYGIENE_REMINDER);
+    expect('handleChatSystemTransform' in hook).toBe(false);
   });
 
   test('does not arm before the current request calls todowrite', async () => {

--- a/src/hooks/todo-continuation/todo-hygiene.test.ts
+++ b/src/hooks/todo-continuation/todo-hygiene.test.ts
@@ -246,6 +246,28 @@ describe('todo hygiene', () => {
     expect(output.output).not.toContain(TODO_HYGIENE_REMINDER);
   });
 
+  test('shouldInject rejection prevents immediate final-active reminder', async () => {
+    const hook = createTodoHygiene({
+      getTodoState: async () =>
+        createState({
+          openCount: 1,
+          inProgressCount: 1,
+          pendingCount: 0,
+        }),
+      shouldInject: () => false,
+    });
+    const output = createToolOutput();
+
+    hook.handleRequestStart({ sessionID: 's1' });
+    await hook.handleToolExecuteAfter(
+      { tool: 'todowrite', sessionID: 's1' },
+      output,
+    );
+
+    expect(output.output).toBe('tool result');
+    expect(output.output).not.toContain(TODO_FINAL_ACTIVE_REMINDER);
+  });
+
   test('final-active reminder wins when only one active todo remains', async () => {
     const hook = createTodoHygiene({
       getTodoState: async () =>
@@ -376,7 +398,7 @@ describe('todo hygiene', () => {
     );
     await hook.handleToolExecuteAfter({ tool: 'grep', sessionID: 's1' });
 
-    expect(calls).toBe(1);
+    expect(calls).toBe(0);
     expect(output.output).toBe('tool result');
     expect(output.output).not.toContain(TODO_HYGIENE_REMINDER);
   });

--- a/src/hooks/todo-continuation/todo-hygiene.ts
+++ b/src/hooks/todo-continuation/todo-hygiene.ts
@@ -170,7 +170,7 @@ export function createTodoHygiene(options: Options) {
       }
     },
 
-    consumePendingReminder(sessionID: string): string | null {
+    getPendingReminder(sessionID: string): string | null {
       const reasons = pending.get(sessionID);
       if (!reasons || reasons.size === 0) {
         return null;
@@ -182,8 +182,7 @@ export function createTodoHygiene(options: Options) {
       }
 
       const reminder = pick(reasons);
-      pending.delete(sessionID);
-      options.log?.('Consumed todo hygiene reminder', {
+      options.log?.('Read todo hygiene reminder', {
         sessionID,
         reminder,
         reasons: Array.from(reasons),

--- a/src/hooks/todo-continuation/todo-hygiene.ts
+++ b/src/hooks/todo-continuation/todo-hygiene.ts
@@ -13,10 +13,6 @@ interface ToolInput {
   sessionID?: string;
 }
 
-interface ToolOutput {
-  output?: unknown;
-}
-
 interface EventInput {
   type: string;
   properties?: {
@@ -43,11 +39,9 @@ interface Options {
 export function createTodoHygiene(options: Options) {
   const pending = new Map<string, Set<Reason>>();
   const active = new Set<string>();
-  const injected = new Set<string>();
 
   function clearCycle(sessionID: string): void {
     pending.delete(sessionID);
-    injected.delete(sessionID);
   }
 
   function clear(sessionID: string): void {
@@ -81,27 +75,6 @@ export function createTodoHygiene(options: Options) {
     return TODO_HYGIENE_REMINDER;
   }
 
-  function appendReminder(
-    output: ToolOutput | undefined,
-    reminder: string,
-  ): void {
-    if (!output || typeof output.output !== 'string') {
-      return;
-    }
-
-    if (output.output.includes(reminder)) {
-      return;
-    }
-
-    output.output = [
-      output.output,
-      '',
-      '<internal_reminder>',
-      reminder,
-      '</internal_reminder>',
-    ].join('\n');
-  }
-
   return {
     handleRequestStart(input: RequestStartInput): void {
       clear(input.sessionID);
@@ -109,7 +82,7 @@ export function createTodoHygiene(options: Options) {
 
     async handleToolExecuteAfter(
       input: ToolInput,
-      output?: ToolOutput,
+      _output?: unknown,
     ): Promise<void> {
       if (!input.sessionID) {
         return;
@@ -148,9 +121,6 @@ export function createTodoHygiene(options: Options) {
           }
 
           mark(input.sessionID, 'final_active');
-          appendReminder(output, TODO_FINAL_ACTIVE_REMINDER);
-          pending.delete(input.sessionID);
-          injected.add(input.sessionID);
           options.log?.('Armed final-active todo hygiene reminder', {
             sessionID: input.sessionID,
             tool,
@@ -159,10 +129,6 @@ export function createTodoHygiene(options: Options) {
         }
 
         if (!active.has(input.sessionID)) {
-          return;
-        }
-
-        if (injected.has(input.sessionID)) {
           return;
         }
 
@@ -187,13 +153,6 @@ export function createTodoHygiene(options: Options) {
           mark(input.sessionID, 'general');
         }
 
-        const reasons = pending.get(input.sessionID);
-        if (reasons) {
-          appendReminder(output, pick(reasons));
-          pending.delete(input.sessionID);
-          injected.add(input.sessionID);
-        }
-
         options.log?.('Armed todo hygiene reminder', {
           sessionID: input.sessionID,
           tool,
@@ -209,6 +168,27 @@ export function createTodoHygiene(options: Options) {
           },
         );
       }
+    },
+
+    consumePendingReminder(sessionID: string): string | null {
+      const reasons = pending.get(sessionID);
+      if (!reasons || reasons.size === 0) {
+        return null;
+      }
+
+      if (options.shouldInject && !options.shouldInject(sessionID)) {
+        clear(sessionID);
+        return null;
+      }
+
+      const reminder = pick(reasons);
+      pending.delete(sessionID);
+      options.log?.('Consumed todo hygiene reminder', {
+        sessionID,
+        reminder,
+        reasons: Array.from(reasons),
+      });
+      return reminder;
     },
 
     handleEvent(event: EventInput): void {

--- a/src/hooks/todo-continuation/todo-hygiene.ts
+++ b/src/hooks/todo-continuation/todo-hygiene.ts
@@ -13,6 +13,10 @@ interface ToolInput {
   sessionID?: string;
 }
 
+interface ToolOutput {
+  output?: unknown;
+}
+
 interface SystemInput {
   sessionID?: string;
 }
@@ -47,9 +51,11 @@ interface Options {
 export function createTodoHygiene(options: Options) {
   const pending = new Map<string, Set<Reason>>();
   const active = new Set<string>();
+  const injected = new Set<string>();
 
   function clearCycle(sessionID: string): void {
     pending.delete(sessionID);
+    injected.delete(sessionID);
   }
 
   function clear(sessionID: string): void {
@@ -83,12 +89,36 @@ export function createTodoHygiene(options: Options) {
     return TODO_HYGIENE_REMINDER;
   }
 
+  function appendReminder(
+    output: ToolOutput | undefined,
+    reminder: string,
+  ): void {
+    if (!output || typeof output.output !== 'string') {
+      return;
+    }
+
+    if (output.output.includes(reminder)) {
+      return;
+    }
+
+    output.output = [
+      output.output,
+      '',
+      '<internal_reminder>',
+      reminder,
+      '</internal_reminder>',
+    ].join('\n');
+  }
+
   return {
     handleRequestStart(input: RequestStartInput): void {
       clear(input.sessionID);
     },
 
-    async handleToolExecuteAfter(input: ToolInput): Promise<void> {
+    async handleToolExecuteAfter(
+      input: ToolInput,
+      output?: ToolOutput,
+    ): Promise<void> {
       if (!input.sessionID) {
         return;
       }
@@ -121,6 +151,9 @@ export function createTodoHygiene(options: Options) {
           }
 
           mark(input.sessionID, 'final_active');
+          appendReminder(output, TODO_FINAL_ACTIVE_REMINDER);
+          pending.delete(input.sessionID);
+          injected.add(input.sessionID);
           options.log?.('Armed final-active todo hygiene reminder', {
             sessionID: input.sessionID,
             tool,
@@ -129,6 +162,10 @@ export function createTodoHygiene(options: Options) {
         }
 
         if (!active.has(input.sessionID)) {
+          return;
+        }
+
+        if (injected.has(input.sessionID)) {
           return;
         }
 
@@ -153,6 +190,13 @@ export function createTodoHygiene(options: Options) {
           mark(input.sessionID, 'general');
         }
 
+        const reasons = pending.get(input.sessionID);
+        if (reasons) {
+          appendReminder(output, pick(reasons));
+          pending.delete(input.sessionID);
+          injected.add(input.sessionID);
+        }
+
         options.log?.('Armed todo hygiene reminder', {
           sessionID: input.sessionID,
           tool,
@@ -172,7 +216,7 @@ export function createTodoHygiene(options: Options) {
 
     async handleChatSystemTransform(
       input: SystemInput,
-      output: SystemOutput,
+      _output: SystemOutput,
     ): Promise<void> {
       if (!input.sessionID) {
         return;
@@ -198,7 +242,6 @@ export function createTodoHygiene(options: Options) {
         }
 
         pending.delete(input.sessionID);
-        output.system.push(reminder);
         options.log?.('Injected todo hygiene reminder', {
           sessionID: input.sessionID,
           reminder,

--- a/src/hooks/todo-continuation/todo-hygiene.ts
+++ b/src/hooks/todo-continuation/todo-hygiene.ts
@@ -122,6 +122,11 @@ export function createTodoHygiene(options: Options) {
 
       try {
         if (RESET.has(tool)) {
+          if (options.shouldInject && !options.shouldInject(input.sessionID)) {
+            clear(input.sessionID);
+            return;
+          }
+
           active.add(input.sessionID);
           clearCycle(input.sessionID);
           const state = await options.getTodoState(input.sessionID);

--- a/src/hooks/todo-continuation/todo-hygiene.ts
+++ b/src/hooks/todo-continuation/todo-hygiene.ts
@@ -17,14 +17,6 @@ interface ToolOutput {
   output?: unknown;
 }
 
-interface SystemInput {
-  sessionID?: string;
-}
-
-interface SystemOutput {
-  system: string[];
-}
-
 interface EventInput {
   type: string;
   properties?: {
@@ -208,51 +200,6 @@ export function createTodoHygiene(options: Options) {
           {
             sessionID: input.sessionID,
             tool,
-            error: error instanceof Error ? error.message : String(error),
-          },
-        );
-      }
-    },
-
-    async handleChatSystemTransform(
-      input: SystemInput,
-      _output: SystemOutput,
-    ): Promise<void> {
-      if (!input.sessionID) {
-        return;
-      }
-
-      const reasons = pending.get(input.sessionID);
-      if (!reasons || reasons.size === 0) {
-        return;
-      }
-
-      const reminder = pick(reasons);
-
-      if (options.shouldInject && !options.shouldInject(input.sessionID)) {
-        clear(input.sessionID);
-        return;
-      }
-
-      try {
-        const state = await options.getTodoState(input.sessionID);
-        if (!state.hasOpenTodos) {
-          clear(input.sessionID);
-          return;
-        }
-
-        pending.delete(input.sessionID);
-        options.log?.('Injected todo hygiene reminder', {
-          sessionID: input.sessionID,
-          reminder,
-          reasons: Array.from(reasons),
-        });
-      } catch (error) {
-        pending.delete(input.sessionID);
-        options.log?.(
-          'Skipped todo hygiene reminder: failed to inspect todos',
-          {
-            sessionID: input.sessionID,
             error: error instanceof Error ? error.message : String(error),
           },
         );

--- a/src/index.ts
+++ b/src/index.ts
@@ -914,17 +914,6 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
         }
       }
 
-      await todoContinuationHook.handleChatSystemTransform(input, output);
-      await postFileToolNudgeHook['experimental.chat.system.transform'](
-        input,
-        output,
-      );
-
-      await taskSessionManagerHook['experimental.chat.system.transform'](
-        input,
-        output,
-      );
-
       // Collapse to single system message for provider compatibility.
       // Some providers (e.g. Qwen via VLLM/DashScope) reject multiple
       // system messages. Sub-hooks above may push additional entries; join
@@ -983,6 +972,10 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
         input,
         typedOutput,
       );
+      await taskSessionManagerHook['experimental.chat.messages.transform'](
+        input,
+        typedOutput,
+      );
       await filterAvailableSkillsHook['experimental.chat.messages.transform'](
         input,
         typedOutput,
@@ -1015,6 +1008,7 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
           tool: string;
           sessionID?: string;
         },
+        output as { output?: unknown },
       );
 
       await postFileToolNudgeHook['tool.execute.after'](

--- a/src/index.ts
+++ b/src/index.ts
@@ -956,11 +956,11 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
       await todoContinuationHook.handleMessagesTransform({
         messages: typedOutput.messages,
       });
-      await phaseReminderHook['experimental.chat.messages.transform'](
+      await taskSessionManagerHook['experimental.chat.messages.transform'](
         input,
         typedOutput,
       );
-      await taskSessionManagerHook['experimental.chat.messages.transform'](
+      await phaseReminderHook['experimental.chat.messages.transform'](
         input,
         typedOutput,
       );

--- a/src/index.ts
+++ b/src/index.ts
@@ -754,18 +754,6 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
         },
       );
 
-      await postFileToolNudgeHook.event(
-        input as {
-          event: {
-            type: string;
-            properties?: {
-              info?: { id?: string };
-              sessionID?: string;
-            };
-          };
-        },
-      );
-
       await taskSessionManagerHook.event(
         input as {
           event: {


### PR DESCRIPTION
## Summary
- Closes #415.
- Keeps the orchestrator phase reminder active on every orchestrator turn, but appends it at the final latest user-message tail instead of prepending it or putting it in system.
- Stops dynamic todo hygiene, post-file-tool, and resumable-session state from mutating the cached system prompt.
- Preserves runtime nudges at cache-safe tails: post-file reminders stay in file-tool output, todo hygiene reminders are request-local message-transform instructions, and resumable session context is appended to the latest orchestrator user message before the phase reminder.

## What changed
- `phase-reminder` now appends `<internal_reminder>...</internal_reminder>` after the latest orchestrator user text. It runs after resumable-session injection, skips non-orchestrator and internal notification turns, and avoids duplicate reminders.
- `post-file-tool-nudge` appends the reminder to Read/Write tool output instead of setting pending state for system injection. This nudge is intentionally retained because post-read/write drift is still a useful trigger.
- `todo-continuation` follows the PR #416 transport model: tool activity arms pending reminder state, and `messages.transform` reads that state into a trailing `<instruction name="todo_hygiene">...</instruction>` on the latest orchestrator user message. This keeps todo reminders out of persisted tool output while preserving dynamic intra-turn behavior.
- Todo reminder reads are non-destructive so compaction transforms over cloned history cannot consume/drop a pending live reminder; new request boundaries and session cleanup still clear pending state.
- `task-session-manager` injects `<resumable_sessions>` into request-local message context instead of `experimental.chat.system.transform`.
- Removed the dynamic system-transform hooks/no-op compatibility shims, so the plugin no longer wires unused cache-sensitive reminder paths.

## Why this fixes the issue
OpenCode/provider prompt caching depends on stable cached prefix content. Before this change, runtime state such as file-tool activity, todo state, resumable sessions, and per-request reminders could alter system or prepend content ahead of the user's turn. This PR keeps dynamic reminders out of system and places request-local guidance at the tail/tool-output context, so reminders remain visible without invalidating the stable system prompt.

For todo hygiene specifically, OpenCode persists mutated tool outputs into tool history, so the reminder is no longer appended to `output.output`. It is armed in memory from `tool.execute.after` and injected only into outbound model payloads from `messages.transform`; compaction-safe non-destructive reads prevent cloned compaction transforms from dropping pending reminders.

## Verification
- `bun test src/hooks/phase-reminder/index.test.ts src/hooks/post-file-tool-nudge/index.test.ts src/hooks/todo-continuation/index.test.ts src/hooks/todo-continuation/todo-hygiene.test.ts src/hooks/task-session-manager/index.test.ts`
- `bunx biome check src/hooks/todo-continuation/index.ts src/hooks/todo-continuation/index.test.ts src/hooks/todo-continuation/todo-hygiene.ts src/hooks/todo-continuation/todo-hygiene.test.ts`
- `bun run typecheck`
- `bun run build`
- Manual relaunch/log verification showed system hashes staying stable across plain messages, Read-tool nudges, and todo hygiene activity.