### PR TITLE
fix: handle readonly apply_patch args

### DIFF
--- a/src/hooks/apply-patch/hook.test.ts
+++ b/src/hooks/apply-patch/hook.test.ts
@@ -228,6 +228,62 @@ PATCH`,
     );
   });
 
+  test('rewrites by replacing readonly args instead of mutating them', async () => {
+    const root = await createTempDir('apply-patch-hook-');
+    await writeFixture(root, 'sample.txt', 'prefix\nstale-value\nsuffix\n');
+    const hook = createHook();
+    const patchText = `*** Begin Patch
+*** Update File: sample.txt
+@@
+ prefix
+-old-value
++new-value
+ suffix
+*** End Patch`;
+    const args = Object.freeze({ patchText });
+    const output = { args };
+
+    await hook['tool.execute.before'](
+      { tool: 'apply_patch', directory: root },
+      output,
+    );
+
+    expect(output.args).not.toBe(args);
+    expect(output.args.patchText).toContain('-stale-value');
+    expect(output.args.patchText).toContain('+new-value');
+  });
+
+  test('fails open when output args cannot be replaced', async () => {
+    const root = await createTempDir('apply-patch-hook-');
+    await writeFixture(root, 'sample.txt', 'prefix\nstale-value\nsuffix\n');
+    const hook = createHook();
+    const patchText = `*** Begin Patch
+*** Update File: sample.txt
+@@
+ prefix
+-old-value
++new-value
+ suffix
+*** End Patch`;
+    const args = Object.freeze({ patchText });
+    const output = {} as { args?: typeof args };
+    Object.defineProperty(output, 'args', {
+      configurable: false,
+      enumerable: true,
+      get: () => args,
+    });
+
+    await expect(
+      hook['tool.execute.before'](
+        { tool: 'apply_patch', directory: root },
+        output,
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(output.args).toBe(args);
+    expect(output.args?.patchText).toBe(patchText);
+  });
+
   test('does not alter new_lines during rewrite', async () => {
     const root = await createTempDir('apply-patch-hook-');
     await writeFixture(

--- a/src/hooks/apply-patch/index.ts
+++ b/src/hooks/apply-patch/index.ts
@@ -27,6 +27,22 @@ interface ToolExecuteBeforeOutput {
   };
 }
 
+function replacePatchArgs(
+  output: ToolExecuteBeforeOutput,
+  args: NonNullable<ToolExecuteBeforeOutput['args']>,
+  patchText: string,
+): boolean {
+  const nextArgs = { ...args, patchText };
+
+  try {
+    output.args = nextArgs;
+  } catch {
+    return false;
+  }
+
+  return output.args?.patchText === patchText;
+}
+
 export function createApplyPatchHook(ctx: PluginInput) {
   function logHookStatus(
     state:
@@ -68,8 +84,16 @@ export function createApplyPatchHook(ctx: PluginInput) {
         );
 
         if (result.changed) {
-          args.patchText = result.patchText;
-          logHookStatus('rewrite');
+          if (replacePatchArgs(output, args, result.patchText)) {
+            logHookStatus('rewrite');
+          } else {
+            logHookStatus('skipped', {
+              reason: 'readonly output args',
+              failOpen: true,
+              rescueOptions: APPLY_PATCH_RESCUE_OPTIONS,
+              rewriteStage: 'before-native',
+            });
+          }
           return;
         }
 


### PR DESCRIPTION
## Summary

Fix the `apply_patch` rescue hook so it no longer assumes the tool argument object is directly mutable.

When the hook rewrites a stale-but-recoverable patch, it used to update the patch text by mutating the existing argument object:

```ts
args.patchText = result.patchText
```

In newer/runtime-specific OpenCode tool hook payloads, `output.args` or its properties can be readonly/frozen. In that case the hook throws before the native `apply_patch` tool gets a chance to run, producing an internal hook failure such as:

```text
Unexpected hook failure before native apply: Attempted to assign to readonly property
```

That failure is worse than a normal patch mismatch because it prevents the native tool from handling the request at all.

## Changes

- Replace rewritten patch args by assigning a fresh args object:
  - `{ ...args, patchText: result.patchText }`
- Keep the rescue behavior when `output.args` is replaceable.
- Fail open if `output.args` itself cannot be replaced.
  - The hook logs a skipped/fail-open state.
  - The original patch is left untouched.
  - Native `apply_patch` can continue with its own normal validation/error path.
- Add regression coverage for both cases:
  - frozen/readonly `args` object can still be rewritten by replacing the object
  - non-replaceable `output.args` does not throw and preserves native fallback behavior

## Why this is safe

This keeps the hook best-effort:

- successful rewrites still happen before native execution
- unrecoverable patches still fail through the existing verification path
- readonly hook payloads no longer turn into plugin-internal failures
- if the runtime makes args fully immutable, the plugin does not block native `apply_patch`

## Validation

Executed locally:

- `bun test src/hooks/apply-patch/hook.test.ts`
- `bun run typecheck`
- `bun run check:ci`

Results:

- 28/28 apply-patch hook tests passing
- TypeScript typecheck clean
- Biome check clean