### PR TITLE
Persist companion window position

### DIFF
--- a/companion/src/app.rs
+++ b/companion/src/app.rs
@@ -10,7 +10,10 @@ use eframe::egui;
 use crate::gifs::Gifs;
 use crate::niri;
 use crate::screen::primary_size;
-use crate::state::{read_state, start_watcher, CompanionConfigState, SessionInfo};
+use crate::state::{
+    read_state, start_watcher, write_project_window_position, CompanionConfigState, SessionInfo,
+    WindowPositionState,
+};
 
 const DEFAULT_SIZE: f32 = 120.0;
 const GAP: f32 = 10.0;
@@ -29,7 +32,10 @@ const MENU_POS_KEY: &str = "companion_menu_pos";
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct WindowGeometryKey {
     session_id: String,
+    project_key: String,
     position: String,
+    custom_x: Option<i32>,
+    custom_y: Option<i32>,
     size_px: u32,
     cols: u32,
     rows: u32,
@@ -103,6 +109,20 @@ pub(crate) fn place_window(position: &str, screen: [f32; 2], win: [f32; 2]) -> [
     [x.clamp(GAP, x_max), y.clamp(GAP, y_max)]
 }
 
+fn clamp_window_position(pos: [f32; 2], screen: [f32; 2], win: [f32; 2]) -> [f32; 2] {
+    let x_max = (screen[0] - win[0] - GAP).max(GAP);
+    let y_max = (screen[1] - win[1] - GAP).max(GAP);
+    [pos[0].clamp(GAP, x_max), pos[1].clamp(GAP, y_max)]
+}
+
+fn project_key(cwd: &str) -> String {
+    std::path::Path::new(cwd)
+        .canonicalize()
+        .ok()
+        .and_then(|path| path.to_str().map(str::to_string))
+        .unwrap_or_else(|| cwd.to_string())
+}
+
 fn cell_rects(agents: usize, cols: usize, rows: usize, cell: f32) -> Vec<egui::Rect> {
     let mut rects = Vec::with_capacity(agents);
     let full_rows = agents / cols;
@@ -166,6 +186,8 @@ pub struct CompanionApp {
     has_modern_config: bool,
     applied_config: Option<ConfigKey>,
     applied_geometry: Option<WindowGeometryKey>,
+    window_positions: std::collections::BTreeMap<String, WindowPositionState>,
+    drag_project_key: Option<String>,
     niri_generation: Arc<AtomicU64>,
 }
 
@@ -174,6 +196,7 @@ impl CompanionApp {
         let state_path = crate::state::state_file_path();
         let state = read_state(&state_path);
         let sessions = state.sessions;
+        let window_positions = state.window_positions;
 
         let mut initial_size = DEFAULT_SIZE;
         let mut position = "bottom-right".to_string();
@@ -195,6 +218,8 @@ impl CompanionApp {
             has_modern_config,
             applied_config,
             applied_geometry: None,
+            window_positions,
+            drag_project_key: None,
             niri_generation: Arc::new(AtomicU64::new(0)),
         }
     }
@@ -204,6 +229,7 @@ impl CompanionApp {
             while self.rx.try_recv().is_ok() {}
             let state = read_state(&self.state_path);
             self.sessions = state.sessions;
+            self.window_positions = state.window_positions;
             self.has_modern_config = state.config.is_some();
             let next_config = config_key(state.config.as_ref());
             let config_changed = self.applied_config != next_config;
@@ -268,6 +294,8 @@ impl eframe::App for CompanionApp {
         };
 
         let session = self.sessions[selected_idx].clone();
+        let project_key = project_key(&session.cwd);
+        let saved_position = self.window_positions.get(&project_key).copied();
         let agent_uris: Vec<String> = if session.active_agents.is_empty() {
             vec![self.gifs.uri("intro")]
         } else {
@@ -283,7 +311,10 @@ impl eframe::App for CompanionApp {
 
         let geometry = WindowGeometryKey {
             session_id: session.session_id.clone(),
+            project_key: project_key.clone(),
             position: self.position.clone(),
+            custom_x: saved_position.map(|pos| pos.x.round() as i32),
+            custom_y: saved_position.map(|pos| pos.y.round() as i32),
             size_px: self.size.round() as u32,
             cols: cols as u32,
             rows: rows as u32,
@@ -292,16 +323,41 @@ impl eframe::App for CompanionApp {
         };
         if self.applied_geometry.as_ref() != Some(&geometry) {
             ctx.send_viewport_cmd(egui::ViewportCommand::InnerSize(egui::vec2(win_w, win_h)));
-            let pos = place_window(&self.position, self.screen, [win_w, win_h]);
+            let pos = saved_position
+                .map(|pos| clamp_window_position([pos.x, pos.y], self.screen, [win_w, win_h]))
+                .unwrap_or_else(|| place_window(&self.position, self.screen, [win_w, win_h]));
             ctx.send_viewport_cmd(egui::ViewportCommand::OuterPosition(egui::pos2(
                 pos[0], pos[1],
             )));
             self.applied_geometry = Some(geometry);
-            self.spawn_niri_fallback([win_w, win_h]);
+            self.spawn_niri_fallback([win_w, win_h], saved_position);
         }
 
-        if ctx.input(|i| i.pointer.primary_down()) {
+        let menu_open = ctx.data(|d| {
+            d.get_temp::<bool>(egui::Id::new(MENU_OPEN_KEY))
+                .unwrap_or(false)
+        });
+        if !menu_open && ctx.input(|i| i.pointer.primary_pressed()) {
+            self.drag_project_key = Some(project_key.clone());
+        }
+        if self.drag_project_key.is_some() && ctx.input(|i| i.pointer.primary_down()) {
             ctx.send_viewport_cmd(egui::ViewportCommand::StartDrag);
+        }
+        if ctx.input(|i| i.pointer.primary_released()) {
+            if let Some(project_key) = self.drag_project_key.take() {
+                if let Some(rect) = ctx.input(|i| i.viewport().outer_rect) {
+                    let position = WindowPositionState {
+                        x: rect.min.x,
+                        y: rect.min.y,
+                    };
+                    if write_project_window_position(&self.state_path, &project_key, position)
+                        .is_ok()
+                    {
+                        self.window_positions.insert(project_key, position);
+                        self.applied_geometry = None;
+                    }
+                }
+            }
         }
 
         if ctx.input(|i| i.pointer.secondary_released()) {
@@ -329,17 +385,20 @@ impl eframe::App for CompanionApp {
 }
 
 impl CompanionApp {
-    fn spawn_niri_fallback(&self, win_size: [f32; 2]) {
+    fn spawn_niri_fallback(&self, win_size: [f32; 2], saved_position: Option<WindowPositionState>) {
         let socket = match std::env::var("NIRI_SOCKET") {
             Ok(socket) if !socket.is_empty() => socket,
             _ => return,
         };
-        let desired = place_window(&self.position, self.screen, win_size);
+        let desired = saved_position
+            .map(|pos| clamp_window_position([pos.x, pos.y], self.screen, win_size))
+            .unwrap_or_else(|| place_window(&self.position, self.screen, win_size));
         if !desired[0].is_finite() || !desired[1].is_finite() {
             return;
         }
         let generation = self.niri_generation.fetch_add(1, Ordering::Relaxed) + 1;
         let position = self.position.clone();
+        let target_position = saved_position.map(|pos| [pos.x, pos.y]);
         let screen = self.screen;
         let niri_generation = Arc::clone(&self.niri_generation);
         std::thread::spawn(move || {
@@ -349,6 +408,7 @@ impl CompanionApp {
                 generation,
                 niri_generation,
                 position,
+                target_position,
                 screen,
                 win_size,
             );
@@ -652,7 +712,10 @@ mod tests {
     fn geometry_key_changes_with_layout_inputs() {
         let base = WindowGeometryKey {
             session_id: "a".into(),
+            project_key: "/a".into(),
             position: "bottom-right".into(),
+            custom_x: None,
+            custom_y: None,
             size_px: 120,
             cols: 1,
             rows: 1,

--- a/companion/src/app.rs
+++ b/companion/src/app.rs
@@ -115,7 +115,19 @@ fn clamp_window_position(pos: [f32; 2], screen: [f32; 2], win: [f32; 2]) -> [f32
     [pos[0].clamp(GAP, x_max), pos[1].clamp(GAP, y_max)]
 }
 
-fn project_key(cwd: &str) -> String {
+fn restore_window_position(pos: [f32; 2], screen: [f32; 2], win: [f32; 2]) -> [f32; 2] {
+    // egui 0.29 exposes monitor size but not monitor origin. If a saved native
+    // position is outside origin-zero bounds, it may be on a secondary monitor
+    // with a positive or negative origin. Preserve it instead of snapping it
+    // back to the primary monitor.
+    if 0.0 <= pos[0] && pos[0] < screen[0] && 0.0 <= pos[1] && pos[1] < screen[1] {
+        clamp_window_position(pos, screen, win)
+    } else {
+        pos
+    }
+}
+
+fn canonical_project_key(cwd: &str) -> String {
     std::path::Path::new(cwd)
         .canonicalize()
         .ok()
@@ -187,6 +199,7 @@ pub struct CompanionApp {
     applied_config: Option<ConfigKey>,
     applied_geometry: Option<WindowGeometryKey>,
     window_positions: std::collections::BTreeMap<String, WindowPositionState>,
+    project_keys: std::collections::BTreeMap<String, String>,
     drag_project_key: Option<String>,
     niri_generation: Arc<AtomicU64>,
 }
@@ -219,6 +232,7 @@ impl CompanionApp {
             applied_config,
             applied_geometry: None,
             window_positions,
+            project_keys: std::collections::BTreeMap::new(),
             drag_project_key: None,
             niri_generation: Arc::new(AtomicU64::new(0)),
         }
@@ -230,6 +244,8 @@ impl CompanionApp {
             let state = read_state(&self.state_path);
             self.sessions = state.sessions;
             self.window_positions = state.window_positions;
+            self.project_keys
+                .retain(|cwd, _| self.sessions.iter().any(|session| &session.cwd == cwd));
             self.has_modern_config = state.config.is_some();
             let next_config = config_key(state.config.as_ref());
             let config_changed = self.applied_config != next_config;
@@ -252,6 +268,15 @@ impl CompanionApp {
                 self.screen = [size.x, size.y];
             }
         }
+    }
+
+    fn project_key_for(&mut self, cwd: &str) -> String {
+        if let Some(key) = self.project_keys.get(cwd) {
+            return key.clone();
+        }
+        let key = canonical_project_key(cwd);
+        self.project_keys.insert(cwd.to_string(), key.clone());
+        key
     }
 }
 
@@ -294,7 +319,7 @@ impl eframe::App for CompanionApp {
         };
 
         let session = self.sessions[selected_idx].clone();
-        let project_key = project_key(&session.cwd);
+        let project_key = self.project_key_for(&session.cwd);
         let saved_position = self.window_positions.get(&project_key).copied();
         let agent_uris: Vec<String> = if session.active_agents.is_empty() {
             vec![self.gifs.uri("intro")]
@@ -324,7 +349,7 @@ impl eframe::App for CompanionApp {
         if self.applied_geometry.as_ref() != Some(&geometry) {
             ctx.send_viewport_cmd(egui::ViewportCommand::InnerSize(egui::vec2(win_w, win_h)));
             let pos = saved_position
-                .map(|pos| clamp_window_position([pos.x, pos.y], self.screen, [win_w, win_h]))
+                .map(|pos| restore_window_position([pos.x, pos.y], self.screen, [win_w, win_h]))
                 .unwrap_or_else(|| place_window(&self.position, self.screen, [win_w, win_h]));
             ctx.send_viewport_cmd(egui::ViewportCommand::OuterPosition(egui::pos2(
                 pos[0], pos[1],
@@ -391,7 +416,7 @@ impl CompanionApp {
             _ => return,
         };
         let desired = saved_position
-            .map(|pos| clamp_window_position([pos.x, pos.y], self.screen, win_size))
+            .map(|pos| restore_window_position([pos.x, pos.y], self.screen, win_size))
             .unwrap_or_else(|| place_window(&self.position, self.screen, win_size));
         if !desired[0].is_finite() || !desired[1].is_finite() {
             return;
@@ -599,8 +624,8 @@ fn is_pid_alive(_pid: u32) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        apply_config, choose_session, config_key, grid_dims, place_window, size_from_config,
-        window_size, ConfigKey, SessionInfo, WindowGeometryKey, GAP,
+        apply_config, choose_session, config_key, grid_dims, place_window, restore_window_position,
+        size_from_config, window_size, ConfigKey, SessionInfo, WindowGeometryKey, GAP,
     };
     use crate::state::CompanionConfigState;
 
@@ -705,6 +730,30 @@ mod tests {
         assert_eq!(
             place_window("bottom-right", [300.0, 300.0], [500.0, 500.0]),
             [GAP, GAP]
+        );
+    }
+
+    #[test]
+    fn restore_clamps_origin_zero_positions() {
+        assert_eq!(
+            restore_window_position([1400.0, 850.0], [1440.0, 900.0], [120.0, 120.0]),
+            [1310.0, 770.0]
+        );
+    }
+
+    #[test]
+    fn restore_preserves_negative_origin_monitor_positions() {
+        assert_eq!(
+            restore_window_position([-900.0, 40.0], [1440.0, 900.0], [120.0, 120.0]),
+            [-900.0, 40.0]
+        );
+    }
+
+    #[test]
+    fn restore_preserves_positive_offset_secondary_monitor_positions() {
+        assert_eq!(
+            restore_window_position([2200.0, 80.0], [1440.0, 900.0], [120.0, 120.0]),
+            [2200.0, 80.0]
         );
     }
 

--- a/companion/src/niri.rs
+++ b/companion/src/niri.rs
@@ -45,6 +45,7 @@ pub fn retry_move_current_window(
     generation: u64,
     current_generation: Arc<AtomicU64>,
     position: String,
+    target_position: Option<[f32; 2]>,
     screen: [f32; 2],
     win_size: [f32; 2],
 ) {
@@ -53,7 +54,9 @@ pub fn retry_move_current_window(
         if current_generation.load(Ordering::Relaxed) != generation {
             return;
         }
-        let Some((id, delta)) = resolve_move(&socket, pid, &position, screen, win_size) else {
+        let Some((id, delta)) =
+            resolve_move(&socket, pid, &position, target_position, screen, win_size)
+        else {
             continue;
         };
         if move_window(&socket, &id, delta).is_ok() {
@@ -66,6 +69,7 @@ fn resolve_move(
     socket: &str,
     pid: u32,
     position: &str,
+    target_position: Option<[f32; 2]>,
     screen: [f32; 2],
     win_size: [f32; 2],
 ) -> Option<(String, [i32; 2])> {
@@ -96,6 +100,7 @@ fn resolve_move(
         outputs_json,
         pid,
         position,
+        target_position,
         screen,
         win_size,
     )
@@ -106,6 +111,7 @@ fn resolve_move_from_json(
     outputs_json: Option<&[u8]>,
     pid: u32,
     position: &str,
+    target_position: Option<[f32; 2]>,
     screen: [f32; 2],
     win_size: [f32; 2],
 ) -> Option<(String, [i32; 2])> {
@@ -121,8 +127,17 @@ fn resolve_move_from_json(
             width: screen[0] as f64,
             height: screen[1] as f64,
         });
-    let desired =
-        place_window_on_output(position, output, [win_size[0] as f64, win_size[1] as f64]);
+    let desired = target_position
+        .map(|pos| {
+            clamp_position_on_output(
+                [pos[0] as f64, pos[1] as f64],
+                output,
+                [win_size[0] as f64, win_size[1] as f64],
+            )
+        })
+        .unwrap_or_else(|| {
+            place_window_on_output(position, output, [win_size[0] as f64, win_size[1] as f64])
+        });
     let dx = (desired[0] - current[0]).round() as i32;
     let dy = (desired[1] - current[1]).round() as i32;
     if dx.abs() <= 1 && dy.abs() <= 1 {
@@ -192,6 +207,21 @@ fn place_window_on_output(
     [x.clamp(x_min, x_max), y.clamp(y_min, y_max)]
 }
 
+fn clamp_position_on_output(
+    position: [f64; 2],
+    output: NiriOutputLogical,
+    win_size: [f64; 2],
+) -> [f64; 2] {
+    let x_min = output.x + GAP;
+    let y_min = output.y + GAP;
+    let x_max = (output.x + output.width - win_size[0] - GAP).max(x_min);
+    let y_max = (output.y + output.height - win_size[1] - GAP).max(y_min);
+    [
+        position[0].clamp(x_min, x_max),
+        position[1].clamp(y_min, y_max),
+    ]
+}
+
 fn matches_window(win: &NiriWindow, pid: u32) -> bool {
     win.pid == Some(pid)
         && win.is_floating == Some(true)
@@ -232,8 +262,9 @@ fn format_delta(delta: i32) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_move_args, matches_window, output_for_position, parse_outputs,
-        place_window_on_output, resolve_move_from_json, NiriOutputLogical, NiriWindow,
+        build_move_args, clamp_position_on_output, matches_window, output_for_position,
+        parse_outputs, place_window_on_output, resolve_move_from_json, NiriOutputLogical,
+        NiriWindow,
     };
 
     const FIXTURE: &str = r#"[
@@ -374,6 +405,7 @@ mod tests {
                 Some(OUTPUTS.as_bytes()),
                 1234,
                 "bottom-right",
+                None,
                 [2550.0, 1100.0],
                 [360.0, 240.0],
             ),
@@ -395,6 +427,7 @@ mod tests {
                 Some(outputs.as_bytes()),
                 1234,
                 "top-left",
+                None,
                 [10000.0, 5000.0],
                 [120.0, 120.0],
             ),
@@ -413,6 +446,20 @@ mod tests {
         assert_eq!(
             place_window_on_output("bottom-right", output, [120.0, 120.0]),
             [3070.0, 690.0]
+        );
+    }
+
+    #[test]
+    fn custom_position_is_clamped_to_output() {
+        let output = NiriOutputLogical {
+            x: 0.0,
+            y: 0.0,
+            width: 500.0,
+            height: 300.0,
+        };
+        assert_eq!(
+            clamp_position_on_output([460.0, -20.0], output, [120.0, 120.0]),
+            [370.0, 10.0]
         );
     }
 

--- a/companion/src/niri.rs
+++ b/companion/src/niri.rs
@@ -118,9 +118,15 @@ fn resolve_move_from_json(
     let windows: Vec<NiriWindow> = serde_json::from_slice(windows_json).ok()?;
     let win = windows.into_iter().find(|w| matches_window(w, pid))?;
     let current = win.layout?.tile_pos_in_workspace_view?;
-    let output = outputs_json
-        .and_then(parse_outputs)
-        .and_then(|outputs| output_for_position(&outputs, current))
+    let outputs = outputs_json.and_then(parse_outputs);
+    let output = outputs
+        .as_deref()
+        .and_then(|outputs| {
+            target_position
+                .map(|pos| [pos[0] as f64, pos[1] as f64])
+                .and_then(|pos| output_containing_position(outputs, pos))
+                .or_else(|| output_for_position(outputs, current))
+        })
         .unwrap_or(NiriOutputLogical {
             x: 0.0,
             y: 0.0,
@@ -173,16 +179,19 @@ fn parse_outputs(json: &[u8]) -> Option<Vec<NiriOutputLogical>> {
 }
 
 fn output_for_position(outputs: &[NiriOutputLogical], pos: [f64; 2]) -> Option<NiriOutputLogical> {
-    outputs
-        .iter()
-        .copied()
-        .find(|output| {
-            output.x <= pos[0]
-                && pos[0] < output.x + output.width
-                && output.y <= pos[1]
-                && pos[1] < output.y + output.height
-        })
-        .or_else(|| outputs.first().copied())
+    output_containing_position(outputs, pos).or_else(|| outputs.first().copied())
+}
+
+fn output_containing_position(
+    outputs: &[NiriOutputLogical],
+    pos: [f64; 2],
+) -> Option<NiriOutputLogical> {
+    outputs.iter().copied().find(|output| {
+        output.x <= pos[0]
+            && pos[0] < output.x + output.width
+            && output.y <= pos[1]
+            && pos[1] < output.y + output.height
+    })
 }
 
 fn place_window_on_output(
@@ -279,6 +288,11 @@ mod tests {
 
     const OUTPUTS: &str = r#"{
       "HDMI-A-1": {"logical":{"x":0,"y":0,"width":2560,"height":1080,"scale":1,"transform":"Normal"}}
+    }"#;
+
+    const TWO_OUTPUTS: &str = r#"{
+      "left": {"logical":{"x":0,"y":0,"width":1920,"height":1080,"scale":1,"transform":"Normal"}},
+      "right": {"logical":{"x":1920,"y":0,"width":1280,"height":720,"scale":1,"transform":"Normal"}}
     }"#;
 
     #[test]
@@ -410,6 +424,25 @@ mod tests {
                 [360.0, 240.0],
             ),
             Some(("2".into(), [-234, -114]))
+        );
+    }
+
+    #[test]
+    fn custom_position_uses_target_output() {
+        let windows = r#"[
+          {"id":2,"pid":1234,"app_id":"oh-my-opencode-slim-companion","title":"oh-my-opencode-slim-companion","is_floating":true,"layout":{"tile_pos_in_workspace_view":[10,10]}}
+        ]"#;
+        assert_eq!(
+            resolve_move_from_json(
+                windows.as_bytes(),
+                Some(TWO_OUTPUTS.as_bytes()),
+                1234,
+                "top-left",
+                Some([2100.0, 80.0]),
+                [1920.0, 1080.0],
+                [120.0, 120.0],
+            ),
+            Some(("2".into(), [2090, 70]))
         );
     }
 

--- a/companion/src/state.rs
+++ b/companion/src/state.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::time::Duration;
@@ -17,6 +18,14 @@ pub struct CompanionState {
     pub sessions: Vec<SessionInfo>,
     #[serde(default)]
     pub config: Option<CompanionConfigState>,
+    #[serde(default)]
+    pub window_positions: BTreeMap<String, WindowPositionState>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+pub struct WindowPositionState {
+    pub x: f32,
+    pub y: f32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -55,6 +64,28 @@ pub fn read_state(path: &std::path::Path) -> CompanionState {
         .ok()
         .and_then(|s| serde_json::from_str(&s).ok())
         .unwrap_or_default()
+}
+
+pub fn write_project_window_position(
+    path: &std::path::Path,
+    project: &str,
+    position: WindowPositionState,
+) -> std::io::Result<()> {
+    if project.trim().is_empty() || !position.x.is_finite() || !position.y.is_finite() {
+        return Ok(());
+    }
+
+    let mut state = read_state(path);
+    state.window_positions.insert(project.to_string(), position);
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let tmp = path.with_extension("json.tmp");
+    let json = serde_json::to_string(&state).map_err(std::io::Error::other)?;
+    std::fs::write(&tmp, json)?;
+    std::fs::rename(tmp, path)?;
+    Ok(())
 }
 
 /// Starts a background thread that polls the state file for changes.

--- a/companion/src/state.rs
+++ b/companion/src/state.rs
@@ -4,6 +4,8 @@ use std::path::PathBuf;
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::time::Duration;
 
+const MAX_WINDOW_POSITIONS: usize = 100;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CompanionConfigState {
     pub enabled: bool,
@@ -72,20 +74,70 @@ pub fn write_project_window_position(
     position: WindowPositionState,
 ) -> std::io::Result<()> {
     if project.trim().is_empty() || !position.x.is_finite() || !position.y.is_finite() {
-        return Ok(());
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "invalid companion window position",
+        ));
     }
 
+    let _lock = StateWriteLock::acquire(path)?;
     let mut state = read_state(path);
     state.window_positions.insert(project.to_string(), position);
+    prune_window_positions(&mut state.window_positions, project);
 
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    let tmp = path.with_extension("json.tmp");
+    let tmp = path.with_extension(format!("json.{}.tmp", std::process::id()));
     let json = serde_json::to_string(&state).map_err(std::io::Error::other)?;
     std::fs::write(&tmp, json)?;
     std::fs::rename(tmp, path)?;
     Ok(())
+}
+
+fn prune_window_positions(
+    positions: &mut BTreeMap<String, WindowPositionState>,
+    protected_project: &str,
+) {
+    while positions.len() > MAX_WINDOW_POSITIONS {
+        let Some(key) = positions
+            .keys()
+            .find(|key| key.as_str() != protected_project)
+            .cloned()
+        else {
+            break;
+        };
+        positions.remove(&key);
+    }
+}
+
+struct StateWriteLock {
+    path: PathBuf,
+}
+
+impl StateWriteLock {
+    fn acquire(state_path: &std::path::Path) -> std::io::Result<Self> {
+        let lock_path = state_path.with_extension("json.lock");
+        for _ in 0..40 {
+            match std::fs::create_dir(&lock_path) {
+                Ok(()) => return Ok(Self { path: lock_path }),
+                Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
+                    std::thread::sleep(Duration::from_millis(25));
+                }
+                Err(err) => return Err(err),
+            }
+        }
+        Err(std::io::Error::new(
+            std::io::ErrorKind::WouldBlock,
+            "timed out waiting for companion state lock",
+        ))
+    }
+}
+
+impl Drop for StateWriteLock {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir(&self.path);
+    }
 }
 
 /// Starts a background thread that polls the state file for changes.

--- a/docs/companion.md
+++ b/docs/companion.md
@@ -29,6 +29,16 @@ You can enable the companion by adding a `companion` section to your setting con
   - `medium` (120px) (default)
   - `large` (160px)
 
+### Remembered Window Position
+
+You can drag the companion window to a custom location. The companion remembers
+the last dragged position per project and restores it the next time that project
+opens. If no custom position is saved for a project, the configured
+`companion.position` corner is used.
+
+Saved positions are clamped to the current screen so the companion stays visible
+after monitor or resolution changes.
+
 ---
 
 ## Installer Flag

--- a/src/companion/manager.ts
+++ b/src/companion/manager.ts
@@ -22,6 +22,7 @@ interface CompanionSession {
 interface CompanionState {
   version: 1;
   sessions: CompanionSession[];
+  window_positions?: Record<string, { x: number; y: number }>;
   config?: {
     enabled: boolean;
     position: 'bottom-right' | 'bottom-left' | 'top-right' | 'top-left';

--- a/src/companion/manager.ts
+++ b/src/companion/manager.ts
@@ -141,6 +141,7 @@ export class CompanionManager {
   onLoad(): void {
     if (this.config?.enabled !== true) {
       try {
+        if (!existsSync(stateFilePath())) return;
         writeState((state) => {
           state.sessions = state.sessions.filter(
             (s) => s.session_id !== this.id,

--- a/src/companion/manager.ts
+++ b/src/companion/manager.ts
@@ -4,6 +4,7 @@ import {
   mkdirSync,
   readFileSync,
   renameSync,
+  rmSync,
   writeFileSync,
 } from 'node:fs';
 import * as os from 'node:os';
@@ -77,16 +78,42 @@ function readState(): CompanionState {
   return { version: 1, sessions: [] };
 }
 
-function writeState(state: CompanionState): void {
+function writeState(mutator: (state: CompanionState) => void): void {
   const file = stateFilePath();
   try {
     mkdirSync(path.dirname(file), { recursive: true });
-    const tmp = `${file}.tmp`;
-    writeFileSync(tmp, JSON.stringify(state));
-    renameSync(tmp, file);
+    const release = acquireStateLock(file);
+    try {
+      const state = readState();
+      mutator(state);
+      const tmp = `${file}.${process.pid}.${Date.now()}.tmp`;
+      writeFileSync(tmp, JSON.stringify(state));
+      renameSync(tmp, file);
+    } finally {
+      release();
+    }
   } catch (err) {
     log('[companion] write failed', String(err));
   }
+}
+
+function acquireStateLock(file: string): () => void {
+  const lock = `${file}.lock`;
+  for (let attempt = 0; attempt < 40; attempt++) {
+    try {
+      mkdirSync(lock);
+      return () => {
+        try {
+          rmSync(lock, { recursive: true, force: true });
+        } catch {}
+      };
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== 'EEXIST') throw err;
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 25);
+    }
+  }
+  throw new Error('timed out waiting for companion state lock');
 }
 
 /**
@@ -114,12 +141,11 @@ export class CompanionManager {
   onLoad(): void {
     if (this.config?.enabled !== true) {
       try {
-        const state = readState();
-        const filtered = state.sessions.filter((s) => s.session_id !== this.id);
-        if (filtered.length !== state.sessions.length) {
-          state.sessions = filtered;
-          writeState(state);
-        }
+        writeState((state) => {
+          state.sessions = state.sessions.filter(
+            (s) => s.session_id !== this.id,
+          );
+        });
       } catch {}
       return;
     }
@@ -184,9 +210,9 @@ export class CompanionManager {
 
   onExit(): void {
     if (this.config?.enabled !== true) return;
-    const state = readState();
-    state.sessions = state.sessions.filter((s) => s.session_id !== this.id);
-    writeState(state);
+    writeState((state) => {
+      state.sessions = state.sessions.filter((s) => s.session_id !== this.id);
+    });
   }
 
   /** One entry per running agent instance (two fixers → two cells). */
@@ -201,7 +227,6 @@ export class CompanionManager {
   private flush(): void {
     if (this.config?.enabled !== true) return;
     try {
-      const state = readState();
       const entry: CompanionSession = {
         session_id: this.id,
         cwd: this.cwd,
@@ -209,20 +234,21 @@ export class CompanionManager {
         status: this.status,
         pid: process.pid,
       };
-      const idx = state.sessions.findIndex((s) => s.session_id === this.id);
-      if (idx >= 0) {
-        state.sessions[idx] = entry;
-      } else {
-        state.sessions.push(entry);
-      }
-      if (this.config) {
-        state.config = {
-          enabled: this.config.enabled ?? false,
-          position: this.config.position ?? 'bottom-right',
-          size: this.config.size ?? 'medium',
-        };
-      }
-      writeState(state);
+      writeState((state) => {
+        const idx = state.sessions.findIndex((s) => s.session_id === this.id);
+        if (idx >= 0) {
+          state.sessions[idx] = entry;
+        } else {
+          state.sessions.push(entry);
+        }
+        if (this.config) {
+          state.config = {
+            enabled: this.config.enabled ?? false,
+            position: this.config.position ?? 'bottom-right',
+            size: this.config.size ?? 'medium',
+          };
+        }
+      });
     } catch (err) {
       log('[companion] flush failed', String(err));
     }


### PR DESCRIPTION
Persist companion window position and size in state.

- Restore position on startup and update niri geometry handling.
- Update companion manager flow and docs to reflect position persistence.

## Validation
- `cargo fmt`
- `cargo test`
- `cargo build`
- `bun run check:ci`
- `bun run typecheck`
