### PR TITLE
Fix Node ESM plugin packaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
     "LICENSE"
   ],
   "scripts": {
-    "build:plugin": "bun build src/index.ts src/tui.ts --outdir dist --target node --format esm --external @ast-grep/napi --external @opencode-ai/plugin --external @opencode-ai/sdk --external @opentui/core --external @opentui/solid --external jsdom --external zod",
-    "build:cli": "bun build src/cli/index.ts --outdir dist/cli --target node --format esm --external @ast-grep/napi --external @opencode-ai/plugin --external @opencode-ai/sdk --external jsdom --external zod",
+    "build:plugin": "bun build src/index.ts src/tui.ts --outdir dist --target node --format esm --external @ast-grep/napi --external @opencode-ai/plugin --external @opencode-ai/plugin/* --external @opencode-ai/sdk --external @opencode-ai/sdk/* --external @opentui/core --external @opentui/solid --external jsdom --external zod",
+    "build:cli": "bun build src/cli/index.ts --outdir dist/cli --target node --format esm --external @ast-grep/napi --external @opencode-ai/plugin --external @opencode-ai/plugin/* --external @opencode-ai/sdk --external @opencode-ai/sdk/* --external jsdom --external zod",
     "copy:divoom-assets": "bun run scripts/copy-divoom-assets.ts",
     "build": "bun run build:plugin && bun run build:cli && bun run copy:divoom-assets && tsc --emitDeclarationOnly && bun run generate-schema",
     "prepare": "bun run build",

--- a/scripts/verify-release-artifact.ts
+++ b/scripts/verify-release-artifact.ts
@@ -20,6 +20,7 @@ const suspiciousPathPatterns = [
   /\/Users\/[^\s'"`]+(?:node_modules|oh-my-opencode-slim)[^\s'"`]*/,
   /\/home\/[^\s'"`]+(?:node_modules|oh-my-opencode-slim)[^\s'"`]*/,
 ];
+const suspiciousImportPatterns = [/from\s+["']vscode-jsonrpc\/node["']/];
 
 const packagedRequiredFiles = [
   'package.json',
@@ -97,6 +98,11 @@ function verifyDistHasNoLeakedPaths() {
   for (const file of files) {
     const content = readFileSync(file, 'utf8');
     for (const pattern of suspiciousPathPatterns) {
+      const match = content.match(pattern);
+      if (!match) continue;
+      leaks.push(`${path.relative(repoRoot, file)}: ${match[0]}`);
+    }
+    for (const pattern of suspiciousImportPatterns) {
       const match = content.match(pattern);
       if (!match) continue;
       leaks.push(`${path.relative(repoRoot, file)}: ${match[0]}`);

--- a/src/hooks/todo-continuation/index.ts
+++ b/src/hooks/todo-continuation/index.ts
@@ -1,5 +1,5 @@
 import type { PluginInput } from '@opencode-ai/plugin';
-import { tool } from '@opencode-ai/plugin/tool';
+import { tool } from '@opencode-ai/plugin';
 import {
   createInternalAgentTextPart,
   log,

--- a/src/tools/ast-grep/tools.ts
+++ b/src/tools/ast-grep/tools.ts
@@ -1,4 +1,4 @@
-import { type ToolDefinition, tool } from '@opencode-ai/plugin/tool';
+import { type ToolDefinition, tool } from '@opencode-ai/plugin';
 import { runSg } from './cli';
 import type { CliLanguage } from './types';
 import { CLI_LANGUAGES } from './types';


### PR DESCRIPTION
## Summary

This fixes Node ESM packaging issues in the published plugin artifact.

### Changes
- switch runtime imports from `@opencode-ai/plugin/tool` to `@opencode-ai/plugin`
- externalize `@opencode-ai/plugin/*` and `@opencode-ai/sdk/*` in build scripts
- add a release verification guard to fail if `vscode-jsonrpc/node` leaks into built artifacts

## Why

The published npm package can fail to load in OpenCode desktop because the built artifact may retain an import path that resolves to `vscode-jsonrpc/node` through host-side dependencies. This change keeps those runtime imports external and adds a regression check.

## Validation

Validated locally by code inspection and branch-local commit creation.
Full build/release verification was not run in my environment because `bun` was not available in the repo environment.