### PR TITLE
tune: prefer background agent launches

### DIFF
--- a/src/agents/orchestrator.ts
+++ b/src/agents/orchestrator.ts
@@ -194,7 +194,7 @@ Balance: respect dependencies, avoid parallelizing what must be sequential, and 
 
 ### Background Task Discipline
 - Prefer \`task(..., background: true)\` for delegated work that can run independently.
-- Always prefer background specialist launches; use blocking foreground runs only when the very next step cannot proceed without that result.
+- Launch specialist agents in the background by default so the orchestrator stays unblocked and can reconcile results when they return.
 - Track each task's specialist, objective, task/session ID, and file/topic ownership.
 - Continue orchestration only on non-overlapping work; otherwise briefly report what was launched and stop.
 - Before local edits or another writer task, compare against running task scopes.

--- a/src/agents/orchestrator.ts
+++ b/src/agents/orchestrator.ts
@@ -194,6 +194,7 @@ Balance: respect dependencies, avoid parallelizing what must be sequential, and 
 
 ### Background Task Discipline
 - Prefer \`task(..., background: true)\` for delegated work that can run independently.
+- Always prefer background specialist launches; use blocking foreground runs only when the very next step cannot proceed without that result.
 - Track each task's specialist, objective, task/session ID, and file/topic ownership.
 - Continue orchestration only on non-overlapping work; otherwise briefly report what was launched and stop.
 - Before local edits or another writer task, compare against running task scopes.


### PR DESCRIPTION
## Summary
- Add a concise orchestrator prompt rule to prefer background specialist launches
- Reserve blocking foreground specialist runs for cases where the next step cannot proceed without the result

## Verification
- bun run check:ci
- bun run typecheck