### PR TITLE
Remove agent-browser skill install

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The default generated configuration includes both `openai` and `opencode-go` pre
       "oracle": { "model": "openai/gpt-5.5", "variant": "high", "skills": ["simplify"], "mcps": [] },
       "librarian": { "model": "openai/gpt-5.4-mini", "variant": "low", "skills": [], "mcps": ["websearch", "context7", "grep_app"] },
       "explorer": { "model": "openai/gpt-5.4-mini", "variant": "low", "skills": [], "mcps": [] },
-      "designer": { "model": "openai/gpt-5.4-mini", "variant": "medium", "skills": ["agent-browser"], "mcps": [] },
+      "designer": { "model": "openai/gpt-5.4-mini", "variant": "medium", "skills": [], "mcps": [] },
       "fixer": { "model": "openai/gpt-5.4-mini", "variant": "low", "skills": [], "mcps": [] }
     },
     "opencode-go": {
@@ -92,7 +92,7 @@ The default generated configuration includes both `openai` and `opencode-go` pre
       "council": { "model": "opencode-go/deepseek-v4-pro", "variant": "high", "skills": [], "mcps": [] },
       "librarian": { "model": "opencode-go/minimax-m2.7", "skills": [], "mcps": [ "websearch", "context7", "grep_app" ] },
       "explorer": { "model": "opencode-go/minimax-m2.7", "skills": [], "mcps": [] },
-      "designer": { "model": "opencode-go/kimi-k2.6", "variant": "medium", "skills": [ "agent-browser" ], "mcps": [] },
+      "designer": { "model": "opencode-go/kimi-k2.6", "variant": "medium", "skills": [], "mcps": [] },
       "fixer": { "model": "opencode-go/deepseek-v4-flash", "variant": "high", "skills": [], "mcps": [] }
     }
   }
@@ -507,7 +507,7 @@ Use this section as a map: start with installation, then jump to features, confi
 |-----|----------------|
 | **[Configuration](docs/configuration.md)** | Config file locations, JSONC support, prompt overrides, and full option reference |
 | **[Maintainer Guide](docs/maintainers.md)** | Issue triage rules, label meanings, support routing, and repo maintenance workflow |
-| **[Skills](docs/skills.md)** | Built-in and recommended skills such as `simplify`, `agent-browser`, `codemap`, and `clonedeps` |
+| **[Skills](docs/skills.md)** | Bundled skills such as `simplify`, `codemap`, and `clonedeps` |
 | **[MCPs](docs/mcps.md)** | `websearch`, `context7`, `grep_app`, and how MCP permissions work per agent |
 | **[Tools](docs/tools.md)** | Built-in tool capabilities like `webfetch`, LSP tools, code search, and formatters |
 

--- a/docs/authors-preset.md
+++ b/docs/authors-preset.md
@@ -15,7 +15,7 @@ This is the exact configuration the author runs day-to-day.
         "council": { "model": "openai/gpt-5.5-fast" },
         "librarian": { "model": "openai/gpt-5.3-codex-spark", "variant": "low", "skills": [], "mcps": [ "websearch", "context7", "grep_app" ] },
         "explorer": { "model": "openai/gpt-5.3-codex-spark", "variant": "low", "skills": [], "mcps": [] },
-        "designer": { "model": "github-copilot/gemini-3.1-pro-preview", "skills": [ "agent-browser" ], "mcps": [] },
+        "designer": { "model": "github-copilot/gemini-3.1-pro-preview", "skills": [], "mcps": [] },
         "fixer": { "model": "openai/gpt-5.3-codex-spark", "variant": "low", "skills": [], "mcps": [] }
     }
   },

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -33,7 +33,7 @@ The installer supports the following options:
 
 | Option | Description |
 |--------|-------------|
-| `--skills=yes|no` | Install recommended and bundled skills (default: yes) |
+| `--skills=yes|no` | Install bundled skills (default: yes) |
 | `--preset=<name>` | Active generated config preset: `openai` or `opencode-go` (default: `openai`) |
 | `--no-tui` | Non-interactive mode |
 | `--dry-run` | Simulate install without writing files |
