### PR TITLE
fix: respect OPENCODE_CONFIG_DIR during install

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Then:
    opencode models --refresh
    ```
 3. **Open your plugin config** at `~/.config/opencode/oh-my-opencode-slim.json`
+   or `$OPENCODE_CONFIG_DIR/oh-my-opencode-slim.json` if you use a custom
+   OpenCode config directory
 
 4. **Update the models you want for each agent**
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,6 +15,9 @@ Complete reference for all configuration files and options in oh-my-opencode-sli
 
 > **💡 JSONC recommended:** Use the `.jsonc` extension to add comments and trailing commas. If both `.jsonc` and `.json` exist, `.jsonc` takes precedence.
 
+Set `OPENCODE_CONFIG_DIR` to use a custom user config directory instead of
+`~/.config/opencode`; install and runtime config discovery both honor it.
+
 If OmO-slim detects an invalid plugin config for the current project, the TUI sidebar shows a warning. Run `oh-my-opencode-slim doctor` from your project root for full diagnostics.
 
 ---

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -131,10 +131,12 @@ bunx oh-my-opencode-slim@latest install --reset
 ```
 
 The installer automatically:
-- Adds the plugin to `~/.config/opencode/opencode.json`
+- Adds the plugin to `opencode.json` or `opencode.jsonc` in
+  `$OPENCODE_CONFIG_DIR` when set, otherwise `~/.config/opencode`
 - Disables default OpenCode agents
 - Enables OpenCode LSP integration when no explicit `lsp` setting exists
-- Generates agent model mappings in `~/.config/opencode/oh-my-opencode-slim.json` (or `.jsonc`)
+- Generates agent model mappings in the same OpenCode config directory as
+  `oh-my-opencode-slim.json` (or `.jsonc`)
 
 ### Step 3: Authenticate with Providers
 

--- a/src/cli/config-io.test.ts
+++ b/src/cli/config-io.test.ts
@@ -135,6 +135,32 @@ describe('config-io', () => {
     expect(saved.plugin.length).toBe(2);
   });
 
+  test('addPluginToOpenCodeConfig respects OPENCODE_CONFIG_DIR', async () => {
+    const customConfigDir = join(tmpDir, 'custom-opencode');
+    const defaultConfigDir = join(tmpDir, 'opencode');
+    const customConfigPath = join(customConfigDir, 'opencode.jsonc');
+    const defaultConfigPath = join(defaultConfigDir, 'opencode.json');
+
+    process.env.OPENCODE_CONFIG_DIR = customConfigDir;
+    mkdirSync(customConfigDir, { recursive: true });
+    mkdirSync(defaultConfigDir, { recursive: true });
+    writeFileSync(
+      customConfigPath,
+      JSON.stringify({ plugin: ['other', 'oh-my-opencode-slim@1.0.0'] }),
+    );
+    writeFileSync(defaultConfigPath, JSON.stringify({ plugin: ['default'] }));
+    process.argv[1] = '';
+
+    const result = await addPluginToOpenCodeConfig();
+
+    expect(result.success).toBe(true);
+    expect(result.configPath).toBe(customConfigPath);
+    const customSaved = JSON.parse(readFileSync(customConfigPath, 'utf-8'));
+    const defaultSaved = JSON.parse(readFileSync(defaultConfigPath, 'utf-8'));
+    expect(customSaved.plugin).toEqual(['other', 'oh-my-opencode-slim']);
+    expect(defaultSaved.plugin).toEqual(['default']);
+  });
+
   test('addPluginToOpenCodeConfig stores package name for bunx temp paths', async () => {
     const configPath = join(tmpDir, 'opencode', 'opencode.json');
     const packageRoot = join(

--- a/src/cli/paths.test.ts
+++ b/src/cli/paths.test.ts
@@ -70,12 +70,12 @@ describe('paths', () => {
     ]);
   });
 
-  test('getOpenCodeConfigPaths() ignores OPENCODE_CONFIG_DIR', () => {
+  test('getOpenCodeConfigPaths() respects OPENCODE_CONFIG_DIR', () => {
     process.env.OPENCODE_CONFIG_DIR = '/custom/directory';
     process.env.XDG_CONFIG_HOME = '/tmp/xdg-config';
     expect(getOpenCodeConfigPaths()).toEqual([
-      '/tmp/xdg-config/opencode/opencode.json',
-      '/tmp/xdg-config/opencode/opencode.jsonc',
+      '/custom/directory/opencode.json',
+      '/custom/directory/opencode.jsonc',
     ]);
   });
 

--- a/src/cli/paths.ts
+++ b/src/cli/paths.ts
@@ -55,7 +55,7 @@ export function getConfigSearchDirs(): string[] {
 }
 
 export function getOpenCodeConfigPaths(): string[] {
-  const configDir = getDefaultOpenCodeConfigDir();
+  const configDir = getConfigDir();
   return [join(configDir, 'opencode.json'), join(configDir, 'opencode.jsonc')];
 }
 


### PR DESCRIPTION
## Summary
- Make install-time OpenCode config writes honor `OPENCODE_CONFIG_DIR`
- Add regression coverage for `opencode.json` / `opencode.jsonc` path resolution
- Document custom OpenCode config directorybehavior
 
## Problem
The installer modified the default OpenCode global config directory even when `OPENCODE_CONFIG_DIR` was set. Problems occur when attempting to isolate the Agent stack via `OPENCODE_CONFIG_DIR`, as plugin registration details, disabled default agents, and LSP settings are saved in the global configuration, impacting all isolated profile configurations.

## Fix
`getOpenCodeConfigPaths()` now reuses `getConfigDir()`, which already applies the intended precedence:
1. `OPENCODE_CONFIG_DIR`
2. `XDG_CONFIG_HOME/opencode`
3. `~/.config/opencode`