### PR TITLE
Enable observer for OpenCode Go preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ If any agent fails to respond, check your provider authentication and config fil
 ### Observer: The Silent Witness
 
 > [!NOTE]
-> **Why a separate agent?** If your Orchestrator model is not multimodal, enable Observer to handle images, screenshots, PDFs, and other visual files. Observer is disabled by default and gives the Orchestrator a dedicated multimodal reader without forcing you to change your main reasoning model. Set `disabled_agents: []` and an `observer` model in your configuration.
+> **Why a separate agent?** If your Orchestrator model is not multimodal, enable Observer to handle images, screenshots, PDFs, and other visual files. Observer is disabled by default and gives the Orchestrator a dedicated multimodal reader without forcing you to change your main reasoning model. Set `disabled_agents: []` and an `observer` model in your configuration. The bundled `opencode-go` install preset does this automatically because its GLM Orchestrator is not multimodal.
 
 <table>
   <tr>
@@ -443,7 +443,7 @@ If any agent fails to respond, check your provider authentication and config fil
 
 - Images, screenshots, diagrams → `read` tool (native image support)
 - PDFs and binary documents → `read` tool (text + structure extraction)
-- **Disabled by default** — enable with `"disabled_agents": []` and configure a vision-capable model
+- **Disabled by default** — enable with `"disabled_agents": []` and configure a vision-capable model; installing with `--preset=opencode-go` enables it with `opencode-go/kimi-k2.6`
 
     </td>
   </tr>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -100,6 +100,7 @@ Presets can also be switched at runtime without restarting using the `/preset` c
 | `agents.<customAgent>.prompt` | string | — | Full execution prompt for a custom agent |
 | `agents.<customAgent>.orchestratorPrompt` | string | — | Exact `@agent` block injected into the orchestrator prompt; must start with `@<agent-name>` |
 | `agents.<agent>.displayName` | string | — | Custom user-facing alias for the agent in the active config |
+| `disabled_agents` | string[] | `["observer"]` | Agent names to disable globally. Set to `[]` to enable Observer; this is global, not per-preset |
 | `autoUpdate` | boolean | `true` | Automatically install plugin updates in the background; set to `false` for notification-only mode |
 | `multiplexer.type` | string | `"none"` | Multiplexer mode: `auto`, `tmux`, `zellij`, or `none` |
 | `multiplexer.layout` | string | `"main-vertical"` | Layout preset: `main-vertical`, `main-horizontal`, `tiled`, `even-horizontal`, `even-vertical` |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -57,7 +57,7 @@ bunx oh-my-opencode-slim@latest install --reset
 
 ### After Installation
 
-The installer generates both OpenAI and OpenCode Go presets, with OpenAI active by default (using `gpt-5.5` and `gpt-5.4-mini` models). To make OpenCode Go active during install, run `bunx oh-my-opencode-slim@latest install --preset=opencode-go`. To switch providers later or build a mixed setup, use **[Configuration Reference](configuration.md)** for the full option reference and the preset docs for copyable examples.
+The installer generates both OpenAI and OpenCode Go presets, with OpenAI active by default (using `gpt-5.5` and `gpt-5.4-mini` models). To make OpenCode Go active during install, run `bunx oh-my-opencode-slim@latest install --preset=opencode-go`. That preset uses GLM-5.1 for Orchestrator, so the installer also enables Observer with `opencode-go/kimi-k2.6` for visual analysis. To switch providers later or build a mixed setup, use **[Configuration Reference](configuration.md)** for the full option reference and the preset docs for copyable examples.
 
 Then:
 

--- a/docs/opencode-go-preset.md
+++ b/docs/opencode-go-preset.md
@@ -7,6 +7,10 @@ The installer generates both `openai` and `opencode-go` presets. OpenAI stays
 active by default unless you select OpenCode Go during install or switch to it
 later.
 
+Because the `opencode-go` preset uses GLM-5.1 for Orchestrator and GLM is not
+multimodal, installing with `--preset=opencode-go` also enables the Observer
+agent and configures it with `opencode-go/kimi-k2.6` for visual analysis.
+
 ## Install with OpenCode Go Active
 
 ```bash
@@ -29,7 +33,13 @@ If both presets are already in your config, switch from inside OpenCode:
 ```
 
 See [Preset Switching](preset-switching.md) for the full runtime switching
-workflow.
+workflow. If you originally installed with the default OpenAI preset, also add
+`"disabled_agents": []` to your config and restart OpenCode so Observer is
+available before switching to `opencode-go`.
+
+`disabled_agents` is global, not per-preset. If you later switch back to OpenAI
+and restart while keeping `"disabled_agents": []`, Observer will remain enabled
+and use the default Observer model unless you configure one explicitly.
 
 ## Bundled Model Mapping
 
