### PR TITLE
feat: map zellij main layouts to pane directions

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -108,8 +108,8 @@ Presets can also be switched at runtime without restarting using the `/preset` c
 | `disabled_agents` | string[] | `["observer"]` | Agent names to disable globally. Set to `[]` to enable Observer; this is global, not per-preset |
 | `autoUpdate` | boolean | `true` | Automatically install plugin updates in the background; set to `false` for notification-only mode |
 | `multiplexer.type` | string | `"none"` | Multiplexer mode: `auto`, `tmux`, `zellij`, or `none` |
-| `multiplexer.layout` | string | `"main-vertical"` | Layout preset: `main-vertical`, `main-horizontal`, `tiled`, `even-horizontal`, `even-vertical` |
-| `multiplexer.main_pane_size` | number | `60` | Main pane size as percentage (20–80) |
+| `multiplexer.layout` | string | `"main-vertical"` | Layout preset: `main-vertical`, `main-horizontal`, `tiled`, `even-horizontal`, `even-vertical`. Tmux applies full layouts; Zellij maps `main-vertical` to right and `main-horizontal` to down |
+| `multiplexer.main_pane_size` | number | `60` | Main pane size as percentage (20–80) for tmux main layouts; ignored by Zellij |
 | `multiplexer.zellij_pane_mode` | string | `"agent-tab"` | Zellij pane placement: `agent-tab` creates/reuses a dedicated `opencode-agents` tab; `current-tab` opens subagents as panes in the tab containing the parent OpenCode pane, falling back to the focused tab if the parent pane cannot be resolved |
 | `divoom.enabled` | boolean | `false` | Enable Divoom Bluetooth display status GIFs for plugin load and delegated agent calls |
 | `divoom.python` | string | Divoom MiniToo bundled Python | Python executable used to run Divoom MiniToo's `divoom_send.py` helper |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -110,7 +110,7 @@ Presets can also be switched at runtime without restarting using the `/preset` c
 | `multiplexer.type` | string | `"none"` | Multiplexer mode: `auto`, `tmux`, `zellij`, or `none` |
 | `multiplexer.layout` | string | `"main-vertical"` | Layout preset: `main-vertical`, `main-horizontal`, `tiled`, `even-horizontal`, `even-vertical` |
 | `multiplexer.main_pane_size` | number | `60` | Main pane size as percentage (20–80) |
-| `multiplexer.zellij_pane_mode` | string | `"agent-tab"` | Zellij pane placement: `agent-tab` creates/reuses a dedicated `opencode-agents` tab; `current-tab` opens subagents as panes in the current tab |
+| `multiplexer.zellij_pane_mode` | string | `"agent-tab"` | Zellij pane placement: `agent-tab` creates/reuses a dedicated `opencode-agents` tab; `current-tab` opens subagents as panes in the tab containing the parent OpenCode pane, falling back to the focused tab if the parent pane cannot be resolved |
 | `divoom.enabled` | boolean | `false` | Enable Divoom Bluetooth display status GIFs for plugin load and delegated agent calls |
 | `divoom.python` | string | Divoom MiniToo bundled Python | Python executable used to run Divoom MiniToo's `divoom_send.py` helper |
 | `divoom.script` | string | Divoom MiniToo `divoom_send.py` | Divoom sender script path |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -110,6 +110,7 @@ Presets can also be switched at runtime without restarting using the `/preset` c
 | `multiplexer.type` | string | `"none"` | Multiplexer mode: `auto`, `tmux`, `zellij`, or `none` |
 | `multiplexer.layout` | string | `"main-vertical"` | Layout preset: `main-vertical`, `main-horizontal`, `tiled`, `even-horizontal`, `even-vertical` |
 | `multiplexer.main_pane_size` | number | `60` | Main pane size as percentage (20–80) |
+| `multiplexer.zellij_pane_mode` | string | `"agent-tab"` | Zellij pane placement: `agent-tab` creates/reuses a dedicated `opencode-agents` tab; `current-tab` opens subagents as panes in the current tab |
 | `divoom.enabled` | boolean | `false` | Enable Divoom Bluetooth display status GIFs for plugin load and delegated agent calls |
 | `divoom.python` | string | Divoom MiniToo bundled Python | Python executable used to run Divoom MiniToo's `divoom_send.py` helper |
 | `divoom.script` | string | Divoom MiniToo `divoom_send.py` | Divoom sender script path |

--- a/docs/multiplexer-integration.md
+++ b/docs/multiplexer-integration.md
@@ -130,13 +130,25 @@ Please analyze this codebase and create a documentation structure.
 | `type` | string | `"none"` | `"auto"`, `"tmux"`, `"zellij"`, or `"none"` |
 | `layout` | string | `"main-vertical"` | Layout preset for tmux only |
 | `main_pane_size` | number | `60` | Main pane size percentage for tmux only (`20`-`80`) |
+| `zellij_pane_mode` | string | `"agent-tab"` | Zellij pane placement: `"agent-tab"` creates/reuses a dedicated tab; `"current-tab"` opens panes in the active tab |
 
 ### Supported Multiplexers
 
 | Multiplexer | Status | Notes |
 |-------------|--------|-------|
 | **Tmux** | ✅ Supported | Full layout control with `main-vertical`, `main-horizontal`, `tiled`, and more |
-| **Zellij** | ✅ Supported | Creates a dedicated `opencode-agents` tab and reuses the default pane |
+| **Zellij** | ✅ Supported | Creates a dedicated `opencode-agents` tab by default; can open panes in the current tab with `zellij_pane_mode: "current-tab"` |
+
+**Example: open Zellij subagents in the current tab**
+
+```jsonc
+{
+  "multiplexer": {
+    "type": "zellij",
+    "zellij_pane_mode": "current-tab"
+  }
+}
+```
 
 ### Legacy tmux config
 