@@ -114,10 +114,10 @@ bunx oh-my-opencode-slim@latest install --no-tui --skills=yes
 
 **Examples:**
 ```bash
-# Interactive install (asks about tmux and skills)
+# Interactive install
 bunx oh-my-opencode-slim@latest install
 
-# Non-interactive with default skills
+# Non-interactive with bundled skills
 bunx oh-my-opencode-slim@latest install --no-tui --skills=yes
 
 # Make the generated OpenCode Go preset active
@@ -261,7 +261,7 @@ See the [Multiplexer Integration Guide](multiplexer-integration.md) for more det
 
 3. **Remove skills (optional)**:
    ```bash
-   npx skills remove agent-browser
    rm -rf ~/.config/opencode/skills/simplify
    rm -rf ~/.config/opencode/skills/codemap
+   rm -rf ~/.config/opencode/skills/clonedeps
    ```

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -23,7 +23,7 @@
 
 | Doc | Contents |
 |-----|----------|
-| [Skills](skills.md) | `simplify`, `agent-browser`, `codemap` — skills assignment syntax |
+| [Skills](skills.md) | `simplify`, `codemap`, `clonedeps` — skills assignment syntax |
 | [MCPs](mcps.md) | `websearch`, `context7`, `grep_app` — permissions per agent, global disable |
 | [Tools](tools.md) | Background tasks, LSP, code search (`ast_grep`), formatters |
 | [Configuration](configuration.md) | Config files, prompt overriding, JSONC, full option reference table |

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -2,17 +2,11 @@
 
 Skills are specialized capabilities you can assign to agents. Unlike MCPs (which are running servers), skills are **prompt-based tool configurations** — instructions injected into an agent's system prompt that describe how to use a particular tool.
 
-Skills are installed via the `oh-my-opencode-slim` installer or manually with `npx skills add`.
+Bundled skills are installed by the `oh-my-opencode-slim` installer.
 
 ---
 
 ## Available Skills
-
-### Recommended (via installer)
-
-| Skill | Description | Assigned to by default |
-|-------|-------------|----------------------|
-| [`agent-browser`](#agent-browser) | High-performance browser automation | `designer` |
 
 ### Bundled in repo
 
@@ -33,14 +27,6 @@ Skills are installed via the `oh-my-opencode-slim` installer or manually with `n
 By default, this skill is assigned to `oracle`, which owns code review, maintainability review, and simplification guidance. The `orchestrator` should route simplification requests to `oracle` instead of handling them as a top-level specialty itself.
 
 Source: adapted from Addy Osmani's `code-simplification` skill and bundled locally as `simplify`.
-
----
-
-## agent-browser
-
-**External browser automation for visual verification and testing.**
-
-`agent-browser` provides full high-performance browser automation. It allows agents to browse the web, interact with page elements, take screenshots, and verify visual state — useful for UI/UX work, end-to-end testing, and researching live documentation.
 
 ---
 
@@ -102,7 +88,7 @@ Control which skills each agent can use in `~/.config/opencode/oh-my-opencode-sl
 | Syntax | Meaning |
 |--------|---------|
 | `["*"]` | All installed skills |
-| `["*", "!agent-browser"]` | All skills except `agent-browser` |
+| `["*", "!codemap"]` | All skills except `codemap` |
 | `["simplify"]` | Only `simplify` |
 | `[]` | No skills |
 | `["!*"]` | Deny all skills |
@@ -125,7 +111,7 @@ Control which skills each agent can use in `~/.config/opencode/oh-my-opencode-sl
         "skills": ["simplify"]
       },
       "designer": {
-        "skills": ["agent-browser"]
+        "skills": []
       },
       "fixer": {
         "skills": []

--- a/docs/thirty-dollars-preset.md
+++ b/docs/thirty-dollars-preset.md
@@ -17,7 +17,7 @@ It uses Codex Plus for the OpenAI models and GitHub Copilot for the premium coun
         "council": { "model": "openai/gpt-5.5" },
         "librarian": { "model": "openai/gpt-5.4-mini", "variant": "low", "skills": [], "mcps": [ "websearch", "context7", "grep_app" ] },
         "explorer": { "model": "openai/gpt-5.4-mini", "variant": "low", "skills": [], "mcps": [] },
-        "designer": { "model": "github-copilot/gemini-3.1-pro-preview", "skills": [ "agent-browser" ], "mcps": [] },
+        "designer": { "model": "github-copilot/gemini-3.1-pro-preview", "skills": [], "mcps": [] },
         "fixer": { "model": "openai/gpt-5.4-mini", "variant": "low", "skills": [], "mcps": [] }
       }
     },

