### PR TITLE
Fix installer plugin path for bunx installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,10 @@ bunx oh-my-opencode-slim@latest install
 
 The installer also registers the companion TUI plugin in OpenCode's
 `tui.json`, which adds a small sidebar showing specialist-agent status plus
-active/reusable task sessions. For manual setups, add `oh-my-opencode-slim` to
-the `plugin` array in both `opencode.json` and `tui.json`.
+active/reusable task sessions. It writes the local package root into OpenCode's
+plugin config so OpenCode can load the installed package directly.
+For manual setups, add `oh-my-opencode-slim` to the `plugin` array in both
+`opencode.json` and `tui.json`.
 
 ### Getting Started
 

--- a/src/cli/config-io.test.ts
+++ b/src/cli/config-io.test.ts
@@ -135,7 +135,7 @@ describe('config-io', () => {
     expect(saved.plugin.length).toBe(2);
   });
 
-  test('addPluginToOpenCodeConfig stores package name for bunx temp paths', async () => {
+  test('addPluginToOpenCodeConfig stores package root for bunx temp paths', async () => {
     const configPath = join(tmpDir, 'opencode', 'opencode.json');
     const packageRoot = join(
       tmpDir,
@@ -152,7 +152,7 @@ describe('config-io', () => {
 
     expect(result.success).toBe(true);
     const saved = JSON.parse(readFileSync(configPath, 'utf-8'));
-    expect(saved.plugin).toEqual(['oh-my-opencode-slim']);
+    expect(saved.plugin).toEqual([packageRoot]);
   });
 
   test('addPluginToOpenCodeConfig stores local repo path for local dev paths', async () => {
@@ -267,7 +267,7 @@ describe('config-io', () => {
     expect(saved.plugin.length).toBe(2);
   });
 
-  test('addPluginToOpenCodeTuiConfig stores package name for bunx temp paths', async () => {
+  test('addPluginToOpenCodeTuiConfig stores package root for bunx temp paths', async () => {
     const tuiPath = join(tmpDir, 'opencode', 'tui.json');
     const packageRoot = join(
       tmpDir,
@@ -284,7 +284,7 @@ describe('config-io', () => {
 
     expect(result.success).toBe(true);
     const saved = JSON.parse(readFileSync(tuiPath, 'utf-8'));
-    expect(saved.plugin).toEqual(['oh-my-opencode-slim']);
+    expect(saved.plugin).toEqual([packageRoot]);
   });
 
   test('addPluginToOpenCodeTuiConfig removes tuple plugin entries', async () => {

--- a/src/cli/config-io.ts
+++ b/src/cli/config-io.ts
@@ -45,10 +45,6 @@ function getPluginSpec(entry: unknown): string | undefined {
   return isString(spec) ? spec : undefined;
 }
 
-function normalizePathForMatch(path: string): string {
-  return path.replaceAll('\\', '/');
-}
-
 function findPackageRoot(startPath: string): string | null {
   let currentPath = dirname(startPath);
 
@@ -77,11 +73,6 @@ function findPackageRoot(startPath: string): string | null {
     }
     currentPath = parentPath;
   }
-}
-
-function isPackageManagerInstall(path: string): boolean {
-  const normalizedPath = normalizePathForMatch(path);
-  return normalizedPath.includes(`/node_modules/${PACKAGE_NAME}`);
 }
 
 function isLocalPackageRootEntry(entry: string): boolean {
@@ -128,11 +119,7 @@ function getPluginEntry(): string {
   try {
     const packageRoot = findPackageRoot(cliEntryPath);
 
-    if (!packageRoot || isPackageManagerInstall(packageRoot)) {
-      return PACKAGE_NAME;
-    }
-
-    return packageRoot;
+    return packageRoot ?? PACKAGE_NAME;
   } catch {
     return PACKAGE_NAME;
   }


### PR DESCRIPTION
## Summary
- Store the resolved local package root in OpenCode plugin config when the installer runs from an installed package.
- Avoid relying on OpenCode's package cache when `bunx oh-my-opencode-slim@latest install` writes plugin entries.
- Update tests and README to cover the package-root behavior.

Fixes #445

## Verification
- `bun test src/cli/config-io.test.ts`
- `bun run build`
- Temp install using isolated `XDG_CONFIG_HOME`, confirming `plugin=G:\DM\oh-my-opencode-slim`
- `opencode agent list` with the isolated config showed OMO Slim agents, including `orchestrator`, `oracle`, `librarian`, `designer`, `explorer`, and `fixer`