--- a/docs/multiplexer-integration.md
+++ b/docs/multiplexer-integration.md
@@ -128,7 +128,7 @@ Please analyze this codebase and create a documentation structure.
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
 | `type` | string | `"none"` | `"auto"`, `"tmux"`, `"zellij"`, or `"none"` |
-| `layout` | string | `"main-vertical"` | Layout preset for tmux only |
+| `layout` | string | `"main-vertical"` | Layout preset for tmux; mapped to Zellij pane directions where possible |
 | `main_pane_size` | number | `60` | Main pane size percentage for tmux only (`20`-`80`) |
 | `zellij_pane_mode` | string | `"agent-tab"` | Zellij pane placement: `"agent-tab"` creates/reuses a dedicated tab; `"current-tab"` opens panes in the tab containing the parent OpenCode pane |
 
@@ -137,7 +137,7 @@ Please analyze this codebase and create a documentation structure.
 | Multiplexer | Status | Notes |
 |-------------|--------|-------|
 | **Tmux** | ✅ Supported | Full layout control with `main-vertical`, `main-horizontal`, `tiled`, and more |
-| **Zellij** | ✅ Supported | Creates a dedicated `opencode-agents` tab by default; can open panes in the parent OpenCode tab with `zellij_pane_mode: "current-tab"` |
+| **Zellij** | ✅ Supported | Creates a dedicated `opencode-agents` tab by default; can open panes in the parent OpenCode tab with `zellij_pane_mode: "current-tab"`; maps `main-*` layouts to pane directions |
 
 **Example: open Zellij subagents in the parent OpenCode tab**
 
@@ -175,7 +175,9 @@ This is converted automatically to `multiplexer.type: "tmux"`.
 
 ## Layouts
 
-These layouts apply to **tmux only**:
+Tmux supports full layout control and main pane sizing. Zellij maps only the
+`main-*` layout settings to pane creation directions; exact `main_pane_size`
+rebalancing is tmux-only.
 
 | Layout | Description |
 |--------|-------------|
@@ -184,6 +186,16 @@ These layouts apply to **tmux only**:
 | `tiled` | All panes in an equal-sized grid |
 | `even-horizontal` | All panes side by side |
 | `even-vertical` | All panes stacked vertically |
+
+For Zellij:
+
+| Layout | Zellij behavior |
+|--------|-----------------|
+| `main-vertical` | Opens new subagent panes to the right |
+| `main-horizontal` | Opens new subagent panes down |
+| `even-horizontal` | Uses Zellij's native pane placement |
+| `even-vertical` | Uses Zellij's native pane placement |
+| `tiled` | Uses Zellij's native pane placement |
 
 **Example: wide-screen layout**
 

--- a/docs/multiplexer-integration.md
+++ b/docs/multiplexer-integration.md
@@ -130,16 +130,16 @@ Please analyze this codebase and create a documentation structure.
 | `type` | string | `"none"` | `"auto"`, `"tmux"`, `"zellij"`, or `"none"` |
 | `layout` | string | `"main-vertical"` | Layout preset for tmux only |
 | `main_pane_size` | number | `60` | Main pane size percentage for tmux only (`20`-`80`) |
-| `zellij_pane_mode` | string | `"agent-tab"` | Zellij pane placement: `"agent-tab"` creates/reuses a dedicated tab; `"current-tab"` opens panes in the active tab |
+| `zellij_pane_mode` | string | `"agent-tab"` | Zellij pane placement: `"agent-tab"` creates/reuses a dedicated tab; `"current-tab"` opens panes in the tab containing the parent OpenCode pane |
 
 ### Supported Multiplexers
 
 | Multiplexer | Status | Notes |
 |-------------|--------|-------|
 | **Tmux** | ✅ Supported | Full layout control with `main-vertical`, `main-horizontal`, `tiled`, and more |
-| **Zellij** | ✅ Supported | Creates a dedicated `opencode-agents` tab by default; can open panes in the current tab with `zellij_pane_mode: "current-tab"` |
+| **Zellij** | ✅ Supported | Creates a dedicated `opencode-agents` tab by default; can open panes in the parent OpenCode tab with `zellij_pane_mode: "current-tab"` |
 
-**Example: open Zellij subagents in the current tab**
+**Example: open Zellij subagents in the parent OpenCode tab**
 
 ```jsonc
 {
@@ -149,6 +149,11 @@ Please analyze this codebase and create a documentation structure.
   }
 }
 ```
+
+In `current-tab` mode, panes are targeted to the tab that contains the parent
+OpenCode pane, even if another Zellij tab is focused when a subagent starts.
+If the parent pane cannot be resolved, it falls back to the currently focused
+tab.
 
 ### Legacy tmux config
 

--- a/oh-my-opencode-slim.schema.json
+++ b/oh-my-opencode-slim.schema.json
@@ -413,6 +413,14 @@
           "type": "number",
           "minimum": 20,
           "maximum": 80
