### PR TITLE
ci: cross-compile macos-x64 companion on macos-latest runner

### DIFF
--- a/.github/workflows/companion-release.yml
+++ b/.github/workflows/companion-release.yml
@@ -9,7 +9,7 @@ on:
         type: string
       targets:
         description: >-
-          Comma-separated targets to build: macos-arm64,linux-x64,linux-arm64,windows-x64
+          Comma-separated targets to build: macos-arm64,macos-x64,linux-x64,linux-arm64,windows-x64
         required: true
         default: macos-arm64
         type: string
@@ -42,6 +42,32 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: companion-macos-arm64
+          path: '*.tar.gz'
+
+  macos-x64:
+    name: macOS x64
+    if: contains(github.event.inputs.targets, 'macos-x64')
+    runs-on: macos-13
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-apple-darwin
+      - name: Build companion
+        working-directory: companion
+        run: cargo build --release --target x86_64-apple-darwin
+      - name: Package companion
+        run: |
+          set -euo pipefail
+          version='${{ github.event.inputs.version }}'
+          target='x86_64-apple-darwin'
+          name="oh-my-opencode-slim-companion-v${version}-${target}"
+          mkdir -p dist
+          cp "companion/target/${target}/release/oh-my-opencode-slim-companion" dist/oh-my-opencode-slim-companion
+          tar -C dist -czf "${name}.tar.gz" oh-my-opencode-slim-companion
+      - uses: actions/upload-artifact@v4
+        with:
+          name: companion-macos-x64
           path: '*.tar.gz'
 
   linux-x64:
@@ -134,6 +160,7 @@ jobs:
     name: Publish companion release
     needs:
       - macos-arm64
+      - macos-x64
       - linux-x64
       - linux-arm64
       - windows-x64

--- a/.github/workflows/companion-release.yml
+++ b/.github/workflows/companion-release.yml
@@ -47,7 +47,7 @@ jobs:
   macos-x64:
     name: macOS x64
     if: contains(github.event.inputs.targets, 'macos-x64')
-    runs-on: macos-13
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
### Problem
GitHub-hosted Intel macOS runners (`macos-13` / `macos-12`) have extremely restricted queue times or are deprecated, causing the `macos-x64` build job to get stuck indefinitely waiting for a runner.

### Solution
Since the newer standard GitHub `macos-latest` (Apple Silicon M1/arm64) runners are instantly available and natively support cross-compilation to Intel targets through the Xcode SDK, we can compile the `x86_64` binary on an arm64 host:
* Changed `runs-on` from `macos-13` to `macos-latest` for the `macos-x64` job.
* Maintained the cargo target argument `--target x86_64-apple-darwin`.

### Verification
Successfully tested on a fork: the runner starts immediately and generates a valid `Mach-O 64-bit executable x86_64` companion binary without SDK or linker errors.

    
    
<img width="1385" height="1022" alt="Screenshot 2026-06-15 at 15-31-37" src="https://github.com/user-attachments/assets/e537e80c-98f7-4feb-aa72-b7da3495682e" />
<img width="818" height="161" alt="Screenshot 2026-06-15 at 15-32-13" src="https://github.com/user-attachments/assets/42405703-2957-4be9-8971-c0d0cab817eb" />
