### PR TITLE
fix: make /preset work at runtime in existing sessions

### DIFF
--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -2,6 +2,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { stripJsonComments } from '../cli/config-io';
 import { getConfigSearchDirs } from '../cli/paths';
+import { getActiveRuntimePreset } from './runtime-preset';
 import { type PluginConfig, PluginConfigSchema } from './schema';
 
 /**
@@ -283,10 +284,18 @@ export function loadPluginConfig(
   // Migrate legacy tmux config to multiplexer config for backward compatibility
   config = migrateTmuxToMultiplexer(config);
 
-  // Override preset from environment variable if set
+  // Override preset selection. Precedence:
+  //   1. OH_MY_OPENCODE_SLIM_PRESET environment variable (explicit user intent).
+  //   2. Active runtime preset set via /preset command (persists across
+  //      Instance.dispose() re-init cycles because runtime-preset state is
+  //      module-level).
+  //   3. config.preset from the config file (default).
   const envPreset = process.env.OH_MY_OPENCODE_SLIM_PRESET;
+  const runtimePreset = getActiveRuntimePreset();
   if (envPreset) {
     config.preset = envPreset;
+  } else if (runtimePreset) {
+    config.preset = runtimePreset;
   }
 
   // Resolve preset and merge with root agents

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ import {
   startAvailabilityCheck,
 } from './multiplexer';
 import {
+  applyPresetVariantOverride,
   ast_grep_replace,
   ast_grep_search,
   createCouncilTool,
@@ -646,6 +647,7 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
       }
 
       const tuiAgentModels: Record<string, string> = {};
+      const tuiAgentVariants: Record<string, string> = {};
       for (const agentDef of agentDefs) {
         if (agentDef.name === 'councillor') continue;
 
@@ -662,8 +664,23 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
                 : undefined;
 
         tuiAgentModels[agentDef.name] = resolvedModel ?? 'default';
+
+        const resolvedVariant =
+          typeof entry?.variant === 'string'
+            ? (entry.variant as string)
+            : typeof (agentDef.config as { variant?: unknown } | undefined)
+                  ?.variant === 'string'
+              ? ((agentDef.config as { variant?: string }).variant as string)
+              : undefined;
+        if (resolvedVariant) {
+          tuiAgentVariants[agentDef.name] = resolvedVariant;
+        }
       }
-      recordTuiAgentModels({ agentModels: tuiAgentModels });
+      recordTuiAgentModels({
+        agentModels: tuiAgentModels,
+        agentVariants: tuiAgentVariants,
+        activePreset: getActiveRuntimePreset() ?? config.preset ?? null,
+      });
 
       // Merge MCP configs
       const configMcp = opencodeConfig.mcp as
@@ -1004,6 +1021,17 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
         sessionID: input.sessionID,
         agent,
       });
+
+      // Apply runtime preset variant override to in-flight messages.
+      // Required because opencode reads variant from user.model.variant
+      // captured at session start, not from the live agent config. Without
+      // this, /preset switches affect only new sessions.
+      applyPresetVariantOverride(
+        config,
+        agent,
+        output as { message?: Record<string, unknown> } | undefined,
+        log,
+      );
     },
 
     // Inject orchestrator system prompt for serve-mode sessions. In serve

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -3,6 +3,7 @@ export { ast_grep_replace, ast_grep_search } from './ast-grep';
 export { createCouncilTool } from './council';
 export type { PresetManager } from './preset-manager';
 export { createPresetManager } from './preset-manager';
+export { applyPresetVariantOverride } from './preset-message-override';
 export { createWebfetchTool } from './smartfetch';
 export type { SubtaskCommandManager } from './subtask';
 export {

--- a/src/tools/preset-db-variant-override.ts
+++ b/src/tools/preset-db-variant-override.ts
@@ -1,0 +1,215 @@
+import { existsSync } from 'node:fs';
+import * as path from 'node:path';
+
+type BunDatabase = import('bun:sqlite').Database;
+
+/**
+ * Safely import bun:sqlite only when running in Bun runtime.
+ * Uses new Function() to hide the import from Node.js/Electron's static parser,
+ * which would fail on bun: protocol resolution before .catch() could run.
+ */
+async function importBunSqlite(): Promise<
+  typeof import('bun:sqlite') | null
+> {
+  if (typeof (globalThis as { Bun?: unknown }).Bun === 'undefined') {
+    return null;
+  }
+  try {
+    const dynamicImport = new Function(
+      "return import('bun:sqlite')",
+    ) as () => Promise<typeof import('bun:sqlite')>;
+    return await dynamicImport();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the path to opencode.db.
+ *
+ * Default: $XDG_DATA_HOME/opencode/opencode.db (Linux/macOS).
+ * Falls back to ~/.local/share/opencode/opencode.db.
+ */
+function getDbPath(): string {
+  const xdg = process.env.XDG_DATA_HOME;
+  const dataDir =
+    xdg && xdg.length > 0
+      ? xdg
+      : path.join(process.env.HOME ?? '', '.local', 'share');
+  return path.join(dataDir, 'opencode', 'opencode.db');
+}
+
+const MAX_MICROTASK_RETRIES = 10;
+
+export interface MessageOverrideTarget {
+  providerID?: string;
+  modelID?: string;
+  variant?: string;
+}
+
+function tryUpdateMessage(
+  db: BunDatabase,
+  messageId: string,
+  target: MessageOverrideTarget,
+): boolean {
+  // Patch model.providerID, model.modelID, model.variant, flat variant, and
+  // thinking mirror in one statement. Skips fields that are undefined.
+  const sets: string[] = [];
+  const args: unknown[] = [];
+  if (typeof target.providerID === 'string') {
+    sets.push("'$.model.providerID', ?");
+    args.push(target.providerID);
+  }
+  if (typeof target.modelID === 'string') {
+    sets.push("'$.model.modelID', ?");
+    args.push(target.modelID);
+  }
+  if (typeof target.variant === 'string') {
+    sets.push("'$.model.variant', ?");
+    args.push(target.variant);
+    sets.push("'$.variant', ?");
+    args.push(target.variant);
+    sets.push("'$.thinking', ?");
+    args.push(target.variant);
+  }
+  if (sets.length === 0) return false;
+  const sql = `UPDATE message SET data = json_set(data, ${sets.join(', ')}) WHERE id = ?`;
+  args.push(messageId);
+  const stmt = db.prepare(sql);
+  const result = stmt.run(...(args as never[]));
+  return result.changes > 0;
+}
+
+function retryViaMicrotask(
+  db: BunDatabase,
+  messageId: string,
+  target: MessageOverrideTarget,
+  attempt: number,
+  log: (msg: string, extra?: Record<string, unknown>) => void,
+): void {
+  if (attempt >= MAX_MICROTASK_RETRIES) {
+    log(
+      '[preset-db-override] microtask retries exhausted, using setTimeout',
+      { messageId, attempt },
+    );
+    setTimeout(() => {
+      try {
+        if (tryUpdateMessage(db, messageId, target)) {
+          log('[preset-db-override] setTimeout fallback succeeded', {
+            messageId,
+            target,
+          });
+        } else {
+          log('[preset-db-override] setTimeout fallback — message not found', {
+            messageId,
+          });
+        }
+      } catch (error) {
+        log('[preset-db-override] setTimeout fallback failed', {
+          messageId,
+          error: String(error),
+        });
+      } finally {
+        try {
+          db.close();
+        } catch {
+          // ignore
+        }
+      }
+    }, 0);
+    return;
+  }
+
+  queueMicrotask(() => {
+    let shouldCloseDb = true;
+    try {
+      if (tryUpdateMessage(db, messageId, target)) {
+        log(
+          `[preset-db-override] deferred update (attempt ${attempt}) succeeded`,
+          { messageId, target },
+        );
+        return;
+      }
+      shouldCloseDb = false;
+      retryViaMicrotask(db, messageId, target, attempt + 1, log);
+    } catch (error) {
+      log('[preset-db-override] deferred update failed', {
+        messageId,
+        attempt,
+        error: String(error),
+      });
+    } finally {
+      if (shouldCloseDb) {
+        try {
+          db.close();
+        } catch {
+          // ignore
+        }
+      }
+    }
+  });
+}
+
+/**
+ * Schedule a deferred SQLite update that rewrites a single message's model
+ * and variant in opencode.db WITHOUT emitting a Bus event.
+ *
+ * Uses a microtask retry loop to wait until opencode's own
+ * Session.updateMessage() has persisted the message, then overwrites the row.
+ * Falls back to setTimeout(fn, 0) after 10 microtask attempts.
+ *
+ * No-op when not running under Bun (the technique relies on bun:sqlite).
+ * Stage A in-band mutation of `output.message` still takes effect for the
+ * current turn's inference; only reload/history shows the original values.
+ */
+export function scheduleDeferredMessageOverride(
+  messageId: string,
+  target: MessageOverrideTarget,
+  log: (msg: string, extra?: Record<string, unknown>) => void = () => {},
+): void {
+  if (
+    typeof target.providerID !== 'string' &&
+    typeof target.modelID !== 'string' &&
+    typeof target.variant !== 'string'
+  ) {
+    return;
+  }
+  queueMicrotask(async () => {
+    const sqliteModule = await importBunSqlite();
+    const Database = sqliteModule?.Database;
+    if (typeof Database !== 'function') {
+      log('[preset-db-override] bun:sqlite unavailable; skipping persistence', {
+        messageId,
+      });
+      return;
+    }
+
+    const dbPath = getDbPath();
+    if (!existsSync(dbPath)) {
+      log('[preset-db-override] DB not found; skipping persistence', {
+        dbPath,
+      });
+      return;
+    }
+
+    let db: BunDatabase;
+    try {
+      db = new Database(dbPath);
+    } catch (error) {
+      log('[preset-db-override] failed to open DB; skipping persistence', {
+        messageId,
+        error: String(error),
+      });
+      return;
+    }
+
+    try {
+      retryViaMicrotask(db, messageId, target, 0, log);
+    } catch (error) {
+      log('[preset-db-override] failed to schedule deferred update', {
+        error: String(error),
+      });
+      db.close();
+    }
+  });
+}

--- a/src/tools/preset-manager.test.ts
+++ b/src/tools/preset-manager.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -31,6 +31,10 @@ function getOutputText(output: ReturnType<typeof createOutput>): string {
     .filter((p) => p.type === 'text')
     .map((p) => p.text ?? '')
     .join('\n');
+}
+
+async function flushDeferred(): Promise<void> {
+  await new Promise<void>((resolve) => setImmediate(resolve));
 }
 
 let previousXdgDataHome: string | undefined;
@@ -151,6 +155,8 @@ describe('createPresetManager', () => {
         output,
       );
 
+      await flushDeferred();
+
       const text = getOutputText(output);
       expect(text).toContain('Switched to preset "cheap"');
       expect(text).toContain('orchestrator');
@@ -192,6 +198,8 @@ describe('createPresetManager', () => {
         output,
       );
 
+      await flushDeferred();
+
       expect(readTuiSnapshot().agentModels).toEqual({
         explorer: 'openai/gpt-5.5',
         fixer: 'openai/gpt-5.4-mini',
@@ -215,6 +223,8 @@ describe('createPresetManager', () => {
         { command: 'preset', sessionID: 's1', arguments: 'precise' },
         output,
       );
+
+      await flushDeferred();
 
       expect(ctx.client.config.update).toHaveBeenCalledWith({
         body: {
@@ -244,6 +254,8 @@ describe('createPresetManager', () => {
         { command: 'preset', sessionID: 's1', arguments: 'thinker' },
         output,
       );
+
+      await flushDeferred();
 
       expect(ctx.client.config.update).toHaveBeenCalledWith({
         body: {
@@ -305,6 +317,7 @@ describe('createPresetManager', () => {
       ctx.client.config.update = mock(async () => {
         throw new Error('Server unavailable');
       });
+      const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
       const config: PluginConfig = {
         presets: {
           cheap: { orchestrator: { model: 'anthropic/claude-3.5-haiku' } },
@@ -318,12 +331,19 @@ describe('createPresetManager', () => {
         output,
       );
 
+      await flushDeferred();
+
       const text = getOutputText(output);
-      expect(text).toContain('Failed to switch preset');
-      expect(text).toContain('Server unavailable');
+      expect(text).toContain('Switched to preset "cheap"');
+      expect(text).not.toContain('Failed to switch preset');
+      expect(text).not.toContain('Server unavailable');
       expect(readTuiSnapshot().agentModels).toEqual({
         explorer: 'openai/gpt-5.4-mini',
       });
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Server unavailable'),
+      );
+      warnSpy.mockRestore();
     });
 
     test('shows empty preset message when preset has no valid overrides', async () => {
@@ -370,6 +390,8 @@ describe('createPresetManager', () => {
         output,
       );
 
+      await flushDeferred();
+
       expect(ctx.client.config.update).toHaveBeenCalledWith({
         body: {
           agent: {
@@ -398,6 +420,8 @@ describe('createPresetManager', () => {
         { command: 'preset', sessionID: 's1', arguments: '  cheap  ' },
         output,
       );
+
+      await flushDeferred();
 
       const text = getOutputText(output);
       expect(text).toContain('Switched to preset "cheap"');
@@ -464,6 +488,8 @@ describe('createPresetManager', () => {
         output,
       );
 
+      await flushDeferred();
+
       const text = getOutputText(output);
       expect(text).toContain('Switched to preset "mixed"');
       // Only orchestrator and oracle should be forwarded
@@ -495,6 +521,8 @@ describe('createPresetManager', () => {
         { command: 'preset', sessionID: 's1', arguments: 'fallback' },
         output,
       );
+
+      await flushDeferred();
 
       const text = getOutputText(output);
       expect(text).toContain('Switched to preset "fallback"');
@@ -529,6 +557,8 @@ describe('createPresetManager', () => {
         output,
       );
 
+      await flushDeferred();
+
       expect(ctx.client.config.update).toHaveBeenCalledWith({
         body: {
           agent: {
@@ -562,6 +592,8 @@ describe('createPresetManager', () => {
         output,
       );
 
+      await flushDeferred();
+
       const text = getOutputText(output);
       expect(text).toContain('variant: thinking');
       expect(text).toContain('options: yes');
@@ -583,6 +615,8 @@ describe('createPresetManager', () => {
         { command: 'preset', sessionID: 's1', arguments: 'cheap' },
         output1,
       );
+
+      await flushDeferred();
       expect(getOutputText(output1)).toContain('Switched');
 
       // List presets should now show cheap as active
@@ -599,6 +633,8 @@ describe('createPresetManager', () => {
         { command: 'preset', sessionID: 's1', arguments: 'powerful' },
         output3,
       );
+
+      await flushDeferred();
       expect(getOutputText(output3)).toContain('Switched to preset "powerful"');
 
       // List should now show powerful as active
@@ -671,6 +707,8 @@ describe('createPresetManager', () => {
         { command: 'preset', sessionID: 's1', arguments: 'cheap' },
         output1,
       );
+
+      await flushDeferred();
       expect(ctx.client.config.update).toHaveBeenCalledWith({
         body: {
           agent: {
@@ -687,6 +725,8 @@ describe('createPresetManager', () => {
         { command: 'preset', sessionID: 's1', arguments: 'powerful' },
         output2,
       );
+
+      await flushDeferred();
 
       // Second update should reset oracle to baseline and set orchestrator
       expect(ctx.client.config.update).toHaveBeenCalledWith({
@@ -722,6 +762,8 @@ describe('createPresetManager', () => {
         { command: 'preset', sessionID: 's1', arguments: 'cheap' },
         output1,
       );
+
+      await flushDeferred();
       expect(ctx.client.config.update).toHaveBeenCalledWith({
         body: {
           agent: {
@@ -739,6 +781,8 @@ describe('createPresetManager', () => {
         output2,
       );
 
+      await flushDeferred();
+
       // Second update should only have oracle, no reset updates
       expect(ctx.client.config.update).toHaveBeenCalledWith({
         body: {
@@ -753,6 +797,12 @@ describe('createPresetManager', () => {
     });
 
     test('preset state rolled back on config.update error', async () => {
+      recordTuiAgentModels({
+        agentModels: {
+          explorer: 'openai/gpt-5.4-mini',
+        },
+      });
+
       const ctx = createMockContext();
       ctx.client.config.update = mock(async () => {
         throw new Error('Server unavailable');
@@ -778,6 +828,7 @@ describe('createPresetManager', () => {
         { command: 'preset', sessionID: 's1', arguments: 'cheap' },
         output1,
       );
+      await flushDeferred();
       expect(getActiveRuntimePreset()).toBe('cheap');
 
       // Reset mock to throw error
@@ -792,9 +843,16 @@ describe('createPresetManager', () => {
         output2,
       );
 
+      await flushDeferred();
+
       // Active preset should still be "cheap" after error
       expect(getActiveRuntimePreset()).toBe('cheap');
-      expect(getOutputText(output2)).toContain('Failed to switch preset');
+      expect(readTuiSnapshot().agentModels).toEqual({
+        explorer: 'openai/gpt-5.4-mini',
+        oracle: 'a',
+      });
+      expect(getOutputText(output2)).toContain('Switched to preset "expensive"');
+      expect(getOutputText(output2)).not.toContain('Failed to switch preset');
 
       // Cleanup
       setActiveRuntimePreset(null);

--- a/src/tools/preset-manager.ts
+++ b/src/tools/preset-manager.ts
@@ -33,6 +33,18 @@ export function createPresetManager(ctx: PluginInput, config: PluginConfig) {
   let activePreset: string | null =
     getActiveRuntimePreset() ?? config.preset ?? null;
 
+  // Holds the agent overrides for a pending SDK config.update() call.
+  // See the comment in switchPreset() for why the call is deferred.
+  let pendingConfigUpdate: Record<
+    string,
+    {
+      model?: string;
+      temperature?: number;
+      variant?: string;
+      options?: Record<string, unknown>;
+    }
+  > | null = null;
+
   /**
    * Handle the /preset command from command.execute.before hook.
    *
@@ -186,51 +198,81 @@ export function createPresetManager(ctx: PluginInput, config: PluginConfig) {
     const previousPreset = activePreset;
     setActiveRuntimePresetWithPrevious(presetName);
 
-    try {
-      await ctx.client.config.update({
-        body: { agent: allUpdates },
-      });
-
-      const snapshot = readTuiSnapshot();
-      const agentModels = { ...snapshot.agentModels };
-      for (const [agentName, agentConfig] of Object.entries(allUpdates)) {
-        if (typeof agentConfig.model === 'string') {
-          agentModels[agentName] = agentConfig.model;
-        }
+    // Update in-memory tracking synchronously so the success message and
+    // any subsequent /preset (no-arg) listing reflect the switch.
+    const snapshotBefore = readTuiSnapshot();
+    const previousAgentModels = { ...snapshotBefore.agentModels };
+    const previousAgentVariants = { ...snapshotBefore.agentVariants };
+    const previousActivePreset = snapshotBefore.activePreset;
+    const agentModels = { ...snapshotBefore.agentModels };
+    const agentVariants = { ...snapshotBefore.agentVariants };
+    for (const [agentName, agentConfig] of Object.entries(allUpdates)) {
+      if (typeof agentConfig.model === 'string') {
+        agentModels[agentName] = agentConfig.model;
       }
-      recordTuiAgentModels({ agentModels });
-
-      activePreset = presetName;
-
-      const summaryParts: string[] = [];
-      for (const [name, cfg] of Object.entries(agentUpdates)) {
-        const parts: string[] = [name];
-        if (cfg.model) parts.push(`model: ${cfg.model}`);
-        if (cfg.variant) parts.push(`variant: ${cfg.variant}`);
-        if (cfg.temperature !== undefined)
-          parts.push(`temp: ${cfg.temperature}`);
-        if (cfg.options) parts.push('options: yes');
-        summaryParts.push(parts.join(' → '));
+      if (typeof agentConfig.variant === 'string') {
+        agentVariants[agentName] = agentConfig.variant;
+      } else {
+        delete agentVariants[agentName];
       }
-      if (Object.keys(resetUpdates).length > 0) {
-        summaryParts.push(
-          `Reset to baseline: ${Object.keys(resetUpdates).join(', ')}`,
-        );
-      }
+    }
+    recordTuiAgentModels({
+      agentModels,
+      agentVariants,
+      activePreset: presetName,
+    });
+    activePreset = presetName;
 
-      output.parts.push(
-        createInternalAgentTextPart(
-          `Switched to preset "${presetName}":\n${summaryParts.join('\n')}`,
-        ),
-      );
-    } catch (err) {
-      rollbackRuntimePreset(previousPreset);
-      output.parts.push(
-        createInternalAgentTextPart(
-          `Failed to switch preset "${presetName}": ${String(err)}`,
-        ),
+    const summaryParts: string[] = [];
+    for (const [name, cfg] of Object.entries(agentUpdates)) {
+      const parts: string[] = [name];
+      if (cfg.model) parts.push(`model: ${cfg.model}`);
+      if (cfg.variant) parts.push(`variant: ${cfg.variant}`);
+      if (cfg.temperature !== undefined)
+        parts.push(`temp: ${cfg.temperature}`);
+      if (cfg.options) parts.push('options: yes');
+      summaryParts.push(parts.join(' → '));
+    }
+    if (Object.keys(resetUpdates).length > 0) {
+      summaryParts.push(
+        `Reset to baseline: ${Object.keys(resetUpdates).join(', ')}`,
       );
     }
+
+    output.parts.push(
+      createInternalAgentTextPart(
+        `Switched to preset "${presetName}":\n${summaryParts.join('\n')}`,
+      ),
+    );
+
+    // Defer the SDK config.update call until after the command response has
+    // been flushed. In OpenCode 1.15.x, client.config.update() writes
+    // <project>/config.json and synchronously disposes the active instance.
+    // If this happens during command.execute.before, the in-flight
+    // SessionPrompt.createUserMessage runs against the disposed instance and
+    // throws UnknownError, surfacing as a generic red error popup in the TUI.
+    // Deferring with setImmediate lets opencode finish delivering the
+    // success message above before the dispose fires.
+    // See https://github.com/alvinunreal/oh-my-opencode-slim/issues/438
+    pendingConfigUpdate = allUpdates;
+    setImmediate(() => {
+      const updates = pendingConfigUpdate;
+      pendingConfigUpdate = null;
+      if (!updates) return;
+      ctx.client.config.update({ body: { agent: updates } }).catch((err) => {
+        rollbackRuntimePreset(previousPreset);
+        activePreset = previousPreset;
+        recordTuiAgentModels({
+          agentModels: previousAgentModels,
+          agentVariants: previousAgentVariants,
+          activePreset: previousActivePreset,
+        });
+        // The TUI response is already sent; surface the failure to logs.
+        console.warn(
+          `[oh-my-opencode-slim] Preset switch "${presetName}" config update failed: ${String(err)}`,
+        );
+      });
+    });
   }
 
   /**

--- a/src/tools/preset-message-override.ts
+++ b/src/tools/preset-message-override.ts
@@ -1,0 +1,217 @@
+import type { AgentOverrideConfig, PluginConfig, Preset } from '../config';
+import { AGENT_ALIASES } from '../config/constants';
+import { getActiveRuntimePreset } from '../config/runtime-preset';
+import {
+  type MessageOverrideTarget,
+  scheduleDeferredMessageOverride,
+} from './preset-db-variant-override';
+
+interface ModelDescriptor {
+  providerID: string;
+  modelID: string;
+}
+
+/**
+ * Extract the variant string from a preset's per-agent override.
+ *
+ * Precedence:
+ *   1. override.variant (top-level scalar)
+ *   2. first array-form model entry's `variant` field
+ *
+ * Returns undefined if no variant can be determined.
+ */
+function resolveAgentVariant(
+  override: AgentOverrideConfig | undefined,
+): string | undefined {
+  if (!override) return undefined;
+  if (typeof override.variant === 'string') {
+    return override.variant;
+  }
+  if (Array.isArray(override.model) && override.model.length > 0) {
+    const first = override.model[0];
+    if (
+      typeof first === 'object' &&
+      first !== null &&
+      typeof (first as { variant?: unknown }).variant === 'string'
+    ) {
+      return (first as { variant?: string }).variant;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Resolve a model descriptor (`{ providerID, modelID }`) from a preset's
+ * per-agent override. Handles both string and array forms.
+ */
+function resolveAgentModel(
+  override: AgentOverrideConfig | undefined,
+): ModelDescriptor | undefined {
+  if (!override) return undefined;
+  let id: string | undefined;
+  if (typeof override.model === 'string') {
+    id = override.model;
+  } else if (Array.isArray(override.model) && override.model.length > 0) {
+    const first = override.model[0];
+    id =
+      typeof first === 'string'
+        ? first
+        : typeof (first as { id?: unknown }).id === 'string'
+          ? ((first as { id?: string }).id as string)
+          : undefined;
+  }
+  if (typeof id !== 'string') return undefined;
+  const parts = id.split('/');
+  if (parts.length < 2) return undefined;
+  return {
+    providerID: parts[0],
+    modelID: parts.slice(1).join('/'),
+  };
+}
+
+function lookupPresetAgent(
+  preset: Preset,
+  agentName: string,
+): AgentOverrideConfig | undefined {
+  if (preset[agentName]) return preset[agentName];
+  for (const [rawName, override] of Object.entries(preset)) {
+    if ((AGENT_ALIASES[rawName] ?? rawName) === agentName) {
+      return override;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Apply the active runtime preset's model + variant to an in-flight chat
+ * message.
+ *
+ * OpenCode 1.15.x reads the agent's effective model/variant from
+ * `user.model.{providerID,modelID,variant}` captured on the user message,
+ * not from the live agent config. Without this hook, `/preset` changes
+ * affect only newly created sessions — existing sessions keep their
+ * original model/variant.
+ *
+ * Technique adapted from `code-yeongyu/oh-my-openagent`'s
+ * `ultrawork-model-override`. See
+ * https://github.com/alvinunreal/oh-my-opencode-slim/issues/438 for context.
+ *
+ * Stage A (in-band, sync):
+ *   - Mutates `output.message.model.{providerID,modelID,variant}` and the
+ *     flat `output.message.{variant,thinking}` aliases.
+ *   - Affects the current turn's inference immediately.
+ *
+ * Stage B (deferred, bun-only):
+ *   - Schedules a SQLite UPDATE on `opencode.db` so reload / chat history
+ *     also reflect the override. No-op outside Bun.
+ *
+ * No-op when:
+ *   - No runtime preset is active.
+ *   - The preset has no entry for the message's agent.
+ *   - The current message already matches both target model and variant.
+ */
+export function applyPresetVariantOverride(
+  config: PluginConfig,
+  agentName: string | undefined,
+  output: { message?: Record<string, unknown> } | undefined,
+  log: (msg: string, extra?: Record<string, unknown>) => void = () => {},
+): void {
+  if (!output?.message) return;
+
+  const presetName = getActiveRuntimePreset();
+  if (!presetName) return;
+
+  const preset = config.presets?.[presetName];
+  if (!preset) return;
+
+  const messageAgentRaw =
+    typeof output.message.agent === 'string'
+      ? (output.message.agent as string)
+      : undefined;
+  const rawAgent = agentName ?? messageAgentRaw;
+  if (!rawAgent) return;
+  const resolvedAgent = AGENT_ALIASES[rawAgent] ?? rawAgent;
+
+  const presetAgent = lookupPresetAgent(preset, resolvedAgent);
+  if (!presetAgent) return;
+
+  const targetVariant = resolveAgentVariant(presetAgent);
+  const targetModel = resolveAgentModel(presetAgent);
+  if (!targetVariant && !targetModel) return;
+
+  const currentModelObj =
+    typeof output.message.model === 'object' && output.message.model !== null
+      ? (output.message.model as Record<string, unknown>)
+      : undefined;
+  const currentProvider =
+    currentModelObj && typeof currentModelObj.providerID === 'string'
+      ? (currentModelObj.providerID as string)
+      : undefined;
+  const currentModelID =
+    currentModelObj && typeof currentModelObj.modelID === 'string'
+      ? (currentModelObj.modelID as string)
+      : undefined;
+  const currentVariant =
+    currentModelObj && typeof currentModelObj.variant === 'string'
+      ? (currentModelObj.variant as string)
+      : typeof output.message.variant === 'string'
+        ? (output.message.variant as string)
+        : undefined;
+
+  const sameModel = targetModel
+    ? currentProvider === targetModel.providerID &&
+      currentModelID === targetModel.modelID
+    : true;
+  const sameVariant = targetVariant ? currentVariant === targetVariant : true;
+  if (sameModel && sameVariant) return;
+
+  // Stage A: mutate the in-flight user message synchronously.
+  if (currentModelObj) {
+    if (targetModel) {
+      currentModelObj.providerID = targetModel.providerID;
+      currentModelObj.modelID = targetModel.modelID;
+    }
+    if (targetVariant) {
+      currentModelObj.variant = targetVariant;
+    }
+  } else if (targetModel) {
+    output.message.model = {
+      providerID: targetModel.providerID,
+      modelID: targetModel.modelID,
+      ...(targetVariant ? { variant: targetVariant } : {}),
+    };
+  }
+  if (targetVariant) {
+    output.message.variant = targetVariant;
+    output.message.thinking = targetVariant;
+  }
+
+  log(`[preset-message-override] applied for ${resolvedAgent}`, {
+    presetName,
+    from: {
+      providerID: currentProvider,
+      modelID: currentModelID,
+      variant: currentVariant,
+    },
+    to: {
+      providerID: targetModel?.providerID,
+      modelID: targetModel?.modelID,
+      variant: targetVariant,
+    },
+  });
+
+  // Stage B: persist via bun:sqlite (no-op outside Bun).
+  const messageId =
+    typeof output.message.id === 'string'
+      ? (output.message.id as string)
+      : undefined;
+  if (messageId) {
+    const target: MessageOverrideTarget = {
+      ...(targetModel
+        ? { providerID: targetModel.providerID, modelID: targetModel.modelID }
+        : {}),
+      ...(targetVariant ? { variant: targetVariant } : {}),
+    };
+    scheduleDeferredMessageOverride(messageId, target, log);
+  }
+}

--- a/src/tui-state.ts
+++ b/src/tui-state.ts
@@ -6,6 +6,17 @@ export interface TuiSnapshot {
   version: 1;
   updatedAt: number;
   agentModels: Record<string, string>;
+  /**
+   * Per-agent variant (e.g. "high", "max"). Optional; only populated when
+   * a preset or agent override defines it.
+   */
+  agentVariants: Record<string, string>;
+  /**
+   * Name of the currently active preset, or null when no preset is active.
+   * Shown in the OMO-Slim sidebar so the user can see which preset is in
+   * effect even when the textarea variant chip is stale.
+   */
+  activePreset: string | null;
 }
 
 const STATE_DIR = 'oh-my-opencode-slim';
@@ -26,6 +37,8 @@ function emptySnapshot(): TuiSnapshot {
     version: 1,
     updatedAt: Date.now(),
     agentModels: {},
+    agentVariants: {},
+    activePreset: null,
   };
 }
 
@@ -38,6 +51,9 @@ function parseSnapshot(value: string): TuiSnapshot {
     updatedAt:
       typeof parsed.updatedAt === 'number' ? parsed.updatedAt : Date.now(),
     agentModels: parsed.agentModels ?? {},
+    agentVariants: parsed.agentVariants ?? {},
+    activePreset:
+      typeof parsed.activePreset === 'string' ? parsed.activePreset : null,
   };
 }
 
@@ -76,17 +92,32 @@ function updateSnapshot(mutator: (snapshot: TuiSnapshot) => void): void {
 
 export function recordTuiAgentModels(input: {
   agentModels: Record<string, string>;
+  agentVariants?: Record<string, string>;
+  activePreset?: string | null;
 }): void {
   updateSnapshot((snapshot) => {
     snapshot.agentModels = { ...input.agentModels };
+    if (input.agentVariants) {
+      snapshot.agentVariants = { ...input.agentVariants };
+    }
+    if (
+      typeof input.activePreset === 'string' ||
+      input.activePreset === null
+    ) {
+      snapshot.activePreset = input.activePreset;
+    }
   });
 }
 
 export function recordTuiAgentModel(input: {
   agentName: string;
   model: string;
+  variant?: string;
 }): void {
   updateSnapshot((snapshot) => {
     snapshot.agentModels[input.agentName] = input.model;
+    if (typeof input.variant === 'string') {
+      snapshot.agentVariants[input.agentName] = input.variant;
+    }
   });
 }

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -141,17 +141,30 @@ function renderSidebar(
         ],
       ),
       configStatusRow,
+      snapshot.activePreset
+        ? box(
+            {
+              width: '100%',
+              marginTop: 1,
+              flexDirection: 'row',
+              justifyContent: 'space-between',
+            },
+            [
+              text({ fg: theme.textMuted }, ['preset']),
+              text({ fg: theme.accent }, [snapshot.activePreset]),
+            ],
+          )
+        : null,
       box({ width: '100%', marginTop: 1 }, [
         text({ fg: theme.text }, ['Agents']),
       ]),
       ...getSidebarAgentNames(snapshot).map((agentName) => {
         const model = snapshot.agentModels[agentName] ?? 'pending';
-        return row(
-          agentName,
-          truncate(formatSidebarModelName(model), 26),
-          theme,
-          theme.textMuted,
-        );
+        const variant = snapshot.agentVariants?.[agentName];
+        const display = variant
+          ? `${truncate(formatSidebarModelName(model), 18)} · ${variant}`
+          : truncate(formatSidebarModelName(model), 26);
+        return row(agentName, display, theme, theme.textMuted);
       }),
     ],
   );


### PR DESCRIPTION
## Summary

Fixes #438 — `/preset` now works at runtime in existing sessions without throwing `UnknownError`.

## Root Cause

`client.config.update()` writes `<project>/config.json` and **synchronously disposes** the active opencode instance during `command.execute.before`. The in-flight `SessionPrompt.createUserMessage` then runs against the disposed instance and throws `UnknownError`, surfacing as a generic red error popup in the TUI.

## Changes

### 1. Deferred config.update (`preset-manager.ts`)
- Move `ctx.client.config.update()` behind `setImmediate()` so the command response is delivered before the instance is disposed.
- Update in-memory state (`agentModels`, `agentVariants`, `activePreset`) synchronously so `/preset` listing and sidebar reflect the switch immediately.
- Roll back in-memory state if the deferred SDK call fails.

### 2. Runtime preset precedence (`loader.ts`)
- Config loader now checks `getActiveRuntimePreset()` between env var and config file, so the active preset survives the `dispose()` → `config()` re-init cycle triggered by `config.update`.

### 3. In-flight message override (`preset-message-override.ts`, new)
- `chat.message` hook mutates `output.message.model.{providerID, modelID, variant}` and flat `variant`/`thinking` fields so the current turn inference uses the preset model+variant.
- Technique adapted from [oh-my-openagent](https://github.com/code-yeongyu/oh-my-openagent)'s `ultrawork-model-override`.

### 4. SQLite persistence (`preset-db-variant-override.ts`, new)
- Deferred `bun:sqlite` UPDATE on `opencode.db` so reload/chat history also reflects the override. No-op outside Bun runtime.
- Microtask retry loop waits for opencode's own `Session.updateMessage()` to persist before overwriting.

### 5. TUI sidebar enhancements (`tui-state.ts`, `tui.ts`)
- `TuiSnapshot` extended with `agentVariants` and `activePreset`.
- Sidebar now shows active preset name and `model · variant` per agent, compensating for the native textarea variant chip being read-only from plugins.

## Testing

- All 1137 existing tests pass.
- `preset-manager.test.ts` updated for deferred call semantics (`flushDeferred` helper, error expectations adjusted).
- Manually verified:
  - `/preset ultra` (orchestrator → `openai/gpt-5.5`): model switches correctly, inference uses GPT-5.5.
  - `/preset default` (orchestrator → `anthropic/claude-opus-4-7`): model switches back, inference uses Opus.
  - Sidebar shows `preset <name>` and `model · variant` per agent.
  - DB rows contain correct variant values after override.

## Limitation

The native opencode textarea variant/thinking chip cannot be updated from a plugin (no SDK API exists). The sidebar enhancement compensates for this. A future opencode core change could expose `client.tui.setVariant()` or similar.