### PR TITLE
Remove startup update toast

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -100,7 +100,6 @@ Presets can also be switched at runtime without restarting using the `/preset` c
 | `agents.<customAgent>.prompt` | string | — | Full execution prompt for a custom agent |
 | `agents.<customAgent>.orchestratorPrompt` | string | — | Exact `@agent` block injected into the orchestrator prompt; must start with `@<agent-name>` |
 | `agents.<agent>.displayName` | string | — | Custom user-facing alias for the agent in the active config |
-| `showStartupToast` | boolean | `true` | Show the startup activation toast (`oh-my-opencode-slim is active`) when OpenCode starts |
 | `autoUpdate` | boolean | `true` | Automatically install plugin updates in the background; set to `false` for notification-only mode |
 | `multiplexer.type` | string | `"none"` | Multiplexer mode: `auto`, `tmux`, `zellij`, or `none` |
 | `multiplexer.layout` | string | `"main-vertical"` | Layout preset: `main-vertical`, `main-horizontal`, `tiled`, `even-horizontal`, `even-vertical` |
@@ -142,17 +141,6 @@ Presets can also be switched at runtime without restarting using the `/preset` c
 - The **councillor models** are configured separately under
   `council.presets.<name>.<councillor>.model`.
 - Deprecated `council.master*` fields should not be used in new configs.
-
-### Startup Toast
-
-Set `showStartupToast` to `false` if you want to disable the startup toast that
-appears when the plugin activates.
-
-```jsonc
-{
-  "showStartupToast": false
-}
-```
 
 ### Manual Update Mode
 

--- a/oh-my-opencode-slim.schema.json
+++ b/oh-my-opencode-slim.schema.json
@@ -19,10 +19,6 @@
     "balanceProviderUsage": {
       "type": "boolean"
     },
