### PR TITLE
fix(multiplexer): skip missing cleanup for sessions never observed in status

### DIFF
--- a/src/multiplexer/session-manager.test.ts
+++ b/src/multiplexer/session-manager.test.ts
@@ -390,6 +390,61 @@ describe('MultiplexerSessionManager', () => {
       expect(mockMultiplexer.closePane).not.toHaveBeenCalled();
     });
 
+    test('does not close missing session that was never seen in status', async () => {
+      const ctx = createMockContext();
+      mockMultiplexer.spawnPane.mockResolvedValue({
+        success: true,
+        paneId: 'p-never-seen',
+      });
+      const manager = new MultiplexerSessionManager(
+        ctx,
+        defaultMultiplexerConfig,
+      );
+
+      await manager.onSessionCreated({
+        type: 'session.created',
+        properties: { info: { id: 'never-seen', parentID: 'p1' } },
+      });
+
+      const tracked = (manager as any).sessions.get('never-seen');
+      tracked.missingSince = Date.now() - 60_000;
+
+      setMockSessionStatuses({});
+      await (manager as any).pollSessions();
+
+      expect(mockMultiplexer.closePane).not.toHaveBeenCalled();
+    });
+
+    test('keeps missing cleanup for sessions previously seen in status', async () => {
+      const ctx = createMockContext();
+      mockMultiplexer.spawnPane.mockResolvedValue({
+        success: true,
+        paneId: 'p-seen-before-missing',
+      });
+      const manager = new MultiplexerSessionManager(
+        ctx,
+        defaultMultiplexerConfig,
+      );
+
+      await manager.onSessionCreated({
+        type: 'session.created',
+        properties: { info: { id: 'seen-before-missing', parentID: 'p1' } },
+      });
+
+      setMockSessionStatuses({ 'seen-before-missing': { type: 'busy' } });
+      await (manager as any).pollSessions();
+
+      const tracked = (manager as any).sessions.get('seen-before-missing');
+      tracked.missingSince = Date.now() - 60_000;
+
+      setMockSessionStatuses({});
+      await (manager as any).pollSessions();
+
+      expect(mockMultiplexer.closePane).toHaveBeenCalledWith(
+        'p-seen-before-missing',
+      );
+    });
+
     test('polls the actual serverUrl instead of the plugin SDK default URL', async () => {
       const ctx = createMockContext({
         serverUrl: 'http://127.0.0.1:63871/',

--- a/src/multiplexer/session-manager.ts
+++ b/src/multiplexer/session-manager.ts
@@ -16,6 +16,7 @@ interface TrackedSession {
   directory: string;
   createdAt: number;
   lastSeenAt: number;
+  seenInStatus: boolean;
   missingSince?: number;
 }
 
@@ -221,6 +222,7 @@ export class MultiplexerSessionManager {
         directory,
         createdAt: now,
         lastSeenAt: now,
+        seenInStatus: false,
       });
 
       log('[multiplexer-session-manager] pane spawned', {
@@ -330,12 +332,14 @@ export class MultiplexerSessionManager {
 
         if (status) {
           tracked.lastSeenAt = now;
+          tracked.seenInStatus = true;
           tracked.missingSince = undefined;
         } else if (!tracked.missingSince) {
           tracked.missingSince = now;
         }
 
         const missingTooLong =
+          tracked.seenInStatus &&
           !!tracked.missingSince &&
           now - tracked.missingSince >= SESSION_MISSING_GRACE_MS;
         const isTimedOut = now - tracked.createdAt > SESSION_TIMEOUT_MS;
@@ -505,6 +509,7 @@ export class MultiplexerSessionManager {
         directory: known.directory,
         createdAt: now,
         lastSeenAt: now,
+        seenInStatus: false,
       });
 
       log('[multiplexer-session-manager] pane respawned on busy', {


### PR DESCRIPTION
## Summary
- Track whether a multiplexer child session has appeared in `/session/status`.
- Skip `missing` cleanup for sessions that were never observed in `/session/status`.
- Keep the existing `missing` fallback for previously observed sessions, with idle/deleted/timeout cleanup unchanged.
- Add regression coverage for never-seen and previously-seen status cases.

Nested council child sessions can emit lifecycle events and spawn panes without appearing in `/session/status`. Before this fix, the polling fallback could close those panes as `missing`, then later `busy` events would respawn them and cause a pane flicker loop.

This is intentionally narrower than removing `missing` cleanup entirely: sessions that were previously observed in `/session/status` still use the existing fallback cleanup path.

## Validation
- `bun test src/multiplexer/session-manager.test.ts`
- `bun run typecheck`
- `bun run check:ci`
- `bun test`