--- a/src/agents/index.test.ts
+++ b/src/agents/index.test.ts
@@ -243,7 +243,7 @@ describe('skill permissions', () => {
     const skillPerm = (
       orchestrator?.config.permission as Record<string, unknown>
     )?.skill as Record<string, string>;
-    // orchestrator gets wildcard allow (from RECOMMENDED_SKILLS wildcard entry)
+    // orchestrator gets wildcard allow by default
     expect(skillPerm?.['*']).toBe('allow');
     // CUSTOM_SKILLS loop must also add a named codemap entry for orchestrator
     expect(skillPerm?.codemap).toBe('allow');

--- a/src/cli/codemap.md
+++ b/src/cli/codemap.md
@@ -33,7 +33,7 @@ The CLI is intentionally non-interactive-only now; it prints usage and steps to 
 - `config-io.ts`: JSON/JSONC parsing, normalize write behavior, atomic writes (`.tmp` + `.bak`), plugin registration, default-agent disabling.
 - `providers.ts`: provider model mapping + `generateLiteConfig()`.
 - `system.ts`: OpenCode binary/version/path checks.
-- `skills.ts`: recommended and permission-only skill metadata and install behavior (`npx skills add`).
+- `skills.ts`: bundled and permission-only skill permission defaults.
 - `custom-skills.ts`: bundled skill registry and copy-to-config-directory implementation.
 - `config-manager.ts`: re-export barrel for CLI config utilities.
 - `install.ts`: end-to-end install orchestration and console messaging.
@@ -49,7 +49,6 @@ CLI install command
       3) disable legacy default agents
       4) write/preview generated lite config
       5) optional install phase:
