### PR TITLE
feat(preset): add Anthropic Claude preset (Haiku / Sonnet / Opus)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ OPENCODE_EXPERIMENTAL_BACKGROUND_SUBAGENTS=1 opencode
 
 ### Getting Started
 
-The installer generates both OpenAI and OpenCode Go presets, with OpenAI active by default. OpenAI uses `openai/gpt-5.5` for the higher-judgment agents and `openai/gpt-5.4-mini` for the faster scoped agents. To make OpenCode Go active during install, run `bunx oh-my-opencode-slim@latest install --preset=opencode-go` or change the default preset name in `~/.config/opencode/oh-my-opencode-slim.json` after installation.
+The installer generates OpenAI, Anthropic, and OpenCode Go presets, with OpenAI active by default. OpenAI uses `openai/gpt-5.5` for the higher-judgment agents and `openai/gpt-5.4-mini` for the faster scoped agents. The Anthropic preset uses `anthropic/claude-sonnet-4.6` for the core engineering roles, `anthropic/claude-opus-4.7` for the oracle, and `anthropic/claude-haiku-4.5` for the lightweight specialist roles. To change the active preset during install, run `bunx oh-my-opencode-slim@latest install --preset=anthropic` (or `--preset=opencode-go`), or change the default preset name in `~/.config/opencode/oh-my-opencode-slim.json` after installation.
 
 Then:
 
@@ -77,7 +77,7 @@ Then:
 > [!TIP]
 > It's **recommended** to understand how automatic delegation works. The **[Orchestrator prompt](https://github.com/alvinunreal/oh-my-opencode-slim/blob/master/src/agents/orchestrator.ts#L28)** contains the delegation rules, specialist routing logic, and the thresholds for when the main agent should hand work off to subagents. You can alway delegate manually by calling a subagent via: `@agentName <task>`
 