+        },
+        "zellij_pane_mode": {
+          "default": "agent-tab",
+          "type": "string",
+          "enum": [
+            "agent-tab",
+            "current-tab"
+          ]
         }
       }
     },

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -405,6 +405,7 @@ function migrateTmuxToMultiplexer(config: PluginConfig): PluginConfig {
         type: 'tmux',
         layout: config.tmux.layout ?? 'main-vertical',
         main_pane_size: config.tmux.main_pane_size ?? 60,
+        zellij_pane_mode: 'agent-tab',
       },
     };
   }

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -124,6 +124,10 @@ export const MultiplexerLayoutSchema = z.enum([
 
 export type MultiplexerLayout = z.infer<typeof MultiplexerLayoutSchema>;
 
+// Zellij pane placement options
+export const ZellijPaneModeSchema = z.enum(['agent-tab', 'current-tab']);
+export type ZellijPaneMode = z.infer<typeof ZellijPaneModeSchema>;
+
 // Legacy Tmux layout options (for backward compatibility)
 export const TmuxLayoutSchema = MultiplexerLayoutSchema;
 export type TmuxLayout = MultiplexerLayout;
@@ -133,6 +137,7 @@ export const MultiplexerConfigSchema = z.object({
   type: MultiplexerTypeSchema.default('none'),
   layout: MultiplexerLayoutSchema.default('main-vertical'),
   main_pane_size: z.number().min(20).max(80).default(60), // percentage for main pane
+  zellij_pane_mode: ZellijPaneModeSchema.default('agent-tab'),
 });
 
 export type MultiplexerConfig = z.infer<typeof MultiplexerConfigSchema>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -229,6 +229,7 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
       type: config.multiplexer?.type ?? 'none',
       layout: config.multiplexer?.layout ?? 'main-vertical',
       main_pane_size: config.multiplexer?.main_pane_size ?? 60,
+      zellij_pane_mode: config.multiplexer?.zellij_pane_mode ?? 'agent-tab',
     };
 
     // Get multiplexer instance for capability checks

--- a/src/multiplexer/codemap.md
+++ b/src/multiplexer/codemap.md
@@ -36,6 +36,9 @@
   - First child uses default pane in that tab; additional children create panes.
   - Falls back to first available pane ID heuristics and restores original tab
     context around cross-tab operations.
+  - `current-tab` pane mode targets the tab containing the parent OpenCode pane
+    via `ZELLIJ_PANE_ID` + `list-panes --json --tab --all`, not whichever tab
+    is focused when a child session starts.
   - Layout configuration is accepted but effectively no-op (tool semantics differ
     from tmux).
 

--- a/src/multiplexer/codemap.md
+++ b/src/multiplexer/codemap.md
@@ -39,8 +39,9 @@
   - `current-tab` pane mode targets the tab containing the parent OpenCode pane
     via `ZELLIJ_PANE_ID` + `list-panes --json --tab --all`, not whichever tab
     is focused when a child session starts.
-  - Layout configuration is accepted but effectively no-op (tool semantics differ
-    from tmux).
+  - Layout configuration maps `main-vertical` to right and `main-horizontal` to
+    down; `tiled`/`even-horizontal`/`even-vertical` use Zellij native placement
+    and `main_pane_size` remains a no-op.
 
 - `session-manager.ts` (`MultiplexerSessionManager`)
   - Initialized once from plugin context and config.

--- a/src/multiplexer/factory.test.ts
+++ b/src/multiplexer/factory.test.ts
@@ -23,6 +23,7 @@ describe('multiplexer factory', () => {
       type: 'tmux',
       layout: 'main-vertical',
       main_pane_size: 60,
+      zellij_pane_mode: 'agent-tab',
     });
 
     process.env.TMUX_PANE = '%2';
@@ -34,6 +35,7 @@ describe('multiplexer factory', () => {
       type: 'tmux',
       layout: 'main-vertical',
       main_pane_size: 60,
+      zellij_pane_mode: 'agent-tab',
     });
 
     expect(first).not.toBeNull();
@@ -51,6 +53,7 @@ describe('multiplexer factory', () => {
       type: 'auto',
       layout: 'main-vertical',
       main_pane_size: 60,
+      zellij_pane_mode: 'agent-tab',
     });
 
     process.env.TMUX_PANE = '%2';
@@ -62,6 +65,7 @@ describe('multiplexer factory', () => {
       type: 'auto',
       layout: 'main-vertical',
       main_pane_size: 60,
+      zellij_pane_mode: 'agent-tab',
     });
 
     expect(first).not.toBeNull();

--- a/src/multiplexer/factory.ts
+++ b/src/multiplexer/factory.ts
@@ -32,7 +32,11 @@ export function getMultiplexer(config: MultiplexerConfig): Multiplexer | null {
       actualType = 'tmux';
       break;
     case 'zellij':
-      multiplexer = new ZellijMultiplexer(config.layout, config.main_pane_size);
+      multiplexer = new ZellijMultiplexer(
+        config.layout,
+        config.main_pane_size,
+        config.zellij_pane_mode,
+      );
       actualType = 'zellij';
       break;
     case 'auto': {
@@ -45,6 +49,7 @@ export function getMultiplexer(config: MultiplexerConfig): Multiplexer | null {
         multiplexer = new ZellijMultiplexer(
           config.layout,
           config.main_pane_size,
+          config.zellij_pane_mode,
         );
         actualType = 'zellij';
       } else {

--- a/src/multiplexer/session-manager.test.ts
+++ b/src/multiplexer/session-manager.test.ts
@@ -64,6 +64,7 @@ const defaultMultiplexerConfig = {
   type: 'tmux' as const,
   layout: 'main-vertical' as const,
   main_pane_size: 60,
+  zellij_pane_mode: 'agent-tab' as const,
 };
 
 function createDeferred<T>() {

--- a/src/multiplexer/zellij/index.test.ts
+++ b/src/multiplexer/zellij/index.test.ts
@@ -107,6 +107,8 @@ describe('ZellijMultiplexer', () => {
       'new-pane',
       '--tab-id',
       '0',
+      '--direction',
+      'right',
       '--name',
       'Current tab worker',
       '--close-on-exit',
@@ -243,5 +245,77 @@ describe('ZellijMultiplexer', () => {
 
     expect(tabIdArgIndex).toBeGreaterThanOrEqual(0);
     expect(newPaneCommand?.[tabIdArgIndex + 1]).toBe('1');
+  });
+
+  test('main-horizontal layout opens current-tab panes down', async () => {
+    const { ZellijMultiplexer } = await importFreshZellij();
+    const zellij = new ZellijMultiplexer('main-horizontal', 60, 'current-tab');
+
+    await zellij.spawnPane(
+      'session-1',
+      'Current tab worker',
+      'http://localhost:4096',
+      '/repo',
+    );
+
+    const newPaneCommand = commands().find((command) =>
+      command.includes('new-pane'),
+    );
+    const directionArgIndex = newPaneCommand?.indexOf('--direction') ?? -1;
+
+    expect(directionArgIndex).toBeGreaterThanOrEqual(0);
+    expect(newPaneCommand?.[directionArgIndex + 1]).toBe('down');
+  });
+
+  test('even-horizontal layout uses zellij native current-tab pane placement', async () => {
+    const { ZellijMultiplexer } = await importFreshZellij();
+    const zellij = new ZellijMultiplexer('even-horizontal', 60, 'current-tab');
+
+    await zellij.spawnPane(
+      'session-1',
+      'Current tab worker',
+      'http://localhost:4096',
+      '/repo',
+    );
+
+    const newPaneCommand = commands().find((command) =>
+      command.includes('new-pane'),
+    );
+    expect(newPaneCommand).not.toContain('--direction');
+  });
+
+  test('even-vertical layout uses zellij native current-tab pane placement', async () => {
+    const { ZellijMultiplexer } = await importFreshZellij();
+    const zellij = new ZellijMultiplexer('even-vertical', 60, 'current-tab');
+
+    await zellij.spawnPane(
+      'session-1',
+      'Current tab worker',
+      'http://localhost:4096',
+      '/repo',
+    );
+
+    const newPaneCommand = commands().find((command) =>
+      command.includes('new-pane'),
+    );
+    expect(newPaneCommand).not.toContain('--direction');
+  });
+
+  test('tiled layout uses zellij native current-tab pane placement', async () => {
+    const { ZellijMultiplexer } = await importFreshZellij();
+    const zellij = new ZellijMultiplexer('tiled', 60, 'current-tab');
+
+    await zellij.spawnPane(
+      'session-1',
+      'Current tab worker',
+      'http://localhost:4096',
+      '/repo',
+    );
+
+    const newPaneCommand = commands().find((command) =>
+      command.includes('new-pane'),
+    );
+
+    expect(newPaneCommand).not.toContain('--direction');
   });
 });

--- a/src/multiplexer/zellij/index.test.ts
+++ b/src/multiplexer/zellij/index.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+type SpawnResult = {
+  exited: Promise<number>;
+  stdout: () => Promise<string>;
+  stderr: () => Promise<string>;
+  kill: () => boolean;
+  exitCode: number | null;
+  proc: never;
+};
+
+const crossSpawnMock = mock((_command: string[]) => createSpawnResult());
+
+mock.module('../../utils/compat', () => ({
+  crossSpawn: crossSpawnMock,
+}));
+
+let importCounter = 0;
+
+function createSpawnResult(
+  exitCode = 0,
+  stdout = '',
+  stderr = '',
+): SpawnResult {
+  return {
+    exited: Promise.resolve(exitCode),
+    stdout: () => Promise.resolve(stdout),
+    stderr: () => Promise.resolve(stderr),
+    kill: () => true,
+    exitCode,
+    proc: {} as never,
+  };
+}
+
+async function importFreshZellij() {
+  return import(`./index?test=${importCounter++}`);
+}
+
+function commands(): string[][] {
+  return crossSpawnMock.mock.calls.map((call) => call[0] as string[]);
+}
+
+describe('ZellijMultiplexer', () => {
+  const originalZellij = process.env.ZELLIJ;
+
+  beforeEach(() => {
+    process.env.ZELLIJ = '1';
+
+    crossSpawnMock.mockReset();
+    crossSpawnMock.mockImplementation((command: string[]) => {
+      if (command[0] === 'which') {
+        return createSpawnResult(0, '/usr/bin/zellij\n');
+      }
+      if (command.includes('new-pane')) {
+        return createSpawnResult(0, 'terminal_2\n');
+      }
+      return createSpawnResult();
+    });
+  });
+
+  afterEach(() => {
+    process.env.ZELLIJ = originalZellij;
+  });
+
+  test('current-tab mode spawns a pane in the active tab', async () => {
+    const { ZellijMultiplexer } = await importFreshZellij();
+    const zellij = new ZellijMultiplexer('main-vertical', 60, 'current-tab');
+
+    const result = await zellij.spawnPane(
+      'session-1',
+      'Current tab worker',
+      'http://localhost:4096',
+      '/repo',
+    );
+
+    expect(result).toEqual({ success: true, paneId: 'terminal_2' });
+
+    const allCommands = commands();
+    const newPaneCommand = allCommands.find((command) =>
+      command.includes('new-pane'),
+    );
+
+    expect(newPaneCommand).toEqual([
+      '/usr/bin/zellij',
+      'action',
+      'new-pane',
+      '--name',
+      'Current tab worker',
+      '--close-on-exit',
+      '--',
+      'sh',
+      '-lc',
+      "opencode attach 'http://localhost:4096' --session 'session-1' --dir '/repo'",
+    ]);
+    expect(allCommands.some((command) => command.includes('new-tab'))).toBe(
+      false,
+    );
+    expect(
+      allCommands.some((command) => command.includes('go-to-tab-by-id')),
+    ).toBe(false);
+  });
+
+  test('current-tab mode reports failure when zellij does not return a terminal pane id', async () => {
+    const { ZellijMultiplexer } = await importFreshZellij();
+    const zellij = new ZellijMultiplexer('main-vertical', 60, 'current-tab');
+
+    crossSpawnMock.mockImplementation((command: string[]) => {
+      if (command[0] === 'which') {
+        return createSpawnResult(0, '/usr/bin/zellij\n');
+      }
+      if (command.includes('new-pane')) {
+        return createSpawnResult(0, 'plugin_2\n');
+      }
+      return createSpawnResult();
+    });
+
+    const result = await zellij.spawnPane(
+      'session-1',
+      'Current tab worker',
+      'http://localhost:4096',
+      '/repo',
+    );
+
+    expect(result).toEqual({ success: false });
+  });
+});

--- a/src/multiplexer/zellij/index.test.ts
+++ b/src/multiplexer/zellij/index.test.ts
@@ -32,6 +32,21 @@ function createSpawnResult(
   };
 }
 
+function createPaneListJson(parentTabId = 0): string {
+  return JSON.stringify([
+    {
+      id: 0,
+      is_plugin: false,
+      tab_id: parentTabId,
+    },
+    {
+      id: 4,
+      is_plugin: false,
+      tab_id: 1,
+    },
+  ]);
+}
+
 async function importFreshZellij() {
   return import(`./index?test=${importCounter++}`);
 }
@@ -42,14 +57,19 @@ function commands(): string[][] {
 
 describe('ZellijMultiplexer', () => {
   const originalZellij = process.env.ZELLIJ;
+  const originalZellijPaneId = process.env.ZELLIJ_PANE_ID;
 
   beforeEach(() => {
     process.env.ZELLIJ = '1';
+    process.env.ZELLIJ_PANE_ID = '0';
 
     crossSpawnMock.mockReset();
     crossSpawnMock.mockImplementation((command: string[]) => {
       if (command[0] === 'which') {
         return createSpawnResult(0, '/usr/bin/zellij\n');
+      }
+      if (command.includes('list-panes')) {
+        return createSpawnResult(0, createPaneListJson());
       }
       if (command.includes('new-pane')) {
         return createSpawnResult(0, 'terminal_2\n');
@@ -60,9 +80,10 @@ describe('ZellijMultiplexer', () => {
 
   afterEach(() => {
     process.env.ZELLIJ = originalZellij;
+    process.env.ZELLIJ_PANE_ID = originalZellijPaneId;
   });
 
-  test('current-tab mode spawns a pane in the active tab', async () => {
+  test('current-tab mode spawns a pane in the parent OpenCode tab', async () => {
     const { ZellijMultiplexer } = await importFreshZellij();
     const zellij = new ZellijMultiplexer('main-vertical', 60, 'current-tab');
 
@@ -84,6 +105,8 @@ describe('ZellijMultiplexer', () => {
       '/usr/bin/zellij',
       'action',
       'new-pane',
+      '--tab-id',
+      '0',
       '--name',
       'Current tab worker',
       '--close-on-exit',
@@ -108,6 +131,9 @@ describe('ZellijMultiplexer', () => {
       if (command[0] === 'which') {
         return createSpawnResult(0, '/usr/bin/zellij\n');
       }
+      if (command.includes('list-panes')) {
+        return createSpawnResult(0, createPaneListJson());
+      }
       if (command.includes('new-pane')) {
         return createSpawnResult(0, 'plugin_2\n');
       }
@@ -122,5 +148,100 @@ describe('ZellijMultiplexer', () => {
     );
 
     expect(result).toEqual({ success: false });
+  });
+
+  test('current-tab mode targets the parent OpenCode tab even when another tab is focused', async () => {
+    const { ZellijMultiplexer } = await importFreshZellij();
+    const zellij = new ZellijMultiplexer('main-vertical', 60, 'current-tab');
+
+    crossSpawnMock.mockImplementation((command: string[]) => {
+      if (command[0] === 'which') {
+        return createSpawnResult(0, '/usr/bin/zellij\n');
+      }
+      if (command.includes('list-panes')) {
+        return createSpawnResult(0, createPaneListJson(0));
+      }
+      if (command.includes('current-tab-info')) {
+        return createSpawnResult(0, JSON.stringify({ tab_id: 1 }));
+      }
+      if (command.includes('new-pane')) {
+        return createSpawnResult(0, 'terminal_2\n');
+      }
+      return createSpawnResult();
+    });
+
+    const result = await zellij.spawnPane(
+      'session-1',
+      'Current tab worker',
+      'http://localhost:4096',
+      '/repo',
+    );
+
+    const newPaneCommand = commands().find((command) =>
+      command.includes('new-pane'),
+    );
+
+    const tabIdArgIndex = newPaneCommand?.indexOf('--tab-id') ?? -1;
+    expect(result).toEqual({ success: true, paneId: 'terminal_2' });
+    expect(tabIdArgIndex).toBeGreaterThanOrEqual(0);
+    expect(newPaneCommand?.[tabIdArgIndex + 1]).toBe('0');
+  });
+
+  test('current-tab mode accepts terminal-prefixed parent pane ids', async () => {
+    process.env.ZELLIJ_PANE_ID = 'terminal_0';
+
+    const { ZellijMultiplexer } = await importFreshZellij();
+    const zellij = new ZellijMultiplexer('main-vertical', 60, 'current-tab');
+
+    await zellij.spawnPane(
+      'session-1',
+      'Current tab worker',
+      'http://localhost:4096',
+      '/repo',
+    );
+
+    const newPaneCommand = commands().find((command) =>
+      command.includes('new-pane'),
+    );
+    const tabIdArgIndex = newPaneCommand?.indexOf('--tab-id') ?? -1;
+
+    expect(tabIdArgIndex).toBeGreaterThanOrEqual(0);
+    expect(newPaneCommand?.[tabIdArgIndex + 1]).toBe('0');
+  });
+
+  test('current-tab mode falls back to the focused tab if parent tab lookup fails', async () => {
+    const { ZellijMultiplexer } = await importFreshZellij();
+    const zellij = new ZellijMultiplexer('main-vertical', 60, 'current-tab');
+
+    crossSpawnMock.mockImplementation((command: string[]) => {
+      if (command[0] === 'which') {
+        return createSpawnResult(0, '/usr/bin/zellij\n');
+      }
+      if (command.includes('list-panes')) {
+        return createSpawnResult(1, '', 'list failed');
+      }
+      if (command.includes('current-tab-info')) {
+        return createSpawnResult(0, JSON.stringify({ tab_id: 1 }));
+      }
+      if (command.includes('new-pane')) {
+        return createSpawnResult(0, 'terminal_2\n');
+      }
+      return createSpawnResult();
+    });
+
+    await zellij.spawnPane(
+      'session-1',
+      'Current tab worker',
+      'http://localhost:4096',
+      '/repo',
+    );
+
+    const newPaneCommand = commands().find((command) =>
+      command.includes('new-pane'),
+    );
+    const tabIdArgIndex = newPaneCommand?.indexOf('--tab-id') ?? -1;
+
+    expect(tabIdArgIndex).toBeGreaterThanOrEqual(0);
+    expect(newPaneCommand?.[tabIdArgIndex + 1]).toBe('1');
   });
 });

--- a/src/multiplexer/zellij/index.test.ts
+++ b/src/multiplexer/zellij/index.test.ts
@@ -55,6 +55,51 @@ function commands(): string[][] {
   return crossSpawnMock.mock.calls.map((call) => call[0] as string[]);
 }
 
+async function spawnSecondAgentTabPane(
+  layout: 'main-vertical' | 'main-horizontal' | 'tiled',
+): Promise<string[] | undefined> {
+  const { ZellijMultiplexer } = await importFreshZellij();
+  const zellij = new ZellijMultiplexer(layout, 60, 'agent-tab');
+
+  crossSpawnMock.mockImplementation((command: string[]) => {
+    if (command[0] === 'which') {
+      return createSpawnResult(0, '/usr/bin/zellij\n');
+    }
+    if (command.includes('list-tabs')) {
+      return createSpawnResult(
+        0,
+        JSON.stringify([{ name: 'opencode-agents', tab_id: 5 }]),
+      );
+    }
+    if (command.includes('current-tab-info')) {
+      return createSpawnResult(0, JSON.stringify({ tab_id: 0 }));
+    }
+    if (command.includes('list-panes')) {
+      return createSpawnResult(0, 'PANE ID\nterminal_7\n');
+    }
+    if (command.includes('new-pane')) {
+      return createSpawnResult(0, 'terminal_8\n');
+    }
+    return createSpawnResult();
+  });
+
+  await zellij.spawnPane(
+    'session-1',
+    'First agent worker',
+    'http://localhost:4096',
+    '/repo',
+  );
+
+  await zellij.spawnPane(
+    'session-2',
+    'Second agent worker',
+    'http://localhost:4096',
+    '/repo',
+  );
+
+  return commands().findLast((command) => command.includes('new-pane'));
+}
+
 describe('ZellijMultiplexer', () => {
   const originalZellij = process.env.ZELLIJ;
   const originalZellijPaneId = process.env.ZELLIJ_PANE_ID;
@@ -247,6 +292,52 @@ describe('ZellijMultiplexer', () => {
     expect(newPaneCommand?.[tabIdArgIndex + 1]).toBe('1');
   });
 
+  test('current-tab mode caches the fallback focused tab after parent tab lookup fails', async () => {
+    const { ZellijMultiplexer } = await importFreshZellij();
+    const zellij = new ZellijMultiplexer('main-vertical', 60, 'current-tab');
+    let currentTabId = 1;
+
+    crossSpawnMock.mockImplementation((command: string[]) => {
+      if (command[0] === 'which') {
+        return createSpawnResult(0, '/usr/bin/zellij\n');
+      }
+      if (command.includes('list-panes')) {
+        return createSpawnResult(1, '', 'list failed');
+      }
+      if (command.includes('current-tab-info')) {
+        return createSpawnResult(0, JSON.stringify({ tab_id: currentTabId++ }));
+      }
+      if (command.includes('new-pane')) {
+        return createSpawnResult(0, 'terminal_2\n');
+      }
+      return createSpawnResult();
+    });
+
+    await zellij.spawnPane(
+      'session-1',
+      'Current tab worker',
+      'http://localhost:4096',
+      '/repo',
+    );
+    await zellij.spawnPane(
+      'session-2',
+      'Current tab worker 2',
+      'http://localhost:4096',
+      '/repo',
+    );
+
+    const newPaneCommands = commands().filter((command) =>
+      command.includes('new-pane'),
+    );
+
+    expect(
+      newPaneCommands.map((command) => {
+        const tabIdArgIndex = command.indexOf('--tab-id');
+        return command[tabIdArgIndex + 1];
+      }),
+    ).toEqual(['1', '1']);
+  });
+
   test('main-horizontal layout opens current-tab panes down', async () => {
     const { ZellijMultiplexer } = await importFreshZellij();
     const zellij = new ZellijMultiplexer('main-horizontal', 60, 'current-tab');
@@ -315,6 +406,28 @@ describe('ZellijMultiplexer', () => {
     const newPaneCommand = commands().find((command) =>
       command.includes('new-pane'),
     );
+
+    expect(newPaneCommand).not.toContain('--direction');
+  });
+
+  test('main-vertical layout opens agent-tab panes right', async () => {
+    const newPaneCommand = await spawnSecondAgentTabPane('main-vertical');
+    const directionArgIndex = newPaneCommand?.indexOf('--direction') ?? -1;
+
+    expect(directionArgIndex).toBeGreaterThanOrEqual(0);
+    expect(newPaneCommand?.[directionArgIndex + 1]).toBe('right');
+  });
+
+  test('main-horizontal layout opens agent-tab panes down', async () => {
+    const newPaneCommand = await spawnSecondAgentTabPane('main-horizontal');
+    const directionArgIndex = newPaneCommand?.indexOf('--direction') ?? -1;
+
+    expect(directionArgIndex).toBeGreaterThanOrEqual(0);
+    expect(newPaneCommand?.[directionArgIndex + 1]).toBe('down');
+  });
+
+  test('tiled layout uses zellij native agent-tab pane placement', async () => {
+    const newPaneCommand = await spawnSecondAgentTabPane('tiled');
 
     expect(newPaneCommand).not.toContain('--direction');
   });

--- a/src/multiplexer/zellij/index.ts
+++ b/src/multiplexer/zellij/index.ts
@@ -8,7 +8,8 @@
  * - Subsequent sub-agents create new panes
  * - User stays in their original tab
  *
- * The optional "current-tab" mode creates panes in the active tab instead.
+ * The optional "current-tab" mode creates panes in the tab containing the
+ * parent OpenCode pane instead.
  */
 
 import type { MultiplexerLayout, ZellijPaneMode } from '../../config/schema';
@@ -22,6 +23,12 @@ interface ZellijTabInfo {
   tab_id: number;
 }
 
+interface ZellijPaneInfo {
+  id: number;
+  is_plugin: boolean;
+  tab_id?: number;
+}
+
 export class ZellijMultiplexer implements Multiplexer {
   readonly type = 'zellij' as const;
 
@@ -30,6 +37,8 @@ export class ZellijMultiplexer implements Multiplexer {
   private agentTabId: string | null = null;
   private firstPaneId: string | null = null;
   private firstPaneUsed = false;
+  private parentTabId: string | null = null;
+  private readonly parentPaneId = process.env.ZELLIJ_PANE_ID;
 
   constructor(
     layout: MultiplexerLayout = 'main-vertical',
@@ -127,10 +136,12 @@ export class ZellijMultiplexer implements Multiplexer {
       directory,
     );
     const paneName = description.slice(0, 30).replace(/"/g, '\\"');
+    const targetTabId = await this.getParentTabId(zellij);
 
     const args = [
       'action',
       'new-pane',
+      ...this.tabIdArgs(targetTabId),
       '--name',
       paneName,
       '--close-on-exit',
@@ -511,6 +522,53 @@ export class ZellijMultiplexer implements Multiplexer {
     // Unlike tmux, zellij does not support programmatic layout control.
   }
 
+  private tabIdArgs(tabId: string | null): string[] {
+    return tabId ? ['--tab-id', tabId] : [];
+  }
+
+  private async getParentTabId(zellij: string): Promise<string | null> {
+    if (this.parentTabId) return this.parentTabId;
+
+    if (this.parentPaneId) {
+      const tabId = await this.findTabIdForPane(zellij, this.parentPaneId);
+      if (tabId) {
+        this.parentTabId = tabId;
+        return tabId;
+      }
+    }
+
+    return await this.getCurrentTabId(zellij);
+  }
+
+  private async findTabIdForPane(
+    zellij: string,
+    paneId: string,
+  ): Promise<string | null> {
+    try {
+      const proc = crossSpawn(
+        [zellij, 'action', 'list-panes', '--json', '--tab', '--all'],
+        {
+          stdout: 'pipe',
+          stderr: 'pipe',
+        },
+      );
+
+      if ((await proc.exited) !== 0) return null;
+
+      const stdout = await proc.stdout();
+      const panes: ZellijPaneInfo[] = JSON.parse(stdout);
+      const normalizedPaneId = normalizePaneId(paneId);
+      const pane = panes.find(
+        (candidate) =>
+          !candidate.is_plugin && String(candidate.id) === normalizedPaneId,
+      );
+
+      return pane?.tab_id === undefined ? null : String(pane.tab_id);
+    } catch {
+      return null;
+    }
+  }
+
   private async getBinary(): Promise<string | null> {
     await this.isAvailable();
     return this.binaryPath;
@@ -530,6 +588,10 @@ export class ZellijMultiplexer implements Multiplexer {
       return null;
     }
   }
+}
+
+function normalizePaneId(paneId: string): string {
+  return paneId.replace(/^terminal_/, '');
 }
 
 function buildOpencodeAttachCommand(

--- a/src/multiplexer/zellij/index.ts
+++ b/src/multiplexer/zellij/index.ts
@@ -1,13 +1,17 @@
 /**
  * Zellij multiplexer implementation
  *
- * Creates a dedicated "opencode-agents" tab for all sub-agent panes.
+ * Creates panes for sub-agent sessions in Zellij.
+ *
+ * The default mode creates a dedicated "opencode-agents" tab:
  * - First sub-agent uses the default pane from new-tab
  * - Subsequent sub-agents create new panes
  * - User stays in their original tab
+ *
+ * The optional "current-tab" mode creates panes in the active tab instead.
  */
 
-import type { MultiplexerLayout } from '../../config/schema';
+import type { MultiplexerLayout, ZellijPaneMode } from '../../config/schema';
 import { crossSpawn } from '../../utils/compat';
 import type { Multiplexer, PaneResult } from '../types';
 
@@ -27,7 +31,11 @@ export class ZellijMultiplexer implements Multiplexer {
   private firstPaneId: string | null = null;
   private firstPaneUsed = false;
 
-  constructor(layout: MultiplexerLayout = 'main-vertical', mainPaneSize = 60) {
+  constructor(
+    layout: MultiplexerLayout = 'main-vertical',
+    mainPaneSize = 60,
+    private readonly paneMode: ZellijPaneMode = 'agent-tab',
+  ) {
     // Note: Zellij does NOT support layout configuration like tmux.
     // These params are accepted for API consistency but are no-ops.
     // Zellij uses its own native layout algorithm for pane arrangement.
@@ -58,6 +66,16 @@ export class ZellijMultiplexer implements Multiplexer {
     if (!zellij) return { success: false };
 
     try {
+      if (this.paneMode === 'current-tab') {
+        return await this.createPaneInCurrentTab(
+          zellij,
+          sessionId,
+          serverUrl,
+          directory,
+          description,
+        );
+      }
+
       // Ensure agent tab exists on first call
       if (!this.agentTabId) {
         const result = await this.ensureAgentTab(zellij);
@@ -94,6 +112,47 @@ export class ZellijMultiplexer implements Multiplexer {
     } catch {
       return { success: false };
     }
+  }
+
+  private async createPaneInCurrentTab(
+    zellij: string,
+    sessionId: string,
+    serverUrl: string,
+    directory: string,
+    description: string,
+  ): Promise<PaneResult> {
+    const opencodeCmd = buildOpencodeAttachCommand(
+      sessionId,
+      serverUrl,
+      directory,
+    );
+    const paneName = description.slice(0, 30).replace(/"/g, '\\"');
+
+    const args = [
+      'action',
+      'new-pane',
+      '--name',
+      paneName,
+      '--close-on-exit',
+      '--',
+      'sh',
+      '-lc',
+      opencodeCmd,
+    ];
+
+    const proc = crossSpawn([zellij, ...args], {
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+
+    const exitCode = await proc.exited;
+    const stdout = await proc.stdout();
+    const paneId = stdout.trim();
+
+    if (exitCode === 0 && paneId?.startsWith('terminal_')) {
+      return { success: true, paneId };
+    }
+    return { success: false };
   }
 
   private async createPaneInAgentTab(

--- a/src/multiplexer/zellij/index.ts
+++ b/src/multiplexer/zellij/index.ts
@@ -29,6 +29,8 @@ interface ZellijPaneInfo {
   tab_id?: number;
 }
 
+type ZellijPaneDirection = 'right' | 'down';
+
 export class ZellijMultiplexer implements Multiplexer {
   readonly type = 'zellij' as const;
 
@@ -39,17 +41,17 @@ export class ZellijMultiplexer implements Multiplexer {
   private firstPaneUsed = false;
   private parentTabId: string | null = null;
   private readonly parentPaneId = process.env.ZELLIJ_PANE_ID;
+  private readonly paneDirection: ZellijPaneDirection | null;
 
   constructor(
     layout: MultiplexerLayout = 'main-vertical',
     mainPaneSize = 60,
     private readonly paneMode: ZellijPaneMode = 'agent-tab',
   ) {
-    // Note: Zellij does NOT support layout configuration like tmux.
-    // These params are accepted for API consistency but are no-ops.
-    // Zellij uses its own native layout algorithm for pane arrangement.
-    void layout;
+    // Note: Zellij does not support exact main pane sizing like tmux.
+    // Layout config is mapped to pane creation directions where possible.
     void mainPaneSize;
+    this.paneDirection = getPaneDirection(layout);
   }
 
   async isAvailable(): Promise<boolean> {
@@ -142,6 +144,7 @@ export class ZellijMultiplexer implements Multiplexer {
       'action',
       'new-pane',
       ...this.tabIdArgs(targetTabId),
+      ...this.directionArgs(),
       '--name',
       paneName,
       '--close-on-exit',
@@ -188,6 +191,7 @@ export class ZellijMultiplexer implements Multiplexer {
       const args = [
         'action',
         'new-pane',
+        ...this.directionArgs(),
         '--name',
         paneName,
         '--close-on-exit',
@@ -230,6 +234,7 @@ export class ZellijMultiplexer implements Multiplexer {
     const args = [
       'action',
       'new-pane',
+      ...this.directionArgs(),
       '--name',
       paneName,
       '--close-on-exit',
@@ -518,8 +523,13 @@ export class ZellijMultiplexer implements Multiplexer {
     _layout: MultiplexerLayout,
     _mainPaneSize: number,
   ): Promise<void> {
-    // No-op for zellij - zellij uses its own native layout algorithm.
-    // Unlike tmux, zellij does not support programmatic layout control.
+    // No-op for zellij after panes are spawned. Zellij does not support tmux-like
+    // exact main pane sizing/rebalancing; layout is applied to future pane
+    // creation by mapping configured layouts to pane directions.
+  }
+
+  private directionArgs(): string[] {
+    return this.paneDirection ? ['--direction', this.paneDirection] : [];
   }
 
   private tabIdArgs(tabId: string | null): string[] {
@@ -592,6 +602,21 @@ export class ZellijMultiplexer implements Multiplexer {
 
 function normalizePaneId(paneId: string): string {
   return paneId.replace(/^terminal_/, '');
+}
+
+function getPaneDirection(
+  layout: MultiplexerLayout,
+): ZellijPaneDirection | null {
+  switch (layout) {
+    case 'main-vertical':
+      return 'right';
+    case 'main-horizontal':
+      return 'down';
+    case 'even-horizontal':
+    case 'even-vertical':
+    case 'tiled':
+      return null;
+  }
 }
 
 function buildOpencodeAttachCommand(

--- a/src/multiplexer/zellij/index.ts
+++ b/src/multiplexer/zellij/index.ts
@@ -547,7 +547,8 @@ export class ZellijMultiplexer implements Multiplexer {
       }
     }
 
-    return await this.getCurrentTabId(zellij);
+    this.parentTabId = await this.getCurrentTabId(zellij);
+    return this.parentTabId;
   }
 
   private async findTabIdForPane(


### PR DESCRIPTION
## Summary
- maps Zellij `multiplexer.layout` values to pane creation directions where Zellij supports it
- `main-vertical` opens new subagent panes to the right
- `main-horizontal` opens new subagent panes down
- `tiled`, `even-horizontal`, and `even-vertical` keep Zellij native/default pane placement
- documents that `main_pane_size` remains tmux-only / ignored by Zellij
- adds focused tests for forced direction and native-placement layouts

## Dependency
Depends on #533. This is a stacked PR on top of the `zellij_pane_mode` / parent-tab targeting work. Until #533 is merged, this PR diff may include those prerequisite commits; the feature-specific commit is `feat: map zellij main layouts to pane directions`.

## Visual verification
Locally verified with `zellij_pane_mode: "current-tab"`:
- `main-vertical` opened the subagent pane in the parent OpenCode tab to the right
- `main-horizontal` opened the subagent pane in the parent OpenCode tab down
- native/default placement is preserved for non-`main-*` layouts

## Validation
- `bun test src/multiplexer/zellij/index.test.ts src/multiplexer/factory.test.ts src/multiplexer/session-manager.test.ts`
- `bun run typecheck`
- `bun run check:ci`
- `bun run build`
- `bun test`