### PR TITLE
fix(job-board): distinguish resumed sessions from new launches in age label

### DIFF
--- a/src/utils/background-job-board.test.ts
+++ b/src/utils/background-job-board.test.ts
@@ -165,6 +165,7 @@ describe('BackgroundJobBoard', () => {
       terminalUnreconciled: false,
       completedAt: undefined,
       resultSummary: undefined,
+      lastLaunchedAt: 300,
       updatedAt: 300,
     });
   });
@@ -267,6 +268,37 @@ describe('BackgroundJobBoard', () => {
     expect(board.formatForPrompt('parent-1')).toBeUndefined();
   });
 
+  test('annotates just-launched running jobs with age in the prompt', () => {
+    const board = new BackgroundJobBoard();
+    board.registerLaunch({
+      taskID: 'ses_1',
+      parentSessionID: 'parent-1',
+      agent: 'fixer',
+      description: 'implement feature',
+      now: 1_000,
+    });
+
+    // 4 seconds after launch — should show age annotation
+    const prompt = board.formatForPrompt('parent-1', 5_000);
+    expect(prompt).toContain('running [just launched, 4s ago]');
+  });
+
+  test('does not annotate running jobs older than 30s', () => {
+    const board = new BackgroundJobBoard();
+    board.registerLaunch({
+      taskID: 'ses_1',
+      parentSessionID: 'parent-1',
+      agent: 'fixer',
+      description: 'implement feature',
+      now: 1_000,
+    });
+
+    // 39 seconds after launch — age label should be absent
+    const prompt = board.formatForPrompt('parent-1', 40_000);
+    expect(prompt).not.toContain('just launched');
+    expect(prompt).toContain('/ running\n');
+  });
+
   test('registerLaunch can reset a reconciled job to running', () => {
     const board = new BackgroundJobBoard();
     board.registerLaunch({
@@ -295,5 +327,29 @@ describe('BackgroundJobBoard', () => {
       resultSummary: undefined,
       updatedAt: 400,
     });
+  });
+
+  test('annotates resumed running jobs with resumed label in the prompt', () => {
+    const board = new BackgroundJobBoard();
+    // Initial launch at t=1000
+    board.registerLaunch({
+      taskID: 'ses_1',
+      parentSessionID: 'parent-1',
+      agent: 'fixer',
+      description: 'implement feature',
+      now: 1_000,
+    });
+    // Reuse the same session ID at t=5000 (session reuse)
+    board.registerLaunch({
+      taskID: 'ses_1',
+      parentSessionID: 'parent-1',
+      agent: 'fixer',
+      description: 'implement feature continued',
+      now: 5_000,
+    });
+
+    // 4 seconds after relaunch — should show [resumed, 4s ago]
+    const prompt = board.formatForPrompt('parent-1', 9_000);
+    expect(prompt).toContain('running [resumed, 4s ago]');
   });
 });

--- a/src/utils/background-job-board.ts
+++ b/src/utils/background-job-board.ts
@@ -12,6 +12,7 @@ export interface BackgroundJobRecord {
   timedOut: boolean;
   terminalUnreconciled: boolean;
   launchedAt: number;
+  lastLaunchedAt: number;
   updatedAt: number;
   completedAt?: number;
   resultSummary?: string;
@@ -70,6 +71,7 @@ export class BackgroundJobBoard {
         terminalUnreconciled: false,
         completedAt: undefined,
         resultSummary: undefined,
+        lastLaunchedAt: now,
         updatedAt: now,
       } satisfies BackgroundJobRecord;
       this.jobs.set(input.taskID, updated);
@@ -86,6 +88,7 @@ export class BackgroundJobBoard {
       timedOut: false,
       terminalUnreconciled: false,
       launchedAt: now,
+      lastLaunchedAt: now,
       updatedAt: now,
       alias: this.nextAlias(input.parentSessionID, input.agent),
     };
@@ -180,7 +183,7 @@ export class BackgroundJobBoard {
     return this.list(parentSessionID).some((job) => job.terminalUnreconciled);
   }
 
-  formatForPrompt(parentSessionID: string): string | undefined {
+  formatForPrompt(parentSessionID: string, now = Date.now()): string | undefined {
     const jobs = this.list(parentSessionID).filter(
       (job) => job.state === 'running' || job.terminalUnreconciled,
     );
@@ -191,7 +194,7 @@ export class BackgroundJobBoard {
       '### Background Job Board',
       'Use task_status before consuming running jobs. Reconcile terminal jobs before final response.',
       '',
-      ...jobs.map(formatJob),
+      ...jobs.map((job) => formatJob(job, now)),
     ].join('\n');
   }
 
@@ -215,12 +218,18 @@ export class BackgroundJobBoard {
   }
 }
 
-function formatJob(job: BackgroundJobRecord): string {
+function formatJob(job: BackgroundJobRecord, now = Date.now()): string {
+  const ageMs = now - job.lastLaunchedAt;
+  const isResume = job.lastLaunchedAt !== job.launchedAt;
+  const ageLabel =
+    job.state === 'running' && ageMs < 30_000
+      ? ` [${isResume ? 'resumed' : 'just launched'}, ${Math.round(ageMs / 1000)}s ago]`
+      : '';
   const status = job.terminalUnreconciled
     ? `${job.state}, unreconciled`
     : job.timedOut
       ? `${job.state}, timed out`
-      : job.state;
+      : `${job.state}${ageLabel}`;
   const lines = [
     `- ${job.alias} / ${job.taskID} / ${job.agent} / ${status}`,
     `  Objective: ${job.objective || job.description}`,


### PR DESCRIPTION
## What changed

Added `lastLaunchedAt: number` field to `BackgroundJobRecord`.

- **New session** (first time a taskID is registered): `lastLaunchedAt = launchedAt = now`
- **Session reuse** (same taskID relaunched): `lastLaunchedAt = now`, `launchedAt` preserved from original launch

`formatJob` now uses `lastLaunchedAt` for age and compares it to `launchedAt` to select the right label:
- `running [just launched, Xs ago]` — new session, dispatched < 30s ago
- `running [resumed, Xs ago]` — existing session reused, resumed < 30s ago
- `running` — no annotation if > 30s (unchanged)

## Why

The v2 beta job board already annotates freshly dispatched tasks with `[just launched]`, which is a big help. But session reuse shows the same label — an orchestrator that dispatches `task(..., task_id=existing)` can't tell whether it just dispatched a new task or resumed a pre-existing one.

The `resumed` label closes that gap: after calling `task(task_id=X)` for an existing session, the board immediately shows `running [resumed, Xs ago]`, making the intent unambiguous.

## Tests

One new test: `'annotates resumed running jobs with resumed label in the prompt'`
One updated test: `'resets terminal state when an existing task id is relaunched'` (asserts `lastLaunchedAt`)

All 14 tests pass.