### PR TITLE
Defer todo auto-continue while background agents are active (#587)

### DIFF
--- a/docs/background-orchestration.md
+++ b/docs/background-orchestration.md
@@ -313,6 +313,28 @@ multiplexer panes attached while the parent orchestrator continues scheduling.
 
 ---
 
+## Auto-Continue Deferral
+
+OpenCode's built-in todo auto-continue wakes the orchestrator session as soon
+as it becomes idle with incomplete todos, by injecting a synthetic user
+message into the prompt pipeline.
+
+The `todo-continuation` hook (issue #587) defers that wake-up when the
+orchestrator is idle only because it is waiting for background work. On
+`session.idle`, the hook consults
+`BackgroundJobBoard.hasActiveBackgroundTasks(parentSessionID)`. If at least
+one job under the parent is in a non-terminal state (still `running`, or
+terminal but `terminalUnreconciled`), the session is marked deferred. The
+next synthetic wake-up targeting that session is then removed from the
+outbound message array before the request reaches the LLM, so the
+orchestrator is not woken unnecessarily. The deferral is cleared on
+`session.status` `busy`, on `session.deleted`, and immediately after the
+synthetic wake-up is removed; the next idle cycle re-evaluates the board.
+Auto-continue itself remains enabled — only the specific wake-up is
+skipped.
+
+---
+
 ## Startup Behavior
 
 The installer and docs configure background subagents as a requirement for the

--- a/src/hooks/codemap.md
+++ b/src/hooks/codemap.md
@@ -50,12 +50,12 @@ and managers for all hook-based runtime behaviors used by
 |---|---|---|
 | `tool.execute.before` | Pre-process tool inputs | `apply-patch`, `task-session-manager` |
 | `tool.execute.after` | Post-process tool outputs | `delegate-task-retry`, `json-error-recovery`, `post-file-tool-nudge`, `task-session-manager` |
-| `experimental.chat.messages.transform` | Rewrite outbound user content | `filter-available-skills`, `phase-reminder` |
+| `experimental.chat.messages.transform` | Rewrite outbound user content | `filter-available-skills`, `phase-reminder`, `todo-continuation` |
 | `experimental.chat.system.transform` | Inject system-level directives | `post-file-tool-nudge`, `task-session-manager` |
 | `chat.headers` | Mutate request headers | `chat-headers` |
 | `chat.message` | Track runtime session/agent mapping | `src/index.ts` session map |
 | `command.execute.before` | Handle slash-command UX | `interview`, `preset-manager`, `deepwork` |
-| `event` | React to session lifecycle and runtime failures | `foreground-fallback`, `post-file-tool-nudge`, `auto-update-checker`, multiplexer managers, `task-session-manager` |
+| `event` | React to session lifecycle and runtime failures | `foreground-fallback`, `post-file-tool-nudge`, `auto-update-checker`, multiplexer managers, `task-session-manager`, `todo-continuation` |
 
 ## Implementation Notes
 

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -15,3 +15,4 @@ export { createPhaseReminderHook } from './phase-reminder';
 export { createPostFileToolNudgeHook } from './post-file-tool-nudge';
 export { createReflectCommandHook } from './reflect';
 export { createTaskSessionManagerHook } from './task-session-manager';
+export { createTodoContinuationHook } from './todo-continuation';

--- a/src/hooks/todo-continuation/codemap.md
+++ b/src/hooks/todo-continuation/codemap.md
@@ -1,0 +1,71 @@
+# src/hooks/todo-continuation/
+
+## Responsibility
+
+- Defer OpenCode's built-in todo auto-continue wake-up while a
+  parent/orchestrator session still has non-terminal background tasks
+  (issue #587). The completion of the background job will wake the
+  orchestrator naturally with its result; an auto-continue injected
+  before then can cause duplicate work, race conditions, or the
+  orchestrator advancing past the result it was actually waiting for.
+
+## Design
+
+- Reuses the existing `BackgroundJobBoard` as the single source of
+  truth for background-task state (it already groups jobs by
+  `parentSessionID`).
+- Adds a `hasActiveBackgroundTasks(parentSessionID)` predicate on the
+  board that returns `true` if any job under the parent is in a
+  non-terminal state — either `running`, or terminal but
+  `terminalUnreconciled` (i.e. the orchestrator has not yet consumed
+  the result in a prior turn). Reconciled jobs are not considered
+  active; they have already been incorporated by the orchestrator.
+- Maintains a small in-memory `deferredSessions: Set<string>` of parent
+  sessions that should have their next auto-continue wake-up
+  suppressed. The set is populated by `session.idle` (and the
+  `session.status` with `type === 'idle'` variant) and cleared by
+  `session.status` with `type === 'busy'` (the session has woken up on
+  its own) or by `session.deleted`.
+- The `experimental.chat.messages.transform` hook inspects the last
+  user message in the outbound stream for a deferred session. If the
+  message is synthetic (`TextPart.synthetic === true` — the flag
+  OpenCode sets for auto-continue wake-ups), the message is removed
+  from the array before the request reaches the LLM. Real user
+  messages and internal notifications (those carrying
+  `SLIM_INTERNAL_INITIATOR_MARKER`) are always preserved.
+- The hook is read-only with respect to background jobs. It never
+  launches, mutates, reconciles, or cancels tasks. The
+  `task-session-manager` hook keeps the `BackgroundJobBoard` in sync.
+
+## Flow
+
+1. `task-session-manager` updates `BackgroundJobBoard` as background
+   tasks are launched, finish, and are reconciled.
+2. The orchestrator session goes idle (`session.idle` event). The
+   `todo-continuation` hook checks
+   `backgroundJobBoard.hasActiveBackgroundTasks(parentSessionID)` and,
+   if true, marks the session as deferred.
+3. OpenCode's auto-continue wakes the orchestrator by injecting a
+   synthetic user message into the next prompt. The synthetic message
+   is the last user message in the stream.
+4. `experimental.chat.messages.transform` runs. The hook sees the
+   synthetic wake-up, the session is deferred, and the synthetic
+   message is spliced out of the outbound list.
+5. The deferral is cleared (a) immediately after the synthetic message
+   is removed, (b) when the session becomes busy, or (c) on
+   `session.deleted`. The next idle cycle re-evaluates the
+   `BackgroundJobBoard`.
+
+## Integration
+
+- Registered in `src/index.ts` as `todoContinuationHook`.
+- The hook runs **before** `taskSessionManagerHook` in the message
+  transform pipeline so the synthetic wake-up is removed before any
+  other transformation. Running it earlier (rather than later) means
+  downstream hooks never see the message at all and cannot mutate or
+  leak it.
+- Wired into both `event` and `experimental.chat.messages.transform`
+  hook surfaces; no `tool.execute.*` integration.
+- The hook is gated by the same `shouldManageSession` predicate used
+  by `task-session-manager`, so it only acts on orchestrator
+  sessions.

--- a/src/hooks/todo-continuation/index.test.ts
+++ b/src/hooks/todo-continuation/index.test.ts
@@ -1,0 +1,425 @@
+import { describe, expect, test } from 'bun:test';
+import { BackgroundJobBoard } from '../../utils/background-job-board';
+import { createTodoContinuationHook } from './index';
+
+function makeBoard(): BackgroundJobBoard {
+  return new BackgroundJobBoard();
+}
+
+function makeOutput(messages: unknown[]): {
+  messages: {
+    info: { role: string; agent?: string; sessionID?: string };
+    parts: Array<{ type: string; text?: string; synthetic?: boolean }>;
+  }[];
+} {
+  return { messages: messages as never };
+}
+
+describe('createTodoContinuationHook (issue #587)', () => {
+  test('does nothing when the session has no background jobs and no idle event', async () => {
+    const board = makeBoard();
+    const hook = createTodoContinuationHook({
+      backgroundJobBoard: board,
+      shouldManageSession: () => true,
+    });
+
+    const output = makeOutput([
+      {
+        info: { role: 'user', agent: 'orchestrator', sessionID: 'parent-1' },
+        parts: [{ type: 'text', text: 'continue with the next step' }],
+      },
+    ]);
+
+    await hook['experimental.chat.messages.transform']({}, output);
+
+    expect(output.messages).toHaveLength(1);
+  });
+
+  test('does not suppress non-synthetic user messages on a deferred session', async () => {
+    const board = makeBoard();
+    board.registerLaunch({
+      taskID: 'ses_1',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+    });
+
+    const hook = createTodoContinuationHook({
+      backgroundJobBoard: board,
+      shouldManageSession: () => true,
+    });
+
+    // Simulate the orchestrator going idle while a background task is
+    // still running.
+    await hook.event({
+      event: { type: 'session.idle', properties: { sessionID: 'parent-1' } },
+    });
+
+    const output = makeOutput([
+      {
+        info: { role: 'user', agent: 'orchestrator', sessionID: 'parent-1' },
+        parts: [{ type: 'text', text: 'I typed something new' }],
+      },
+    ]);
+
+    await hook['experimental.chat.messages.transform']({}, output);
+
+    // Real user messages are never suppressed.
+    expect(output.messages).toHaveLength(1);
+    expect(output.messages[0].parts[0].text).toBe('I typed something new');
+  });
+
+  test('suppresses the synthetic auto-continue wake-up when background tasks are active', async () => {
+    const board = makeBoard();
+    board.registerLaunch({
+      taskID: 'ses_1',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+    });
+
+    const hook = createTodoContinuationHook({
+      backgroundJobBoard: board,
+      shouldManageSession: () => true,
+    });
+
+    // Simulate session.idle for the parent while a background task
+    // is still running.
+    await hook.event({
+      event: { type: 'session.idle', properties: { sessionID: 'parent-1' } },
+    });
+
+    const output = makeOutput([
+      {
+        info: { role: 'assistant', agent: 'orchestrator' },
+        parts: [{ type: 'text', text: 'partial response' }],
+      },
+      {
+        info: { role: 'user', agent: 'orchestrator', sessionID: 'parent-1' },
+        parts: [
+          {
+            type: 'text',
+            text: 'Continue with the next step.',
+            synthetic: true,
+          },
+        ],
+      },
+    ]);
+
+    await hook['experimental.chat.messages.transform']({}, output);
+
+    // The synthetic wake-up must be removed.
+    expect(output.messages).toHaveLength(1);
+    expect(output.messages[0].info.role).toBe('assistant');
+  });
+
+  test('does not defer when the parent has no active background tasks', async () => {
+    const board = makeBoard();
+    // No background tasks registered.
+
+    const hook = createTodoContinuationHook({
+      backgroundJobBoard: board,
+      shouldManageSession: () => true,
+    });
+
+    await hook.event({
+      event: { type: 'session.idle', properties: { sessionID: 'parent-1' } },
+    });
+
+    const output = makeOutput([
+      {
+        info: { role: 'user', agent: 'orchestrator', sessionID: 'parent-1' },
+        parts: [
+          {
+            type: 'text',
+            text: 'Continue with the next step.',
+            synthetic: true,
+          },
+        ],
+      },
+    ]);
+
+    await hook['experimental.chat.messages.transform']({}, output);
+
+    // Without active background tasks, the auto-continue prompt is
+    // allowed through.
+    expect(output.messages).toHaveLength(1);
+  });
+
+  test('clears deferral when the session becomes busy', async () => {
+    const board = makeBoard();
+    board.registerLaunch({
+      taskID: 'ses_1',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+    });
+
+    const hook = createTodoContinuationHook({
+      backgroundJobBoard: board,
+      shouldManageSession: () => true,
+    });
+
+    await hook.event({
+      event: { type: 'session.idle', properties: { sessionID: 'parent-1' } },
+    });
+
+    // The session woke up on its own (e.g. user typed something).
+    await hook.event({
+      event: {
+        type: 'session.status',
+        properties: { sessionID: 'parent-1', status: { type: 'busy' } },
+      },
+    });
+
+    const output = makeOutput([
+      {
+        info: { role: 'user', agent: 'orchestrator', sessionID: 'parent-1' },
+        parts: [
+          {
+            type: 'text',
+            text: 'Continue with the next step.',
+            synthetic: true,
+          },
+        ],
+      },
+    ]);
+
+    await hook['experimental.chat.messages.transform']({}, output);
+
+    // The deferral was cleared on busy, so the synthetic prompt is
+    // allowed through.
+    expect(output.messages).toHaveLength(1);
+  });
+
+  test('clears deferral on session.deleted', async () => {
+    const board = makeBoard();
+    board.registerLaunch({
+      taskID: 'ses_1',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+    });
+
+    const hook = createTodoContinuationHook({
+      backgroundJobBoard: board,
+      shouldManageSession: () => true,
+    });
+
+    await hook.event({
+      event: { type: 'session.idle', properties: { sessionID: 'parent-1' } },
+    });
+    await hook.event({
+      event: {
+        type: 'session.deleted',
+        properties: { info: { id: 'parent-1' } },
+      },
+    });
+
+    // A new session with the same id should not be deferred.
+    const output = makeOutput([
+      {
+        info: { role: 'user', agent: 'orchestrator', sessionID: 'parent-1' },
+        parts: [
+          {
+            type: 'text',
+            text: 'Continue with the next step.',
+            synthetic: true,
+          },
+        ],
+      },
+    ]);
+
+    await hook['experimental.chat.messages.transform']({}, output);
+    expect(output.messages).toHaveLength(1);
+  });
+
+  test('skips non-managed sessions entirely', async () => {
+    const board = makeBoard();
+    board.registerLaunch({
+      taskID: 'ses_1',
+      parentSessionID: 'subagent-1',
+      agent: 'explorer',
+    });
+
+    const hook = createTodoContinuationHook({
+      backgroundJobBoard: board,
+      shouldManageSession: (sessionID) => sessionID === 'parent-1',
+    });
+
+    // subagent-1 going idle must not mark it as deferred because it
+    // is not the orchestrator.
+    await hook.event({
+      event: { type: 'session.idle', properties: { sessionID: 'subagent-1' } },
+    });
+
+    const output = makeOutput([
+      {
+        info: { role: 'user', agent: 'explorer', sessionID: 'subagent-1' },
+        parts: [
+          {
+            type: 'text',
+            text: 'Continue with the next step.',
+            synthetic: true,
+          },
+        ],
+      },
+    ]);
+
+    await hook['experimental.chat.messages.transform']({}, output);
+    expect(output.messages).toHaveLength(1);
+  });
+
+  test('ignores synthetic text parts that carry the internal initiator marker', async () => {
+    const board = makeBoard();
+    board.registerLaunch({
+      taskID: 'ses_1',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+    });
+
+    const hook = createTodoContinuationHook({
+      backgroundJobBoard: board,
+      shouldManageSession: () => true,
+    });
+
+    await hook.event({
+      event: { type: 'session.idle', properties: { sessionID: 'parent-1' } },
+    });
+
+    const output = makeOutput([
+      {
+        info: { role: 'user', agent: 'orchestrator', sessionID: 'parent-1' },
+        parts: [
+          {
+            type: 'text',
+            text: `Background task completion <!-- SLIM_INTERNAL_INITIATOR -->`,
+            synthetic: true,
+          },
+        ],
+      },
+    ]);
+
+    await hook['experimental.chat.messages.transform']({}, output);
+
+    // Internal notifications are not auto-continue prompts; preserve
+    // them so the rest of the pipeline can process them.
+    expect(output.messages).toHaveLength(1);
+  });
+
+  test('handles session.status idle variant (not just session.idle event)', async () => {
+    const board = makeBoard();
+    board.registerLaunch({
+      taskID: 'ses_1',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+    });
+
+    const hook = createTodoContinuationHook({
+      backgroundJobBoard: board,
+      shouldManageSession: () => true,
+    });
+
+    await hook.event({
+      event: {
+        type: 'session.status',
+        properties: { sessionID: 'parent-1', status: { type: 'idle' } },
+      },
+    });
+
+    const output = makeOutput([
+      {
+        info: { role: 'user', agent: 'orchestrator', sessionID: 'parent-1' },
+        parts: [
+          {
+            type: 'text',
+            text: 'Continue with the next step.',
+            synthetic: true,
+          },
+        ],
+      },
+    ]);
+
+    await hook['experimental.chat.messages.transform']({}, output);
+    expect(output.messages).toHaveLength(0);
+  });
+
+  test('clears deferral when a background task becomes reconciled between idle cycles', async () => {
+    const board = makeBoard();
+    board.registerLaunch({
+      taskID: 'ses_1',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+    });
+
+    const hook = createTodoContinuationHook({
+      backgroundJobBoard: board,
+      shouldManageSession: () => true,
+    });
+
+    await hook.event({
+      event: { type: 'session.idle', properties: { sessionID: 'parent-1' } },
+    });
+
+    // Background task completes and the parent consumes the result.
+    board.updateStatus({ taskID: 'ses_1', state: 'completed' });
+    board.markReconciled('ses_1');
+
+    // Next idle cycle should clear the deferral.
+    await hook.event({
+      event: { type: 'session.idle', properties: { sessionID: 'parent-1' } },
+    });
+
+    const output = makeOutput([
+      {
+        info: { role: 'user', agent: 'orchestrator', sessionID: 'parent-1' },
+        parts: [
+          {
+            type: 'text',
+            text: 'Continue with the next step.',
+            synthetic: true,
+          },
+        ],
+      },
+    ]);
+
+    await hook['experimental.chat.messages.transform']({}, output);
+    expect(output.messages).toHaveLength(1);
+  });
+
+  test('handles empty messages array', async () => {
+    const board = makeBoard();
+    const hook = createTodoContinuationHook({
+      backgroundJobBoard: board,
+      shouldManageSession: () => true,
+    });
+
+    const output = makeOutput([]);
+    await hook['experimental.chat.messages.transform']({}, output);
+    expect(output.messages).toEqual([]);
+  });
+
+  test('handles messages with no user role', async () => {
+    const board = makeBoard();
+    board.registerLaunch({
+      taskID: 'ses_1',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+    });
+
+    const hook = createTodoContinuationHook({
+      backgroundJobBoard: board,
+      shouldManageSession: () => true,
+    });
+
+    await hook.event({
+      event: { type: 'session.idle', properties: { sessionID: 'parent-1' } },
+    });
+
+    const output = makeOutput([
+      {
+        info: { role: 'assistant', agent: 'orchestrator' },
+        parts: [{ type: 'text', text: 'partial' }],
+      },
+    ]);
+
+    await hook['experimental.chat.messages.transform']({}, output);
+    expect(output.messages).toHaveLength(1);
+  });
+});

--- a/src/hooks/todo-continuation/index.ts
+++ b/src/hooks/todo-continuation/index.ts
@@ -1,0 +1,185 @@
+/**
+ * Todo auto-continuation hook with background-task deferral.
+ *
+ * OpenCode's built-in todo auto-continue wakes the orchestrator session
+ * when it goes idle with incomplete todos. The wake-up is delivered as
+ * a synthetic user message injected into the prompt pipeline.
+ *
+ * If the orchestrator is idle only because it is waiting for one or more
+ * background agents, the auto-continue should be deferred. The completion
+ * of the background job will wake the orchestrator naturally with the
+ * result, and continuing before then can cause duplicate work, race
+ * conditions, or the orchestrator advancing past the result it was
+ * actually waiting for.
+ *
+ * This hook:
+ * - exposes a `hasActiveBackgroundTasks` predicate on the shared
+ *   `BackgroundJobBoard` (see `../../utils/background-job-board.ts`);
+ * - on `session.idle` (or `session.status` with type `idle`) for a
+ *   managed (orchestrator) parent session, asks the board whether any
+ *   background job is still non-terminal. If yes, records the session
+ *   as "deferred" so any incoming synthetic auto-continue message will
+ *   be suppressed on its way to the LLM;
+ * - on `session.status === 'busy'` (or on session deletion), clears the
+ *   deferred flag — the session has either woken up on its own or is
+ *   gone, and the next idle cycle should re-evaluate;
+ * - in `experimental.chat.messages.transform`, scans the outbound
+ *   message list for the last user message of a deferred session. If
+ *   the last user message is the synthetic auto-continue wake-up
+ *   (`TextPart.synthetic === true`), the message is removed from the
+ *   outbound list so it never reaches the model. Auto-continue remains
+ *   enabled — only this particular wake-up is skipped, exactly as
+ *   described in issue #587.
+ *
+ * The hook is read-only with respect to background jobs: it never
+ * launches, mutates, reconciles, or cancels tasks. The
+ * `BackgroundJobBoard` is the single source of truth for job state and
+ * the existing `task-session-manager` keeps it in sync.
+ */
+import { SLIM_INTERNAL_INITIATOR_MARKER } from '../../utils';
+import type { BackgroundJobBoard } from '../../utils/background-job-board';
+import type { MessageWithParts } from '../types';
+
+export interface TodoContinuationHookOptions {
+  /**
+   * Shared background job board. Used to query whether the parent
+   * session still has active (non-terminal) background tasks.
+   */
+  backgroundJobBoard: BackgroundJobBoard;
+  /**
+   * Returns true when the given session is the orchestrator (the
+   * session whose todos drive auto-continue). Subagent sessions are
+   * never managed by this hook.
+   */
+  shouldManageSession: (sessionID: string) => boolean;
+}
+
+type SessionLifecycleEvent = {
+  type: string;
+  properties?: {
+    info?: { id?: string };
+    sessionID?: string;
+    status?: { type?: string };
+  };
+};
+
+/**
+ * A part that is a text part and was authored synthetically (e.g. the
+ * todo auto-continue wake-up). Mirrors the SDK's `TextPart.synthetic`
+ * flag without importing the SDK type.
+ */
+function isSyntheticTextPart(part: {
+  type: string;
+  text?: unknown;
+  synthetic?: unknown;
+}): boolean {
+  if (part.type !== 'text') return false;
+  if (part.synthetic !== true) return false;
+  if (typeof part.text !== 'string') return false;
+  if (part.text.includes(SLIM_INTERNAL_INITIATOR_MARKER)) return false;
+  return true;
+}
+
+export function createTodoContinuationHook(
+  options: TodoContinuationHookOptions,
+) {
+  /**
+   * Sessions that went idle with active background tasks. The next
+   * synthetic auto-continue prompt targeting one of these sessions
+   * will be suppressed. Cleared on `session.status === 'busy'` (the
+   * session has woken up on its own) or on `session.deleted`.
+   */
+  const deferredSessions = new Set<string>();
+
+  function deferIfBackgroundTasksActive(sessionID: string): void {
+    if (!options.shouldManageSession(sessionID)) return;
+    if (options.backgroundJobBoard.hasActiveBackgroundTasks(sessionID)) {
+      deferredSessions.add(sessionID);
+    } else {
+      deferredSessions.delete(sessionID);
+    }
+  }
+
+  function clearDeferral(sessionID: string): void {
+    deferredSessions.delete(sessionID);
+  }
+
+  return {
+    event: async (input: { event: SessionLifecycleEvent }): Promise<void> => {
+      const event = input.event;
+
+      if (event.type === 'session.deleted') {
+        const sessionId =
+          event.properties?.info?.id ?? event.properties?.sessionID;
+        if (sessionId) clearDeferral(sessionId);
+        return;
+      }
+
+      if (event.type === 'session.idle') {
+        const sessionId =
+          event.properties?.info?.id ?? event.properties?.sessionID;
+        if (sessionId) deferIfBackgroundTasksActive(sessionId);
+        return;
+      }
+
+      if (
+        event.type === 'session.status' &&
+        event.properties?.status?.type === 'idle'
+      ) {
+        const sessionId =
+          event.properties?.info?.id ?? event.properties?.sessionID;
+        if (sessionId) deferIfBackgroundTasksActive(sessionId);
+        return;
+      }
+
+      if (
+        event.type === 'session.status' &&
+        event.properties?.status?.type === 'busy'
+      ) {
+        const sessionId =
+          event.properties?.info?.id ?? event.properties?.sessionID;
+        if (sessionId) clearDeferral(sessionId);
+      }
+    },
+
+    'experimental.chat.messages.transform': async (
+      _input: Record<string, never>,
+      output: { messages: MessageWithParts[] },
+    ): Promise<void> => {
+      if (output.messages.length === 0) return;
+
+      // Find the last user message in the outbound stream.
+      let lastUserMessageIndex = -1;
+      for (let i = output.messages.length - 1; i >= 0; i -= 1) {
+        if (output.messages[i].info.role === 'user') {
+          lastUserMessageIndex = i;
+          break;
+        }
+      }
+      if (lastUserMessageIndex === -1) return;
+
+      const lastUserMessage = output.messages[lastUserMessageIndex];
+      const sessionID = lastUserMessage.info.sessionID;
+      if (!sessionID || !options.shouldManageSession(sessionID)) return;
+      if (!deferredSessions.has(sessionID)) return;
+
+      // Only act if the last user message is the auto-continue wake-up
+      // itself — i.e. it is synthetic. If the user has typed something
+      // new, the wake-up has already done its job and the new turn
+      // belongs to the user.
+      const isSyntheticWakeUp = lastUserMessage.parts.some(isSyntheticTextPart);
+      if (!isSyntheticWakeUp) {
+        // The user (or a background task) sent a real message; the
+        // session is no longer in the auto-continue window.
+        deferredSessions.delete(sessionID);
+        return;
+      }
+
+      // Drop the synthetic wake-up so it never reaches the LLM. The
+      // hook never mutates the user's authored text or non-synthetic
+      // parts; it only removes the synthetic auto-continue turn.
+      output.messages.splice(lastUserMessageIndex, 1);
+      deferredSessions.delete(sessionID);
+    },
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import {
   createPostFileToolNudgeHook,
   createReflectCommandHook,
   createTaskSessionManagerHook,
+  createTodoContinuationHook,
   ForegroundFallbackManager,
 } from './hooks';
 import { processImageAttachments } from './hooks/image-hook';
@@ -143,6 +144,7 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
   let deepworkCommandHook: ReturnType<typeof createDeepworkCommandHook>;
   let reflectCommandHook: ReturnType<typeof createReflectCommandHook>;
   let taskSessionManagerHook: ReturnType<typeof createTaskSessionManagerHook>;
+  let todoContinuationHook: ReturnType<typeof createTodoContinuationHook>;
   let backgroundJobBoard: BackgroundJobBoard;
   let interviewManager: ReturnType<typeof createInterviewManager>;
   let presetManager: ReturnType<typeof createPresetManager>;
@@ -303,6 +305,16 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
       maxSessionsPerAgent: config.backgroundJobs?.maxSessionsPerAgent ?? 2,
       readContextMinLines: config.backgroundJobs?.readContextMinLines ?? 10,
       readContextMaxFiles: config.backgroundJobs?.readContextMaxFiles ?? 8,
+      backgroundJobBoard,
+      shouldManageSession: (sessionID) =>
+        sessionAgentMap.get(sessionID) === 'orchestrator',
+    });
+    // Defer OpenCode's built-in todo auto-continue while background
+    // agents are still active. Without this, the orchestrator can be
+    // woken unnecessarily while it is only idle because it is waiting
+    // on background results, leading to duplicate work and race
+    // conditions (issue #587).
+    todoContinuationHook = createTodoContinuationHook({
       backgroundJobBoard,
       shouldManageSession: (sessionID) =>
         sessionAgentMap.get(sessionID) === 'orchestrator',
@@ -826,6 +838,19 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
         },
       );
 
+      await todoContinuationHook.event(
+        input as {
+          event: {
+            type: string;
+            properties?: {
+              info?: { id?: string };
+              sessionID?: string;
+              status?: { type?: string };
+            };
+          };
+        },
+      );
+
       if (
         event.type === 'permission.asked' ||
         event.type === 'question.asked'
@@ -1053,6 +1078,10 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
         log,
       });
 
+      await todoContinuationHook['experimental.chat.messages.transform'](
+        input,
+        typedOutput,
+      );
       await taskSessionManagerHook['experimental.chat.messages.transform'](
         input,
         typedOutput,

--- a/src/utils/background-job-board.test.ts
+++ b/src/utils/background-job-board.test.ts
@@ -698,4 +698,97 @@ describe('BackgroundJobBoard', () => {
     const prompt = board.formatForPrompt('parent-1', 9_000);
     expect(prompt).toContain('running [resumed, 4s ago]');
   });
+
+  describe('hasActiveBackgroundTasks (issue #587)', () => {
+    test('returns false when the parent session has no jobs', () => {
+      const board = new BackgroundJobBoard();
+      expect(board.hasActiveBackgroundTasks('parent-1')).toBe(false);
+    });
+
+    test('returns true when a job is running', () => {
+      const board = new BackgroundJobBoard();
+      board.registerLaunch({
+        taskID: 'ses_1',
+        parentSessionID: 'parent-1',
+        agent: 'explorer',
+      });
+      expect(board.hasActiveBackgroundTasks('parent-1')).toBe(true);
+    });
+
+    test('returns true when a job is terminal but unreconciled', () => {
+      const board = new BackgroundJobBoard();
+      board.registerLaunch({
+        taskID: 'ses_1',
+        parentSessionID: 'parent-1',
+        agent: 'oracle',
+      });
+      board.updateStatus({
+        taskID: 'ses_1',
+        state: 'completed',
+        resultSummary: 'done',
+      });
+      // Job is terminal but the orchestrator has not consumed it yet.
+      expect(board.hasActiveBackgroundTasks('parent-1')).toBe(true);
+    });
+
+    test('returns true when a job is cancelled and unreconciled', () => {
+      const board = new BackgroundJobBoard();
+      board.registerLaunch({
+        taskID: 'ses_1',
+        parentSessionID: 'parent-1',
+        agent: 'fixer',
+      });
+      board.markCancelled('ses_1', 'obsolete');
+      expect(board.hasActiveBackgroundTasks('parent-1')).toBe(true);
+    });
+
+    test('returns false once all jobs are reconciled', () => {
+      const board = new BackgroundJobBoard();
+      board.registerLaunch({
+        taskID: 'ses_1',
+        parentSessionID: 'parent-1',
+        agent: 'oracle',
+      });
+      board.updateStatus({
+        taskID: 'ses_1',
+        state: 'completed',
+        resultSummary: 'done',
+      });
+      board.markReconciled('ses_1');
+      // Reconciled jobs are no longer "active" — they have been
+      // consumed by the orchestrator in a prior turn.
+      expect(board.hasActiveBackgroundTasks('parent-1')).toBe(false);
+    });
+
+    test('returns false when the only jobs belong to a different parent', () => {
+      const board = new BackgroundJobBoard();
+      board.registerLaunch({
+        taskID: 'ses_1',
+        parentSessionID: 'parent-1',
+        agent: 'explorer',
+      });
+      expect(board.hasActiveBackgroundTasks('parent-2')).toBe(false);
+    });
+
+    test('returns true when at least one job under the parent is still active', () => {
+      const board = new BackgroundJobBoard();
+      board.registerLaunch({
+        taskID: 'ses_1',
+        parentSessionID: 'parent-1',
+        agent: 'oracle',
+      });
+      board.registerLaunch({
+        taskID: 'ses_2',
+        parentSessionID: 'parent-1',
+        agent: 'explorer',
+      });
+      board.updateStatus({
+        taskID: 'ses_1',
+        state: 'completed',
+      });
+      board.markReconciled('ses_1');
+      // ses_2 is still running under parent-1.
+      expect(board.hasActiveBackgroundTasks('parent-1')).toBe(true);
+    });
+  });
 });

--- a/src/utils/background-job-board.ts
+++ b/src/utils/background-job-board.ts
@@ -367,6 +367,30 @@ export class BackgroundJobBoard {
     return this.list(parentSessionID).some((job) => job.terminalUnreconciled);
   }
 
+  /**
+   * True when the given parent/orchestrator session still has at least one
+   * background job that is non-terminal. Non-terminal means the job is
+   * either still running, queued, or has just become terminal but has not
+   * yet been reconciled by the parent (e.g. a background agent's result
+   * is in flight and the parent's turn will wake up naturally once the
+   * reconciliation completes).
+   *
+   * Reconciled jobs are not considered active — they have already been
+   * "consumed" by the orchestrator in a prior turn.
+   *
+   * Used by the todo-continuation hook to defer auto-continue prompts
+   * while background work is still in flight (issue #587).
+   */
+  hasActiveBackgroundTasks(parentSessionID: string): boolean {
+    const jobs = this.list(parentSessionID);
+    for (const job of jobs) {
+      if (job.state === 'reconciled') continue;
+      if (job.state === 'running') return true;
+      if (job.terminalUnreconciled) return true;
+    }
+    return false;
+  }
+
   formatForPrompt(
     parentSessionID: string,
     now = Date.now(),

--- a/src/utils/background-job-board.ts
+++ b/src/utils/background-job-board.ts
@@ -369,11 +369,11 @@ export class BackgroundJobBoard {
 
   /**
    * True when the given parent/orchestrator session still has at least one
-   * background job that is non-terminal. Non-terminal means the job is
-   * either still running, queued, or has just become terminal but has not
-   * yet been reconciled by the parent (e.g. a background agent's result
-   * is in flight and the parent's turn will wake up naturally once the
-   * reconciliation completes).
+   * background job that is non-terminal. A job is considered non-terminal
+   * when it is still `running`, or when it has just become terminal but
+   * has not yet been reconciled by the parent (e.g. a background agent's
+   * result is in flight and the parent's turn will wake up naturally once
+   * the reconciliation completes).
    *
    * Reconciled jobs are not considered active — they have already been
    * "consumed" by the orchestrator in a prior turn.


### PR DESCRIPTION
Fixes #587

## Problem

OpenCode's todo auto-continue wakes the main/orchestrator session as
soon as it becomes idle with incomplete todos. When the orchestrator
is idle only because it is waiting for one or more background agents,
the wake-up is unnecessary: the background completion will wake the
orchestrator naturally with its result, and continuing before then
causes duplicate work, race conditions, or the orchestrator advancing
past the result it was actually waiting for.

## Changes

- `BackgroundJobBoard.hasActiveBackgroundTasks(parentSessionID)`: a
  predicate that returns `true` when any job under the parent is in
  a non-terminal state — still `running`, or terminal but
  `terminalUnreconciled`. Reconciled jobs are not considered active;
  they have already been consumed by the orchestrator in a prior
  turn.

- `createTodoContinuationHook`: a new hook under
  `src/hooks/todo-continuation/` that
  - on `session.idle` (or `session.status` with `type === 'idle'`)
    for a managed parent, marks the session as 'deferred' if the
    board reports active background tasks;
  - on `session.status === 'busy'` or `session.deleted`, clears
    the deferral so the next idle cycle re-evaluates the board;
  - in `experimental.chat.messages.transform`, removes the last
    user message from the outbound stream when it is a synthetic
    wake-up (`TextPart.synthetic === true`) targeting a deferred
    session. Real user messages and internal notifications (those
    carrying the `SLIM_INTERNAL_INITIATOR_MARKER` sentinel) are
    preserved.

- `src/index.ts` wires the hook into both `event` and
  `experimental.chat.messages.transform`. It runs **before**
  `taskSessionManagerHook` in the message transform pipeline so
  the synthetic wake-up is removed before any other transformation.

## Behavior

Per the issue's proposed behavior:

- Auto-continue is not injected when at least one background job is
  non-terminal.
- Auto-continue remains enabled — only the specific wake-up is
  skipped.
- The deferral is cleared as soon as the wake-up is removed, the
  session becomes busy, or the session is deleted. The next idle
  cycle re-evaluates the `BackgroundJobBoard`.

## Tests

- 7 new tests for `BackgroundJobBoard.hasActiveBackgroundTasks`
  covering: no jobs, running job, terminal-unreconciled job,
  cancelled-unreconciled job, reconciled job, parent isolation, and
  multi-job mixed states.
- 12 new tests for `createTodoContinuationHook` covering: no-op
  when no idle, non-synthetic user message preservation, synthetic
  wake-up suppression, no-defer-when-no-active-tasks, busy-clears,
  deletion-clears, non-managed-session skip, internal-marker
  preservation, `session.status` idle variant, post-reconciliation
  re-evaluation, empty messages, and no-user-message handling.
- `bun run typecheck` passes.
- `bun run check:ci` reports no new issues from these changes
  (one pre-existing format nit in `src/config/constants.ts` is
  unrelated).
- Full `bun test`: 1211 pass, 1 pre-existing failure in
  `src/agents/index.test.ts` unrelated to this PR.

## Docs

- New `src/hooks/todo-continuation/codemap.md`.
- New "Auto-Continue Deferral" section in
  `docs/background-orchestration.md`.
- `src/hooks/codemap.md` updated to list the new hook.