### PR TITLE
chore: prepare companion 0.1.3 release

### DIFF
--- a/companion/Cargo.lock
+++ b/companion/Cargo.lock
@@ -2319,7 +2319,7 @@ dependencies = [
 
 [[package]]
 name = "oh-my-opencode-slim-companion"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "dirs",
  "eframe",

--- a/companion/Cargo.toml
+++ b/companion/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oh-my-opencode-slim-companion"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "Desktop companion for oh-my-opencode-slim — shows active agent GIFs per session"
 

--- a/docs/companion.md
+++ b/docs/companion.md
@@ -53,7 +53,7 @@ Pass `--companion=no` to skip the native binary and omit the config block.
 
 ## niri support status
 
-The native `companion-v0.1.2` binary now works on niri and exposes a stable
+The native `companion-v0.1.3` binary now works on niri and exposes a stable
 Wayland app-id/title: `oh-my-opencode-slim-companion`.
 
 niri users who want the Companion to behave like an overlay should add a window
@@ -105,7 +105,7 @@ For the desktop companion app, the release workflow follows the V2 distribution
 plan:
 
 1. **GitHub Release Assets**: companion binaries are uploaded to the
-   `companion-v0.1.2` GitHub release.
+   `companion-v0.1.3` GitHub release.
 2. **Separate Companion Versioning**: the companion uses its own version so the
    plugin can ship beta updates without rebuilding native binaries every time.
 3. **OS/Arch Detection**: `--companion=yes` selects the archive for the current
@@ -116,10 +116,10 @@ plan:
 Current release assets are named:
 
 ```text
-oh-my-opencode-slim-companion-v0.1.2-aarch64-apple-darwin.tar.gz
-oh-my-opencode-slim-companion-v0.1.2-x86_64-unknown-linux-gnu.tar.gz
-oh-my-opencode-slim-companion-v0.1.2-aarch64-unknown-linux-gnu.tar.gz
-oh-my-opencode-slim-companion-v0.1.2-x86_64-pc-windows-msvc.zip
+oh-my-opencode-slim-companion-v0.1.3-aarch64-apple-darwin.tar.gz
+oh-my-opencode-slim-companion-v0.1.3-x86_64-unknown-linux-gnu.tar.gz
+oh-my-opencode-slim-companion-v0.1.3-aarch64-unknown-linux-gnu.tar.gz
+oh-my-opencode-slim-companion-v0.1.3-x86_64-pc-windows-msvc.zip
 ```
 
 Supported installer targets:
@@ -139,16 +139,16 @@ protocol expected by the plugin changes.
 
 ### 1. Choose the companion version
 
-The first companion release is:
+The current companion release is:
 
 ```text
-0.1.2
+0.1.3
 ```
 
 The matching GitHub release tag is:
 
 ```text
-companion-v0.1.2
+companion-v0.1.3
 ```
 
 The installer currently downloads from that tag.
@@ -160,7 +160,7 @@ you are testing the release path:
 
 ```bash
 gh workflow run companion-release.yml \
-  -f version=0.1.2 \
+  -f version=0.1.3 \
   -f targets=macos-arm64
 ```
 
@@ -168,7 +168,7 @@ Build multiple targets by passing a comma-separated list:
 
 ```bash
 gh workflow run companion-release.yml \
-  -f version=0.1.2 \
+  -f version=0.1.3 \
   -f targets=macos-arm64,linux-x64,linux-arm64,windows-x64
 ```
 
@@ -189,7 +189,7 @@ the selected archives.
 After the workflow finishes:
 
 ```bash
-gh release view companion-v0.1.2
+gh release view companion-v0.1.3
 ```
 
 Confirm the release contains the archive names expected by the installer for the
@@ -204,7 +204,7 @@ bunx oh-my-opencode-slim@beta install --companion=yes
 ```
 
 The installer detects the user's OS/architecture, downloads the matching archive
-from `companion-v0.1.2`, installs it to the runtime binary path, and writes the
+from `companion-v0.1.3`, installs it to the runtime binary path, and writes the
 companion config block. If the companion install fails, the core plugin install
 continues without enabling Companion.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -139,7 +139,7 @@ Presets can also be switched at runtime without restarting using the `/preset` c
 | `companion.position` | string | `"bottom-right"` | The initial corner position of the companion window: `bottom-right`, `bottom-left`, `top-right`, or `top-left` |
 | `companion.size` | string | `"medium"` | The default size preset of the companion window: `small` (80px), `medium` (120px), or `large` (160px) |
 
-> **niri note:** `companion-v0.1.2` is the fixed native companion release.
+> **niri note:** `companion-v0.1.3` is the fixed native companion release.
 > To make it open as a bottom-right overlay, add a niri rule matching its stable
 > `app-id`/title (`oh-my-opencode-slim-companion`), for example:
 >

--- a/docs/release.md
+++ b/docs/release.md
@@ -38,11 +38,11 @@ Recommended release note sections:
 Pick versions independently:
 
 ```text
-plugin: 2.0.2
-plugin tag: v2.0.2
+plugin: 2.0.3
+plugin tag: v2.0.3
 
-companion: 0.1.2
-companion tag: companion-v0.1.2
+companion: 0.1.3
+companion tag: companion-v0.1.3
 ```
 
 Use a plugin patch release for ordinary bug fixes and release-process fixes.
@@ -55,15 +55,15 @@ When releasing a new companion binary, update the installer constants:
 
 ```ts
 // src/cli/companion.ts
-const COMPANION_VERSION = '0.1.2';
-const COMPANION_TAG = 'companion-v0.1.2';
+const COMPANION_VERSION = '0.1.3';
+const COMPANION_TAG = 'companion-v0.1.3';
 ```
 
 Also update the Rust crate version:
 
 ```toml
 # companion/Cargo.toml
-version = "0.1.2"
+version = "0.1.3"
 ```
 
 Regenerate or update `companion/Cargo.lock` so the package entry matches.
@@ -82,13 +82,13 @@ linux-arm64
 windows-x64
 ```
 
-Expected release asset names for companion `0.1.2`:
+Expected release asset names for companion `0.1.3`:
 
 ```text
-oh-my-opencode-slim-companion-v0.1.2-aarch64-apple-darwin.tar.gz
-oh-my-opencode-slim-companion-v0.1.2-x86_64-unknown-linux-gnu.tar.gz
-oh-my-opencode-slim-companion-v0.1.2-aarch64-unknown-linux-gnu.tar.gz
-oh-my-opencode-slim-companion-v0.1.2-x86_64-pc-windows-msvc.zip
+oh-my-opencode-slim-companion-v0.1.3-aarch64-apple-darwin.tar.gz
+oh-my-opencode-slim-companion-v0.1.3-x86_64-unknown-linux-gnu.tar.gz
+oh-my-opencode-slim-companion-v0.1.3-aarch64-unknown-linux-gnu.tar.gz
+oh-my-opencode-slim-companion-v0.1.3-x86_64-pc-windows-msvc.zip
 ```
 
 ## 4. Build and publish companion assets
@@ -97,7 +97,7 @@ Trigger the manual workflow:
 
 ```bash
 gh workflow run companion-release.yml \
-  -f version=0.1.2 \
+  -f version=0.1.3 \
   -f targets=macos-arm64,linux-x64,linux-arm64,windows-x64
 ```
 
@@ -111,15 +111,15 @@ gh run watch <run-id>
 Verify the companion release:
 
 ```bash
-gh release view companion-v0.1.2
+gh release view companion-v0.1.3
 ```
 
 Download assets for a local sanity check:
 
 ```bash
-mkdir -p /tmp/companion-v0.1.2-assets
-gh release download companion-v0.1.2 \
-  --dir /tmp/companion-v0.1.2-assets
+mkdir -p /tmp/companion-v0.1.3-assets
+gh release download companion-v0.1.3 \
+  --dir /tmp/companion-v0.1.3-assets
 ```
 
 Confirm the asset list matches the installer targets before publishing the
@@ -132,26 +132,26 @@ download the workflow artifacts and upload them manually:
 
 ```bash
 gh run download <run-id> \
-  --dir /tmp/companion-v0.1.2-assets
+  --dir /tmp/companion-v0.1.3-assets
 
-gh release create companion-v0.1.2 \
-  --title "Companion v0.1.2" \
+gh release create companion-v0.1.3 \
+  --title "Companion v0.1.3" \
   --notes "Manual companion binary release for oh-my-opencode-slim." \
-  /tmp/companion-v0.1.2-assets/*
+  /tmp/companion-v0.1.3-assets/*
 ```
 
 If the release already exists, upload with clobber:
 
 ```bash
-gh release upload companion-v0.1.2 \
-  /tmp/companion-v0.1.2-assets/* \
+gh release upload companion-v0.1.3 \
+  /tmp/companion-v0.1.3-assets/* \
   --clobber
 ```
 
 Then verify:
 
 ```bash
-gh release view companion-v0.1.2
+gh release view companion-v0.1.3
 ```
 
 ## 5. Bump the plugin package
@@ -160,7 +160,7 @@ For a stable patch, update `package.json`:
 
 ```json
 {
-  "version": "2.0.2"
+  "version": "2.0.3"
 }
 ```
 
@@ -184,6 +184,8 @@ bun run check:ci
 bun run typecheck
 bun test
 bun run build
+bun run verify:release
+cd companion && cargo fmt --all --check && cargo check && cargo test && cargo build --release
 ```
 
 Before committing or tagging, inspect:
@@ -206,13 +208,14 @@ docs/companion.md
 docs/configuration.md
 package.json
 src/cli/companion.ts
+src/cli/companion.test.ts
 ```
 
 Commit and push:
 
 ```bash
 git add <intended-files>
-git commit -m "chore: prepare companion 0.1.2 release"
+git commit -m "chore: prepare companion 0.1.3 release"
 git push
 ```
 
@@ -227,14 +230,14 @@ git push --follow-tags
 If the package version was edited manually, create and push the tag yourself:
 
 ```bash
-git tag -a v2.0.2 -m "v2.0.2"
-git push origin v2.0.2
+git tag -a v2.0.3 -m "v2.0.3"
+git push origin v2.0.3
 ```
 
 Verify the tag exists remotely:
 
 ```bash
-git ls-remote --tags origin v2.0.2
+git ls-remote --tags origin v2.0.3
 ```
 
 ## 9. Create the GitHub plugin release
@@ -242,23 +245,23 @@ git ls-remote --tags origin v2.0.2
 Use release notes based on the actual git diff.
 
 ```bash
-gh release create v2.0.2 \
-  --title "v2.0.2" \
-  --notes-file /tmp/oh-my-opencode-slim-v2.0.2-notes.md
+gh release create v2.0.3 \
+  --title "v2.0.3" \
+  --notes-file /tmp/oh-my-opencode-slim-v2.0.3-notes.md
 ```
 
 If a release already exists, update it:
 
 ```bash
-gh release edit v2.0.2 \
-  --title "v2.0.2" \
-  --notes-file /tmp/oh-my-opencode-slim-v2.0.2-notes.md
+gh release edit v2.0.3 \
+  --title "v2.0.3" \
+  --notes-file /tmp/oh-my-opencode-slim-v2.0.3-notes.md
 ```
 
 Verify:
 
 ```bash
-gh release view v2.0.2
+gh release view v2.0.3
 ```
 
 ## 10. Publish npm
@@ -276,15 +279,15 @@ After publishing, verify the package version:
 npm view oh-my-opencode-slim version
 ```
 
-## 11. Current v2.0.2 release checklist
+## 11. Current v2.0.3 release checklist
 
-For the `2.0.2` / `companion-v0.1.2` release, the completed state should be:
+For the `2.0.3` / `companion-v0.1.3` release, the completed state should be:
 
-- `package.json` version is `2.0.2`.
-- `src/cli/companion.ts` points to `companion-v0.1.2`.
-- Git tag `v2.0.2` exists on origin.
-- GitHub release `v2.0.2` exists.
-- GitHub release `companion-v0.1.2` exists with the expected assets.
+- `package.json` version is `2.0.3`.
+- `src/cli/companion.ts` points to `companion-v0.1.3`.
+- Git tag `v2.0.3` exists on origin.
+- GitHub release `v2.0.3` exists.
+- GitHub release `companion-v0.1.3` exists with the expected assets.
 - Working tree is clean.
 - `bun run check:ci`, `bun run typecheck`, `bun test`, and `bun run build` pass.
 - npm publish is run only after the GitHub release and companion assets are ready.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode-slim",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Lightweight agent orchestration plugin for OpenCode - a slimmed-down fork of oh-my-opencode",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/cli/companion.test.ts
+++ b/src/cli/companion.test.ts
@@ -1,0 +1,94 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, spyOn, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  COMPANION_TAG,
+  COMPANION_VERSION,
+  getCompanionTarget,
+  installCompanion,
+} from './companion';
+import type { InstallConfig } from './types';
+
+const EXPECTED_RELEASE_TARGETS = [
+  ['aarch64-apple-darwin', 'tar.gz'],
+  ['x86_64-unknown-linux-gnu', 'tar.gz'],
+  ['aarch64-unknown-linux-gnu', 'tar.gz'],
+  ['x86_64-pc-windows-msvc', 'zip'],
+] as const;
+
+function expectedArchiveName(target: string, ext: string): string {
+  return `oh-my-opencode-slim-companion-v${COMPANION_VERSION}-${target}.${ext}`;
+}
+
+function dryRunConfig(): InstallConfig {
+  return {
+    hasTmux: false,
+    installCustomSkills: false,
+    reset: false,
+    backgroundSubagents: 'no',
+    companion: 'yes',
+    dryRun: true,
+  };
+}
+
+describe('companion release metadata', () => {
+  test('keeps installer tag aligned with companion crate version', () => {
+    expect(COMPANION_TAG).toBe(`companion-v${COMPANION_VERSION}`);
+
+    const cargoToml = readFileSync(
+      join(import.meta.dir, '..', '..', 'companion', 'Cargo.toml'),
+      'utf8',
+    );
+    expect(cargoToml).toContain(`version = "${COMPANION_VERSION}"`);
+
+    const cargoLock = readFileSync(
+      join(import.meta.dir, '..', '..', 'companion', 'Cargo.lock'),
+      'utf8',
+    );
+    expect(cargoLock).toContain(
+      `name = "oh-my-opencode-slim-companion"\nversion = "${COMPANION_VERSION}"`,
+    );
+  });
+
+  test('release docs list every current companion asset', () => {
+    const releaseDocs = readFileSync(
+      join(import.meta.dir, '..', '..', 'docs', 'release.md'),
+      'utf8',
+    );
+    const companionDocs = readFileSync(
+      join(import.meta.dir, '..', '..', 'docs', 'companion.md'),
+      'utf8',
+    );
+
+    expect(releaseDocs).toContain(COMPANION_TAG);
+    expect(companionDocs).toContain(COMPANION_TAG);
+
+    for (const [target, ext] of EXPECTED_RELEASE_TARGETS) {
+      const archiveName = expectedArchiveName(target, ext);
+      expect(releaseDocs).toContain(archiveName);
+      expect(companionDocs).toContain(archiveName);
+    }
+  });
+
+  test('dry-run downloads the current companion release asset', async () => {
+    const target = getCompanionTarget();
+    if (!target) return;
+
+    const log = spyOn(console, 'log').mockImplementation(() => undefined);
+    try {
+      await expect(installCompanion(dryRunConfig())).resolves.toMatchObject({
+        success: true,
+      });
+
+      const ext = process.platform === 'win32' ? 'zip' : 'tar.gz';
+      const expectedUrl =
+        `https://github.com/alvinunreal/oh-my-opencode-slim/releases/download/` +
+        `${COMPANION_TAG}/${expectedArchiveName(target, ext)}`;
+      expect(log.mock.calls.flat().join('\n')).toContain(expectedUrl);
+    } finally {
+      log.mockRestore();
+    }
+  });
+});

