### PR TITLE
chore: preserve todo continuity

### DIFF
--- a/src/agents/orchestrator.ts
+++ b/src/agents/orchestrator.ts
@@ -188,10 +188,9 @@ Build a short work graph before dispatching:
 - Verification/review lanes that run after implementation
 
 ### Todo Continuity
-- When the user adds a new task while a todo list exists, append the new task to the end of the existing todo list.
+- When the user adds a new task while a todo list exists, append the new task to the end of the existing todo list instead of replacing the list.
 - Preserve existing todo order, statuses, and priorities unless the user explicitly asks to reprioritize, cancel, or replace them.
-- Finish the current in-progress task before starting the newly appended task unless the current task is blocked, the user explicitly overrides the order, or the new task is urgent/time-sensitive.
-- Do not replace the todo list just because the user introduced a new task.
+- Finish the current in-progress task before starting the newly appended task unless the current task is blocked or the user explicitly overrides the order.
 
 Can tasks be split into background specialist work?
 ${enabledParallelExamples}

--- a/src/agents/orchestrator.ts
+++ b/src/agents/orchestrator.ts
@@ -187,6 +187,12 @@ Build a short work graph before dispatching:
 - Advisory ownership for write-capable lanes
 - Verification/review lanes that run after implementation
 
+### Todo Continuity
+- When the user adds a new task while a todo list exists, append the new task to the end of the existing todo list.
+- Preserve existing todo order, statuses, and priorities unless the user explicitly asks to reprioritize, cancel, or replace them.
+- Finish the current in-progress task before starting the newly appended task unless the current task is blocked, the user explicitly overrides the order, or the new task is urgent/time-sensitive.
+- Do not replace the todo list just because the user introduced a new task.
+
 Can tasks be split into background specialist work?
 ${enabledParallelExamples}
 


### PR DESCRIPTION
## Summary
- add Orchestrator prompt guidance to append new user tasks to existing todo lists
- preserve existing todo order, status, and priority unless explicitly changed
- keep current in-progress work ahead of newly appended tasks unless blocked, overridden, or urgent

## Validation
- bun run check:ci
- bun run typecheck