-The default generated configuration includes both `openai` and `opencode-go` presets.
+The default generated configuration includes `openai`, `anthropic`, and `opencode-go` presets.
 
 ```jsonc
 {
@@ -91,6 +91,14 @@ The default generated configuration includes both `openai` and `opencode-go` pre
       "explorer": { "model": "openai/gpt-5.4-mini", "variant": "low", "skills": [], "mcps": [] },
       "designer": { "model": "openai/gpt-5.4-mini", "variant": "medium", "skills": [], "mcps": [] },
       "fixer": { "model": "openai/gpt-5.4-mini", "variant": "low", "skills": [], "mcps": [] }
+    },
+    "anthropic": {
+      "orchestrator": { "model": "anthropic/claude-sonnet-4.6", "skills": ["*"], "mcps": ["*", "!context7"] },
+      "oracle": { "model": "anthropic/claude-opus-4.7", "variant": "high", "skills": ["simplify"], "mcps": [] },
+      "librarian": { "model": "anthropic/claude-haiku-4.5", "variant": "low", "skills": [], "mcps": ["websearch", "context7", "grep_app"] },
+      "explorer": { "model": "anthropic/claude-haiku-4.5", "variant": "low", "skills": [], "mcps": [] },
+      "designer": { "model": "anthropic/claude-sonnet-4.6", "variant": "medium", "skills": [], "mcps": [] },
+      "fixer": { "model": "anthropic/claude-haiku-4.5", "variant": "low", "skills": [], "mcps": [] }
     },
     "opencode-go": {
       "orchestrator": { "model": "opencode-go/glm-5.1", "skills": [ "*" ], "mcps": [ "*", "!context7" ] },
@@ -107,7 +115,7 @@ The default generated configuration includes both `openai` and `opencode-go` pre
 
 ### For Alternative Providers
 
-To use custom providers or a mixed-provider setup, use **[Configuration](docs/configuration.md)** for the full reference. If you want a ready-made starting point, check the **[Author's Preset](docs/authors-preset.md)** and **[$30 Preset](docs/thirty-dollars-preset.md)** - the `$30` preset is the best cheap setup.
+To use custom providers or a mixed-provider setup, use **[Configuration](docs/configuration.md)** for the full reference. If you want a ready-made starting point, check the **[Anthropic Preset](docs/anthropic-preset.md)**, **[Author's Preset](docs/authors-preset.md)**, and **[$30 Preset](docs/thirty-dollars-preset.md)** - the `$30` preset is the best cheap setup.
 
 The configuration guide also covers custom subagents via `agents.<name>`, where
 you can define both a normal `prompt` and an `orchestratorPrompt` block for
@@ -171,7 +179,7 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Recommended Models:</b> <code>openai/gpt-5.5</code> <code>anthropic/claude-opus-4.6</code>
+      <b>Recommended Models:</b> <code>openai/gpt-5.5</code> <code>anthropic/claude-sonnet-4.6</code>
     </td>
   </tr>
   <tr>
@@ -212,7 +220,7 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Recommended Models:</b> <code>cerebras/zai-glm-4.7</code> <code>fireworks-ai/accounts/fireworks/routers/kimi-k2p5-turbo</code> <code>openai/gpt-5.4-mini</code>
+      <b>Recommended Models:</b> <code>cerebras/zai-glm-4.7</code> <code>fireworks-ai/accounts/fireworks/routers/kimi-k2p5-turbo</code> <code>openai/gpt-5.4-mini</code> <code>anthropic/claude-haiku-4.5</code>
     </td>
   </tr>
   <tr>
@@ -253,7 +261,7 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Recommended Models:</b> <code>openai/gpt-5.5 (high)</code> <code>google/gemini-3.1-pro-preview (high)</code>
+      <b>Recommended Models:</b> <code>openai/gpt-5.5 (high)</code> <code>google/gemini-3.1-pro-preview (high)</code> <code>anthropic/claude-opus-4.7 (high)</code>
     </td>
   </tr>
   <tr>
@@ -343,7 +351,7 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Recommended Models:</b> <code>cerebras/zai-glm-4.7</code> <code>fireworks-ai/accounts/fireworks/routers/kimi-k2p5-turbo</code> <code>openai/gpt-5.4-mini</code>
+      <b>Recommended Models:</b> <code>cerebras/zai-glm-4.7</code> <code>fireworks-ai/accounts/fireworks/routers/kimi-k2p5-turbo</code> <code>openai/gpt-5.4-mini</code> <code>anthropic/claude-haiku-4.5</code>
     </td>
   </tr>
   <tr>
@@ -384,7 +392,7 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Recommended Models:</b> <code>google/gemini-3.1-pro-preview</code> <code>kimi-for-coding/k2p5</code> 
+      <b>Recommended Models:</b> <code>google/gemini-3.1-pro-preview</code> <code>kimi-for-coding/k2p5</code> <code>anthropic/claude-sonnet-4.6</code>
     </td>
   </tr>
   <tr>
@@ -425,7 +433,7 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Recommended Models:</b> <code>cerebras/zai-glm-4.7</code> <code>fireworks-ai/accounts/fireworks/routers/kimi-k2p5-turbo</code> <code>openai/gpt-5.4-mini</code>
+      <b>Recommended Models:</b> <code>cerebras/zai-glm-4.7</code> <code>fireworks-ai/accounts/fireworks/routers/kimi-k2p5-turbo</code> <code>openai/gpt-5.4-mini</code> <code>anthropic/claude-haiku-4.5</code>
     </td>
   </tr>
   <tr>
@@ -522,6 +530,7 @@ Use this section as a map: start with installation, then jump to features, confi
 
 | Doc | What it covers |
 |-----|----------------|
+| **[Anthropic Preset](docs/anthropic-preset.md)** | The bundled `anthropic` preset generated by the installer (Haiku / Sonnet / Opus) |
 | **[Author's Preset](docs/authors-preset.md)** | The author's daily mixed-provider setup |
 | **[$30 Preset](docs/thirty-dollars-preset.md)** | A budget mixed-provider setup for around $30/month |
 | **[OpenCode Go Preset](docs/opencode-go-preset.md)** | The bundled `opencode-go` preset generated by the installer |

--- a/docs/anthropic-preset.md
+++ b/docs/anthropic-preset.md
@@ -1,0 +1,81 @@
+# Anthropic Preset
+
+The `anthropic` preset uses the Claude model family for all agents, optimizing for
+cost and capability by assigning each agent the right Claude tier:
+
+- **Haiku** for lightweight, high-frequency tasks (librarian, explorer, fixer)
+- **Sonnet** for core engineering work (orchestrator, designer)
+- **Opus** for deep reasoning and long-horizon planning (oracle)
+
+This preset is available out of the box — no extra configuration needed beyond
+having an Anthropic API key (or using OpenRouter).
+
+---
+
+## Model assignment
+
+| Agent | Model | Variant | Role |
+|---|---|---|---|
+| orchestrator | `anthropic/claude-sonnet-4.6` | — | Task decomposition and agent routing |
+| oracle | `anthropic/claude-opus-4.7` | high | Deep architecture and planning decisions |
+| librarian | `anthropic/claude-haiku-4.5` | low | Fast documentation and search tasks |
+| explorer | `anthropic/claude-haiku-4.5` | low | Codebase traversal and discovery |
+| designer | `anthropic/claude-sonnet-4.6` | medium | UI and interface design |
+| fixer | `anthropic/claude-haiku-4.5` | low | Targeted bug fixes and small edits |
+
+---
+
+## Activating the preset
+
+### At install time
+
+```bash
+bunx oh-my-opencode-slim@latest install --preset=anthropic
+```
+
+### By editing your config
+
+In `~/.config/opencode/oh-my-opencode-slim.json`, set the active preset:
+
+```jsonc
+{
+  "preset": "anthropic",
+  "presets": {
+    "anthropic": { /* generated automatically */ }
+  }
+}
+```
+
+### Switching at runtime
+
+Use the `/preset` slash command inside an OpenCode session:
+
+```
+/preset anthropic
+```
+
+---
+
+## Authentication
+
+Log in to Anthropic (or OpenRouter) before starting:
+
+```bash
+opencode auth login
+opencode models --refresh
+```
+
+---
+
+## Cost profile
+
+Approximate costs at typical usage (token prices as of 2025):
+
+| Model | Input | Output |
+|---|---|---|
+| claude-haiku-4.5 | $1 / 1M | $5 / 1M |
+| claude-sonnet-4.6 | $3 / 1M | $15 / 1M |
+| claude-opus-4.7 | $5 / 1M | $25 / 1M |
+
+Because Haiku handles the three most frequent roles (librarian, explorer,
+fixer), the majority of token spend lands on the cheapest tier.

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -296,8 +296,8 @@ async function runInstall(config: InstallConfig): Promise<number> {
 
   const modelsInfo =
     config.preset && config.preset !== 'openai'
-      ? `Generated OpenAI and OpenCode Go presets; ${config.preset} is active.`
-      : 'Generated OpenAI and OpenCode Go presets; OpenAI is active by default.';
+      ? `Generated OpenAI, Anthropic, and OpenCode Go presets; ${config.preset} is active.`
+      : 'Generated OpenAI, Anthropic, and OpenCode Go presets; OpenAI is active by default.';
   console.log(`${modelsInfo}`);
   const altProviders = 'For the full configuration reference, see:';
   console.log(altProviders);

--- a/src/cli/providers.test.ts
+++ b/src/cli/providers.test.ts
@@ -89,29 +89,6 @@ describe('providers', () => {
     expect(agents.fixer.variant).toBe('low');
   });
 
-  test('generateLiteConfig uses correct Anthropic models', () => {
-    const config = generateLiteConfig({
-      hasTmux: false,
-      installCustomSkills: false,
-      preset: 'anthropic',
-      reset: false,
-    });
-
-    const agents = (config.presets as any).anthropic;
-    expect(agents.orchestrator.model).toBe(
-      MODEL_MAPPINGS.anthropic.orchestrator.model,
-    );
-    // Sonnet for orchestrator and designer (medium-complexity SW engineering)
-    expect(agents.orchestrator.model).toBe('anthropic/claude-sonnet-4.6');
-    expect(agents.designer.model).toBe('anthropic/claude-sonnet-4.6');
-    // Opus for oracle (heavy planning and architecture)
-    expect(agents.oracle.model).toBe('anthropic/claude-opus-4.7');
-    // Haiku for lightweight roles
-    expect(agents.librarian.model).toBe('anthropic/claude-haiku-4.5');
-    expect(agents.explorer.model).toBe('anthropic/claude-haiku-4.5');
-    expect(agents.fixer.model).toBe('anthropic/claude-haiku-4.5');
-  });
-
   test('generateLiteConfig anthropic preset includes correct mcps', () => {
     const config = generateLiteConfig({
       hasTmux: false,

--- a/src/cli/providers.test.ts
+++ b/src/cli/providers.test.ts
@@ -7,6 +7,7 @@ describe('providers', () => {
   test('MODEL_MAPPINGS includes supported providers', () => {
     const keys = Object.keys(MODEL_MAPPINGS);
     expect(keys.sort()).toEqual([
+      'anthropic',
       'copilot',
       'kimi',
       'openai',
@@ -31,6 +32,7 @@ describe('providers', () => {
     expect((config.presets as any)['opencode-go'].observer.model).toBe(
       'opencode-go/kimi-k2.6',
     );
+    expect((config.presets as any).anthropic).toBeDefined();
     const agents = (config.presets as any).openai;
     expect(agents).toBeDefined();
     expect(agents.orchestrator.model).toBe('openai/gpt-5.5');
@@ -58,6 +60,72 @@ describe('providers', () => {
     expect(agents.explorer.variant).toBe('low');
     expect(agents.designer.model).toBe('openai/gpt-5.4-mini');
     expect(agents.designer.variant).toBe('medium');
+  });
+
+  test('generateLiteConfig can set anthropic as active preset', () => {
+    const config = generateLiteConfig({
+      hasTmux: false,
+      installCustomSkills: false,
+      preset: 'anthropic',
+      reset: false,
+    });
+
+    expect(config.preset).toBe('anthropic');
+    expect(config.disabled_agents).toBeUndefined();
+    expect((config.presets as any).openai).toBeDefined();
+    const agents = (config.presets as any).anthropic;
+    expect(agents).toBeDefined();
+    expect(agents.orchestrator.model).toBe('anthropic/claude-sonnet-4.6');
+    expect(agents.orchestrator.variant).toBeUndefined();
+    expect(agents.oracle.model).toBe('anthropic/claude-opus-4.7');
+    expect(agents.oracle.variant).toBe('high');
+    expect(agents.librarian.model).toBe('anthropic/claude-haiku-4.5');
+    expect(agents.librarian.variant).toBe('low');
+    expect(agents.explorer.model).toBe('anthropic/claude-haiku-4.5');
+    expect(agents.explorer.variant).toBe('low');
+    expect(agents.designer.model).toBe('anthropic/claude-sonnet-4.6');
+    expect(agents.designer.variant).toBe('medium');
+    expect(agents.fixer.model).toBe('anthropic/claude-haiku-4.5');
+    expect(agents.fixer.variant).toBe('low');
+  });
+
+  test('generateLiteConfig uses correct Anthropic models', () => {
+    const config = generateLiteConfig({
+      hasTmux: false,
+      installCustomSkills: false,
+      preset: 'anthropic',
+      reset: false,
+    });
+
+    const agents = (config.presets as any).anthropic;
+    expect(agents.orchestrator.model).toBe(
+      MODEL_MAPPINGS.anthropic.orchestrator.model,
+    );
+    // Sonnet for orchestrator and designer (medium-complexity SW engineering)
+    expect(agents.orchestrator.model).toBe('anthropic/claude-sonnet-4.6');
+    expect(agents.designer.model).toBe('anthropic/claude-sonnet-4.6');
+    // Opus for oracle (heavy planning and architecture)
+    expect(agents.oracle.model).toBe('anthropic/claude-opus-4.7');
+    // Haiku for lightweight roles
+    expect(agents.librarian.model).toBe('anthropic/claude-haiku-4.5');
+    expect(agents.explorer.model).toBe('anthropic/claude-haiku-4.5');
+    expect(agents.fixer.model).toBe('anthropic/claude-haiku-4.5');
+  });
+
+  test('generateLiteConfig anthropic preset includes correct mcps', () => {
+    const config = generateLiteConfig({
+      hasTmux: false,
+      installCustomSkills: false,
+      preset: 'anthropic',
+      reset: false,
+    });
+
+    const agents = (config.presets as any).anthropic;
+    expect(agents.orchestrator.mcps).toEqual(['*', '!context7']);
+    expect(agents.librarian.mcps).toContain('websearch');
+    expect(agents.librarian.mcps).toContain('context7');
+    expect(agents.librarian.mcps).toContain('grep_app');
+    expect(agents.designer.mcps).toEqual([]);
   });
 
   test('generateLiteConfig can set opencode-go as active preset', () => {

--- a/src/cli/providers.ts
+++ b/src/cli/providers.ts
@@ -5,7 +5,11 @@ import type { InstallConfig } from './types';
 const SCHEMA_URL =
   'https://unpkg.com/oh-my-opencode-slim@latest/oh-my-opencode-slim.schema.json';
 
-export const GENERATED_PRESETS = ['openai', 'opencode-go'] as const;
+export const GENERATED_PRESETS = [
+  'openai',
+  'anthropic',
+  'opencode-go',
+] as const;
 
 // Model mappings by provider/preset.
 export const MODEL_MAPPINGS = {
@@ -16,6 +20,14 @@ export const MODEL_MAPPINGS = {
     explorer: { model: 'openai/gpt-5.4-mini', variant: 'low' },
     designer: { model: 'openai/gpt-5.4-mini', variant: 'medium' },
     fixer: { model: 'openai/gpt-5.4-mini', variant: 'low' },
+  },
+  anthropic: {
+    orchestrator: { model: 'anthropic/claude-sonnet-4.6' },
+    oracle: { model: 'anthropic/claude-opus-4.7', variant: 'high' },
+    librarian: { model: 'anthropic/claude-haiku-4.5', variant: 'low' },
+    explorer: { model: 'anthropic/claude-haiku-4.5', variant: 'low' },
+    designer: { model: 'anthropic/claude-sonnet-4.6', variant: 'medium' },
+    fixer: { model: 'anthropic/claude-haiku-4.5', variant: 'low' },
   },
   kimi: {
     orchestrator: { model: 'kimi-for-coding/k2p5' },


### PR DESCRIPTION
## Submission note
This PR was authored using oh-my-opencode-slim 🚀 installed in OpenCode.

## Summary

Adds `anthropic` as a first-class generated preset alongside `openai` and `opencode-go`.

The preset follows the same tiered-model philosophy used elsewhere in the project:

| Agent | Model | Variant | Rationale |
|---|---|---|---|
| orchestrator | `anthropic/claude-sonnet-4.6` | — | Core SW engineering tasks |
| oracle | `anthropic/claude-opus-4.7` | high | Deep planning and architecture |
| librarian | `anthropic/claude-haiku-4.5` | low | Fast search and lookup |
| explorer | `anthropic/claude-haiku-4.5` | low | Codebase traversal |
| designer | `anthropic/claude-sonnet-4.6` | medium | UI and interface work |
| fixer | `anthropic/claude-haiku-4.5` | low | Targeted fixes |

Haiku handles the three highest-frequency roles (librarian, explorer, fixer) to keep token costs low; Sonnet covers the engineering core; Opus is reserved for the oracle's heavyweight reasoning.

## Changes

- `src/cli/providers.ts` — adds `anthropic` to `MODEL_MAPPINGS` and `GENERATED_PRESETS`
- `src/cli/install.ts` — updates success message to mention all three generated presets
- `src/cli/providers.test.ts` — adds tests for the new preset (model names, variants, mcps, active-preset flag)
- `docs/anthropic-preset.md` — new doc page covering activation, model table, and cost profile

## Usage

```bash
# activate at install time
bunx oh-my-opencode-slim@latest install --preset=anthropic

# or switch at runtime
/preset anthropic
```

## Tests

1142 pass, 0 fail across 72 files (`bun test`). Biome check:ci clean.