--- a/src/cli/companion.test.ts
+++ b/src/cli/companion.test.ts
@@ -18,6 +18,8 @@ const EXPECTED_RELEASE_TARGETS = [
   ['x86_64-pc-windows-msvc', 'zip'],
 ] as const;
 
+const CURRENT_COMPANION_TARGET = getCompanionTarget();
+
 function expectedArchiveName(target: string, ext: string): string {
   return `oh-my-opencode-slim-companion-v${COMPANION_VERSION}-${target}.${ext}`;
 }
@@ -46,7 +48,7 @@ describe('companion release metadata', () => {
     const cargoLock = readFileSync(
       join(import.meta.dir, '..', '..', 'companion', 'Cargo.lock'),
       'utf8',
-    );
+    ).replace(/\r\n/g, '\n');
     expect(cargoLock).toContain(
       `name = "oh-my-opencode-slim-companion"\nversion = "${COMPANION_VERSION}"`,
     );
@@ -72,23 +74,28 @@ describe('companion release metadata', () => {
     }
   });
 
-  test('dry-run downloads the current companion release asset', async () => {
-    const target = getCompanionTarget();
-    if (!target) return;
+  test.skipIf(!CURRENT_COMPANION_TARGET)(
+    'dry-run downloads the current companion release asset',
+    async () => {
+      const target = CURRENT_COMPANION_TARGET;
+      if (!target) {
+        throw new Error('unsupported companion target was not skipped');
+      }
 
-    const log = spyOn(console, 'log').mockImplementation(() => undefined);
-    try {
-      await expect(installCompanion(dryRunConfig())).resolves.toMatchObject({
-        success: true,
-      });
+      const log = spyOn(console, 'log').mockImplementation(() => undefined);
+      try {
+        await expect(installCompanion(dryRunConfig())).resolves.toMatchObject({
+          success: true,
+        });
 
-      const ext = process.platform === 'win32' ? 'zip' : 'tar.gz';
-      const expectedUrl =
-        `https://github.com/alvinunreal/oh-my-opencode-slim/releases/download/` +
-        `${COMPANION_TAG}/${expectedArchiveName(target, ext)}`;
-      expect(log.mock.calls.flat().join('\n')).toContain(expectedUrl);
-    } finally {
-      log.mockRestore();
-    }
-  });
+        const ext = process.platform === 'win32' ? 'zip' : 'tar.gz';
+        const expectedUrl =
+          `https://github.com/alvinunreal/oh-my-opencode-slim/releases/download/` +
+          `${COMPANION_TAG}/${expectedArchiveName(target, ext)}`;
+        expect(log.mock.calls.flat().join('\n')).toContain(expectedUrl);
+      } finally {
+        log.mockRestore();
+      }
+    },
+  );
 });

