### PR TITLE
fix(preset): resolve /preset race condition and council default hint

### DIFF
--- a/src/agents/council.ts
+++ b/src/agents/council.ts
@@ -17,7 +17,7 @@ orchestration system that runs consensus across multiple models.
 
 **Usage**:
 1. Call the \`council_session\` tool with the user's prompt
-2. Optionally specify a preset (default: "default")
+2. Optionally specify a preset (if omitted, uses council.default_preset from config)
 3. Receive the councillor responses formatted for synthesis
 4. Follow the Synthesis Process below
 5. Present the result to the user

--- a/src/tools/council.ts
+++ b/src/tools/council.ts
@@ -46,7 +46,7 @@ Returns the councillor responses with a summary footer.`,
         .string()
         .optional()
         .describe(
-          'Council preset to use (default: "default"). Must match a preset in the council config.',
+          'Council preset to use. If omitted, uses council.default_preset from config (falls back to "default"). Must match a preset in the council config.',
         ),
     },
     async execute(args, toolContext) {

--- a/src/tools/preset-manager.test.ts
+++ b/src/tools/preset-manager.test.ts
@@ -319,7 +319,9 @@ describe('createPresetManager', () => {
       );
 
       const text = getOutputText(output);
-      expect(text).toContain('Failed to switch preset');
+      expect(text).toContain(
+        'Warning: preset "cheap" may not have fully applied',
+      );
       expect(text).toContain('Server unavailable');
       expect(readTuiSnapshot().agentModels).toEqual({
         explorer: 'openai/gpt-5.4-mini',
@@ -794,7 +796,9 @@ describe('createPresetManager', () => {
 
       // Active preset should still be "cheap" after error
       expect(getActiveRuntimePreset()).toBe('cheap');
-      expect(getOutputText(output2)).toContain('Failed to switch preset');
+      expect(getOutputText(output2)).toContain(
+        'Warning: preset "expensive" may not have fully applied',
+      );
 
       // Cleanup
       setActiveRuntimePreset(null);

--- a/src/tools/preset-manager.ts
+++ b/src/tools/preset-manager.ts
@@ -186,6 +186,30 @@ export function createPresetManager(ctx: PluginInput, config: PluginConfig) {
     const previousPreset = activePreset;
     setActiveRuntimePresetWithPrevious(presetName);
 
+    // Build summary and emit response BEFORE config.update() to avoid
+    // race condition where instance disposal kills the in-flight response.
+    // See GitHub issues #488 and #438.
+    const summaryParts: string[] = [];
+    for (const [name, cfg] of Object.entries(agentUpdates)) {
+      const parts: string[] = [name];
+      if (cfg.model) parts.push(`model: ${cfg.model}`);
+      if (cfg.variant) parts.push(`variant: ${cfg.variant}`);
+      if (cfg.temperature !== undefined) parts.push(`temp: ${cfg.temperature}`);
+      if (cfg.options) parts.push('options: yes');
+      summaryParts.push(parts.join(' → '));
+    }
+    if (Object.keys(resetUpdates).length > 0) {
+      summaryParts.push(
+        `Reset to baseline: ${Object.keys(resetUpdates).join(', ')}`,
+      );
+    }
+
+    output.parts.push(
+      createInternalAgentTextPart(
+        `Switched to preset "${presetName}":\n${summaryParts.join('\n')}`,
+      ),
+    );
+
     try {
       await ctx.client.config.update({
         body: { agent: allUpdates },
@@ -201,33 +225,11 @@ export function createPresetManager(ctx: PluginInput, config: PluginConfig) {
       recordTuiAgentModels({ agentModels });
 
       activePreset = presetName;
-
-      const summaryParts: string[] = [];
-      for (const [name, cfg] of Object.entries(agentUpdates)) {
-        const parts: string[] = [name];
-        if (cfg.model) parts.push(`model: ${cfg.model}`);
-        if (cfg.variant) parts.push(`variant: ${cfg.variant}`);
-        if (cfg.temperature !== undefined)
-          parts.push(`temp: ${cfg.temperature}`);
-        if (cfg.options) parts.push('options: yes');
-        summaryParts.push(parts.join(' → '));
-      }
-      if (Object.keys(resetUpdates).length > 0) {
-        summaryParts.push(
-          `Reset to baseline: ${Object.keys(resetUpdates).join(', ')}`,
-        );
-      }
-
-      output.parts.push(
-        createInternalAgentTextPart(
-          `Switched to preset "${presetName}":\n${summaryParts.join('\n')}`,
-        ),
-      );
     } catch (err) {
       rollbackRuntimePreset(previousPreset);
       output.parts.push(
         createInternalAgentTextPart(
-          `Failed to switch preset "${presetName}": ${String(err)}`,
+          `Warning: preset "${presetName}" may not have fully applied: ${String(err)}`,
         ),
       );
     }


### PR DESCRIPTION
## Summary

Fixes three preset-related bugs in one PR:

### #488 / #438 — `/preset` race condition (same root cause)

`switchPreset()` pushed the success response to `output.parts` **after** calling `client.config.update()`, which triggers `Instance.dispose()` → plugin re-init. The in-flight response was lost because the instance was disposed before the output could be processed, causing "Agent not found" errors.

**Fix**: Reorder `switchPreset()` to emit the success response **before** calling `config.update()`. This ensures the user sees the confirmation before the disposal cycle runs. On `config.update()` failure, a follow-up warning is emitted and runtime preset state is rolled back.

### #479 — Council `default_preset` bypass

The council tool description and agent prompt hardcoded `(default: "default")`, which misled the LLM into explicitly passing `preset: "default"` instead of omitting the parameter. When omitted, the runtime correctly falls back to `council.default_preset` → `"default"`, but the explicit `"default"` bypassed the user's configured default.

**Fix**: Update description to indicate omitting uses `council.default_preset` from config.

## Changes

| File | Change |
|------|--------|
| `src/tools/preset-manager.ts` | Reorder `switchPreset()` — emit response before `config.update()` |
| `src/tools/preset-manager.test.ts` | Update test expectations for new error message wording |
| `src/tools/council.ts` | Remove misleading `(default: "default")` from tool param description |
| `src/agents/council.ts` | Remove misleading `(default: "default")` from agent prompt |

## Validation

- `bun run check:ci` - passes clean
- `bun test -t "preset"` - 76 pass, 0 regressions
- Pre-existing typecheck errors (missing SDK modules) unchanged

Closes #488, closes #438, closes #479