@@ -45,6 +55,7 @@ role:
 | Explorer | `opencode-go/minimax-m2.7` |
 | Designer | `opencode-go/kimi-k2.6` (`medium`) |
 | Fixer | `opencode-go/deepseek-v4-flash` (`high`) |
+| Observer | `opencode-go/kimi-k2.6` |
 
 ## Generated Config Shape
 
@@ -54,6 +65,7 @@ setting the top-level `preset` field:
 ```jsonc
 {
   "preset": "opencode-go",
+  "disabled_agents": [],
   "presets": {
     "opencode-go": {
       "orchestrator": { "model": "opencode-go/glm-5.1" },
@@ -74,7 +86,8 @@ setting the top-level `preset` field:
       "fixer": {
         "model": "opencode-go/deepseek-v4-flash",
         "variant": "high"
-      }
+      },
+      "observer": { "model": "opencode-go/kimi-k2.6" }
     }
   }
 }

--- a/src/cli/config-io.test.ts
+++ b/src/cli/config-io.test.ts
@@ -430,9 +430,13 @@ describe('config-io', () => {
 
     const saved = JSON.parse(readFileSync(litePath, 'utf-8'));
     expect(saved.preset).toBe('opencode-go');
+    expect(saved.disabled_agents).toEqual([]);
     expect(saved.presets.openai).toBeDefined();
     expect(saved.presets['opencode-go'].orchestrator.model).toBe(
       'opencode-go/glm-5.1',
+    );
+    expect(saved.presets['opencode-go'].observer.model).toBe(
+      'opencode-go/kimi-k2.6',
     );
   });
 

--- a/src/cli/providers.test.ts
+++ b/src/cli/providers.test.ts
@@ -27,7 +27,11 @@ describe('providers', () => {
       'https://unpkg.com/oh-my-opencode-slim@latest/oh-my-opencode-slim.schema.json',
     );
     expect(config.preset).toBe('openai');
+    expect(config.disabled_agents).toBeUndefined();
     expect((config.presets as any)['opencode-go']).toBeDefined();
+    expect((config.presets as any)['opencode-go'].observer.model).toBe(
+      'opencode-go/kimi-k2.6',
+    );
     const agents = (config.presets as any).openai;
     expect(agents).toBeDefined();
     expect(agents.orchestrator.model).toBe('openai/gpt-5.5');
@@ -68,6 +72,7 @@ describe('providers', () => {
     });
 
     expect(config.preset).toBe('opencode-go');
+    expect(config.disabled_agents).toEqual([]);
     expect((config.presets as any).openai).toBeDefined();
     const agents = (config.presets as any)['opencode-go'];
     expect(agents).toBeDefined();
@@ -81,6 +86,7 @@ describe('providers', () => {
     expect(agents.designer.model).toBe('opencode-go/kimi-k2.6');
     expect(agents.fixer.model).toBe('opencode-go/deepseek-v4-flash');
     expect(agents.fixer.variant).toBe('high');
+    expect(agents.observer.model).toBe('opencode-go/kimi-k2.6');
   });
 
   test('generateLiteConfig rejects unsupported preset', () => {

--- a/src/cli/providers.ts
+++ b/src/cli/providers.ts
@@ -53,6 +53,7 @@ export const MODEL_MAPPINGS = {
     explorer: { model: 'opencode-go/minimax-m2.7' },
     designer: { model: 'opencode-go/kimi-k2.6', variant: 'medium' },
     fixer: { model: 'opencode-go/deepseek-v4-flash', variant: 'high' },
+    observer: { model: 'opencode-go/kimi-k2.6' },
   },
 } as const;
 
@@ -92,6 +93,10 @@ export function generateLiteConfig(
     preset,
     presets: {},
   };
+
+  if (preset === 'opencode-go') {
+    config.disabled_agents = [];
+  }
 
   const createAgentConfig = (
     agentName: string,


### PR DESCRIPTION
## Summary
- Enable Observer in generated installs when `opencode-go` is the active preset because its GLM orchestrator is not multimodal.
- Add an Observer mapping to the bundled `opencode-go` preset using `opencode-go/kimi-k2.6`.
- Document Observer behavior, global `disabled_agents` implications, and add regression coverage for generated config output.

## Validation
- `bun test src/cli/providers.test.ts src/cli/config-io.test.ts`
- `bun run check:ci`
- `bun run typecheck`

## Notes
- Full `bun test` was attempted earlier but hit an unrelated temp path mismatch in `doctor.test.ts` (`/private/var/...` vs `/var/...`).