### PR TITLE
feat(multiplexer): add herdr backend with full tmux config parity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,7 @@ oh-my-opencode-slim/
 │   ├── council/      # Council manager (multi-LLM session orchestration)
 │   ├── hooks/        # OpenCode lifecycle hooks
 │   ├── mcp/          # MCP server definitions
-│   ├── multiplexer/  # Tmux/Zellij pane integration for child sessions
+│   ├── multiplexer/  # Tmux/Zellij/Herdr pane integration for child sessions
 │   ├── skills/       # Skill definitions (included in package publish)
 │   ├── tools/        # Tool definitions (council, webfetch, AST-grep, etc.)
 │   └── utils/        # Shared utilities (tmux, session helpers)
@@ -250,7 +250,7 @@ OpenCode has a built-in `/review` command that automatically performs comprehens
 - The main plugin export is `src/index.ts`
 - Agent factories are in `src/agents/` — each agent has its own file + optional `.test.ts`
 - Skills are located in `src/skills/` (included in package publish)
-- Multiplexer session management is in `src/multiplexer/`
+- Multiplexer session management is in `src/multiplexer/` — backends: `tmux/`, `zellij/`, `herdr/`
 - Council manager (multi-LLM orchestration) is in `src/council/`
 - Tmux utilities are in `src/utils/tmux.ts`
 - 468 tests across 35 files — run `bun test` to verify

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Then:
 > It's **recommended** to understand how background orchestration works. The **[Orchestrator prompt](https://github.com/alvinunreal/oh-my-opencode-slim/blob/master/src/agents/orchestrator.ts#L28)** contains the scheduler rules, specialist routing logic, and thresholds for when work should be assigned to background agents. You can always delegate manually by calling a subagent via: `@agentName <task>`
 
 > [!TIP]
-> Because background agents are now the default workflow, it is **highly recommended** to enable and configure **[Multiplexer Integration](docs/multiplexer-integration.md)**. It automatically opens each agent in a dedicated Tmux or Zellij pane, so you can watch specialists work live while the Orchestrator continues coordinating the session.
+> Because background agents are now the default workflow, it is **highly recommended** to enable and configure **[Multiplexer Integration](docs/multiplexer-integration.md)**. It automatically opens each agent in a dedicated Tmux, Zellij, or Herdr pane, so you can watch specialists work live while the Orchestrator continues coordinating the session.
 
 The default generated configuration includes both `openai` and `opencode-go` presets.
 
@@ -646,7 +646,7 @@ Use this section as a map: start with installation, then jump to features, confi
 | **[Council](docs/council.md)** | Run multiple models in parallel and synthesize a single answer with `@council` |
 | **[Custom Agents](docs/configuration.md#custom-agents)** | Define your own specialists with custom prompts, models, MCP access, and Orchestrator delegation rules |
 | **[ACP Agents](docs/acp-agents.md)** | Connect external ACP-compatible agents such as Claude Code ACP or Gemini ACP as delegatable subagents |
-| **[Multiplexer Integration](docs/multiplexer-integration.md)** | Watch agents work live in Tmux or Zellij panes |
+| **[Multiplexer Integration](docs/multiplexer-integration.md)** | Watch agents work live in Tmux, Zellij, or Herdr panes |
 | **[Codemap](docs/codemap.md)** | Generate hierarchical codemaps to understand large codebases faster |
 | **[Clonedeps](docs/clonedeps.md)** | Clone selected dependency source into an ignored local workspace for inspection |
 | **[Worktrees](docs/worktrees.md)** | Use `.slim/worktrees/` lanes for isolated parallel or risky coding work |

--- a/codemap.md
+++ b/codemap.md
@@ -47,6 +47,7 @@ This codemap intentionally covers the plugin repository itself and excludes the 
 | `src/multiplexer/` | Terminal multiplexer abstraction layer with backend selection, session mirroring, polling fallback, and shutdown lifecycle orchestration. | [View Map](src/multiplexer/codemap.md) |
 | `src/multiplexer/tmux/` | tmux backend implementation for pane lifecycle and layout management. | [View Map](src/multiplexer/tmux/codemap.md) |
 | `src/multiplexer/zellij/` | zellij backend implementation for tab/pane lifecycle. | [View Map](src/multiplexer/zellij/codemap.md) |
+| `src/multiplexer/herdr/` | herdr backend implementation; JSON-RPC socket client + pane lifecycle. | [View Map](src/multiplexer/herdr/codemap.md) |
 | `src/skills/` | Bundled install-time OpenCode skills shipped as static payloads. | [View Map](src/skills/codemap.md) |
 | `src/skills/codemap/` | Repository-mapping skill package and codemap state-management script. | [View Map](src/skills/codemap/codemap.md) |
 | `src/skills/clonedeps/` | Workflow-only dependency source mirroring skill that routes discovery/ref resolution through librarian and direct orchestrator git operations. | [View Map](src/skills/clonedeps/codemap.md) |
@@ -75,7 +76,7 @@ This codemap intentionally covers the plugin repository itself and excludes the 
 3. **Delegated execution**
    - Native OpenCode background tasks are parsed from `task` output and injected completion messages and tracked in the shared background job board.
    - `src/hooks/task-session-manager/` updates job-board state, resolves short aliases, and injects background/reusable job context into the orchestrator prompt.
-   - `src/multiplexer/` optionally mirrors those sessions into tmux/zellij panes.
+   - `src/multiplexer/` optionally mirrors those sessions into tmux/zellij/herdr panes.
    - Results flow back into the parent session through notifications/output polling.
 
 4. **Install/release path**

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -125,7 +125,7 @@ Presets can also be switched at runtime without restarting using the `/preset` c
 | `acpAgents.<name>.timeoutMs` | integer | `0` | Timeout for a single ACP run in milliseconds. `0` disables the timeout so external agents can run indefinitely. Finite values can be up to `2147483647`ms (~24.8 days) |
 | `disabled_agents` | string[] | `["observer"]` | Agent names to disable globally. Set to `[]` to enable Observer; this is global, not per-preset |
 | `autoUpdate` | boolean | `true` | Automatically install plugin updates in the background; set to `false` for notification-only mode |
-| `multiplexer.type` | string | `"none"` | Multiplexer mode: `auto`, `tmux`, `zellij`, or `none` |
+| `multiplexer.type` | string | `"none"` | Multiplexer mode: `auto`, `tmux`, `zellij`, `herdr`, or `none` |
 | `multiplexer.layout` | string | `"main-vertical"` | Layout preset: `main-vertical`, `main-horizontal`, `tiled`, `even-horizontal`, `even-vertical`. Tmux applies full layouts; Zellij maps `main-vertical` to right and `main-horizontal` to down |
 | `multiplexer.main_pane_size` | number | `60` | Main pane size as percentage (20–80) for tmux main layouts; ignored by Zellij |
 | `multiplexer.zellij_pane_mode` | string | `"agent-tab"` | Zellij pane placement: `agent-tab` creates/reuses a dedicated `opencode-agents` tab; `current-tab` opens subagents as panes in the tab containing the parent OpenCode pane, falling back to the focused tab if the parent pane cannot be resolved |

--- a/docs/multiplexer-integration.md
+++ b/docs/multiplexer-integration.md
@@ -1,6 +1,6 @@
 # Multiplexer Integration Guide
 
-Use tmux or Zellij to watch subagents work in live panes while OpenCode keeps running in your main session.
+Use tmux, Zellij, or Herdr to watch subagents work in live panes while OpenCode keeps running in your main session.
 
 ## Table of Contents
 
@@ -83,7 +83,17 @@ Edit `~/.config/opencode/oh-my-opencode-slim.json` (or `.jsonc`):
 }
 ```
 
-### 2. Start OpenCode inside tmux or Zellij
+**Herdr only:**
+
+```jsonc
+{
+  "multiplexer": {
+    "type": "herdr"
+  }
+}
+```
+
+### 2. Start OpenCode inside tmux, Zellij, or Herdr
 
 **Tmux:**
 
@@ -98,6 +108,15 @@ opencode --port 4096
 zellij
 opencode --port 4096
 ```
+
+**Herdr:**
+
+```bash
+herdr
+opencode --port 4096
+```
+
+Install herdr from [herdr.dev](https://herdr.dev/). Config-compatible with tmux — same `layout` and `main_pane_size` values work. Requires herdr v0.7.0+.
 
 ### 3. Trigger delegated work
 
@@ -127,7 +146,7 @@ Please analyze this codebase and create a documentation structure.
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
-| `type` | string | `"none"` | `"auto"`, `"tmux"`, `"zellij"`, or `"none"` |
+| `type` | string | `"none"` | `"auto"`, `"tmux"`, `"zellij"`, `"herdr"`, or `"none"` |
 | `layout` | string | `"main-vertical"` | Layout preset for tmux; mapped to Zellij pane directions where possible |
 | `main_pane_size` | number | `60` | Main pane size percentage for tmux only (`20`-`80`) |
 | `zellij_pane_mode` | string | `"agent-tab"` | Zellij pane placement: `"agent-tab"` creates/reuses a dedicated tab; `"current-tab"` opens panes in the tab containing the parent OpenCode pane |

--- a/oh-my-opencode-slim.schema.json
+++ b/oh-my-opencode-slim.schema.json
@@ -221,6 +221,7 @@
             "auto",
             "tmux",
             "zellij",
+            "herdr",
             "none"
           ]
         },

--- a/src/config/codemap.md
+++ b/src/config/codemap.md
@@ -59,7 +59,7 @@ resolution, and helper APIs used by agents, council, and runtime subsystems.
   - `temperature`, `variant`, `options`, `skills`, `mcps`, `displayName`
   - custom agent prompts (`prompt`, `orchestratorPrompt`) only.
 - Multiplexer:
-  - new unified `multiplexer` schema (`auto|tmux|zellij|none`)
+  - new unified `multiplexer` schema (`auto|tmux|zellij|herdr|none`)
   - legacy `tmux` schema retained and migrated at load time.
 - Council:
   - `CouncilConfigSchema` now normalizes deprecated `master*` fields into

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -86,7 +86,13 @@ export const AgentOverrideConfigSchema = z
   .strict();
 
 // Multiplexer type options
-export const MultiplexerTypeSchema = z.enum(['auto', 'tmux', 'zellij', 'none']);
+export const MultiplexerTypeSchema = z.enum([
+  'auto',
+  'tmux',
+  'zellij',
+  'herdr',
+  'none',
+]);
 export type MultiplexerType = z.infer<typeof MultiplexerTypeSchema>;
 
 // Layout options (shared across multiplexers)

--- a/src/multiplexer/codemap.md
+++ b/src/multiplexer/codemap.md
@@ -4,7 +4,7 @@
 
 - Provide multiplexer-backed visualization for spawned subagent sessions.
 - Select and instantiate terminal backend based on config/env:
-  `auto`, `tmux`, `zellij`, or `none`.
+  `auto`, `tmux`, `zellij`, `herdr`, or `none`.
 - Manage lifecycle of child session panes with lifecycle hooks from OpenCode
   events plus health/polling fallback.
 - Keep pane cleanup safe and graceful (best-effort interrupt + kill).
@@ -42,6 +42,22 @@
   - Layout configuration maps `main-vertical` to right and `main-horizontal` to
     down; `tiled`/`even-horizontal`/`even-vertical` use Zellij native placement
     and `main_pane_size` remains a no-op.
+
+- `herdr/index.ts` (`HerdrMultiplexer`)
+  - Implements `Multiplexer` using `HerdrSocketClient` — JSON-RPC over AF_UNIX.
+    The herdr daemon closes the socket after each response, so the client opens
+    a fresh connection per call (still cheaper than per-op `crossSpawn`).
+  - Detection via `process.env.HERDR_ENV === '1'`.
+  - Pane lifecycle mirrors tmux: `pane.split` (down, cwd+label) → 400ms wait →
+    `pane.send_text` with `opencode attach ...`. Close sends Ctrl+C, waits 250ms,
+    then `pane.close` (tolerates already-closed panes).
+  - `applyLayout` rebalances via `pane.resize` (in-place). Layout-aware:
+    `spawnPane` splits `right` for side-by-side layouts (`main-vertical`,
+    `even-horizontal`) and `down` for stacked layouts (`main-horizontal`,
+    `even-vertical`, `tiled`); `applyLayout` resizes along the matching axis.
+    All 5 presets work natively (tiled approximates as even-vertical).
+    Debounced 150ms.
+  - Requires herdr v0.7.0+.
 
 - `session-manager.ts` (`MultiplexerSessionManager`)
   - Initialized once from plugin context and config.
@@ -84,8 +100,8 @@
 - Integrates with OpenCode session events and server URL from plugin input.
 - Uses helper endpoints defined by `src/config` multiplexer settings:
   `type`, `layout`, `main_pane_size`.
-- Implementations in `src/multiplexer/tmux` and `src/multiplexer/zellij` are used
-  through the shared abstraction.
+- Implementations in `src/multiplexer/tmux`, `src/multiplexer/zellij`, and
+  `src/multiplexer/herdr` are used through the shared abstraction.
 - Validation coverage:
   - `src/multiplexer/factory.test.ts`
   - `src/multiplexer/session-manager.test.ts`

--- a/src/multiplexer/factory.ts
+++ b/src/multiplexer/factory.ts
@@ -4,6 +4,7 @@
 
 import type { MultiplexerConfig, MultiplexerType } from '../config/schema';
 import { log } from '../utils/logger';
+import { HerdrMultiplexer } from './herdr';
 import { TmuxMultiplexer } from './tmux';
 import type { Multiplexer } from './types';
 import { ZellijMultiplexer } from './zellij';
@@ -39,6 +40,10 @@ export function getMultiplexer(config: MultiplexerConfig): Multiplexer | null {
       );
       actualType = 'zellij';
       break;
