### PR TITLE
Fix multiplexer pane flicker from missing session status

### DIFF
--- a/src/multiplexer/codemap.md
+++ b/src/multiplexer/codemap.md
@@ -56,9 +56,8 @@
   - `respawnIfKnown` handles busy sessions that reappear after being closed.
   - Polling fallback (`pollSessions`) is enabled when event coverage is incomplete.
     It handles:
-    - idle detection,
-    - missing status grace period,
-    - max session lifetime timeout.
+    - idle detection.
+    - A session missing from `/session/status` is not treated as a close signal.
 
 - `index.ts`
   - Re-exports factory, manager, and implementations for external import.

--- a/src/multiplexer/session-manager.test.ts
+++ b/src/multiplexer/session-manager.test.ts
@@ -493,41 +493,7 @@ describe('MultiplexerSessionManager', () => {
       expect(mockMultiplexer.closePane).not.toHaveBeenCalled();
     });
 
-    test('keeps missing running background job pane open', async () => {
-      const ctx = createMockContext();
-      const board = new BackgroundJobBoard();
-      board.registerLaunch({
-        taskID: 'running-background-job',
-        parentSessionID: 'parent-1',
-        agent: 'explorer',
-      });
-      mockMultiplexer.spawnPane.mockResolvedValue({
-        success: true,
-        paneId: 'p-running-background-job',
-      });
-      const manager = new MultiplexerSessionManager(
-        ctx,
-        defaultMultiplexerConfig,
-        board,
-      );
-
-      await manager.onSessionCreated({
-        type: 'session.created',
-        properties: {
-          info: { id: 'running-background-job', parentID: 'parent-1' },
-        },
-      });
-
-      const tracked = (manager as any).sessions.get('running-background-job');
-      tracked.missingSince = Date.now() - 60_000;
-
-      setMockSessionStatuses({});
-      await (manager as any).pollSessions();
-
-      expect(mockMultiplexer.closePane).not.toHaveBeenCalled();
-    });
-
-    test('closes never-seen pane when no running background job exists', async () => {
+    test('does not close never-seen pane when missing from status', async () => {
       const ctx = createMockContext();
       mockMultiplexer.spawnPane.mockResolvedValue({
         success: true,
@@ -543,15 +509,10 @@ describe('MultiplexerSessionManager', () => {
         properties: { info: { id: 'never-seen-orphan', parentID: 'p1' } },
       });
 
-      const tracked = (manager as any).sessions.get('never-seen-orphan');
-      tracked.missingSince = Date.now() - 60_000;
-
       setMockSessionStatuses({});
       await (manager as any).pollSessions();
 
-      expect(mockMultiplexer.closePane).toHaveBeenCalledWith(
-        'p-never-seen-orphan',
-      );
+      expect(mockMultiplexer.closePane).not.toHaveBeenCalled();
     });
 
     test('ignores empty session status response without closing panes', async () => {
@@ -570,9 +531,6 @@ describe('MultiplexerSessionManager', () => {
         properties: { info: { id: 'empty-status', parentID: 'p1' } },
       });
 
-      const tracked = (manager as any).sessions.get('empty-status');
-      tracked.seenInStatus = true;
-      tracked.missingSince = Date.now() - 60_000;
       mockFetch.mockImplementationOnce(
         async () => new Response('', { status: 200 }),
       );
@@ -582,7 +540,7 @@ describe('MultiplexerSessionManager', () => {
       expect(mockMultiplexer.closePane).not.toHaveBeenCalled();
     });
 
-    test('keeps missing cleanup for sessions previously seen in status', async () => {
+    test('does not close previously seen session when later missing from status', async () => {
       const ctx = createMockContext();
       mockMultiplexer.spawnPane.mockResolvedValue({
         success: true,
@@ -601,15 +559,46 @@ describe('MultiplexerSessionManager', () => {
       setMockSessionStatuses({ 'seen-before-missing': { type: 'busy' } });
       await (manager as any).pollSessions();
 
-      const tracked = (manager as any).sessions.get('seen-before-missing');
-      tracked.missingSince = Date.now() - 60_000;
+      setMockSessionStatuses({});
+      await (manager as any).pollSessions();
+
+      expect(mockMultiplexer.closePane).not.toHaveBeenCalled();
+    });
+
+    test('does not respawn duplicate pane when missing session becomes busy again', async () => {
+      const ctx = createMockContext();
+      mockMultiplexer.spawnPane.mockResolvedValue({
+        success: true,
+        paneId: 'p-seen-before-busy-again',
+      });
+      const manager = new MultiplexerSessionManager(
+        ctx,
+        defaultMultiplexerConfig,
+      );
+
+      await manager.onSessionCreated({
+        type: 'session.created',
+        properties: {
+          info: { id: 'seen-before-busy-again', parentID: 'p1' },
+        },
+      });
+
+      setMockSessionStatuses({ 'seen-before-busy-again': { type: 'busy' } });
+      await (manager as any).pollSessions();
 
       setMockSessionStatuses({});
       await (manager as any).pollSessions();
 
-      expect(mockMultiplexer.closePane).toHaveBeenCalledWith(
-        'p-seen-before-missing',
-      );
+      await manager.onSessionStatus({
+        type: 'session.status',
+        properties: {
+          sessionID: 'seen-before-busy-again',
+          status: { type: 'busy' },
+        },
+      });
+
+      expect(mockMultiplexer.closePane).not.toHaveBeenCalled();
+      expect(mockMultiplexer.spawnPane).toHaveBeenCalledTimes(1);
     });
 
     test('polls the actual serverUrl instead of the plugin SDK default URL', async () => {

--- a/src/multiplexer/session-manager.ts
+++ b/src/multiplexer/session-manager.ts
@@ -17,7 +17,6 @@ interface TrackedSession {
   directory: string;
   ownerInstanceId: string;
   createdAt: number;
-  lastSeenAt: number;
 }
 
 interface KnownSession {
@@ -223,7 +222,6 @@ export class MultiplexerSessionManager {
         directory,
         ownerInstanceId: this.instanceId,
         createdAt: now,
-        lastSeenAt: now,
       });
 
       log('[multiplexer-session-manager] pane spawned', {
@@ -358,8 +356,6 @@ export class MultiplexerSessionManager {
         if (!status) {
           continue;
         }
-
-        tracked.lastSeenAt = now;
 
         if (status.type !== 'idle') {
           continue;
@@ -583,7 +579,6 @@ export class MultiplexerSessionManager {
         directory: known.directory,
         ownerInstanceId: this.instanceId,
         createdAt: now,
-        lastSeenAt: now,
       });
 
       log('[multiplexer-session-manager] pane respawned on busy', {

--- a/src/multiplexer/session-manager.ts
+++ b/src/multiplexer/session-manager.ts
@@ -18,8 +18,6 @@ interface TrackedSession {
   ownerInstanceId: string;
   createdAt: number;
   lastSeenAt: number;
-  seenInStatus: boolean;
-  missingSince?: number;
 }
 
 interface KnownSession {
@@ -49,9 +47,7 @@ interface SessionEvent {
   };
 }
 
-type CloseReason = 'idle' | 'deleted' | 'missing';
-
-const SESSION_MISSING_GRACE_MS = POLL_INTERVAL_BACKGROUND_MS * 3;
+type CloseReason = 'idle' | 'deleted';
 const SHARED_STATE_KEY = Symbol.for(
   'oh-my-opencode-slim.multiplexer-session-manager.state',
 );
@@ -228,7 +224,6 @@ export class MultiplexerSessionManager {
         ownerInstanceId: this.instanceId,
         createdAt: now,
         lastSeenAt: now,
-        seenInStatus: false,
       });
 
       log('[multiplexer-session-manager] pane spawned', {
@@ -360,40 +355,29 @@ export class MultiplexerSessionManager {
         }
 
         const status = allStatuses[sessionId];
-        const isIdle = status?.type === 'idle';
-
-        if (status) {
-          tracked.lastSeenAt = now;
-          tracked.seenInStatus = true;
-          tracked.missingSince = undefined;
-        } else if (!tracked.missingSince) {
-          tracked.missingSince = now;
+        if (!status) {
+          continue;
         }
 
-        const missingTooLong =
-          !!tracked.missingSince &&
-          now - tracked.missingSince >= SESSION_MISSING_GRACE_MS;
-        const shouldKeepRunningBackgroundJob =
-          (isIdle || missingTooLong) && this.isRunningBackgroundJob(sessionId);
-        if (isIdle || missingTooLong) {
-          if (shouldKeepRunningBackgroundJob) {
-            log(
-              '[multiplexer-session-manager] keeping running background pane',
-              {
-                instanceId: this.instanceId,
-                sessionId,
-                paneId: tracked.paneId,
-                seenInStatus: tracked.seenInStatus,
-              },
-            );
-            continue;
-          }
+        tracked.lastSeenAt = now;
 
-          sessionsToClose.push({
+        if (status.type !== 'idle') {
+          continue;
+        }
+
+        if (this.isRunningBackgroundJob(sessionId)) {
+          log('[multiplexer-session-manager] keeping running background pane', {
+            instanceId: this.instanceId,
             sessionId,
-            reason: isIdle ? 'idle' : 'missing',
+            paneId: tracked.paneId,
           });
+          continue;
         }
+
+        sessionsToClose.push({
+          sessionId,
+          reason: 'idle',
+        });
       }
 
       for (const { sessionId, reason } of sessionsToClose) {
@@ -600,7 +584,6 @@ export class MultiplexerSessionManager {
         ownerInstanceId: this.instanceId,
         createdAt: now,
         lastSeenAt: now,
-        seenInStatus: false,
       });
 
       log('[multiplexer-session-manager] pane respawned on busy', {


### PR DESCRIPTION
## Summary

- Stop treating sessions missing from `/session/status` as a signal to close multiplexer panes.
- Keep poll-based cleanup for explicit `idle` statuses, while preserving `session.deleted`, idle events, the background-job idle veto, owner guards, and busy-session respawn behavior.
- Add regression coverage for sessions that temporarily disappear from `/session/status` and later become busy again without being closed or respawned twice.
- Update the multiplexer codemap to document the polling invariant.

Follow-up to #491.

## Why

Nested council child sessions can remain alive and busy even when they are missing from the aggregate `/session/status` response. Closing panes solely because a session is missing can incorrectly close live panes and trigger a close/respawn flicker loop when busy events arrive later.

## Validation

- `bun run check:ci`
- `bun test src/multiplexer/session-manager.test.ts`
- `bun run typecheck`
- `bun test`