### PR TITLE
detect 'Insufficient balance' as rate-limit error for fallback

### DIFF
--- a/src/hooks/foreground-fallback/index.test.ts
+++ b/src/hooks/foreground-fallback/index.test.ts
@@ -85,6 +85,10 @@ describe('isRateLimitError', () => {
     expect(isRateLimitError({ message: 'overloaded_error' })).toBe(true);
   });
 
+  test('returns true for "Insufficient balance."', () => {
+    expect(isRateLimitError({ message: 'Insufficient balance.' })).toBe(true);
+  });
+
   test('returns false for non-rate-limit error', () => {
     expect(isRateLimitError({ message: 'invalid API key' })).toBe(false);
   });

--- a/src/hooks/foreground-fallback/index.test.ts
+++ b/src/hooks/foreground-fallback/index.test.ts
@@ -330,6 +330,32 @@ describe('ForegroundFallbackManager session.status', () => {
     expect(mocks.promptAsync).toHaveBeenCalledTimes(1);
   });
 
+  test('triggers fallback on retry status with insufficient balance message', async () => {
+    const { client, mocks } = createMockClient();
+    const mgr = new ForegroundFallbackManager(client, makeChains(), true);
+
+    await mgr.handleEvent({
+      type: 'message.updated',
+      properties: {
+        info: {
+          sessionID: 'sess-5',
+          providerID: 'anthropic',
+          modelID: 'claude-opus-4-5',
+        },
+      },
+    });
+
+    await mgr.handleEvent({
+      type: 'session.status',
+      properties: {
+        sessionID: 'sess-5',
+        status: { type: 'retry', message: 'Insufficient balance.' },
+      },
+    });
+
+    expect(mocks.promptAsync).toHaveBeenCalledTimes(1);
+  });
+
   test('ignores session.status with non-rate-limit retry message', async () => {
     const { client, mocks } = createMockClient();
     const mgr = new ForegroundFallbackManager(client, makeChains(), true);

--- a/src/hooks/foreground-fallback/index.ts
+++ b/src/hooks/foreground-fallback/index.ts
@@ -35,7 +35,7 @@ const RATE_LIMIT_PATTERNS = [
   /usage limit/i,
   /overloaded/i,
   /resource.?exhausted/i,
-  /insufficient.?quota/i,
+  /insufficient.?(quota|balance)/i,
   /high concurrency/i,
   /reduce concurrency/i,
 ];

--- a/src/hooks/foreground-fallback/index.ts
+++ b/src/hooks/foreground-fallback/index.ts
@@ -168,6 +168,7 @@ export class ForegroundFallbackManager {
           msg.includes('quota exceeded') ||
           msg.includes('exceededbudget') ||
           msg.includes('over budget') ||
+          msg.includes('insufficient') ||
           msg.includes('high concurrency') ||
           msg.includes('reduce concurrency')
         ) {


### PR DESCRIPTION
## Summary
- Extend `isRateLimitError()` to match "Insufficient balance." errors returned by providers such as OpenCode Zen when an account is depleted
- Add missing `insufficient` keyword to the `session.status` retry handler's keyword list
- This ensures that `ForegroundFallbackManager` triggers fallback to the next model in the chain instead of silently failing

## Problem
1. The existing `RATE_LIMIT_PATTERNS` regex `/insufficient.?quota/i` does not match the error message `"Insufficient balance."` — only `"insufficient quota"`. Providers like OpenCode Zen return this exact message when a subscription runs out, causing the fallback system to never activate.
2. The `session.status` retry handler maintains its own keyword list that was missing `insufficient` entirely, so even if the regex were fixed, "Insufficient balance." arriving via that path would still not trigger fallback.

## Fix
- Changed `/insufficient.?quota/i` → `/insufficient.?(quota|balance)/i` in `RATE_LIMIT_PATTERNS`
- Added `msg.includes('insufficient')` to the `session.status` keyword list
- Added a test case confirming `"Insufficient balance."` is detected as a rate-limit error

## Testing
- Added test: `returns true for "Insufficient balance."` in `isRateLimitError` test suite