### PR TITLE
fix: clamp companion windows on resize

### DIFF
--- a/companion/src/app.rs
+++ b/companion/src/app.rs
@@ -149,6 +149,14 @@ impl CompanionApp {
         self.positioned.retain(|id| live.contains(id));
     }
 
+    fn update_screen_from_ctx(&mut self, ctx: &egui::Context) {
+        if let Some(size) = ctx.input(|i| i.viewport().monitor_size) {
+            if 1.0 < size.x && 1.0 < size.y {
+                self.screen = [size.x, size.y];
+            }
+        }
+    }
+
     fn initial_pos(&self, index: usize, win_w: f32, win_h: f32) -> [f32; 2] {
         let slot = index as f32;
         let (x, y) = match self.position.as_str() {
@@ -183,6 +191,7 @@ impl CompanionApp {
 impl eframe::App for CompanionApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         self.poll();
+        self.update_screen_from_ctx(ctx);
 
         let quit = ctx.data(|d| {
             d.get_temp::<bool>(egui::Id::new("companion_quit"))
@@ -320,6 +329,11 @@ fn render_session_window(ctx: &egui::Context, session_id: &str, _size: f32, scre
     let current = (current_size as u32, cols as u32, rows as u32);
     if applied != current {
         let old_outer_rect = ctx.input(|i| i.viewport().outer_rect);
+        let monitor_size = ctx.input(|i| i.viewport().monitor_size);
+        let screen = monitor_size
+            .filter(|size| 1.0 < size.x && 1.0 < size.y)
+            .map(|size| [size.x, size.y])
+            .unwrap_or(screen);
         ctx.send_viewport_cmd(egui::ViewportCommand::InnerSize(egui::vec2(win_w, win_h)));
         if let Some(rect) = old_outer_rect {
             ctx.send_viewport_cmd(egui::ViewportCommand::OuterPosition(clamp_viewport_pos(

--- a/companion/src/app.rs
+++ b/companion/src/app.rs
@@ -72,6 +72,12 @@ fn cell_rects(agents: usize, cols: usize, rows: usize, cell: f32) -> Vec<egui::R
     rects
 }
 
+fn clamp_viewport_pos(pos: egui::Pos2, win_w: f32, win_h: f32, screen: [f32; 2]) -> egui::Pos2 {
+    let x_max = (screen[0] - win_w - GAP).max(GAP);
+    let y_max = (screen[1] - win_h - GAP).max(GAP);
+    egui::pos2(pos.x.clamp(GAP, x_max), pos.y.clamp(GAP, y_max))
+}
+
 pub struct CompanionApp {
     state_path: std::path::PathBuf,
     sessions: Vec<SessionInfo>,
@@ -161,7 +167,8 @@ impl CompanionApp {
                 let y = GAP;
                 (x, y)
             }
-            _ => { // "bottom-right"
+            _ => {
+                // "bottom-right"
                 let x = self.screen[0] - (win_w + GAP) * (slot + 1.0);
                 let y = self.screen[1] - win_h - GAP;
                 (x, y)
@@ -218,6 +225,7 @@ impl eframe::App for CompanionApp {
             let vid = egui::ViewportId::from_hash_of(&session.session_id);
             let sid = session.session_id.clone();
             let size = self.size;
+            let screen = self.screen;
 
             let agents: Vec<String> = if session.active_agents.is_empty() {
                 vec!["intro".to_string()]
@@ -247,7 +255,7 @@ impl eframe::App for CompanionApp {
             }
 
             ctx.show_viewport_deferred(vid, builder, move |ctx, _class| {
-                render_session_window(ctx, &sid, size);
+                render_session_window(ctx, &sid, size, screen);
             });
         }
 
@@ -255,8 +263,10 @@ impl eframe::App for CompanionApp {
         let menu_open: bool =
             ctx.data(|d| d.get_temp(egui::Id::new(MENU_OPEN_KEY)).unwrap_or(false));
         if menu_open {
-            let pos: [f32; 2] =
-                ctx.data(|d| d.get_temp(egui::Id::new(MENU_POS_KEY)).unwrap_or([200.0, 200.0]));
+            let pos: [f32; 2] = ctx.data(|d| {
+                d.get_temp(egui::Id::new(MENU_POS_KEY))
+                    .unwrap_or([200.0, 200.0])
+            });
 
             ctx.show_viewport_deferred(
                 egui::ViewportId::from_hash_of("size_picker"),
@@ -274,7 +284,7 @@ impl eframe::App for CompanionApp {
     }
 }
 
-fn render_session_window(ctx: &egui::Context, session_id: &str, _size: f32) {
+fn render_session_window(ctx: &egui::Context, session_id: &str, _size: f32, screen: [f32; 2]) {
     let sessions: SessionSnapshot =
         ctx.data(|d| d.get_temp(egui::Id::new(SESSIONS_KEY)).unwrap_or_default());
     let (_, cwd, agents, _) = sessions
@@ -309,7 +319,13 @@ fn render_session_window(ctx: &egui::Context, session_id: &str, _size: f32) {
     let applied: (u32, u32, u32) = ctx.data(|d| d.get_temp(layout_key).unwrap_or((0, 0, 0)));
     let current = (current_size as u32, cols as u32, rows as u32);
     if applied != current {
+        let old_outer_rect = ctx.input(|i| i.viewport().outer_rect);
         ctx.send_viewport_cmd(egui::ViewportCommand::InnerSize(egui::vec2(win_w, win_h)));
+        if let Some(rect) = old_outer_rect {
+            ctx.send_viewport_cmd(egui::ViewportCommand::OuterPosition(clamp_viewport_pos(
+                rect.min, win_w, win_h, screen,
+            )));
+        }
         ctx.data_mut(|d| d.insert_temp(layout_key, current));
     }
 
@@ -345,17 +361,18 @@ fn render_session_window(ctx: &egui::Context, session_id: &str, _size: f32) {
 
             for (i, uri) in uris.iter().enumerate() {
                 if let Some(&cell) = rects.get(i) {
-                    ui.put(cell, egui::Image::new(uri).fit_to_exact_size(egui::vec2(current_size, current_size)));
+                    ui.put(
+                        cell,
+                        egui::Image::new(uri)
+                            .fit_to_exact_size(egui::vec2(current_size, current_size)),
+                    );
                 }
             }
 
             // Project label — overlaid on bottom strip of the window
             let label_h = (current_size * 0.15).clamp(13.0, 30.0);
             let font_size = (current_size * 0.09).clamp(9.0, 13.0);
-            let full_rect = egui::Rect::from_min_size(
-                egui::Pos2::ZERO,
-                egui::vec2(win_w, win_h),
-            );
+            let full_rect = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(win_w, win_h));
             let strip = egui::Rect::from_min_size(
                 egui::pos2(0.0, win_h - label_h),
                 egui::vec2(win_w, label_h),
@@ -412,7 +429,10 @@ fn render_size_picker(ctx: &egui::Context) {
             for (label, preset) in SIZE_PRESETS {
                 let active = (size - preset).abs() < 0.5;
                 let text = if active {
-                    egui::RichText::new(*label).size(12.0).strong().color(egui::Color32::WHITE)
+                    egui::RichText::new(*label)
+                        .size(12.0)
+                        .strong()
+                        .color(egui::Color32::WHITE)
                 } else {
                     egui::RichText::new(*label)
                         .size(12.0)

--- a/companion/src/gifs.rs
+++ b/companion/src/gifs.rs
@@ -8,15 +8,15 @@ pub struct Gifs {
 impl Gifs {
     pub fn new() -> Self {
         let mut map: HashMap<&'static str, &'static [u8]> = HashMap::new();
-        map.insert("council",      include_bytes!("../gifs/council.gif"));
-        map.insert("councillor",   include_bytes!("../gifs/council.gif"));
-        map.insert("designer",     include_bytes!("../gifs/designer.gif"));
-        map.insert("explorer",     include_bytes!("../gifs/explorer.gif"));
-        map.insert("fixer",        include_bytes!("../gifs/fixer.gif"));
-        map.insert("input",        include_bytes!("../gifs/question.gif"));
-        map.insert("intro",        include_bytes!("../gifs/intro.gif"));
-        map.insert("librarian",    include_bytes!("../gifs/librarian.gif"));
-        map.insert("oracle",       include_bytes!("../gifs/oracle.gif"));
+        map.insert("council", include_bytes!("../gifs/council.gif"));
+        map.insert("councillor", include_bytes!("../gifs/council.gif"));
+        map.insert("designer", include_bytes!("../gifs/designer.gif"));
+        map.insert("explorer", include_bytes!("../gifs/explorer.gif"));
+        map.insert("fixer", include_bytes!("../gifs/fixer.gif"));
+        map.insert("input", include_bytes!("../gifs/question.gif"));
+        map.insert("intro", include_bytes!("../gifs/intro.gif"));
+        map.insert("librarian", include_bytes!("../gifs/librarian.gif"));
+        map.insert("oracle", include_bytes!("../gifs/oracle.gif"));
         map.insert("orchestrator", include_bytes!("../gifs/orchestrator.gif"));
         Self { map }
     }
@@ -29,7 +29,11 @@ impl Gifs {
     }
 
     pub fn uri(&self, agent: &str) -> String {
-        let name = if self.map.contains_key(agent) { agent } else { "orchestrator" };
+        let name = if self.map.contains_key(agent) {
+            agent
+        } else {
+            "orchestrator"
+        };
         format!("bytes://{name}.gif")
     }
 }

--- a/companion/src/screen.rs
+++ b/companion/src/screen.rs
@@ -6,11 +6,18 @@ pub fn primary_size() -> [f32; 2] {
 #[cfg(target_os = "macos")]
 fn platform_size() -> Option<[f32; 2]> {
     let out = std::process::Command::new("osascript")
-        .args(["-e", "tell application \"Finder\" to get bounds of window of desktop"])
+        .args([
+            "-e",
+            "tell application \"Finder\" to get bounds of window of desktop",
+        ])
         .output()
         .ok()?;
     let s = String::from_utf8(out.stdout).ok()?;
-    let ns: Vec<f32> = s.trim().split(", ").filter_map(|p| p.parse().ok()).collect();
+    let ns: Vec<f32> = s
+        .trim()
+        .split(", ")
+        .filter_map(|p| p.parse().ok())
+        .collect();
     (ns.len() == 4).then(|| [ns[2], ns[3]])
 }
 


### PR DESCRIPTION
## Summary
- Clamp repositioned companion viewports after resize to keep agent windows on-screen.
- Include rustfmt-driven formatting changes from the companion crate (src/gifs.rs, src/screen.rs).