### PR TITLE
fix(cli): disable OpenCode built-in agents during install

### DIFF
--- a/src/cli/config-io.test.ts
+++ b/src/cli/config-io.test.ts
@@ -438,7 +438,7 @@ describe('config-io', () => {
     );
   });
 
-  test('disableDefaultAgents disables explore and general agents', () => {
+  test('disableDefaultAgents disables OpenCode built-in agents', () => {
     const configPath = join(tmpDir, 'opencode', 'opencode.json');
     paths.ensureConfigDir();
     writeFileSync(configPath, JSON.stringify({}));
@@ -449,6 +449,35 @@ describe('config-io', () => {
     const saved = JSON.parse(readFileSync(configPath, 'utf-8'));
     expect(saved.agent.explore.disable).toBe(true);
     expect(saved.agent.general.disable).toBe(true);
+    expect(saved.agent.build.disable).toBe(true);
+    expect(saved.agent.plan.disable).toBe(true);
+  });
+
+  test('disableDefaultAgents preserves existing built-in agent config', () => {
+    const configPath = join(tmpDir, 'opencode', 'opencode.json');
+    paths.ensureConfigDir();
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        agent: {
+          build: { description: 'custom build agent' },
+          plan: { permission: { edit: 'deny' } },
+        },
+      }),
+    );
+
+    const result = disableDefaultAgents();
+    expect(result.success).toBe(true);
+
+    const saved = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(saved.agent.build).toEqual({
+      description: 'custom build agent',
+      disable: true,
+    });
+    expect(saved.agent.plan).toEqual({
+      permission: { edit: 'deny' },
+      disable: true,
+    });
   });
 
   test('enableLspByDefault sets lsp true when missing', () => {

--- a/src/cli/config-io.ts
+++ b/src/cli/config-io.ts
@@ -27,6 +27,12 @@ import type {
 } from './types';
 
 const PACKAGE_NAME = 'oh-my-opencode-slim';
+const DEFAULT_OPENCODE_AGENTS_TO_DISABLE = [
+  'build',
+  'explore',
+  'general',
+  'plan',
+] as const;
 
 function isString(value: unknown): value is string {
   return typeof value === 'string';
@@ -533,8 +539,15 @@ export function disableDefaultAgents(): ConfigMergeResult {
     const config = parsedConfig ?? {};
 
     const agent = (config.agent ?? {}) as Record<string, unknown>;
-    agent.explore = { disable: true };
-    agent.general = { disable: true };
+    for (const agentName of DEFAULT_OPENCODE_AGENTS_TO_DISABLE) {
+      const existing = agent[agentName];
+      agent[agentName] = {
+        ...(existing && typeof existing === 'object' && !Array.isArray(existing)
+          ? existing
+          : {}),
+        disable: true,
+      };
+    }
     config.agent = agent;
 
     writeConfig(configPath, config);


### PR DESCRIPTION
## Summary

- disable OpenCode built-in `build` and `plan` agents during install
- keep the existing `explore` and `general` disable behavior
- preserve existing built-in agent config while adding `disable: true`

## Why

The installer already has a "Disabling OpenCode default agents..." step, but it only disabled `explore` and `general`.

OpenCode also exposes built-in `build` and `plan` agents. After installing oh-my-opencode-slim, those built-ins could still appear in the available agent list. This patch disables the full built-in set replaced by OMOS:

- `build`
- `explore`
- `general`
- `plan`

Existing user fields on those agent entries are preserved.

## Validation

- `bun test src/cli/config-io.test.ts`
