### PR TITLE
refactor: share agent alias validation pattern

### DIFF
--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -37,6 +37,7 @@ type AgentFactory = (
 ) => AgentDefinition;
 
 const COUNCIL_TOOL_ALLOWED_AGENTS = new Set(['council']);
+const SAFE_AGENT_ALIAS_RE = /^[a-z][a-z0-9_-]*$/i;
 
 function normalizeDisplayName(displayName: string): string {
   const trimmed = displayName.trim();
@@ -44,7 +45,7 @@ function normalizeDisplayName(displayName: string): string {
 }
 
 function isSafeDisplayName(displayName: string): boolean {
-  return /^[a-z][a-z0-9_-]*$/i.test(displayName);
+  return SAFE_AGENT_ALIAS_RE.test(displayName);
 }
 
 function escapeRegExp(value: string): string {
@@ -96,7 +97,7 @@ function normalizeCustomAgentName(name: string): string {
 }
 
 function isSafeCustomAgentName(name: string): boolean {
-  return /^[a-z][a-z0-9_-]*$/i.test(name) && !isKnownAgentName(name);
+  return SAFE_AGENT_ALIAS_RE.test(name) && !isKnownAgentName(name);
 }
 
 function hasCustomAgentModel(


### PR DESCRIPTION
## Summary
- Replace the duplicated agent alias/display-name regex with a shared `SAFE_AGENT_ALIAS_RE` constant.
- Keep the existing validation behavior unchanged for custom agent names and display names.

## Motivation
This addresses the follow-up review note from #431 after that PR was merged. The change is intentionally small and isolated from the async lifecycle hardening work in #437.

## Validation
- `bun test src/agents/display-name.test.ts src/agents/custom.test.ts src/agents/index.test.ts`
- `bun run typecheck`
- `git diff --check`
- `bun test`
- `bun run lint`