### PR TITLE
fix: kill companion process on exit to prevent zombie accumulation

### DIFF
--- a/src/companion/manager.ts
+++ b/src/companion/manager.ts
@@ -1,4 +1,4 @@
-import { spawn } from 'node:child_process';
+import { spawn, type ChildProcess } from 'node:child_process';
 import {
   existsSync,
   mkdirSync,
@@ -143,6 +143,7 @@ export class CompanionManager {
   /** sessionId → agent name, for sessions currently busy. */
   private readonly busyAgentSessions = new Map<string, string>();
   private readonly config?: CompanionConfig;
+  private companionProcess: ChildProcess | null = null;
 
   constructor(sessionId: string, cwd: string, config?: CompanionConfig) {
     this.id = sessionId;
@@ -223,6 +224,12 @@ export class CompanionManager {
 
   onExit(): void {
     if (this.config?.enabled !== true) return;
+    if (this.companionProcess) {
+      try {
+        this.companionProcess.kill();
+      } catch {}
+      this.companionProcess = null;
+    }
     writeState((state) => {
       state.sessions = state.sessions.filter((s) => s.session_id !== this.id);
     });
@@ -304,6 +311,7 @@ export class CompanionManager {
         },
         stdio: 'ignore',
       });
+      this.companionProcess = child;
       child.unref();
       log(
         '[companion] spawned',


### PR DESCRIPTION
## Summary

`CompanionManager` now tracks the spawned companion child process and kills it in `onExit()`. Previously, each opencode TUI reload/restart left a detached companion process running, accumulating CPU/RAM over time and eventually saturating the worker pool.

Fixes #563

## Changes

- Added `companionProcess: ChildProcess | null` field to `CompanionManager`
- Save spawn reference in `spawnIfAvailable()`: `this.companionProcess = child`
- Kill child in `onExit()`: `this.companionProcess.kill()` before cleaning state

## Root cause

`spawn(bin, [], { detached: true })` creates a child process that survives parent exit. `onExit()` only removed the session from `companion-state.json` but never killed the child. Each TUI reload created a new zombie companion.

## Evidence

Before fix (30 min session):
- 4+ companion instances, ~76% CPU, ~2GB RAM
- "Failed to send prompt" / "Worker has been terminated"

After fix: companion is killed on opencode exit — no accumulation.