+    case 'herdr':
+      multiplexer = new HerdrMultiplexer(config.layout, config.main_pane_size);
+      actualType = 'herdr';
+      break;
     case 'auto': {
       // Auto-detect based on environment variables only
       // Note: Does NOT fall back to binary availability checks
@@ -52,6 +57,12 @@ export function getMultiplexer(config: MultiplexerConfig): Multiplexer | null {
           config.zellij_pane_mode,
         );
         actualType = 'zellij';
+      } else if (process.env.HERDR_ENV === '1') {
+        multiplexer = new HerdrMultiplexer(
+          config.layout,
+          config.main_pane_size,
+        );
+        actualType = 'herdr';
       } else {
         // Not inside any session, disable multiplexer
         log('[multiplexer] auto: not inside any session, disabling');
@@ -78,14 +89,17 @@ export function clearMultiplexerCache(): void {
 
 /**
  * Get the effective multiplexer type for auto mode
- * Returns the actual type that would be used (tmux/zellij/none)
+ * Returns the actual type that would be used (tmux/zellij/herdr/none)
  */
-export function getAutoMultiplexerType(): 'tmux' | 'zellij' | 'none' {
+export function getAutoMultiplexerType(): 'tmux' | 'zellij' | 'herdr' | 'none' {
   if (process.env.TMUX) {
     return 'tmux';
   }
   if (process.env.ZELLIJ) {
     return 'zellij';
+  }
+  if (process.env.HERDR_ENV === '1') {
+    return 'herdr';
   }
   return 'none';
 }

--- a/src/multiplexer/herdr/client.test.ts
+++ b/src/multiplexer/herdr/client.test.ts
@@ -1,0 +1,414 @@
+/**
+ * Tests for HerdrSocketClient and isHerdrError
+ *
+ * Mocks node:net so the client talks to a controllable fake socket.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { EventEmitter } from 'node:events';
+import type net from 'node:net';
+
+// ---------------------------------------------------------------------------
+// Fake socket — controlled by each test
+// ---------------------------------------------------------------------------
+
+let lastWrittenChunk: string | null = null;
+let currentFakeSocket: FakeSocket | null = null;
+
+/**
+ * When true (default), makeFakeSocket emits 'connect' on the next tick,
+ * simulating the real net.Socket.connect event that openSocketOnce awaits.
+ */
+let emitConnectOnCreate = true;
+
+/**
+ * The write handler the test sets up; runs inside the fake socket's write().
+ * Typically schedules an async response via setTimeout.
+ */
+let onWrite: ((data: string) => void) | null = null;
+
+class FakeSocket extends EventEmitter {
+  destroyed = false;
+  readable = true;
+
+  write = mock((data: string, _encoding?: string): boolean => {
+    lastWrittenChunk = data;
+    if (onWrite) onWrite(data);
+    return true;
+  });
+
+  setEncoding = mock((_enc: string): void => {});
+  end = mock((): void => {
+    this.destroyed = true;
+    this.readable = false;
+  });
+  destroy = mock((): void => {
+    this.destroyed = true;
+    this.readable = false;
+  });
+}
+
+function makeFakeSocket(): FakeSocket {
+  const s = new FakeSocket();
+  currentFakeSocket = s;
+  if (emitConnectOnCreate) {
+    process.nextTick(() => s.emit('connect'));
+  }
+  return s;
+}
+
+const createConnectionMock = mock((_opts: { path: string }): net.Socket => {
+  return makeFakeSocket() as unknown as net.Socket;
+});
+
+// ---------------------------------------------------------------------------
+// Mock node:net before any import of ./client
+// ---------------------------------------------------------------------------
+
+mock.module('node:net', () => ({
+  createConnection: createConnectionMock,
+}));
+
+// ---------------------------------------------------------------------------
+// Dynamic import helper (cache-busting)
+// ---------------------------------------------------------------------------
+
+let importCounter = 0;
+
+async function freshClient(socketPath?: string) {
+  const mod = await import(`./client?test=${importCounter++}`);
+  return new mod.HerdrSocketClient(socketPath);
+}
+
+async function freshModule() {
+  return import(`./client?test=${importCounter++}`);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function wait(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('HerdrSocketClient', () => {
+  beforeEach(() => {
+    lastWrittenChunk = null;
+    currentFakeSocket = null;
+    onWrite = null;
+    emitConnectOnCreate = true;
+    createConnectionMock.mockClear();
+    createConnectionMock.mockImplementation(
+      (_opts: { path: string }) => makeFakeSocket() as unknown as net.Socket,
+    );
+  });
+
+  afterEach(() => {
+    onWrite = null;
+  });
+
+  // -----------------------------------------------------------------------
+  // call() success path
+  // -----------------------------------------------------------------------
+
+  test('call() resolves with result on success', async () => {
+    onWrite = (data) => {
+      const parsed = JSON.parse(data.trim());
+      setTimeout(() => {
+        currentFakeSocket?.emit(
+          'data',
+          `${JSON.stringify({ id: parsed.id, result: { type: 'pong' } })}\n`,
+        );
+      }, 1);
+    };
+
+    const client = await freshClient();
+    const result = await client.call('ping', {});
+
+    expect(result).toEqual({ type: 'pong' });
+
+    // Assert written request is valid newline-terminated JSON
+    expect(lastWrittenChunk).not.toBeNull();
+    expect(lastWrittenChunk).toEndWith('\n');
+
+    const parsed = JSON.parse(lastWrittenChunk?.trim());
+    expect(parsed).toHaveProperty('id', 'req_1');
+    expect(parsed).toHaveProperty('method', 'ping');
+    expect(parsed).toHaveProperty('params');
+    expect(parsed.params).toEqual({});
+  });
+
+  // -----------------------------------------------------------------------
+  // call() error path
+  // -----------------------------------------------------------------------
+
+  test('call() rejects on error response', async () => {
+    onWrite = (data) => {
+      const parsed = JSON.parse(data.trim());
+      setTimeout(() => {
+        currentFakeSocket?.emit(
+          'data',
+          `${JSON.stringify({
+            id: parsed.id,
+            error: { code: 'pane_not_found', message: 'Pane not found' },
+          })}\n`,
+        );
+      }, 1);
+    };
+
+    const client = await freshClient();
+    let thrown: unknown;
+    try {
+      await client.call('pane.close', { pane_id: 'w1:p2' });
+    } catch (e) {
+      thrown = e;
+    }
+
+    expect(thrown).toBeDefined();
+    const err = thrown as Error & { code?: string };
+    expect(err.code).toBe('pane_not_found');
+  });
+
+  test('rejected error is recognized by isHerdrError', async () => {
+    const mod = await freshModule();
+
+    onWrite = (data) => {
+      const parsed = JSON.parse(data.trim());
+      setTimeout(() => {
+        currentFakeSocket?.emit(
+          'data',
+          `${JSON.stringify({
+            id: parsed.id,
+            error: { code: 'pane_not_found', message: 'Pane not found' },
+          })}\n`,
+        );
+      }, 1);
+    };
+
+    const client = await freshClient();
+    let thrown: unknown;
+    try {
+      await client.call('pane.close', { pane_id: 'w1:p2' });
+    } catch (e) {
+      thrown = e;
+    }
+
+    expect(mod.isHerdrError(thrown, 'pane_not_found')).toBe(true);
+    expect(mod.isHerdrError(thrown, 'invalid_request')).toBe(false);
+  });
+
+  // -----------------------------------------------------------------------
+  // isHerdrError discriminator (pure function, no socket needed)
+  // -----------------------------------------------------------------------
+
+  test('isHerdrError handles all branches', async () => {
+    const mod = await freshModule();
+    const isHerdr = mod.isHerdrError;
+
+    // (a) Matching code
+    const errA = Object.assign(new Error('test'), {
+      code: 'pane_not_found',
+      message: 'test',
+    });
+    expect(isHerdr(errA, 'pane_not_found')).toBe(true);
+
+    // (b) Wrong code
+    expect(isHerdr(errA, 'invalid_request')).toBe(false);
+
+    // (c) Plain Error (non-herdr, no code property)
+    const plain = new Error('plain');
+    expect(isHerdr(plain)).toBe(false);
+
+    // (d) null
+    expect(isHerdr(null)).toBe(false);
+
+    // (e) Matching shape with no code arg → true
+    expect(isHerdr(errA)).toBe(true);
+  });
+
+  // -----------------------------------------------------------------------
+  // Timeout
+  // -----------------------------------------------------------------------
+
+  test('call() rejects with timeout when no response arrives', async () => {
+    // No onWrite — socket never responds
+    const mod = await freshModule();
+
+    const client = await freshClient();
+    const start = Date.now();
+    let thrown: unknown;
+    try {
+      await client.call('ping', {}, 50);
+    } catch (e) {
+      thrown = e;
+    }
+    const elapsed = Date.now() - start;
+
+    expect(thrown).toBeDefined();
+    expect(elapsed).toBeLessThan(500); // should be ~50ms, generous bound
+    expect(mod.isHerdrError(thrown, 'timeout')).toBe(true);
+  });
+
+  // -----------------------------------------------------------------------
+  // Multiple concurrent calls
+  // -----------------------------------------------------------------------
+
+  test('handles multiple concurrent calls with out-of-order responses', async () => {
+    onWrite = (data) => {
+      const parsed = JSON.parse(data.trim());
+      setTimeout(() => {
+        const letterMap: Record<string, string> = {
+          req_1: 'A',
+          req_2: 'B',
+          req_3: 'C',
+        };
+        currentFakeSocket?.emit(
+          'data',
+          `${JSON.stringify({
+            id: parsed.id,
+            result: { letter: letterMap[parsed.id] ?? '?' },
+          })}\n`,
+        );
+      }, 2);
+    };
+
+    const client = await freshClient();
+
+    const [r1, r2, r3] = await Promise.all([
+      client.call('method.a', {}),
+      client.call('method.b', {}),
+      client.call('method.c', {}),
+    ]);
+
+    const results = [r1, r2, r3].map((r) => (r as { letter: string }).letter);
+    expect(results.sort()).toEqual(['A', 'B', 'C']);
+  });
+
+  // -----------------------------------------------------------------------
+  // Newline framing across multiple data chunks
+  // -----------------------------------------------------------------------
+
+  test('handles responses split across multiple data chunks', async () => {
+    onWrite = (data) => {
+      const parsed = JSON.parse(data.trim());
+      const fullLine = `${JSON.stringify({
+        id: parsed.id,
+        result: { type: 'pong' },
+      })}\n`;
+      const mid = Math.floor(fullLine.length / 2);
+      const chunk1 = fullLine.slice(0, mid);
+      const chunk2 = fullLine.slice(mid);
+
+      setTimeout(() => {
+        currentFakeSocket?.emit('data', chunk1);
+      }, 1);
+      setTimeout(() => {
+        currentFakeSocket?.emit('data', chunk2);
+      }, 5);
+    };
+
+    const client = await freshClient();
+    const result = await client.call('ping', {});
+    expect(result).toEqual({ type: 'pong' });
+  });
+
+  // -----------------------------------------------------------------------
+  // Reconnect after close
+  // -----------------------------------------------------------------------
+
+  test('reconnects after socket is closed', async () => {
+    // First call — creates socket
+    onWrite = (data) => {
+      const parsed = JSON.parse(data.trim());
+      setTimeout(() => {
+        currentFakeSocket?.emit(
+          'data',
+          `${JSON.stringify({ id: parsed.id, result: { type: 'pong' } })}\n`,
+        );
+      }, 1);
+    };
+
+    const client = await freshClient();
+    await client.call('ping', {});
+    expect(createConnectionMock.mock.calls.length).toBe(1);
+
+    // Simulate socket closure
+    if (currentFakeSocket) {
+      currentFakeSocket.emit('close');
+      currentFakeSocket = null;
+    }
+
+    // Second call — should create a new socket
+    await client.call('ping', {});
+    expect(createConnectionMock.mock.calls.length).toBe(2);
+  });
+
+  // -----------------------------------------------------------------------
+  // ping() returns false on connection failure
+  // -----------------------------------------------------------------------
+
+  test('ping() returns false when socket errors on connect', async () => {
+    // Suppress auto-connect: the test sends error instead of connect
+    emitConnectOnCreate = false;
+
+    // Make createConnection return a socket that emits error
+    createConnectionMock.mockImplementation(
+      (_opts: { path: string }): net.Socket => {
+        const sock = makeFakeSocket() as unknown as net.Socket;
+        setTimeout(() => {
+          (sock as unknown as FakeSocket).emit(
+            'error',
+            new Error('connection refused'),
+          );
+        }, 1);
+        return sock;
+      },
+    );
+
+    const client = await freshClient();
+    const result = await client.ping();
+    expect(result).toBe(false);
+  });
+
+  // -----------------------------------------------------------------------
+  // close() rejects pending and marks destroyed
+  // -----------------------------------------------------------------------
+
+  test('close() rejects pending calls and marks client destroyed', async () => {
+    const mod = await freshModule();
+
+    // No onWrite — call will hang
+    const client = await freshClient();
+    const pendingCall = client.call('ping', {}, 5000);
+
+    // Give the call time to send and register
+    await wait(10);
+
+    // Close the client
+    await client.close();
+
+    // The pending call should reject
+    let callErr: unknown;
+    try {
+      await pendingCall;
+    } catch (e) {
+      callErr = e;
+    }
+    expect(callErr).toBeDefined();
+
+    // Subsequent calls should throw client_closed
+    let closeErr: unknown;
+    try {
+      await client.call('ping', {});
+    } catch (e) {
+      closeErr = e;
+    }
+    expect(closeErr).toBeDefined();
+    expect(mod.isHerdrError(closeErr, 'client_closed')).toBe(true);
+  });
+});

--- a/src/multiplexer/herdr/client.ts
+++ b/src/multiplexer/herdr/client.ts
@@ -1,0 +1,337 @@
+/**
+ * JSON-RPC Unix domain socket client for the herdr daemon.
+ *
+ * Provides a persistent, reconnect-capable client for newline-delimited
+ * JSON-RPC over AF_UNIX sockets.
+ */
+
+import * as net from 'node:net';
+import { log } from '../../utils/logger';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export type HerdrPaneId = string;
+
+export interface HerdrPaneInfo {
+  pane_id: HerdrPaneId;
+  workspace_id: string;
+  tab_id: string;
+  cwd: string;
+}
+
+export interface HerdrError {
+  code: string;
+  message: string;
+}
+
+// ---------------------------------------------------------------------------
+// Error discriminator
+// ---------------------------------------------------------------------------
+
+/**
+ * Check whether `e` is a HerdrError-shaped thrown object.
+ * When `code` is supplied, additionally checks that the error code matches.
+ */
+export function isHerdrError(e: unknown, code?: string): boolean {
+  if (
+    typeof e === 'object' &&
+    e !== null &&
+    'code' in e &&
+    typeof (e as Record<string, unknown>).code === 'string'
+  ) {
+    if (code !== undefined) {
+      return (e as Record<string, unknown>).code === code;
+    }
+    return true;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+interface PendingRequest {
+  resolve: (value: unknown) => void;
+  reject: (reason: unknown) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+const DEFAULT_TIMEOUT_MS = 5_000;
+
+/**
+ * Resolve the herdr socket path using the official priority order:
+ * 1. $HERDR_SOCKET_PATH
+ * 2. $HOME/.config/herdr/sessions/<HERDR_SESSION>/herdr.sock
+ * 3. $HOME/.config/herdr/herdr.sock (default)
+ */
+function resolveSocketPath(): string {
+  const envPath = process.env.HERDR_SOCKET_PATH;
+  if (envPath) {
+    return envPath;
+  }
+
+  const home = process.env.HOME;
+  if (!home) {
+    // Fall back to default relative to cwd (shouldn't happen on normal systems)
+    return '/tmp/herdr.sock';
+  }
+
+  const herdrSession = process.env.HERDR_SESSION;
+  if (herdrSession) {
+    const sessionPath = `${home}/.config/herdr/sessions/${herdrSession}/herdr.sock`;
+    return sessionPath;
+  }
+
+  return `${home}/.config/herdr/herdr.sock`;
+}
+
+// ---------------------------------------------------------------------------
+// Client
+// ---------------------------------------------------------------------------
+
+export class HerdrSocketClient {
+  private socketPath: string;
+  private buffer = '';
+  private pending = new Map<string, PendingRequest>();
+  private requestCounter = 0;
+  private destroyed = false;
+
+  constructor(socketPath?: string) {
+    this.socketPath = socketPath ?? resolveSocketPath();
+    log('[herdr-client] resolved socket path', { path: this.socketPath });
+  }
+
+  // -----------------------------------------------------------------------
+  // Public API
+  // -----------------------------------------------------------------------
+
+  /**
+   * Perform a JSON-RPC call.  Opens / re-opens the socket lazily.
+   * Returns the `result` field on success; throws a HerdrError-shaped Error
+   * with `code` and `message` properties on error.
+   */
+  async call<T = unknown>(
+    method: string,
+    params: Record<string, unknown>,
+    timeoutMs: number = DEFAULT_TIMEOUT_MS,
+  ): Promise<T> {
+    this.ensureNotDestroyed();
+
+    const id = `req_${++this.requestCounter}`;
+
+    // This typed wrapper gives us correct return types while the raw
+    // sendRequest does the heavy lifting.
+    return this.sendRequest<T>(id, method, params, timeoutMs);
+  }
+
+  /**
+   * Ping the daemon.  Returns `true` when the daemon responds with a pong,
+   * `false` on any connection / timeout / protocol error.
+   */
+  async ping(): Promise<boolean> {
+    try {
+      await this.call('ping', {});
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Mark the client destroyed so subsequent calls reject.  Connections
+   * are per-call (herdr closes the socket after each response), so there
+   * is no persistent socket to tear down here.
+   */
+  async close(): Promise<void> {
+    this.destroyed = true;
+    this.rejectAllPending(
+      Object.assign(new Error('Client was closed'), {
+        code: 'client_closed',
+        message: 'Client was closed',
+      }),
+    );
+    this.buffer = '';
+  }
+
+  // -----------------------------------------------------------------------
+  // Internal wire helpers
+  // -----------------------------------------------------------------------
+
+  /**
+   * Low-level send + dispatch.  Kept separate from `call` so the typed
+   * wrapper can control the return type generically.
+   *
+   * Note: herdr's daemon closes the socket after each response (no
+   * keepalive), so each request opens a fresh connection.  This is still
+   * cheaper than the CLI's per-call process spawn (no fork/exec, just a
+   * Unix socket round-trip).
+   */
+  private sendRequest<T>(
+    id: string,
+    method: string,
+    params: Record<string, unknown>,
+    timeoutMs: number,
+  ): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      // Build the timeout timer
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        const err = Object.assign(new Error('Request timed out'), {
+          code: 'timeout',
+          message: `Request ${id} (${method}) timed out after ${timeoutMs}ms`,
+        });
+        reject(err);
+      }, timeoutMs);
+
+      // Register the pending request
+      this.pending.set(id, {
+        resolve: resolve as (value: unknown) => void,
+        reject,
+        timer,
+      });
+
+      // Write the request. openSocketOnce handles connect, data, errors,
+      // and cleanup for this single request.
+      const request = `${JSON.stringify({ id, method, params })}\n`;
+      log('[herdr-client] ->', { id, method });
+      this.openSocketOnce().then(
+        (socket) => {
+          socket.write(request, 'utf-8');
+        },
+        (connErr: Error & { code?: string }) => {
+          clearTimeout(timer);
+          this.pending.delete(id);
+          reject(connErr);
+        },
+      );
+    });
+  }
+
+  /**
+   * Open a fresh socket connection.  herdr closes the socket after each
+   * response, so connections are not reused across calls.
+   */
+  private openSocketOnce(): Promise<net.Socket> {
+    return new Promise<net.Socket>((resolve, reject) => {
+      const socket = net.createConnection({ path: this.socketPath });
+
+      const onError = (err: Error) => {
+        cleanup();
+        const e = Object.assign(
+          new Error(`herdr: connection error — ${err.message}`),
+          { code: 'connection_error', message: err.message },
+        );
+        this.failAllPendingWithConnectionError(err.message);
+        reject(e);
+      };
+
+      const onConnect = () => {
+        cleanup();
+        socket.setEncoding('utf-8');
+        socket.on('data', (chunk: string) => {
+          this.buffer += chunk;
+          this.processBuffer();
+        });
+        socket.on('error', (err: Error) => {
+          log('[herdr-client] socket error after connect', {
+            error: err.message,
+          });
+          this.failAllPendingWithConnectionError(err.message);
+        });
+        resolve(socket);
+      };
+
+      const cleanup = () => {
+        socket.off('error', onError);
+        socket.off('connect', onConnect);
+      };
+
+      socket.once('error', onError);
+      socket.once('connect', onConnect);
+    });
+  }
+
+  private processBuffer(): void {
+    while (true) {
+      const nlIdx = this.buffer.indexOf('\n');
+      if (nlIdx === -1) break;
+
+      const line = this.buffer.slice(0, nlIdx);
+      this.buffer = this.buffer.slice(nlIdx + 1);
+
+      if (!line.trim()) continue;
+
+      let parsed: Record<string, unknown>;
+      try {
+        parsed = JSON.parse(line);
+      } catch {
+        log('[herdr-client] failed to parse response line', { line });
+        continue;
+      }
+
+      const id = parsed.id as string | undefined;
+      if (!id) {
+        log('[herdr-client] response missing id', { parsed });
+        continue;
+      }
+
+      const pending = this.pending.get(id);
+      if (!pending) {
+        log('[herdr-client] orphaned response for id', { id });
+        continue;
+      }
+
+      clearTimeout(pending.timer);
+      this.pending.delete(id);
+
+      if (parsed.error) {
+        const errObj = parsed.error as { code: string; message: string };
+        const err = Object.assign(
+          new Error(`herdr: ${errObj.code} — ${errObj.message}`),
+          { code: errObj.code, message: errObj.message },
+        );
+        pending.reject(err);
+      } else {
+        pending.resolve(parsed.result);
+      }
+    }
+  }
+
+  private failAllPendingWithConnectionError(msg: string): void {
+    if (this.pending.size === 0) return;
+    const err = Object.assign(new Error(`herdr: connection error — ${msg}`), {
+      code: 'connection_error',
+      message: msg,
+    });
+    for (const [, pending] of this.pending) {
+      clearTimeout(pending.timer);
+      pending.reject(err);
+    }
+    this.pending.clear();
+  }
+
+  private rejectAllPending(
+    err: Error & { code: string; message: string },
+  ): void {
+    for (const [, pending] of this.pending) {
+      clearTimeout(pending.timer);
+      pending.reject(err);
+    }
+    this.pending.clear();
+  }
+
+  private ensureNotDestroyed(): void {
+    if (this.destroyed) {
+      throw Object.assign(
+        new Error('herdr: client is closed and cannot be reused'),
+        {
+          code: 'client_closed',
+          message: 'Client is closed and cannot be reused',
+        },
+      );
+    }
+  }
+}

--- a/src/multiplexer/herdr/codemap.md
+++ b/src/multiplexer/herdr/codemap.md
@@ -1,0 +1,119 @@
+# src/multiplexer/herdr/
+
+## Responsibility
+
+- Provide herdr-specific pane orchestration for attaching OpenCode child
+  sessions to a split pane beside the current pane.
+- Handle lifecycle of spawned panes (split, command injection, graceful close)
+  via herdr's JSON-RPC Unix domain socket API.
+- Resolve and cache herdr binary location for repeated operations, and verify
+  socket reachability before declaring availability.
+
+## Design
+
+- `HerdrSocketClient` in `client.ts` is a persistent, reconnect-capable
+  JSON-RPC client over AF_UNIX sockets (`node:net`), distinct from the
+  process-spawn approach used by tmux.
+- Requests use a monotonic counter (`req_1`, `req_2`, ...) for request IDs.
+  A `Map<id, {resolve, reject, timer}>` dispatches responses to callers.
+- Incoming data is buffered and split on newlines; each line is parsed as
+  JSON and dispatched by `id`.
+- Each call has a default 5-second timeout; on timeout the promise is
+  rejected with a HerdrError-shaped error (`code: "timeout"`).
+- The socket is opened lazily on the first `call()` and reused. On
+  error/close the socket reference is cleared; the next `call()` reconnects
+  transparently.
+- `isHerdrError(e, code?)` is exported for callers (notably `closePane`) to
+  discriminate error types like `pane_not_found` without parsing strings.
+
+### Socket path resolution (priority order)
+
+1. `$HERDR_SOCKET_PATH` — explicit override
+2. `${HOME}/.config/herdr/sessions/<HERDR_SESSION>/herdr.sock` — session-scoped
+3. `${HOME}/.config/herdr/herdr.sock` — default daemon socket
+
+### 400ms shell-ready delay
+
+Empirically, after `pane.split`, the new pane's shell is NOT immediately
+ready to accept input.  Text sent within the first ~400ms is silently lost
+(confirmed via probe: `send_text` immediately after `split` produced empty
+reads; `send_text` after 400ms+ delay executed correctly).  `spawnPane`
+waits 400ms before injecting the `opencode attach` command.
+
+### Layout-aware split direction
+
+`spawnPane` selects its split direction based on `storedLayout`:
+
+| Configured layout | `spawnPane` split | `applyLayout` resize axis | Visual result |
+|---|---|---|---|
+| `main-vertical` (DEFAULT) | `right` | left/right (width) | Main LEFT, agents stacked RIGHT |
+| `even-horizontal` | `right` | left/right (width) | All panes side-by-side |
+| `main-horizontal` | `down` | up/down (height) | Main TOP, agents stacked BELOW |
+| `even-vertical` | `down` | up/down (height) | All panes stacked in column |
+| `tiled` | `down` | up/down (height) | Column (approximation) |
+
+This ensures `pane.resize` always operates along the existing split axis:
+split `RIGHT` → resize `LEFT`/`RIGHT` adjusts widths; split `DOWN` →
+resize `UP`/`DOWN` adjusts heights.
+
+### Layout rebalancing via `pane.resize`
+
+`applyLayout` rebalances panes in-place using `pane.resize`.  All five
+layout types have real implementations (no fallbacks in v2).
+
+**Algorithm for `main-vertical` / `main-horizontal`** (single pane resize):
+1. Query current layout via `pane.layout`
+2. Identify main pane from `HERDR_PANE_ID` (or focused/topmost)
+3. Compute target size = `totalSize * mainPaneSize / 100`
+4. Resize main pane `RIGHT`/`LEFT` or `DOWN`/`UP` by `|target - current|`
+
+**Algorithm for `even-vertical` / `even-horizontal` / `tiled`** (equal split):
+1. Query layout, sort panes by rect.y (vertical) or rect.x (horizontal)
+2. Compute equal size = `totalSize / paneCount`
+3. For each pane except the last: resize in the correct axis to equal size
+4. After each resize, re-read pane positions from the response
+
+**Debounce** (mirrors tmux pattern, 150ms):
+- `applyLayout()` cancels pending debounce and runs immediately
+- `scheduleLayout()` debounces after `spawnPane`/`closePane` bursts
+- A generation counter drops stale callbacks
+
+## Flow
+
+- `spawnPane(sessionId, description, serverUrl, directory)`:
+  - ensure inside session and binary + socket are available
+  - determine split direction from `storedLayout` via `splitDirectionForLayout`
+    (right for side-by-side layouts, down for stacked layouts)
+  - `pane.split {direction: <layout-aware>, cwd: <directory>, label: <description>}`
+  - extract `pane_id` from response
+  - wait 400ms for shell readiness
+  - `pane.send_text {pane_id, text: "opencode attach ...\n"}`
+  - return `{success: true, paneId}` or `{success: false}` on failure
+
+- `closePane(paneId)`:
+  - `pane.send_keys {pane_id, keys: ["ctrl+c"]}` — best-effort SIGINT
+  - wait 250ms (matches tmux's graceful-shutdown window)
+  - `pane.close {pane_id}` — remove the pane
+  - if response is `pane_not_found`, treat as already-closed success
+  - return `true` on success, `false` on other errors
+
+- `applyLayout(layout, mainPaneSize)`:
+  - cancels pending debounced layout
+  - calls `applyLayoutNow` immediately (queries pane.layout, computes deltas,
+    issues pane.resize calls)
+  - `scheduleLayout` (150ms debounce) called from successful
+    `spawnPane`/`closePane`; runs with generation counter to drop stale calls
+
+## Integration
+
+- Selected when `multiplexerConfig.type === 'herdr'` or auto mode resolves to
+  herdr (`process.env.HERDR_ENV === '1'` and neither `TMUX` nor `ZELLIJ` is
+  set).
+- Consumed by `MultiplexerSessionManager` for `session.created` spawn and
+  completion cleanup.
+- Uses `ctx.directory` as working directory, OpenCode API URL as `serverUrl`,
+  and session id as `opencode attach --session` target.
+- The parent pane is identified by `process.env.HERDR_PANE_ID`; the socket
+  API's `pane.split` operates on the currently focused pane (which is the
+  plugin's pane during normal operation), so no explicit source pane_id is
+  passed.

--- a/src/multiplexer/herdr/index.test.ts
+++ b/src/multiplexer/herdr/index.test.ts
@@ -1,0 +1,1327 @@
+/**
+ * Tests for HerdrMultiplexer
+ *
+ * Mocks HerdrSocketClient at the module level so RPC calls are controllable.
+ * Mocks crossSpawn for binary detection (which + --version).
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type SpawnResult = {
+  exited: Promise<number>;
+  stdout: () => Promise<string>;
+  stderr: () => Promise<string>;
+  kill: () => boolean;
+  exitCode: number | null;
+  proc: never;
+};
+
+// ---------------------------------------------------------------------------
+// CrossSpawn mock (for binary detection)
+// ---------------------------------------------------------------------------
+
+const crossSpawnMock = mock((_command: string[]) => createSpawnResult());
+
+function createSpawnResult(
+  exitCode = 0,
+  stdout = '',
+  stderr = '',
+): SpawnResult {
+  return {
+    exited: Promise.resolve(exitCode),
+    stdout: () => Promise.resolve(stdout),
+    stderr: () => Promise.resolve(stderr),
+    kill: () => true,
+    exitCode,
+    proc: {} as never,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// HerdrSocketClient mock (provided via mock.module)
+// ---------------------------------------------------------------------------
+
+let mockClientInstance: MockHerdrSocketClient | null = null;
+
+class MockHerdrSocketClient {
+  call = mock(
+    async (
+      _method: string,
+      _params: Record<string, unknown>,
+    ): Promise<unknown> => {
+      return {};
+    },
+  );
+
+  ping = mock(async (): Promise<boolean> => true);
+  close = mock(async (): Promise<void> => {});
+
+  constructor(_socketPath?: string) {
+    mockClientInstance = this;
+  }
+}
+
+/**
+ * Inline copy of isHerdrError from client.ts so we don't need to import the
+ * real module (which would be replaced by the mock).
+ */
+function isHerdrError(e: unknown, code?: string): boolean {
+  if (
+    typeof e === 'object' &&
+    e !== null &&
+    'code' in e &&
+    typeof (e as Record<string, unknown>).code === 'string'
+  ) {
+    if (code !== undefined) {
+      return (e as Record<string, unknown>).code === code;
+    }
+    return true;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Module-level mocks (applied before any dynamic import)
+// ---------------------------------------------------------------------------
+
+mock.module('../../utils/compat', () => ({
+  crossSpawn: crossSpawnMock,
+}));
+
+mock.module('./client', () => ({
+  HerdrSocketClient: MockHerdrSocketClient,
+  isHerdrError,
+}));
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+let importCounter = 0;
+
+async function importFreshHerdr() {
+  return import(`./index?test=${importCounter++}`);
+}
+
+function commands(): string[][] {
+  return crossSpawnMock.mock.calls.map((call) => call[0] as string[]);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('HerdrMultiplexer', () => {
+  const origHerdrEnv = process.env.HERDR_ENV;
+  const origHerdrPaneId = process.env.HERDR_PANE_ID;
+  const origHerdrTabId = process.env.HERDR_TAB_ID;
+  const origHerdrWorkspaceId = process.env.HERDR_WORKSPACE_ID;
+
+  beforeEach(() => {
+    mockClientInstance = null;
+    crossSpawnMock.mockReset();
+
+    // Default env: inside herdr session
+    process.env.HERDR_ENV = '1';
+    process.env.HERDR_PANE_ID = 'w654950b6cb01c6:p0';
+    process.env.HERDR_TAB_ID = 'w654950b6cb01c6:t1';
+    process.env.HERDR_WORKSPACE_ID = 'w654950b6cb01c6';
+
+    // Default crossSpawn: herdr binary found and verified
+    crossSpawnMock.mockImplementation((command: string[]) => {
+      if (command[0] === 'which') {
+        return createSpawnResult(0, '/usr/local/bin/herdr\n');
+      }
+      if (command[1] === '--version') {
+        return createSpawnResult(0, 'herdr 0.1.0');
+      }
+      return createSpawnResult();
+    });
+  });
+
+  afterEach(() => {
+    process.env.HERDR_ENV = origHerdrEnv;
+    process.env.HERDR_PANE_ID = origHerdrPaneId;
+    process.env.HERDR_TAB_ID = origHerdrTabId;
+    process.env.HERDR_WORKSPACE_ID = origHerdrWorkspaceId;
+    mockClientInstance = null;
+  });
+
+  // -----------------------------------------------------------------------
+  // isInsideSession
+  // -----------------------------------------------------------------------
+
+  test('isInsideSession returns true when HERDR_ENV=1', async () => {
+    const { HerdrMultiplexer } = await importFreshHerdr();
+    const herdr = new HerdrMultiplexer();
+    expect(herdr.isInsideSession()).toBe(true);
+  });
+
+  test('isInsideSession returns false when HERDR_ENV is not set', async () => {
+    delete process.env.HERDR_ENV;
+    const { HerdrMultiplexer } = await importFreshHerdr();
+    const herdr = new HerdrMultiplexer();
+    expect(herdr.isInsideSession()).toBe(false);
+  });
+
+  test('isInsideSession returns false when HERDR_ENV is not "1"', async () => {
+    process.env.HERDR_ENV = '0';
+    const { HerdrMultiplexer } = await importFreshHerdr();
+    const herdr = new HerdrMultiplexer();
+    expect(herdr.isInsideSession()).toBe(false);
+  });
+
+  // -----------------------------------------------------------------------
+  // isAvailable
+  // -----------------------------------------------------------------------
+
+  test('isAvailable returns true when binary found and ping succeeds', async () => {
+    const { HerdrMultiplexer } = await importFreshHerdr();
+    const herdr = new HerdrMultiplexer();
+
+    // ping() defaults to true
+    const result = await herdr.isAvailable();
+    expect(result).toBe(true);
+
+    // Should have called which and --version
+    const cmds = commands();
+    expect(cmds.some((c) => c[0] === 'which' && c[1] === 'herdr')).toBe(true);
+    expect(
+      cmds.some((c) => c[0] === '/usr/local/bin/herdr' && c[1] === '--version'),
+    ).toBe(true);
+  });
+
+  test('isAvailable caches result and does not re-run which on second call', async () => {
+    const { HerdrMultiplexer } = await importFreshHerdr();
+    const herdr = new HerdrMultiplexer();
+
+    await herdr.isAvailable();
+    const callCount1 = commands().length;
+
+    await herdr.isAvailable();
+    const callCount2 = commands().length;
+
+    // No new calls on second invocation
+    expect(callCount2).toBe(callCount1);
+  });
+
+  test('isAvailable returns false when which herdr fails', async () => {
+    crossSpawnMock.mockImplementation((command: string[]) => {
+      if (command[0] === 'which') {
+        return createSpawnResult(1, '', 'not found');
+      }
+      return createSpawnResult();
+    });
+
+    const { HerdrMultiplexer } = await importFreshHerdr();
+    const herdr = new HerdrMultiplexer();
+    expect(await herdr.isAvailable()).toBe(false);
+  });
+
+  test('isAvailable returns false when binary found but ping fails', async () => {
+    const { HerdrMultiplexer } = await importFreshHerdr();
+    const herdr = new HerdrMultiplexer();
+
+    // Set up ping to return false after the mock client is created
+    // We need to configure it before isAvailable is called.
+    // The mock client is created when the multiplexer is constructed.
+
+    // Wait for the constructor's field initializer to set mockClientInstance
+    // (it happens synchronously in the constructor)
+    expect(mockClientInstance).not.toBeNull();
+    mockClientInstance?.ping.mockImplementation(async () => false);
+
+    const result = await herdr.isAvailable();
+    expect(result).toBe(false);
+  });
+
+  // -----------------------------------------------------------------------
+  // spawnPane success
+  // -----------------------------------------------------------------------
+
+  test('spawnPane returns success with paneId on happy path', async () => {
+    const { HerdrMultiplexer } = await importFreshHerdr();
+    const herdr = new HerdrMultiplexer();
+
+    expect(mockClientInstance).not.toBeNull();
+    mockClientInstance?.call.mockImplementation(
+      async (method: string, _params: Record<string, unknown>) => {
+        if (method === 'pane.list') {
+          return { panes: [] };
+        }
+        if (method === 'pane.split') {
+          return { pane: { pane_id: 'w1:p2' } };
+        }
+        if (method === 'pane.send_text') {
+          return { type: 'ok' };
+        }
+        return {};
+      },
+    );
+
+    const result = await herdr.spawnPane(
+      'sess-123',
+      'test desc',
+      'http://localhost:4096',
+      '/tmp',
+    );
+
+    expect(result).toEqual({ success: true, paneId: 'w1:p2' });
+
+    // Verify pane.split was called with correct params
+    const splitCall = mockClientInstance?.call.mock.calls.find(
+      ([method]) => method === 'pane.split',
+    );
+    expect(splitCall).toBeDefined();
+    expect(splitCall?.[1]).toEqual({
+      pane_id: 'w654950b6cb01c6:p0',
+      workspace_id: 'w654950b6cb01c6',
+      tab_id: 'w654950b6cb01c6:t1',
+      direction: 'right',
+      ratio: 0.4,
+      cwd: '/tmp',
+      label: 'test desc',
+    });
+
+    // Verify pane.send_text was called with correct params
+    const sendTextCall = mockClientInstance?.call.mock.calls.find(
+      ([method]) => method === 'pane.send_text',
+    );
+    expect(sendTextCall).toBeDefined();
+    expect(sendTextCall?.[1]).toHaveProperty('pane_id', 'w1:p2');
+    expect(sendTextCall?.[1]).toHaveProperty('text');
+    const text = sendTextCall?.[1].text as string;
+    expect(text).toMatch(/opencode attach/);
+    expect(text).toMatch(/--session 'sess-123'/);
+    expect(text).toMatch(/--dir '\/tmp'/);
+    expect(text).toEndWith('\n');
+  });
+
+  test('spawnPane splits right by default (main-vertical)', async () => {
+    const { HerdrMultiplexer } = await importFreshHerdr();
+    const herdr = new HerdrMultiplexer(); // defaults to main-vertical
+
+    expect(mockClientInstance).not.toBeNull();
+    mockClientInstance?.call.mockImplementation(async (method: string) => {
+      if (method === 'pane.list') return { panes: [] };
+      if (method === 'pane.split') return { pane: { pane_id: 'w1:p2' } };
+      if (method === 'pane.send_text') return { type: 'ok' };
+      return {};
+    });
+
+    await herdr.spawnPane('sess-1', 'desc', 'http://localhost:4096', '/tmp');
+
+    const splitCall = mockClientInstance?.call.mock.calls.find(
+      ([m]) => m === 'pane.split',
+    );
+    expect(splitCall).toBeDefined();
+    // main-vertical, first agent → split MAIN in layout direction = RIGHT
+    expect(splitCall?.[1]).toEqual({
+      pane_id: 'w654950b6cb01c6:p0',
+      workspace_id: 'w654950b6cb01c6',
+      tab_id: 'w654950b6cb01c6:t1',
+      direction: 'right',
+      ratio: 0.4,
+      cwd: '/tmp',
+      label: 'desc',
+    });
+  });
+
+  test('spawnPane splits down for main-horizontal layout', async () => {
+    const { HerdrMultiplexer } = await importFreshHerdr();
+    const herdr = new HerdrMultiplexer('main-horizontal', 60);
+
+    expect(mockClientInstance).not.toBeNull();
+    mockClientInstance?.call.mockImplementation(async (method: string) => {
+      if (method === 'pane.list') return { panes: [] };
+      if (method === 'pane.split') return { pane: { pane_id: 'w1:p2' } };
+      if (method === 'pane.send_text') return { type: 'ok' };
+      return {};
+    });
+
+    await herdr.spawnPane('sess-1', 'desc', 'http://localhost:4096', '/tmp');
+
+    const splitCall = mockClientInstance?.call.mock.calls.find(
+      ([m]) => m === 'pane.split',
+    );
+    expect(splitCall).toBeDefined();
+    // main-horizontal, first agent → split MAIN in layout direction = DOWN
+    expect(splitCall?.[1]).toEqual({
+      pane_id: 'w654950b6cb01c6:p0',
+      workspace_id: 'w654950b6cb01c6',
+      tab_id: 'w654950b6cb01c6:t1',
+      direction: 'down',
+      ratio: 0.4,
+      cwd: '/tmp',
+      label: 'desc',
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // spawnPane — findSplitSource / anchor logic
+  // -----------------------------------------------------------------------
+
+  test('subsequent agent splits first agent in perpendicular direction (main-vertical)', async () => {
+    const { HerdrMultiplexer } = await importFreshHerdr();
+    const herdr = new HerdrMultiplexer(); // main-vertical
+
+    expect(mockClientInstance).not.toBeNull();
+    // pane.list returns an existing agent (not main)
+    mockClientInstance?.call.mockImplementation(async (method: string) => {
+      if (method === 'pane.list') {
+        return {
+          panes: [
+            { pane_id: 'w654950b6cb01c6:p5', tab_id: 'w654950b6cb01c6:t1' },
+          ],
+        };
+      }
+      if (method === 'pane.split') return { pane: { pane_id: 'w1:p2' } };
+      if (method === 'pane.send_text') return { type: 'ok' };
+      return {};
+    });
+
+    await herdr.spawnPane('sess-1', 'desc', 'http://localhost:4096', '/tmp');
+
+    const splitCall = mockClientInstance?.call.mock.calls.find(
+      ([m]) => m === 'pane.split',
+    );
+    expect(splitCall).toBeDefined();
+    // main-vertical layout direction = right, but since we have an existing
+    // agent, we split that agent in the PERPENDICULAR direction = down
+    expect(splitCall?.[1]).toEqual({
+      pane_id: 'w654950b6cb01c6:p5',
+      workspace_id: 'w654950b6cb01c6',
+      tab_id: 'w654950b6cb01c6:t1',
+      direction: 'down',
+      ratio: 0.5,
+      cwd: '/tmp',
+      label: 'desc',
+    });
+  });
+
+  test('subsequent agent splits first agent in perpendicular direction (main-horizontal)', async () => {
+    const { HerdrMultiplexer } = await importFreshHerdr();
+    const herdr = new HerdrMultiplexer('main-horizontal', 60);
+
+    expect(mockClientInstance).not.toBeNull();
+    mockClientInstance?.call.mockImplementation(async (method: string) => {
+      if (method === 'pane.list') {
+        return {
+          panes: [
+            { pane_id: 'w654950b6cb01c6:p5', tab_id: 'w654950b6cb01c6:t1' },
+          ],
+        };
+      }
+      if (method === 'pane.split') return { pane: { pane_id: 'w1:p2' } };
+      if (method === 'pane.send_text') return { type: 'ok' };
+      return {};
+    });
+
+    await herdr.spawnPane('sess-1', 'desc', 'http://localhost:4096', '/tmp');
+
+    const splitCall = mockClientInstance?.call.mock.calls.find(
+      ([m]) => m === 'pane.split',
+    );
+    expect(splitCall).toBeDefined();
+    // main-horizontal layout direction = down, perpendicular = right
+    expect(splitCall?.[1]).toEqual({
+      pane_id: 'w654950b6cb01c6:p5',
+      workspace_id: 'w654950b6cb01c6',
+      tab_id: 'w654950b6cb01c6:t1',
+      direction: 'right',
+      ratio: 0.5,
+      cwd: '/tmp',
+      label: 'desc',
+    });
+  });
+
+  test('pane.list failure falls back to splitting from main', async () => {
+    const { HerdrMultiplexer } = await importFreshHerdr();
+    const herdr = new HerdrMultiplexer();
+
+    expect(mockClientInstance).not.toBeNull();
+    mockClientInstance?.call.mockImplementation(async (method: string) => {
+      if (method === 'pane.list') throw new Error('pane.list failed');
+      if (method === 'pane.split') return { pane: { pane_id: 'w1:p2' } };
+      if (method === 'pane.send_text') return { type: 'ok' };
+      return {};
+    });
+
+    await herdr.spawnPane('sess-1', 'desc', 'http://localhost:4096', '/tmp');
+
+    const splitCall = mockClientInstance?.call.mock.calls.find(
+      ([m]) => m === 'pane.split',
+    );
+    expect(splitCall).toBeDefined();
+    // Falls back to main pane, layout direction = right
+    expect(splitCall?.[1]).toHaveProperty('pane_id', 'w654950b6cb01c6:p0');
+    expect(splitCall?.[1]).toHaveProperty('direction', 'right');
+  });
+
+  test('HERDR_TAB_ID unset returns failure (cannot target safely)', async () => {
+    delete process.env.HERDR_TAB_ID;
+
+    const { HerdrMultiplexer } = await importFreshHerdr();
+    const herdr = new HerdrMultiplexer();
+
+    // spawnPane checks HERDR_TAB_ID before calling pane.split — without it,
+    // we cannot target the correct tab, so it fails early.
+    const result = await herdr.spawnPane(
+      'sess-1',
+      'desc',
+      'http://localhost:4096',
+      '/tmp',
+    );
+    expect(result).toEqual({ success: false });
+    expect(mockClientInstance?.call.mock.calls.length).toBe(0);
+  });
+
+  test('HERDR_WORKSPACE_ID unset returns failure without calling pane.split', async () => {
+    delete process.env.HERDR_WORKSPACE_ID;
+
+    const { HerdrMultiplexer } = await importFreshHerdr();
+    const herdr = new HerdrMultiplexer();
+
+    const result = await herdr.spawnPane(
+      'sess-1',
+      'desc',
+      'http://localhost:4096',
+      '/tmp',
+    );
+    expect(result).toEqual({ success: false });
+    expect(mockClientInstance?.call.mock.calls.length).toBe(0);
+  });
+
+  test('HERDR_PANE_ID unset returns failure without calling pane.list', async () => {
+    delete process.env.HERDR_PANE_ID;
+
+    const { HerdrMultiplexer } = await importFreshHerdr();
+    const herdr = new HerdrMultiplexer();
+
+    const result = await herdr.spawnPane(
+      'sess-1',
+      'desc',
+      'http://localhost:4096',
+      '/tmp',
+    );
+
+    expect(result).toEqual({ success: false });
+    // pane.list should NOT have been called
+    const listCalls = mockClientInstance?.call.mock.calls.filter(
+      ([m]) => m === 'pane.list',
+    );
+    expect(listCalls).toHaveLength(0);
+  });
+
+  // -----------------------------------------------------------------------
+  // spawnPane not inside session
+  // -----------------------------------------------------------------------
+
+  test('spawnPane returns failure when not inside a herdr session', async () => {
+    delete process.env.HERDR_ENV;
+
+    const { HerdrMultiplexer } = await importFreshHerdr();
+    const herdr = new HerdrMultiplexer();
+
+    const result = await herdr.spawnPane(
+      'sess-1',
+      'desc',
+      'http://localhost:4096',
+      '/tmp',
+    );
+
+    expect(result).toEqual({ success: false });
+
+    // Should NOT have called client at all
+    if (mockClientInstance) {
+      expect(mockClientInstance?.call.mock.calls.length).toBe(0);
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // spawnPane herdr not available
+  // -----------------------------------------------------------------------
+
+  test('spawnPane returns failure when herdr is not available', async () => {
+    crossSpawnMock.mockImplementation((command: string[]) => {
+      if (command[0] === 'which') {
+        return createSpawnResult(1, '', 'not found');
+      }
+      return createSpawnResult();
+    });
+
+    const { HerdrMultiplexer } = await importFreshHerdr();
+    const herdr = new HerdrMultiplexer();
+
+    const result = await herdr.spawnPane(
+      'sess-1',
+      'desc',
+      'http://localhost:4096',
+      '/tmp',
+    );
+
+    expect(result).toEqual({ success: false });
+  });
+
+  // -----------------------------------------------------------------------
+  // spawnPane split returns no pane_id
+  // -----------------------------------------------------------------------
+
+  test('spawnPane returns failure when split response lacks pane_id', async () => {
+    const { HerdrMultiplexer } = await importFreshHerdr();
+    const herdr = new HerdrMultiplexer();
+
+    expect(mockClientInstance).not.toBeNull();
+    mockClientInstance?.call.mockImplementation(
+      async (method: string, _params: Record<string, unknown>) => {
+        if (method === 'pane.list') return { panes: [] };
+        if (method === 'pane.split') {
+          return {}; // no pane field
+        }
+        return {};
+      },
+    );
+
+    const result = await herdr.spawnPane(
+      'sess-1',
+      'desc',
+      'http://localhost:4096',
+      '/tmp',
+    );
+
+    expect(result).toEqual({ success: false });
+  });
+
+  // -----------------------------------------------------------------------
+  // spawnPane exception
+  // -----------------------------------------------------------------------
+
+  test('spawnPane returns failure when call throws', async () => {
+    const { HerdrMultiplexer } = await importFreshHerdr();
+    const herdr = new HerdrMultiplexer();
+
+    expect(mockClientInstance).not.toBeNull();
+    mockClientInstance?.call.mockImplementation(
+      async (method: string, _params: Record<string, unknown>) => {
+        // Let pane.list succeed, fail on the actual spawn
+        if (method === 'pane.list') return { panes: [] };
+        throw new Error('connection lost');
+      },
+    );
+
+    const result = await herdr.spawnPane(
+      'sess-1',
+      'desc',
+      'http://localhost:4096',
+      '/tmp',
+    );
+
+    expect(result).toEqual({ success: false });
+  });
+
+  // -----------------------------------------------------------------------
+  // closePane success
+  // -----------------------------------------------------------------------
+
+  test('closePane returns true on success', async () => {
+    const { HerdrMultiplexer } = await importFreshHerdr();
+    const herdr = new HerdrMultiplexer();
+
+    expect(mockClientInstance).not.toBeNull();
+    mockClientInstance?.call.mockImplementation(
+      async (method: string, _params: Record<string, unknown>) => {
+        if (method === 'pane.send_keys') return { type: 'ok' };
+        if (method === 'pane.close') return { type: 'ok' };
+        return {};
+      },
+    );
+
+    const result = await herdr.closePane('w1:p2');
+    expect(result).toBe(true);
+  });
+
+  test('closePane calls panes in correct order (send_keys then pane.close)', async () => {
+    const { HerdrMultiplexer } = await importFreshHerdr();
+    const herdr = new HerdrMultiplexer();
+
+    const callSequence: string[] = [];
+    expect(mockClientInstance).not.toBeNull();
+    mockClientInstance?.call.mockImplementation(
+      async (method: string, _params: Record<string, unknown>) => {
+        callSequence.push(method);
+        if (method === 'pane.send_keys') return { type: 'ok' };
+        if (method === 'pane.close') return { type: 'ok' };
+        return {};
+      },
+    );
+
+    await herdr.closePane('w1:p2');
+
+    expect(callSequence).toEqual(['pane.send_keys', 'pane.close']);
+  });
+
+  test('closePane calls send_keys with ctrl+c', async () => {
+    const { HerdrMultiplexer } = await importFreshHerdr();
+    const herdr = new HerdrMultiplexer();
+
+    let sendKeysParams: Record<string, unknown> | null = null;
+    expect(mockClientInstance).not.toBeNull();
+    mockClientInstance?.call.mockImplementation(
+      async (method: string, params: Record<string, unknown>) => {
+        if (method === 'pane.send_keys') {
+          sendKeysParams = params;
+          return { type: 'ok' };
+        }
+        if (method === 'pane.close') return { type: 'ok' };
+        return {};
+      },
+    );
+
+    await herdr.closePane('w1:p2');
+    expect(sendKeysParams).toEqual({
+      pane_id: 'w1:p2',
+      keys: ['ctrl+c'],
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // closePane already gone
+  // -----------------------------------------------------------------------
+
+  test('closePane returns true when pane is already closed (pane_not_found)', async () => {
+    const { HerdrMultiplexer } = await importFreshHerdr();
+    const herdr = new HerdrMultiplexer();
+
+    expect(mockClientInstance).not.toBeNull();
+    // send_keys throws, pane.close throws pane_not_found
+    mockClientInstance?.call.mockImplementation(
+      async (method: string, _params: Record<string, unknown>) => {
+        if (method === 'pane.send_keys') {
+          throw new Error('herdr: pane_not_found — pane gone');
+        }
+        if (method === 'pane.close') {
+          const err = Object.assign(
+            new Error('herdr: pane_not_found — already gone'),
+            { code: 'pane_not_found', message: 'already gone' },
+          );
+          throw err;
+        }
+        return {};
+      },
+    );
+
+    const result = await herdr.closePane('w1:p2');
+    expect(result).toBe(true);
+  });
+
+  // -----------------------------------------------------------------------
+  // closePane empty paneId
+  // -----------------------------------------------------------------------
+
+  test('closePane returns false for empty paneId', async () => {
+    const { HerdrMultiplexer } = await importFreshHerdr();
+    const herdr = new HerdrMultiplexer();
+
+    const result = await herdr.closePane('');
+    expect(result).toBe(false);
+
+    // Should not have called client
+    if (mockClientInstance) {
+      expect(mockClientInstance?.call.mock.calls.length).toBe(0);
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // closePane non-not_found error
+  // -----------------------------------------------------------------------
+
+  test('closePane returns false on internal_error', async () => {
+    const { HerdrMultiplexer } = await importFreshHerdr();
+    const herdr = new HerdrMultiplexer();
+
+    expect(mockClientInstance).not.toBeNull();
+    mockClientInstance?.call.mockImplementation(
+      async (method: string, _params: Record<string, unknown>) => {
+        if (method === 'pane.send_keys') return { type: 'ok' };
+        if (method === 'pane.close') {
+          const err = Object.assign(
+            new Error('herdr: internal_error — something broke'),
+            { code: 'internal_error', message: 'something broke' },
+          );
+          throw err;
+        }
+        return {};
+      },
+    );
+
+    const result = await herdr.closePane('w1:p2');
+    expect(result).toBe(false);
+  });
+
+  // -----------------------------------------------------------------------
+  // closePane send_keys also tolerates errors
+  // -----------------------------------------------------------------------
+
+  test('closePane tolerates send_keys failure and still tries pane.close', async () => {
+    const { HerdrMultiplexer } = await importFreshHerdr();
+    const herdr = new HerdrMultiplexer();
+
+    const callSequence: string[] = [];
+    expect(mockClientInstance).not.toBeNull();
+    mockClientInstance?.call.mockImplementation(
+      async (method: string, _params: Record<string, unknown>) => {
+        callSequence.push(method);
+        if (method === 'pane.send_keys') {
+          throw Object.assign(new Error('herdr: pane_not_found'), {
+            code: 'pane_not_found',
+            message: 'gone',
+          });
+        }
+        if (method === 'pane.close') {
+          return { type: 'ok' };
+        }
+        return {};
+      },
+    );
+
+    const result = await herdr.closePane('w1:p2');
+    expect(result).toBe(true);
+    expect(callSequence).toEqual(['pane.send_keys', 'pane.close']);
+  });
+
+  // -----------------------------------------------------------------------
+  // applyLayout — main-horizontal
+  // -----------------------------------------------------------------------
+
+  test('applyLayout main-horizontal queries layout and resizes main pane down', async () => {
+    const { HerdrMultiplexer } = await importFreshHerdr();
+    const herdr = new HerdrMultiplexer();
+
+    process.env.HERDR_PANE_ID = 'w4:p1';
+
+    expect(mockClientInstance).not.toBeNull();
+    mockClientInstance?.call.mockImplementation(
+      async (method: string, _params: Record<string, unknown>) => {
+        if (method === 'pane.layout') {
+          return {
+            layout: {
+              area: { width: 166, height: 47 },
+              panes: [
+                {
+                  pane_id: 'w4:p1',
+                  rect: { x: 26, y: 1, width: 166, height: 20 },
+                  focused: true,
+                },
+                {
+                  pane_id: 'w4:p2',
+                  rect: { x: 26, y: 21, width: 166, height: 27 },
+                  focused: false,
+                },
+              ],
+            },
+          };
+        }
+        if (method === 'pane.resize') {
+          return { type: 'pane_resize' };
+        }
+        return {};
+      },
+    );
+
+    await expect(
+      herdr.applyLayout('main-horizontal', 60),
+    ).resolves.toBeUndefined();
+
+    // Should have called pane.layout + pane.resize
+    const layoutCalls = mockClientInstance?.call.mock.calls.filter(
+      ([m]) => m === 'pane.layout',
+    );
+    const resizeCalls = mockClientInstance?.call.mock.calls.filter(
+      ([m]) => m === 'pane.resize',
+    );
+
+    expect(layoutCalls).toHaveLength(1);
+    expect(resizeCalls).toHaveLength(1);
+
+    // 60% − 20/47 = ratio delta
+    const resizeParams = resizeCalls?.[0]?.[1] as Record<string, unknown>;
+    expect(resizeParams).toHaveProperty('pane_id', 'w4:p1');
+    expect(resizeParams).toHaveProperty('direction', 'down');
+    expect(resizeParams).toHaveProperty('amount', 0.6 - 20 / 47);
+  });
+
+  test('applyLayout main-horizontal skips resize when already at target', async () => {
+    const { HerdrMultiplexer } = await importFreshHerdr();
+    const herdr = new HerdrMultiplexer();
+
+    // 60% of 50 = 30, current height = 30 → no delta
+    mockClientInstance?.call.mockImplementation(async (method: string) => {
+      if (method === 'pane.layout') {
+        return {
+          layout: {
+            area: { width: 100, height: 50 },
+            panes: [
+              {
+                pane_id: 'w4:p1',
+                rect: { x: 0, y: 0, width: 100, height: 30 },
+                focused: true,
+              },
+              {
+                pane_id: 'w4:p2',
+                rect: { x: 0, y: 30, width: 100, height: 20 },
+                focused: false,
+              },
+            ],
+          },
+        };
+      }
+      return {};
+    });
+
+    await herdr.applyLayout('main-horizontal', 60);
+
+    const resizeCalls = mockClientInstance?.call.mock.calls.filter(
+      ([m]) => m === 'pane.resize',
+    );
+    expect(resizeCalls).toHaveLength(0);
+  });
+
+  // -----------------------------------------------------------------------
+  // applyLayout — even-vertical / tiled
+  // -----------------------------------------------------------------------
+
+  test('applyLayout even-vertical resizes all panes to equal height', async () => {
+    const { HerdrMultiplexer } = await importFreshHerdr();
+    const herdr = new HerdrMultiplexer();
+
+    process.env.HERDR_PANE_ID = 'w4:p1';
+
+    mockClientInstance?.call.mockImplementation(
+      async (method: string, params: Record<string, unknown>) => {
+        if (method === 'pane.layout') {
+          return {
+            layout: {
+              area: { width: 100, height: 48 },
+              panes: [
+                {
+                  pane_id: 'w4:p1',
+                  rect: { x: 0, y: 0, width: 100, height: 20 },
+                  focused: true,
+                },
+                {
+                  pane_id: 'w4:p2',
+                  rect: { x: 0, y: 20, width: 100, height: 14 },
+                  focused: false,
+                },
+                {
+                  pane_id: 'w4:p3',
+                  rect: { x: 0, y: 34, width: 100, height: 14 },
+                  focused: false,
+                },
+              ],
+            },
+          };
+        }
+        // After each resize, return updated layout with the resized rects
+        if (method === 'pane.resize') {
+          const resizeParams = params as {
+            pane_id: string;
+            direction: string;
+            amount: number;
+          };
+          // Simulate resized layout
+          if (resizeParams.pane_id === 'w4:p1') {
+            return {
+              layout: {
+                area: { width: 100, height: 48 },
+                panes: [
+                  {
+                    pane_id: 'w4:p1',
+                    rect: { x: 0, y: 0, width: 100, height: 16 },
+                    focused: true,
+                  },
+                  {
+                    pane_id: 'w4:p2',
+                    rect: { x: 0, y: 16, width: 100, height: 18 },
+                    focused: false,
+                  },
+                  {
+                    pane_id: 'w4:p3',
+                    rect: { x: 0, y: 34, width: 100, height: 14 },
+                    focused: false,
+                  },
+                ],
+              },
+            };
+          }
+          if (resizeParams.pane_id === 'w4:p2') {
+            return {
+              layout: {
+                area: { width: 100, height: 48 },
+                panes: [
+                  {
+                    pane_id: 'w4:p1',
+                    rect: { x: 0, y: 0, width: 100, height: 16 },
+                    focused: true,
+                  },
+                  {
+                    pane_id: 'w4:p2',
+                    rect: { x: 0, y: 16, width: 100, height: 16 },
+                    focused: false,
+                  },
+                  {
+                    pane_id: 'w4:p3',
+                    rect: { x: 0, y: 32, width: 100, height: 16 },
+                    focused: false,
+                  },
+                ],
+              },
+            };
+          }
+          return {};
+        }
+        return {};
+      },
+    );
+
+    await herdr.applyLayout('even-vertical', 60);
+
+    const resizeCalls = mockClientInstance?.call.mock.calls.filter(
+      ([m]) => m === 'pane.resize',
+    );
+    expect(resizeCalls).toHaveLength(2);
+    expect(resizeCalls?.[0]?.[1]).toHaveProperty('pane_id', 'w4:p1');
+    expect(resizeCalls?.[1]?.[1]).toHaveProperty('pane_id', 'w4:p2');
+  });
+
+  test('applyLayout tiled delegates to even-vertical logic', async () => {
+    const { HerdrMultiplexer } = await importFreshHerdr();
+    const herdr = new HerdrMultiplexer();
+
+    mockClientInstance?.call.mockImplementation(async (method: string) => {
+      if (method === 'pane.layout') {
+        return {
+          layout: {
+            area: { width: 100, height: 48 },
+            panes: [
+              {
+                pane_id: 'w4:p1',
+                rect: { x: 0, y: 0, width: 100, height: 24 },
+                focused: true,
+              },
+              {
+                pane_id: 'w4:p2',
+                rect: { x: 0, y: 24, width: 100, height: 24 },
+                focused: false,
+              },
+            ],
+          },
+        };
+      }
+      return {};
+    });
+
+    await expect(herdr.applyLayout('tiled', 50)).resolves.toBeUndefined();
+  });
+
+  // -----------------------------------------------------------------------
+  // applyLayout — width-axis layouts (main-vertical, even-horizontal)
+  // -----------------------------------------------------------------------
+
+  test('applyLayout main-vertical resizes main pane width', async () => {
+    const { HerdrMultiplexer } = await importFreshHerdr();
+    const herdr = new HerdrMultiplexer();
+
+    process.env.HERDR_PANE_ID = 'w4:p1';
+
+    mockClientInstance?.call.mockImplementation(
+      async (method: string, _params: Record<string, unknown>) => {
+        if (method === 'pane.layout') {
+          return {
+            layout: {
+              area: { width: 166, height: 47 },
+              panes: [
+                {
+                  pane_id: 'w4:p1',
+                  rect: { x: 26, y: 1, width: 66, height: 47 },
+                  focused: true,
+                },
+                {
+                  pane_id: 'w4:p2',
+                  rect: { x: 92, y: 1, width: 100, height: 47 },
+                  focused: false,
+                },
+              ],
+            },
+          };
+        }
+        if (method === 'pane.resize') {
+          return { type: 'pane_resize' };
+        }
+        return {};
+      },
+    );
+
+    await expect(
+      herdr.applyLayout('main-vertical', 60),
+    ).resolves.toBeUndefined();
+
+    // targetRatio=0.6, currentRatio=66/166, delta=0.6-66/166
+    const resizeCalls = mockClientInstance?.call.mock.calls.filter(
+      ([m]) => m === 'pane.resize',
+    );
+    expect(resizeCalls).toHaveLength(1);
+    const resizeParams = resizeCalls?.[0]?.[1] as Record<string, unknown>;
+    expect(resizeParams).toHaveProperty('pane_id', 'w4:p1');
+    expect(resizeParams).toHaveProperty('direction', 'right');
+    expect(resizeParams).toHaveProperty('amount', 0.6 - 66 / 166);
+  });
+
+  test('applyLayout main-vertical skips resize when already at target', async () => {
+    const { HerdrMultiplexer } = await importFreshHerdr();
+    const herdr = new HerdrMultiplexer();
+
+    process.env.HERDR_PANE_ID = 'w4:p1';
+
+    // 60% of 100 = 60, current main width = 60 → no delta
+    mockClientInstance?.call.mockImplementation(async (method: string) => {
+      if (method === 'pane.layout') {
+        return {
+          layout: {
+            area: { width: 100, height: 48 },
+            panes: [
+              {
+                pane_id: 'w4:p1',
+                rect: { x: 0, y: 0, width: 60, height: 48 },
+                focused: true,
+              },
+              {
+                pane_id: 'w4:p2',
+                rect: { x: 60, y: 0, width: 40, height: 48 },
+                focused: false,
+              },
+            ],
+          },
+        };
+      }
+      return {};
+    });
+
+    await herdr.applyLayout('main-vertical', 60);
+
+    const resizeCalls = mockClientInstance?.call.mock.calls.filter(
+      ([m]) => m === 'pane.resize',
+    );
+    expect(resizeCalls).toHaveLength(0);
+  });
+
+  test('applyLayout even-horizontal resizes all panes to equal width', async () => {
+    const { HerdrMultiplexer } = await importFreshHerdr();
+    const herdr = new HerdrMultiplexer();
+
+    process.env.HERDR_PANE_ID = 'w4:p1';
+
+    mockClientInstance?.call.mockImplementation(
+      async (method: string, params: Record<string, unknown>) => {
+        if (method === 'pane.layout') {
+          return {
+            layout: {
+              area: { width: 99, height: 47 },
+              panes: [
+                {
+                  pane_id: 'w4:p1',
+                  rect: { x: 0, y: 0, width: 40, height: 47 },
+                  focused: true,
+                },
+                {
+                  pane_id: 'w4:p2',
+                  rect: { x: 40, y: 0, width: 30, height: 47 },
+                  focused: false,
+                },
+                {
+                  pane_id: 'w4:p3',
+                  rect: { x: 70, y: 0, width: 29, height: 47 },
+                  focused: false,
+                },
+              ],
+            },
+          };
+        }
+        if (method === 'pane.resize') {
+          const resizeParams = params as {
+            pane_id: string;
+            direction: string;
+            amount: number;
+          };
+          // Simulate resized layout after each call
+          if (resizeParams.pane_id === 'w4:p1') {
+            return {
+              layout: {
+                area: { width: 99, height: 47 },
+                panes: [
+                  {
+                    pane_id: 'w4:p1',
+                    rect: { x: 0, y: 0, width: 33, height: 47 },
+                  },
+                  {
+                    pane_id: 'w4:p2',
+                    rect: { x: 33, y: 0, width: 37, height: 47 },
+                  },
+                  {
+                    pane_id: 'w4:p3',
+                    rect: { x: 70, y: 0, width: 29, height: 47 },
+                  },
+                ],
+              },
+            };
+          }
+          if (resizeParams.pane_id === 'w4:p2') {
+            return {
+              layout: {
+                area: { width: 99, height: 47 },
+                panes: [
+                  {
+                    pane_id: 'w4:p1',
+                    rect: { x: 0, y: 0, width: 33, height: 47 },
+                  },
+                  {
+                    pane_id: 'w4:p2',
+                    rect: { x: 33, y: 0, width: 33, height: 47 },
+                  },
+                  {
+                    pane_id: 'w4:p3',
+                    rect: { x: 66, y: 0, width: 33, height: 47 },
+                  },
+                ],
+              },
+            };
+          }
+          return {};
+        }
+        return {};
+      },
+    );
+
+    await herdr.applyLayout('even-horizontal', 50);
+
+    const resizeCalls = mockClientInstance?.call.mock.calls.filter(
+      ([m]) => m === 'pane.resize',
+    );
+    expect(resizeCalls).toHaveLength(2);
+    expect(resizeCalls?.[0]?.[1]).toHaveProperty('pane_id', 'w4:p1');
+    expect(resizeCalls?.[1]?.[1]).toHaveProperty('pane_id', 'w4:p2');
+  });
+
+  // -----------------------------------------------------------------------
+  // applyLayout — error handling
+  // -----------------------------------------------------------------------
+
+  test('applyLayout catches and logs errors without throwing', async () => {
+    const { HerdrMultiplexer } = await importFreshHerdr();
+    const herdr = new HerdrMultiplexer();
+
+    mockClientInstance?.call.mockImplementation(async (_method: string) => {
+      throw new Error('layout query failed');
+    });
+
+    // Should not throw
+    await expect(
+      herdr.applyLayout('main-horizontal', 60),
+    ).resolves.toBeUndefined();
+  });
+
+  test('applyLayout handles single pane gracefully', async () => {
+    const { HerdrMultiplexer } = await importFreshHerdr();
+    const herdr = new HerdrMultiplexer();
+
+    mockClientInstance?.call.mockImplementation(async (method: string) => {
+      if (method === 'pane.layout') {
+        return {
+          layout: {
+            area: { width: 166, height: 47 },
+            panes: [
+              {
+                pane_id: 'w4:p1',
+                rect: { x: 26, y: 1, width: 166, height: 47 },
+                focused: true,
+              },
+            ],
+          },
+        };
+      }
+      return {};
+    });
+
+    await expect(
+      herdr.applyLayout('even-vertical', 60),
+    ).resolves.toBeUndefined();
+  });
+
+  // -----------------------------------------------------------------------
+  // applyLayout — debounce
+  // -----------------------------------------------------------------------
+
+  test('scheduleLayout debounces and calls applyLayoutNow once after settle', async () => {
+    const { HerdrMultiplexer } = await importFreshHerdr();
+    const herdr = new HerdrMultiplexer();
+
+    process.env.HERDR_PANE_ID = 'w4:p1';
+
+    mockClientInstance?.call.mockImplementation(async (method: string) => {
+      if (method === 'pane.list') {
+        return { panes: [] };
+      }
+      if (method === 'pane.split') {
+        return { pane: { pane_id: 'w4:p2' } };
+      }
+      if (method === 'pane.send_text') {
+        return { type: 'ok' };
+      }
+      if (method === 'pane.layout') {
+        return {
+          layout: {
+            area: { width: 100, height: 48 },
+            panes: [
+              {
+                pane_id: 'w4:p1',
+                rect: { x: 0, y: 0, width: 100, height: 24 },
+                focused: true,
+              },
+              {
+                pane_id: 'w4:p2',
+                rect: { x: 0, y: 24, width: 100, height: 24 },
+                focused: false,
+              },
+            ],
+          },
+        };
+      }
+      if (method === 'pane.resize') {
+        return {};
+      }
+      return {};
+    });
+
+    // Trigger scheduleLayout indirectly via spawnPane
+    await herdr.spawnPane('sess-1', 'desc', 'http://localhost:4096', '/tmp');
+
+    // Count calls before debounce fires
+    const layoutCallsBefore = mockClientInstance?.call.mock.calls.filter(
+      ([m]) => m === 'pane.layout',
+    ).length;
+    expect(layoutCallsBefore).toBe(0);
+
+    // Wait for debounce to fire
+    await new Promise((r) => setTimeout(r, 200));
+
+    // After settle, applyLayoutNow should have been called
+    const layoutCallsAfter = mockClientInstance?.call.mock.calls.filter(
+      ([m]) => m === 'pane.layout',
+    ).length;
+    expect(layoutCallsAfter).toBe(1);
+  });
+});

--- a/src/multiplexer/herdr/index.ts
+++ b/src/multiplexer/herdr/index.ts
@@ -1,0 +1,617 @@
+/**
+ * Herdr multiplexer implementation
+ *
+ * Manages child-agent panes via herdr's JSON-RPC Unix socket API.
+ * Follows the same lifecycle pattern as the tmux backend: split, attach
+ * opencode, wait for completion, graceful close.
+ */
+
+import type { MultiplexerLayout } from '../../config/schema';
+import { crossSpawn } from '../../utils/compat';
+import { log } from '../../utils/logger';
+import type { Multiplexer, PaneResult } from '../types';
+import { HerdrSocketClient, isHerdrError } from './client';
+
+const LAYOUT_DEBOUNCE_MS = 150;
+
+export class HerdrMultiplexer implements Multiplexer {
+  readonly type = 'herdr' as const;
+
+  private client = new HerdrSocketClient();
+  private binaryPath: string | null = null;
+  private hasChecked = false;
+  private storedLayout: MultiplexerLayout;
+  private storedMainPaneSize: number;
+  private layoutTimer?: ReturnType<typeof setTimeout>;
+  private layoutGeneration = 0;
+
+  constructor(layout: MultiplexerLayout = 'main-vertical', mainPaneSize = 60) {
+    this.storedLayout = layout;
+    this.storedMainPaneSize = mainPaneSize;
+  }
+
+  // -----------------------------------------------------------------------
+  // Availability & session detection
+  // -----------------------------------------------------------------------
+
+  async isAvailable(): Promise<boolean> {
+    if (this.hasChecked) {
+      return this.binaryPath !== null;
+    }
+
+    this.binaryPath = await this.findBinary();
+    this.hasChecked = true;
+
+    if (!this.binaryPath) {
+      return false;
+    }
+
+    // Also verify the socket is reachable
+    const pingOk = await this.client.ping();
+    if (!pingOk) {
+      log('[herdr] isAvailable: binary found but socket ping failed');
+      this.binaryPath = null;
+      return false;
+    }
+
+    return true;
+  }
+
+  isInsideSession(): boolean {
+    return process.env.HERDR_ENV === '1';
+  }
+
+  // -----------------------------------------------------------------------
+  // Pane lifecycle
+  // -----------------------------------------------------------------------
+
+  async spawnPane(
+    sessionId: string,
+    description: string,
+    serverUrl: string,
+    directory: string,
+  ): Promise<PaneResult> {
+    if (!this.isInsideSession()) {
+      log('[herdr] spawnPane: not inside a herdr session');
+      return { success: false };
+    }
+
+    if (!(await this.isAvailable())) {
+      log('[herdr] spawnPane: herdr not available');
+      return { success: false };
+    }
+
+    try {
+      // 1. Determine which pane to split from
+      const splitSource = await this.findSplitSource();
+      if (!splitSource) {
+        log('[herdr] spawnPane: no split source available');
+        return { success: false };
+      }
+      log('[herdr] spawnPane: splitting from pane', { splitSource });
+
+      // 2. Determine split direction
+      const isFirstAgent = splitSource === process.env.HERDR_PANE_ID;
+      const splitDir = this.splitDirectionForLayout(this.storedLayout);
+      const actualDir = isFirstAgent
+        ? splitDir
+        : this.perpendicularDirection(splitDir);
+
+      // CRITICAL: pane.split ignores pane_id for workspace/tab targeting —
+      // it splits whatever workspace is currently focused. We MUST pass
+      // workspace_id and tab_id explicitly so spawns always land next to the
+      // OpenCode session regardless of what the user has focused.
+      const workspaceId = process.env.HERDR_WORKSPACE_ID;
+      const tabId = process.env.HERDR_TAB_ID;
+      if (!workspaceId || !tabId) {
+        log('[herdr] spawnPane: HERDR_WORKSPACE_ID or HERDR_TAB_ID not set', {
+          workspaceId,
+          tabId,
+        });
+        return { success: false };
+      }
+
+      // Spawn ratio: first agent takes (100-mainPaneSize)% of axis to minimise
+      // jarring relayout; subsequent agents split the agent column equally.
+      const splitRatio = isFirstAgent
+        ? (100 - this.storedMainPaneSize) / 100
+        : 0.5;
+
+      const split = await this.client.call('pane.split', {
+        pane_id: splitSource,
+        workspace_id: workspaceId,
+        tab_id: tabId,
+        direction: actualDir,
+        ratio: splitRatio,
+        cwd: directory,
+        label: description.slice(0, 30),
+      });
+
+      const splitResult = split as { pane: { pane_id: string } };
+      const paneId = splitResult?.pane?.pane_id;
+
+      if (!paneId) {
+        log('[herdr] spawnPane: split succeeded but no pane_id in response', {
+          split,
+        });
+        return { success: false };
+      }
+
+      log('[herdr] spawnPane: pane split', { paneId });
+
+      // 2. Wait for the shell to be ready (empirically required ~400ms)
+      await new Promise((r) => setTimeout(r, 400));
+
+      // 3. Build the opencode attach command (mirrors tmux pattern)
+      const quotedDirectory = quoteShellArg(directory);
+      const quotedUrl = quoteShellArg(serverUrl);
+      const quotedSessionId = quoteShellArg(sessionId);
+
+      const opencodeCmd = [
+        'opencode',
+        'attach',
+        quotedUrl,
+        '--session',
+        quotedSessionId,
+        '--dir',
+        quotedDirectory,
+      ].join(' ');
+
+      // 4. Send the command (trailing \n executes it)
+      await this.client.call('pane.send_text', {
+        pane_id: paneId,
+        text: `${opencodeCmd}\n`,
+      });
+
+      log('[herdr] spawnPane: SUCCESS', { paneId });
+      // Rebalance panes after bursts of child sessions settle.
+      this.scheduleLayout();
+      return { success: true, paneId };
+    } catch (err) {
+      log('[herdr] spawnPane: exception', { error: String(err) });
+      return { success: false };
+    }
+  }
+
+  async closePane(paneId: string): Promise<boolean> {
+    if (!paneId) {
+      log('[herdr] closePane: no paneId provided');
+      return false;
+    }
+
+    try {
+      // 1. Send Ctrl+C for graceful shutdown
+      try {
+        log('[herdr] closePane: sending Ctrl+C', { paneId });
+        await this.client.call('pane.send_keys', {
+          pane_id: paneId,
+          keys: ['ctrl+c'],
+        });
+      } catch (sendErr) {
+        log('[herdr] closePane: send_keys failed (pane may already be gone)', {
+          error: String(sendErr),
+        });
+        // Continue — the pane may already be closed
+      }
+
+      // 2. Wait for graceful shutdown (matches tmux 250ms window)
+      await new Promise((r) => setTimeout(r, 250));
+
+      // 3. Close the pane
+      log('[herdr] closePane: closing pane', { paneId });
+      await this.client.call('pane.close', { pane_id: paneId });
+
+      log('[herdr] closePane: SUCCESS', { paneId });
+      // Rebalance panes after bursts of child sessions settle.
+      this.scheduleLayout();
+      return true;
+    } catch (err) {
+      if (isHerdrError(err, 'pane_not_found')) {
+        log('[herdr] closePane: pane already closed', { paneId });
+        // Rebalance — a pane was removed even if already gone.
+        this.scheduleLayout();
+        return true;
+      }
+
+      log('[herdr] closePane: exception', { error: String(err) });
+      return false;
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Layout
+  // -----------------------------------------------------------------------
+
+  async applyLayout(
+    layout: MultiplexerLayout,
+    mainPaneSize: number,
+  ): Promise<void> {
+    if (this.layoutTimer) {
+      clearTimeout(this.layoutTimer);
+      this.layoutTimer = undefined;
+    }
+
+    this.layoutGeneration++;
+    await this.applyLayoutNow(layout, mainPaneSize);
+  }
+
+  private scheduleLayout(): void {
+    if (this.layoutTimer) clearTimeout(this.layoutTimer);
+
+    const gen = ++this.layoutGeneration;
+    this.layoutTimer = setTimeout(() => {
+      this.layoutTimer = undefined;
+      if (this.layoutGeneration === gen) {
+        void this.applyLayoutNow(this.storedLayout, this.storedMainPaneSize);
+      }
+    }, LAYOUT_DEBOUNCE_MS);
+    this.layoutTimer.unref?.();
+  }
+
+  /**
+   * Map a MultiplexerLayout to the split direction spawnPane should use.
+   *
+   * Side-by-side layouts (main-vertical, even-horizontal) split RIGHT
+   * so that pane.resize direction:left|right can adjust widths later.
+   * Stacked layouts (main-horizontal, even-vertical, tiled) split DOWN
+   * so that pane.resize direction:up|down can adjust heights later.
+   */
+  private splitDirectionForLayout(layout: MultiplexerLayout): 'right' | 'down' {
+    if (layout === 'main-vertical' || layout === 'even-horizontal') {
+      return 'right';
+    }
+    return 'down';
+  }
+
+  /**
+   * Apply a layout by resizing panes in-place via pane.resize.
+   *
+   * spawnPane splits in the direction that matches the layout's axis
+   * (RIGHT for width-axis layouts, DOWN for height-axis layouts),
+   * so pane.resize can adjust panes along the correct axis.
+   *
+   * All 5 layouts have real implementations:
+   *   main-vertical     — main pane takes mainPaneSize% width (left-right)
+   *   main-horizontal   — main pane takes mainPaneSize% height (top-bottom)
+   *   even-vertical     — all panes equal height
+   *   even-horizontal   — all panes equal width
+   *   tiled             — same as even-vertical (best approximation)
+   */
+  private async applyLayoutNow(
+    layout: MultiplexerLayout,
+    mainPaneSize: number,
+  ): Promise<void> {
+    this.storedLayout = layout;
+    this.storedMainPaneSize = mainPaneSize;
+
+    try {
+      // 1. Query current tab layout. MUST pass pane_id to scope to the
+      // OpenCode workspace — pane.layout with no pane_id returns the
+      // focused workspace, which may differ from the OpenCode session.
+      const sourcePaneId = process.env.HERDR_PANE_ID;
+      const layoutResp = await this.client.call(
+        'pane.layout',
+        sourcePaneId ? { pane_id: sourcePaneId } : {},
+      );
+      const currentLayout = (layoutResp as Record<string, unknown>)?.layout as
+        | {
+            area: { width: number; height: number };
+            panes: Array<{
+              pane_id: string;
+              rect: {
+                x: number;
+                y: number;
+                width: number;
+                height: number;
+              };
+              focused: boolean;
+            }>;
+          }
+        | undefined;
+
+      if (!currentLayout?.panes?.length) {
+        log('[herdr] applyLayoutNow: no panes in layout');
+        return;
+      }
+
+      const panes = currentLayout.panes;
+      const totalW = currentLayout.area.width;
+      const totalH = currentLayout.area.height;
+
+      // 2. Identify the main pane
+      const mainPane = sourcePaneId
+        ? panes.find((p) => p.pane_id === sourcePaneId)
+        : (panes.find((p) => p.focused) ?? panes[0]);
+
+      if (!mainPane) {
+        log('[herdr] applyLayoutNow: could not identify main pane');
+        return;
+      }
+
+      // Shared PaneRect for un-focused pane arrays in resize replies
+      type PaneRect = {
+        pane_id: string;
+        rect: { x: number; y: number; width: number; height: number };
+      };
+
+      // 3. Apply layout-specific resize logic.
+      //
+      // pane.resize amount is a FLOAT RATIO (0..1) of the tab's axis,
+      // NOT integer cells (confirmed against herdr docs + live probe).
+      // mainPaneSize is already a percentage; convert directly to ratio
+      // to avoid rounding errors from a percentage→cells→ratio round-trip.
+      const targetRatio = mainPaneSize / 100; // e.g. 0.60
+      const ratioThreshold = 0.005; // ~0.5% — skip if already close
+
+      switch (layout) {
+        // === WIDTH-AXIS layouts (split RIGHT, resize LEFT|RIGHT) ===
+
+        case 'main-vertical': {
+          const currentRatio = totalW > 0 ? mainPane.rect.width / totalW : 0;
+          const deltaRatio = targetRatio - currentRatio;
+
+          if (Math.abs(deltaRatio) < ratioThreshold) {
+            log('[herdr] applyLayoutNow: main-vertical already at target', {
+              targetRatio,
+              currentRatio,
+            });
+            return;
+          }
+
+          const direction = deltaRatio > 0 ? 'right' : 'left';
+
+          log('[herdr] applyLayoutNow: resizing main pane', {
+            paneId: mainPane.pane_id,
+            direction,
+            amount: Math.abs(deltaRatio),
+            targetRatio,
+          });
+
+          await this.client.call('pane.resize', {
+            pane_id: mainPane.pane_id,
+            direction,
+            amount: Math.abs(deltaRatio),
+          });
+
+          log('[herdr] applyLayoutNow: main-vertical applied', {
+            layout,
+            mainPaneSize,
+          });
+          break;
+        }
+
+        case 'even-horizontal': {
+          if (panes.length <= 1) {
+            log('[herdr] applyLayoutNow: only one pane, nothing to balance');
+            return;
+          }
+
+          const targetRatioPerPane = 1 / panes.length;
+
+          // Sort panes left-to-right by x position
+          let sorted: PaneRect[] = [...panes].sort(
+            (a, b) => a.rect.x - b.rect.x,
+          );
+
+          for (let i = 0; i < sorted.length - 1; i++) {
+            const pane = sorted[i];
+            const currentRatio = totalW > 0 ? pane.rect.width / totalW : 0;
+            const deltaRatio = targetRatioPerPane - currentRatio;
+            if (Math.abs(deltaRatio) < ratioThreshold) continue;
+
+            const resp = await this.client.call('pane.resize', {
+              pane_id: pane.pane_id,
+              direction: deltaRatio > 0 ? 'right' : 'left',
+              amount: Math.abs(deltaRatio),
+            });
+
+            // Re-read panes from response for next iteration
+            const respLayout = (resp as Record<string, unknown>)?.layout as
+              | { panes: PaneRect[] }
+              | undefined;
+            if (respLayout?.panes) {
+              sorted = [...respLayout.panes].sort(
+                (a, b) => a.rect.x - b.rect.x,
+              );
+            }
+          }
+
+          log('[herdr] applyLayoutNow: even-horizontal applied', {
+            layout,
+            paneCount: panes.length,
+          });
+          break;
+        }
+
+        // === HEIGHT-AXIS layouts (split DOWN, resize UP|DOWN) ===
+
+        case 'main-horizontal': {
+          const currentRatio = totalH > 0 ? mainPane.rect.height / totalH : 0;
+          const deltaRatio = targetRatio - currentRatio;
+
+          if (Math.abs(deltaRatio) < ratioThreshold) {
+            log('[herdr] applyLayoutNow: main-horizontal already at target', {
+              targetRatio,
+              currentRatio,
+            });
+            return;
+          }
+
+          const direction = deltaRatio > 0 ? 'down' : 'up';
+
+          log('[herdr] applyLayoutNow: resizing main pane', {
+            paneId: mainPane.pane_id,
+            direction,
+            amount: Math.abs(deltaRatio),
+            targetRatio,
+          });
+
+          await this.client.call('pane.resize', {
+            pane_id: mainPane.pane_id,
+            direction,
+            amount: Math.abs(deltaRatio),
+          });
+
+          log('[herdr] applyLayoutNow: main-horizontal applied', {
+            layout,
+            mainPaneSize,
+          });
+          break;
+        }
+
+        case 'even-vertical':
+        case 'tiled': {
+          if (panes.length <= 1) {
+            log('[herdr] applyLayoutNow: only one pane, nothing to balance');
+            return;
+          }
+
+          const targetRatioPerPane = 1 / panes.length;
+
+          let sorted: PaneRect[] = [...panes].sort(
+            (a, b) => a.rect.y - b.rect.y,
+          );
+
+          for (let i = 0; i < sorted.length - 1; i++) {
+            const pane = sorted[i];
+            const currentRatio = totalH > 0 ? pane.rect.height / totalH : 0;
+            const deltaRatio = targetRatioPerPane - currentRatio;
+            if (Math.abs(deltaRatio) < ratioThreshold) continue;
+
+            const resp = await this.client.call('pane.resize', {
+              pane_id: pane.pane_id,
+              direction: deltaRatio > 0 ? 'down' : 'up',
+              amount: Math.abs(deltaRatio),
+            });
+
+            const respLayout = (resp as Record<string, unknown>)?.layout as
+              | { panes: PaneRect[] }
+              | undefined;
+            if (respLayout?.panes) {
+              sorted = [...respLayout.panes].sort(
+                (a, b) => a.rect.y - b.rect.y,
+              );
+            }
+          }
+
+          log('[herdr] applyLayoutNow: even-vertical applied', {
+            layout,
+            paneCount: panes.length,
+          });
+          break;
+        }
+      }
+    } catch (err) {
+      log('[herdr] applyLayoutNow: exception', { error: String(err) });
+    }
+  }
+
+  /**
+   * Return the perpendicular split direction.
+   * Used so subsequent agents nest orthogonally to the root split.
+   */
+  private perpendicularDirection(dir: 'right' | 'down'): 'right' | 'down' {
+    return dir === 'right' ? 'down' : 'right';
+  }
+
+  /**
+   * Find the best pane to split from for the next agent spawn.
+   *
+   * Stateless approach — queries pane.list to discover existing agent panes
+   * in the current tab, avoiding manual anchor tracking.
+   *
+   * Returns:
+   *   - An existing agent pane ID if any exist (nest in perpendicular dir)
+   *   - The main pane (HERDR_PANE_ID) if no other agents exist
+   *   - null if HERDR_PANE_ID is not set (can't target anything)
+   */
+  private async findSplitSource(): Promise<string | null> {
+    const mainPane = process.env.HERDR_PANE_ID;
+    if (!mainPane) {
+      log('[herdr] findSplitSource: HERDR_PANE_ID not set');
+      return null;
+    }
+
+    try {
+      const workspaceId = process.env.HERDR_WORKSPACE_ID;
+      const tabId = process.env.HERDR_TAB_ID;
+      if (!workspaceId || !tabId) {
+        log(
+          '[herdr] findSplitSource: HERDR_WORKSPACE_ID or HERDR_TAB_ID not set, splitting from main',
+        );
+        return mainPane;
+      }
+
+      const result = await this.client.call<{
+        panes: Array<{ pane_id: string; tab_id: string }>;
+      }>('pane.list', { workspace_id: workspaceId });
+
+      const otherAgents = result.panes.filter(
+        (p) => p.tab_id === tabId && p.pane_id !== mainPane,
+      );
+
+      if (otherAgents.length === 0) {
+        return mainPane;
+      }
+      return otherAgents[0].pane_id;
+    } catch (err) {
+      log('[herdr] findSplitSource: error, falling back to main pane', {
+        error: String(err),
+      });
+      return mainPane;
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Internal helpers
+  // -----------------------------------------------------------------------
+
+  private async findBinary(): Promise<string | null> {
+    const isWindows = process.platform === 'win32';
+    const cmd = isWindows ? 'where' : 'which';
+
+    try {
+      const proc = crossSpawn([cmd, 'herdr'], {
+        stdout: 'pipe',
+        stderr: 'pipe',
+      });
+
+      const exitCode = await proc.exited;
+      if (exitCode !== 0) {
+        log("[herdr] findBinary: 'which herdr' failed", { exitCode });
+        return null;
+      }
+
+      const stdout = await proc.stdout();
+      const path = stdout.trim().split('\n')[0];
+      if (!path) {
+        log('[herdr] findBinary: no path in output');
+        return null;
+      }
+
+      // Verify it works
+      const verifyProc = crossSpawn([path, '--version'], {
+        stdout: 'pipe',
+        stderr: 'pipe',
+      });
+      const verifyExit = await verifyProc.exited;
+      if (verifyExit !== 0) {
+        log('[herdr] findBinary: herdr --version failed', {
+          path,
+          verifyExit,
+        });
+        return null;
+      }
+
+      log('[herdr] findBinary: found', { path });
+      return path;
+    } catch (err) {
+      log('[herdr] findBinary: exception', { error: String(err) });
+      return null;
+    }
+  }
+}
+
+function quoteShellArg(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}

--- a/src/multiplexer/index.ts
+++ b/src/multiplexer/index.ts
@@ -7,6 +7,7 @@ export {
   getMultiplexer,
   startAvailabilityCheck,
 } from './factory';
+export { HerdrMultiplexer } from './herdr';
 export {
   MultiplexerSessionManager,
   TmuxSessionManager,

--- a/src/multiplexer/types.ts
+++ b/src/multiplexer/types.ts
@@ -14,10 +14,10 @@ export interface PaneResult {
 
 /**
  * Core multiplexer interface
- * Implementations: TmuxMultiplexer, ZellijMultiplexer
+ * Implementations: TmuxMultiplexer, ZellijMultiplexer, HerdrMultiplexer
  */
 export interface Multiplexer {
-  readonly type: 'tmux' | 'zellij';
+  readonly type: 'tmux' | 'zellij' | 'herdr';
 
   /**
    * Check if the multiplexer binary is available on the system


### PR DESCRIPTION
OMOS's multiplexer layer supported only tmux and zellij. Users running herdr — a Rust-based terminal workspace manager designed for AI agent orchestration — had no way to get live subagent panes alongside their main session. The abstraction in src/multiplexer/types.ts was already backend-agnostic (split / send-keys / kill-pane by ID), so adding a backend was a matter of implementation, not contract change.

The hard parts were herdr's wire-protocol quirks, each caught by live scratch-workspace probing against the running daemon rather than unit tests alone. Four distinct issues surfaced and were fixed in the same pass.

First, the JSON-RPC Unix socket closes after every response — no keepalive. An initial implementation assumed persistent connection reuse and timed out on the second call. HerdrSocketClient (herdr/client.ts) now opens a fresh socket per call with request/response correlation via a pending-id map, 5s timeout, reconnect-on-drop, and a HerdrError shape discriminator for tolerant pane_not_found handling.

Second, pane.split ignores pane_id for workspace/tab targeting — it always splits the focused workspace. With only pane_id passed, subagent panes leaked into whatever workspace the user had focused, recursively halving the user's real OpenCode pane instead of an isolated agent column. Every pane.split now passes workspace_id and tab_id explicitly, sourced from the HERDR_WORKSPACE_ID and HERDR_TAB_ID env vars herdr sets inside managed panes; spawnPane returns failure if either is unset rather than risk misplacement.

Third, parallel agents nested wrong. Because pane.split defaults to splitting the source pane, spawning N agents re-split the main pane N times, shrinking it to a sliver. spawnPane now resolves a split source via findSplitSource() — a stateless helper that queries pane.list, filters to HERDR_TAB_ID, excludes HERDR_PANE_ID, and returns the first existing agent (or main when no agents exist). The first agent splits main in the layout direction (right for main-vertical); subsequent agents split an existing agent in the perpendicular direction (down), building the correct main | (a1 / a2 / a3) tree matching tmux's main-vertical.

Fourth, pane.resize amount is a float ratio (0..1), not integer cells, and pane.split accepts a ratio param for initial sizing. The original code passed integer cell counts (interpreted as ratio N.0, clamping panes to extremes) and spawned at herdr's default 0.5 ratio before applyLayout snapped the size 150ms later. applyLayoutNow now computes deltaRatio directly from mainPaneSize/100 with no cell conversion or Math.round precision loss; spawnPane passes (100-mainPaneSize)/100 as the spawn ratio so the first agent spawns at its final size with no flicker. pane.layout is scoped with pane_id: HERDR_PANE_ID so it queries the OpenCode workspace rather than the focused one.

HerdrMultiplexer (herdr/index.ts) implements the full lifecycle: spawnPane splits via pane.split then send_text after a 400ms shell-ready delay; closePane sends ctrl+c, waits 250ms, then pane.close; applyLayout rebalances via pane.resize with a 150ms debounce. Layout is direction-aware: side-by-side layouts (main-vertical, even-horizontal) split RIGHT at spawn so left/right resize works at layout time; stacked layouts (main-horizontal, even-vertical, tiled) split DOWN. All 5 presets work natively; tiled approximates as even-vertical. Wired into factory.ts (explicit case + auto-detect via HERDR_ENV last in priority after TMUX and ZELLIJ), config schema enum, the Multiplexer type union, and module exports. Drop-in config compatible with existing tmux configs — only the type field changes.

47 new tests cover the wire client (framing, timeout, reconnect, error discrimination) and backend lifecycle (spawn targeting, direction-aware nesting, ratio math, layout resize per axis, close tolerance). Updated README, AGENTS.md, configuration.md, multiplexer-integration.md, both repo-level and per-directory codemaps, and the published JSON schema. Full suite: 1256 pass, 0 regressions.