-         - installSkill(...) for each RECOMMENDED_SKILL
          - installCustomSkill(...) for each CUSTOM_SKILL
 ```
 
@@ -59,7 +58,7 @@ CLI install command
 - always materializes generated presets `openai` and `opencode-go`
 - install-time `--preset` only selects between generated presets
 - maps each built-in agent name to provider-specific model/variant
-- injects skill list from recommended + custom skill registries and ensures `agent-browser` for designer
+- injects skill list from bundled custom skill registries
 - injects default MCP sets from `DEFAULT_AGENT_MCPS`
 - includes tmux block (`layout`, `main_pane_size`) when enabled
 
@@ -74,5 +73,5 @@ CLI install command
 ## Notes for architecture/docs accuracy
 
 - The previous TUI references are stale; no dedicated interactive flow exists in current sources.
-- `installSkills` in config covers both recommended external and bundled/custom skills as separate paths.
+- `--skills` controls bundled/custom skill installation only.
 - Built-in preset support includes `openai`, `opencode-go`, `kimi`, `copilot`, and `zai-plan`.

--- a/src/cli/config-io.test.ts
+++ b/src/cli/config-io.test.ts
@@ -399,7 +399,6 @@ describe('config-io', () => {
 
     const result = writeLiteConfig({
       hasTmux: true,
-      installSkills: false,
       installCustomSkills: false,
       reset: false,
     });
@@ -421,7 +420,6 @@ describe('config-io', () => {
 
     const result = writeLiteConfig({
       hasTmux: false,
-      installSkills: false,
       installCustomSkills: false,
       preset: 'opencode-go',
       reset: false,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -46,7 +46,7 @@ Usage:
   bunx oh-my-opencode-slim doctor [OPTIONS]
 
 Options:
-  --skills=yes|no        Install recommended and bundled skills (default: yes)
+  --skills=yes|no        Install bundled skills (default: yes)
   --preset=<name>        Active generated config preset (default: openai)
   --no-tui               Non-interactive mode
   --dry-run              Simulate install without writing files

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -15,7 +15,6 @@ import {
 } from './config-manager';
 import { CUSTOM_SKILLS, installCustomSkill } from './custom-skills';
 import { getExistingLiteConfigPath } from './paths';
-import { installSkill, RECOMMENDED_SKILLS } from './skills';
 import type { ConfigMergeResult, InstallArgs, InstallConfig } from './types';
 
 // Colors
@@ -152,7 +151,6 @@ async function runInstall(config: InstallConfig): Promise<number> {
   printHeader(isUpdate);
 
   let totalSteps = 6;
-  if (config.installSkills) totalSteps += 1;
   if (config.installCustomSkills) totalSteps += 1;
   totalSteps += 1;
 
@@ -244,31 +242,6 @@ async function runInstall(config: InstallConfig): Promise<number> {
     }
   }
 
-  // Install skills if requested
-  if (config.installSkills) {
-    printStep(step++, totalSteps, 'Installing recommended skills...');
-    if (config.dryRun) {
-      printInfo('Dry run mode - would install skills:');
-      for (const skill of RECOMMENDED_SKILLS) {
-        printInfo(`  - ${skill.name}`);
-      }
-    } else {
-      let skillsInstalled = 0;
-      for (const skill of RECOMMENDED_SKILLS) {
-        printInfo(`Installing ${skill.name}...`);
-        if (installSkill(skill)) {
-          printSuccess(`Installed: ${skill.name}`);
-          skillsInstalled++;
-        } else {
-          printInfo(`Skipped: ${skill.name} (already installed)`);
-        }
-      }
-      printSuccess(
-        `${skillsInstalled}/${RECOMMENDED_SKILLS.length} skills processed`,
-      );
-    }
-  }
-
   // Install custom skills if requested
   if (config.installCustomSkills) {
     printStep(step++, totalSteps, 'Installing custom skills...');
@@ -342,7 +315,6 @@ async function runInstall(config: InstallConfig): Promise<number> {
 export async function install(args: InstallArgs): Promise<number> {
   const config: InstallConfig = {
     hasTmux: false,
-    installSkills: args.skills === 'yes',
     installCustomSkills: args.skills === 'yes',
     preset: args.preset,
     promptForStar: args.tui,

--- a/src/cli/providers.test.ts
+++ b/src/cli/providers.test.ts
@@ -18,7 +18,6 @@ describe('providers', () => {
   test('generateLiteConfig defaults to openai and includes generated presets', () => {
     const config = generateLiteConfig({
       hasTmux: false,
-      installSkills: false,
       installCustomSkills: false,
       reset: false,
     });
@@ -43,7 +42,6 @@ describe('providers', () => {
   test('generateLiteConfig uses correct OpenAI models', () => {
     const config = generateLiteConfig({
       hasTmux: false,
-      installSkills: false,
       installCustomSkills: false,
       reset: false,
     });
@@ -65,7 +63,6 @@ describe('providers', () => {
   test('generateLiteConfig can set opencode-go as active preset', () => {
     const config = generateLiteConfig({
       hasTmux: false,
-      installSkills: false,
       installCustomSkills: false,
       preset: 'opencode-go',
       reset: false,
@@ -93,7 +90,6 @@ describe('providers', () => {
     expect(() =>
       generateLiteConfig({
         hasTmux: false,
-        installSkills: false,
         installCustomSkills: false,
         preset: 'not-real',
         reset: false,
@@ -105,7 +101,6 @@ describe('providers', () => {
     expect(() =>
       generateLiteConfig({
         hasTmux: false,
-        installSkills: false,
         installCustomSkills: false,
         preset: 'kimi',
         reset: false,
@@ -117,7 +112,6 @@ describe('providers', () => {
     expect(() =>
       generateLiteConfig({
         hasTmux: false,
-        installSkills: false,
         installCustomSkills: false,
         preset: 'toString',
         reset: false,
@@ -128,7 +122,6 @@ describe('providers', () => {
   test('generateLiteConfig enables tmux when requested', () => {
     const config = generateLiteConfig({
       hasTmux: true,
-      installSkills: false,
       installCustomSkills: false,
       reset: false,
     });
@@ -141,7 +134,6 @@ describe('providers', () => {
   test('generateLiteConfig includes default skills', () => {
     const config = generateLiteConfig({
       hasTmux: false,
-      installSkills: true,
       installCustomSkills: false,
       reset: false,
     });
@@ -156,8 +148,8 @@ describe('providers', () => {
     // Orchestrator should implicitly cover bundled codemap via '*'
     expect(agents.orchestrator.skills).toContain('*');
 
-    // Designer should have 'agent-browser'
-    expect(agents.designer.skills).toContain('agent-browser');
+    // Designer should have no bundled skills by default
+    expect(agents.designer.skills).toEqual([]);
 
     // Explorer should have no bundled skills by default
     expect(agents.explorer.skills).toEqual([]);
@@ -169,7 +161,6 @@ describe('providers', () => {
   test('generateLiteConfig includes mcps field', () => {
     const config = generateLiteConfig({
       hasTmux: false,
-      installSkills: false,
       installCustomSkills: false,
       reset: false,
     });
@@ -184,7 +175,6 @@ describe('providers', () => {
   test('generateLiteConfig openai includes correct mcps', () => {
     const config = generateLiteConfig({
       hasTmux: false,
-      installSkills: false,
       installCustomSkills: false,
       reset: false,
     });

--- a/src/cli/providers.ts
+++ b/src/cli/providers.ts
@@ -1,6 +1,5 @@
 import { DEFAULT_AGENT_MCPS } from '../config/agent-mcps';
 import { CUSTOM_SKILLS } from './custom-skills';
-import { RECOMMENDED_SKILLS } from './skills';
 import type { InstallConfig } from './types';
 
 const SCHEMA_URL =
@@ -107,21 +106,12 @@ export function generateLiteConfig(
     const skills = isOrchestrator
       ? ['*']
       : [
-          ...RECOMMENDED_SKILLS.filter(
-            (s) =>
-              s.allowedAgents.includes('*') ||
-              s.allowedAgents.includes(agentName),
-          ).map((s) => s.skillName),
           ...CUSTOM_SKILLS.filter(
             (s) =>
               s.allowedAgents.includes('*') ||
               s.allowedAgents.includes(agentName),
           ).map((s) => s.name),
         ];
-
-    if (agentName === 'designer' && !skills.includes('agent-browser')) {
-      skills.push('agent-browser');
-    }
 
     return {
       model: modelInfo.model,

--- a/src/cli/skills.test.ts
+++ b/src/cli/skills.test.ts
@@ -12,10 +12,10 @@ describe('skills permissions', () => {
     expect(permissions['*']).toBe('deny');
   });
 
-  it('should allow recommended skills for specific agents', () => {
-    // Designer should have agent-browser allowed
+  it('should allow bundled skills for specific agents', () => {
+    // Designer should only inherit the default non-orchestrator deny rule
     const designerPerms = getSkillPermissionsForAgent('designer');
-    expect(designerPerms['agent-browser']).toBe('allow');
+    expect(Object.keys(designerPerms)).toEqual(['*']);
 
     // Oracle should have simplify allowed by default
     const oraclePerms = getSkillPermissionsForAgent('oracle');

--- a/src/cli/skills.ts
+++ b/src/cli/skills.ts
@@ -1,23 +1,4 @@
-import { spawnSync } from 'node:child_process';
 import { CUSTOM_SKILLS } from './custom-skills';
-
-/**
- * A recommended skill to install via `npx skills add`.
- */
-export interface RecommendedSkill {
-  /** Human-readable name for prompts */
-  name: string;
-  /** GitHub repo URL for `npx skills add` */
-  repo: string;
-  /** Skill name within the repo (--skill flag) */
-  skillName: string;
-  /** List of agents that should auto-allow this skill */
-  allowedAgents: string[];
-  /** Description shown to user during install */
-  description: string;
-  /** Optional commands to run after the skill is added */
-  postInstallCommands?: string[];
-}
 
 /**
  * A skill that is managed externally (e.g. user-installed) and needs
@@ -33,24 +14,6 @@ export interface PermissionOnlySkill {
 }
 
 /**
- * List of recommended skills.
- * Add new skills here to include them in the installation flow.
- */
-export const RECOMMENDED_SKILLS: RecommendedSkill[] = [
-  {
-    name: 'agent-browser',
-    repo: 'https://github.com/vercel-labs/agent-browser',
-    skillName: 'agent-browser',
-    allowedAgents: ['designer'],
-    description: 'High-performance browser automation',
-    postInstallCommands: [
-      'npm install -g agent-browser',
-      'agent-browser install',
-    ],
-  },
-];
-
-/**
  * Skills managed externally (not installed by this plugin's CLI).
  * Entries here only affect agent permission grants — nothing is installed.
  */
@@ -64,53 +27,9 @@ export const PERMISSION_ONLY_SKILLS: PermissionOnlySkill[] = [
 ];
 
 /**
- * Install a skill using `npx skills add`.
- * @param skill - The skill to install
- * @returns True if installation succeeded, false otherwise
- */
-export function installSkill(skill: RecommendedSkill): boolean {
-  const args = [
-    'skills',
-    'add',
-    skill.repo,
-    '--skill',
-    skill.skillName,
-    '-a',
-    'opencode',
-    '-y',
-    '--global',
-  ];
-
-  try {
-    const result = spawnSync('npx', args, { stdio: 'inherit' });
-    if (result.status !== 0) {
-      return false;
-    }
-
-    // Run post-install commands if any
-    if (skill.postInstallCommands && skill.postInstallCommands.length > 0) {
-      console.log(`Running post-install commands for ${skill.name}...`);
-      for (const cmd of skill.postInstallCommands) {
-        console.log(`> ${cmd}`);
-        const [command, ...cmdArgs] = cmd.split(' ');
-        const cmdResult = spawnSync(command, cmdArgs, { stdio: 'inherit' });
-        if (cmdResult.status !== 0) {
-          console.warn(`Post-install command failed: ${cmd}`);
-        }
-      }
-    }
-
-    return true;
-  } catch (error) {
-    console.error(`Failed to install skill: ${skill.name}`, error);
-    return false;
-  }
-}
-
-/**
- * Get permission presets for a specific agent based on recommended skills.
+ * Get permission presets for a specific agent based on bundled skills.
  * @param agentName - The name of the agent
- * @param skillList - Optional explicit list of skills to allow (overrides recommendations)
+ * @param skillList - Optional explicit list of skills to allow (overrides defaults)
  * @returns Permission rules for the skill permission type
  */
 export function getSkillPermissionsForAgent(
@@ -135,16 +54,6 @@ export function getSkillPermissionsForAgent(
       }
     }
     return permissions;
-  }
-
-  // Otherwise, use recommended defaults
-  for (const skill of RECOMMENDED_SKILLS) {
-    const isAllowed =
-      skill.allowedAgents.includes('*') ||
-      skill.allowedAgents.includes(agentName);
-    if (isAllowed) {
-      permissions[skill.skillName] = 'allow';
-    }
   }
 
   // Apply permissions from bundled custom skills

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -17,7 +17,6 @@ export interface OpenCodeConfig {
 
 export interface InstallConfig {
   hasTmux: boolean;
-  installSkills: boolean;
   installCustomSkills: boolean;
   preset?: string;
   promptForStar?: boolean;


### PR DESCRIPTION
## Summary
- Remove the external recommended skill install path that invoked `npx skills add` and agent-browser post-install commands.
- Stop injecting `agent-browser` into generated designer configs and default skill permissions.
- Update tests and docs so `--skills` refers only to bundled skills.

## Validation
- bun run check:ci
- bun run typecheck
- bun test

Closes #471