### PR TITLE
fix: sync TUI agent variant from message updates

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -401,6 +401,36 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
 
   companionManager.onLoad();
 
+  function resolveTuiVariantForModel(
+    agentName: string,
+    model: string,
+  ): string | undefined {
+    const configEntry = config.agents?.[agentName];
+    const defaultVariant =
+      typeof configEntry?.variant === 'string'
+        ? configEntry.variant
+        : undefined;
+    const chainMatches = modelArrayMap[agentName]?.filter(
+      (entry) => entry.id === model,
+    );
+    if (chainMatches?.length === 1) {
+      return chainMatches[0].variant ?? defaultVariant;
+    }
+    if (chainMatches && chainMatches.length > 1) {
+      return undefined;
+    }
+
+    if (
+      typeof configEntry?.model === 'string' &&
+      configEntry.model === model &&
+      defaultVariant
+    ) {
+      return defaultVariant;
+    }
+
+    return undefined;
+  }
+
   return {
     name: 'oh-my-opencode-slim',
 
@@ -714,6 +744,10 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
             agent?: string;
             providerID?: string;
             modelID?: string;
+            model?: {
+              providerID?: string;
+              modelID?: string;
+            };
             sessionID?: string;
           };
           sessionID?: string;
@@ -725,14 +759,26 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
 
       if (event.type === 'message.updated') {
         const info = event.properties?.info;
-        if (
-          typeof info?.agent === 'string' &&
-          typeof info.providerID === 'string' &&
-          typeof info.modelID === 'string'
-        ) {
+        const providerID =
+          typeof info?.providerID === 'string'
+            ? info.providerID
+            : typeof info?.model?.providerID === 'string'
+              ? info.model.providerID
+              : undefined;
+        const modelID =
+          typeof info?.modelID === 'string'
+            ? info.modelID
+            : typeof info?.model?.modelID === 'string'
+              ? info.model.modelID
+              : undefined;
+        if (typeof info?.agent === 'string' && providerID && modelID) {
+          const agentName = resolveRuntimeAgentName(config, info.agent);
+          const model = `${providerID}/${modelID}`;
+          const variant = resolveTuiVariantForModel(agentName, model);
           recordTuiAgentModel({
-            agentName: resolveRuntimeAgentName(config, info.agent),
-            model: `${info.providerID}/${info.modelID}`,
+            agentName,
+            model,
+            variant: variant ?? null,
           });
         }
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -413,10 +413,10 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
     const chainMatches = modelArrayMap[agentName]?.filter(
       (entry) => entry.id === model,
     );
-    if (chainMatches?.length === 1) {
-      return chainMatches[0].variant ?? defaultVariant;
-    }
-    if (chainMatches && chainMatches.length > 1) {
+    if (chainMatches) {
+      if (chainMatches.length === 1) {
+        return chainMatches[0].variant ?? defaultVariant;
+      }
       return undefined;
     }
 

--- a/src/tui-state.ts
+++ b/src/tui-state.ts
@@ -90,12 +90,16 @@ export function recordTuiAgentModels(input: {
 export function recordTuiAgentModel(input: {
   agentName: string;
   model: string;
-  variant?: string;
+  variant?: string | null;
 }): void {
   updateSnapshot((snapshot) => {
     snapshot.agentModels[input.agentName] = input.model;
     if (input.variant !== undefined) {
-      snapshot.agentVariants[input.agentName] = input.variant;
+      if (input.variant === null) {
+        delete snapshot.agentVariants[input.agentName];
+      } else {
+        snapshot.agentVariants[input.agentName] = input.variant;
+      }
     }
   });
 }

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -94,7 +94,7 @@ function agentRow(
   label: string,
   model: string,
   variant: string | undefined,
-  theme: { textMuted: unknown; text: unknown },
+  theme: { textMuted: unknown },
 ): JSX.Element {
   const modelParts = splitSidebarModelId(model);
   const detailRows: JSX.Element[] = [];


### PR DESCRIPTION
## Summary

- Read runtime model details from the nested `message.updated` payload shape (`info.model.providerID` / `info.model.modelID`) while keeping compatibility with the older flat shape.
- Sync the TUI sidebar model and variant state after message updates.
- Clear stale variants when the runtime model cannot be matched unambiguously.

## Notes

- The TUI sidebar may not visually refresh immediately after the state file changes; it can require a layout refresh such as resizing the terminal. This appears to be a separate TUI reactivity issue.
- The real `message.updated` payload observed at runtime stores model details under `info.model`, not directly under `info.providerID` / `info.modelID`.

## Tests

- `bun test src/tui-state.test.ts src/tui.test.ts src/tools/preset-manager.test.ts`
- `bun run typecheck`
- `bun run build`