-    "showStartupToast": {
-      "description": "Show the startup activation toast when OpenCode starts. Defaults to true.",
-      "type": "boolean"
-    },
     "autoUpdate": {
       "description": "Disable automatic installation of plugin updates when false. Defaults to true.",
       "type": "boolean"

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -80,21 +80,6 @@ describe("loadPluginConfig", () => {
     expect(config.balanceProviderUsage).toBe(true);
   });
 
-  test("loads showStartupToast flag when configured", () => {
-    const projectDir = path.join(tempDir, "project");
-    const projectConfigDir = path.join(projectDir, ".opencode");
-    fs.mkdirSync(projectConfigDir, { recursive: true });
-    fs.writeFileSync(
-      path.join(projectConfigDir, "oh-my-opencode-slim.json"),
-      JSON.stringify({
-        showStartupToast: false,
-      })
-    );
-
-    const config = loadPluginConfig(projectDir);
-    expect(config.showStartupToast).toBe(false);
-  });
-
   test("loads autoUpdate flag when configured", () => {
     const projectDir = path.join(tempDir, "project");
     const projectConfigDir = path.join(projectDir, ".opencode");

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -282,12 +282,6 @@ export const PluginConfigSchema = z
     setDefaultAgent: z.boolean().optional(),
     scoringEngineVersion: z.enum(['v1', 'v2-shadow', 'v2']).optional(),
     balanceProviderUsage: z.boolean().optional(),
-    showStartupToast: z
-      .boolean()
-      .optional()
-      .describe(
-        'Show the startup activation toast when OpenCode starts. Defaults to true.',
-      ),
     autoUpdate: z
       .boolean()
       .optional()

--- a/src/hooks/auto-update-checker/index.test.ts
+++ b/src/hooks/auto-update-checker/index.test.ts
@@ -117,7 +117,7 @@ describe('auto-update-checker/index', () => {
     expect(getAutoUpdateInstallDir()).toBe('/tmp/opencode');
   });
 
-  test('shows development toast and skips background update for local dev installs', async () => {
+  test('skips background update for local dev installs without startup toast', async () => {
     checkerMocks.getLocalDevVersion.mockImplementation(() => '0.9.11-dev');
 
     const { createAutoUpdateCheckerHook } = await import(
@@ -127,16 +127,9 @@ describe('auto-update-checker/index', () => {
 
     const hook = createAutoUpdateCheckerHook(ctx as never);
     hook.event({ event: { type: 'session.created', properties: {} } });
-    await waitForCalls(showToast);
+    await waitForCalls(logMock);
 
-    expect(showToast).toHaveBeenCalledWith({
-      body: {
-        title: 'OMO-Slim 0.9.11-dev (dev)',
-        message: 'Running in local development mode.',
-        variant: 'info',
-        duration: 3000,
-      },
-    });
+    expect(showToast).not.toHaveBeenCalled();
     expect(checkerMocks.findPluginEntry).not.toHaveBeenCalled();
     expect(checkerMocks.getLatestVersion).not.toHaveBeenCalled();
   });
@@ -163,9 +156,7 @@ describe('auto-update-checker/index', () => {
     );
     const { ctx, showToast } = createCtx();
 
-    const hook = createAutoUpdateCheckerHook(ctx as never, {
-      showStartupToast: false,
-    });
+    const hook = createAutoUpdateCheckerHook(ctx as never);
     hook.event({ event: { type: 'session.created', properties: {} } });
     await waitForCalls(showToast);
 
@@ -201,7 +192,6 @@ describe('auto-update-checker/index', () => {
     const { ctx, showToast } = createCtx();
 
     const hook = createAutoUpdateCheckerHook(ctx as never, {
-      showStartupToast: false,
       autoUpdate: false,
     });
     hook.event({ event: { type: 'session.created', properties: {} } });
@@ -233,9 +223,7 @@ describe('auto-update-checker/index', () => {
     );
     const { ctx, showToast } = createCtx();
 
-    const hook = createAutoUpdateCheckerHook(ctx as never, {
-      showStartupToast: false,
-    });
+    const hook = createAutoUpdateCheckerHook(ctx as never);
     hook.event({ event: { type: 'session.created', properties: {} } });
     await waitForCalls(showToast);
 
@@ -273,9 +261,7 @@ describe('auto-update-checker/index', () => {
     );
     const { ctx, showToast } = createCtx();
 
-    const hook = createAutoUpdateCheckerHook(ctx as never, {
-      showStartupToast: false,
-    });
+    const hook = createAutoUpdateCheckerHook(ctx as never);
     hook.event({ event: { type: 'session.created', properties: {} } });
     await waitForCalls(showToast);
 

--- a/src/hooks/auto-update-checker/index.ts
+++ b/src/hooks/auto-update-checker/index.ts
@@ -22,7 +22,7 @@ export function createAutoUpdateCheckerHook(
   ctx: PluginInput,
   options: AutoUpdateCheckerOptions = {},
 ) {
-  const { showStartupToast = true, autoUpdate = true } = options;
+  const { autoUpdate = true } = options;
 
   let hasChecked = false;
 
@@ -39,30 +39,11 @@ export function createAutoUpdateCheckerHook(
       hasChecked = true;
 
       setTimeout(async () => {
-        const cachedVersion = getCachedVersion();
         const localDevVersion = getLocalDevVersion(ctx.directory);
-        const displayVersion = localDevVersion ?? cachedVersion;
 
         if (localDevVersion) {
-          if (showStartupToast) {
-            showToast(
-              ctx,
-              `OMO-Slim ${displayVersion} (dev)`,
-              'Running in local development mode.',
-              'info',
-            );
-          }
           log('[auto-update-checker] Local development mode');
           return;
-        }
-
-        if (showStartupToast) {
-          showToast(
-            ctx,
-            `OMO-Slim ${displayVersion ?? 'unknown'}`,
-            'oh-my-opencode-slim is active.',
-            'info',
-          );
         }
 
         runBackgroundUpdateCheck(ctx, autoUpdate).catch((err) => {

--- a/src/hooks/auto-update-checker/types.ts
+++ b/src/hooks/auto-update-checker/types.ts
@@ -15,7 +15,6 @@ export interface PackageJson {
 }
 
 export interface AutoUpdateCheckerOptions {
-  showStartupToast?: boolean;
   autoUpdate?: boolean;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -255,7 +255,6 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
 
     // Initialize auto-update checker hook
     autoUpdateChecker = createAutoUpdateCheckerHook(ctx, {
-      showStartupToast: config.showStartupToast ?? true,
       autoUpdate: config.autoUpdate ?? true,
     });
 


### PR DESCRIPTION
## Summary
- Remove the startup/local-dev activation toast from auto-update initialization.
- Keep update-related toasts for available updates, auto-update status, and install results.
- Remove the obsolete `showStartupToast` config/schema/docs/test wiring.

## Validation
- `bun test src/hooks/auto-update-checker/index.test.ts src/config/loader.test.ts`
- `bun run typecheck`
- `bun run check:ci` currently reports unrelated existing formatting issues in other files.