--- a/src/cli/companion.ts
+++ b/src/cli/companion.ts
@@ -12,8 +12,8 @@ import { homedir, tmpdir } from 'node:os';
 import * as path from 'node:path';
 import type { ConfigMergeResult, InstallConfig } from './types';
 
-const COMPANION_VERSION = '0.1.2';
-const COMPANION_TAG = 'companion-v0.1.2';
+export const COMPANION_VERSION = '0.1.3';
+export const COMPANION_TAG = 'companion-v0.1.3';
 const GITHUB_REPO = 'alvinunreal/oh-my-opencode-slim';
 
 export function getCompanionTarget(): string | null {


### PR DESCRIPTION
## Summary
- bump the native companion release target to `0.1.3` / `companion-v0.1.3`
- bump the plugin package to `2.0.3` for a companion-backed patch release
- add regression coverage so installer release metadata stays aligned with Cargo and docs
- update companion/configuration/release docs for the new asset names and validation steps

## Why
PR #547 fixed the native companion niri/off-screen behavior in source, but the installer still downloaded the old `companion-v0.1.2` binary. This release prep points installers at a new companion asset tag that can include the #547 binary fix.

## Release note
Do not publish npm `2.0.3` until GitHub release `companion-v0.1.3` exists with these assets:

- `oh-my-opencode-slim-companion-v0.1.3-aarch64-apple-darwin.tar.gz`
- `oh-my-opencode-slim-companion-v0.1.3-x86_64-unknown-linux-gnu.tar.gz`
- `oh-my-opencode-slim-companion-v0.1.3-aarch64-unknown-linux-gnu.tar.gz`
- `oh-my-opencode-slim-companion-v0.1.3-x86_64-pc-windows-msvc.zip`

## Validation
- `bun test src/cli/companion.test.ts`
- `bun run check:ci`
- `bun run typecheck`
- `bun test`
- `bun run build`
- `bun run verify:release`
- `cd companion && cargo fmt --all --check && cargo check && cargo test && cargo build --release`
