### PR TITLE
fix: clean up subagent attach sessions

### DIFF
--- a/src/multiplexer/session-manager.test.ts
+++ b/src/multiplexer/session-manager.test.ts
@@ -522,6 +522,53 @@ describe('MultiplexerSessionManager', () => {
       }
     });
 
+    test('deferred idle close retries when the background job times out', async () => {
+      const ctx = createMockContext();
+      const board = new BackgroundJobBoard();
+      board.registerLaunch({
+        taskID: 'timed-out-deferred',
+        parentSessionID: 'parent-1',
+        agent: 'explorer',
+      });
+      mockMultiplexer.spawnPane.mockResolvedValue({
+        success: true,
+        paneId: 'p-timed-out-deferred',
+      });
+      const manager = new MultiplexerSessionManager(
+        ctx,
+        defaultMultiplexerConfig,
+        board,
+      );
+      board.setTerminalStateListener((taskID) => {
+        void manager.retryDeferredIdleClose(taskID);
+      });
+
+      await manager.onSessionCreated({
+        type: 'session.created',
+        properties: {
+          info: { id: 'timed-out-deferred', parentID: 'parent-1' },
+        },
+      });
+      await manager.onSessionStatus({
+        type: 'session.status',
+        properties: {
+          sessionID: 'timed-out-deferred',
+          status: { type: 'idle' },
+        },
+      });
+
+      board.updateStatus({
+        taskID: 'timed-out-deferred',
+        state: 'running',
+        timedOut: true,
+      });
+      await Promise.resolve();
+
+      expect(mockMultiplexer.closePane).toHaveBeenCalledWith(
+        'p-timed-out-deferred',
+      );
+    });
+
     test('deferred idle close retries on markCancelled', async () => {
       const ctx = createMockContext();
       const board = new BackgroundJobBoard();
@@ -563,7 +610,7 @@ describe('MultiplexerSessionManager', () => {
       );
     });
 
-    test('terminal status without deferred idle close does not close pane', async () => {
+    test('terminal status without prior defer closes tracked pane', async () => {
       const ctx = createMockContext();
       const board = new BackgroundJobBoard();
       const coordinator = new BackgroundJobCoordinator(board);
@@ -597,7 +644,9 @@ describe('MultiplexerSessionManager', () => {
       });
       await Promise.resolve();
 
-      expect(mockMultiplexer.closePane).not.toHaveBeenCalled();
+      expect(mockMultiplexer.closePane).toHaveBeenCalledWith(
+        'p-terminal-without-defer',
+      );
     });
 
     test('deleted clears deferred idle close and later terminal update is no-op', async () => {
@@ -787,7 +836,10 @@ describe('MultiplexerSessionManager', () => {
       });
       await Promise.resolve();
 
-      expect(mockMultiplexer.closePane).not.toHaveBeenCalled();
+      expect(mockMultiplexer.closePane).toHaveBeenCalledWith(
+        'p-retry-event-deferred',
+      );
+      expect(mockMultiplexer.closePane).toHaveBeenCalledTimes(1);
 
       await manager.onSessionStatus({
         type: 'session.status',
@@ -796,9 +848,7 @@ describe('MultiplexerSessionManager', () => {
           status: { type: 'idle' },
         },
       });
-      expect(mockMultiplexer.closePane).toHaveBeenCalledWith(
-        'p-retry-event-deferred',
-      );
+      expect(mockMultiplexer.closePane).toHaveBeenCalledTimes(1);
     });
 
     test('explicit non-idle poll clears stale deferred idle close', async () => {
@@ -840,7 +890,10 @@ describe('MultiplexerSessionManager', () => {
       board.updateStatus({ taskID: 'resumed-deferred', state: 'completed' });
       await Promise.resolve();
 
-      expect(mockMultiplexer.closePane).not.toHaveBeenCalled();
+      expect(mockMultiplexer.closePane).toHaveBeenCalledWith(
+        'p-resumed-deferred',
+      );
+      expect(mockMultiplexer.closePane).toHaveBeenCalledTimes(1);
 
       await manager.onSessionStatus({
         type: 'session.status',
@@ -849,9 +902,7 @@ describe('MultiplexerSessionManager', () => {
           status: { type: 'idle' },
         },
       });
-      expect(mockMultiplexer.closePane).toHaveBeenCalledWith(
-        'p-resumed-deferred',
-      );
+      expect(mockMultiplexer.closePane).toHaveBeenCalledTimes(1);
     });
 
     test('does not close on transient status absence', async () => {

--- a/src/multiplexer/session-manager.test.ts
+++ b/src/multiplexer/session-manager.test.ts
@@ -540,7 +540,7 @@ describe('MultiplexerSessionManager', () => {
         board,
       );
       board.setTerminalStateListener((taskID) => {
-        void manager.retryDeferredIdleClose(taskID);
+        void manager.closeSessionFromCoordinator(taskID);
       });
 
       await manager.onSessionCreated({
@@ -567,6 +567,47 @@ describe('MultiplexerSessionManager', () => {
       expect(mockMultiplexer.closePane).toHaveBeenCalledWith(
         'p-timed-out-deferred',
       );
+    });
+
+    test('timed out running job closes tracked pane without prior defer', async () => {
+      const ctx = createMockContext();
+      const board = new BackgroundJobBoard();
+      board.registerLaunch({
+        taskID: 'timed-out-direct',
+        parentSessionID: 'parent-1',
+        agent: 'explorer',
+      });
+      mockMultiplexer.spawnPane.mockResolvedValue({
+        success: true,
+        paneId: 'p-timed-out-direct',
+      });
+      const manager = new MultiplexerSessionManager(
+        ctx,
+        defaultMultiplexerConfig,
+        board,
+      );
+      board.setTerminalStateListener((taskID) => {
+        void manager.closeSessionFromCoordinator(taskID);
+      });
+
+      await manager.onSessionCreated({
+        type: 'session.created',
+        properties: {
+          info: { id: 'timed-out-direct', parentID: 'parent-1' },
+        },
+      });
+
+      board.updateStatus({
+        taskID: 'timed-out-direct',
+        state: 'running',
+        timedOut: true,
+      });
+      await Promise.resolve();
+
+      expect(mockMultiplexer.closePane).toHaveBeenCalledWith(
+        'p-timed-out-direct',
+      );
+      expect(mockMultiplexer.closePane).toHaveBeenCalledTimes(1);
     });
 
     test('deferred idle close retries on markCancelled', async () => {
@@ -729,7 +770,7 @@ describe('MultiplexerSessionManager', () => {
       });
 
       // The coordinator's terminal state listener will handle the close
-      // when the job completes, so we don't need to call retryDeferredIdleClose directly
+      // when the job completes, so we don't need to call closeSessionFromCoordinator directly
       expect(mockMultiplexer.closePane).not.toHaveBeenCalled();
 
       board.updateStatus({

--- a/src/multiplexer/session-manager.ts
+++ b/src/multiplexer/session-manager.ts
@@ -624,7 +624,7 @@ export class MultiplexerSessionManager {
     if (!this.enabled) return;
     // Coordinator already vetted lifecycle policy; skip re-check
     // ponytail: theoretical race if new job starts between coordinator's
-    // retryDeferredClose() and this call, but session IDs are unique per launch
+    // policy decision and this call, but session IDs are unique per launch
     await this.closeSession(sessionId, 'idle', true);
   }
 

--- a/src/utils/background-job-board.test.ts
+++ b/src/utils/background-job-board.test.ts
@@ -432,6 +432,22 @@ describe('BackgroundJobBoard', () => {
     expect(listener).toHaveBeenCalledTimes(1);
   });
 
+  test('notifies terminal listener when running job times out', () => {
+    const board = new BackgroundJobBoard();
+    const listener = mock(() => {});
+    board.setTerminalStateListener(listener);
+    board.registerLaunch({
+      taskID: 'ses_1',
+      parentSessionID: 'parent-1',
+      agent: 'fixer',
+    });
+
+    board.updateStatus({ taskID: 'ses_1', state: 'running', timedOut: true });
+
+    expect(listener).toHaveBeenCalledWith('ses_1');
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
   test('notifies terminal listener on markCancelled mutation', () => {
     const board = new BackgroundJobBoard();
     const listener = mock(() => {});

--- a/src/utils/background-job-board.ts
+++ b/src/utils/background-job-board.ts
@@ -192,6 +192,8 @@ export class BackgroundJobBoard implements BackgroundJobStore {
     const now = input.now ?? Date.now();
     const terminal = TERMINAL_STATES.has(input.state);
     const notifyTerminal = terminal && !TERMINAL_STATES.has(existing.state);
+    const notifyTimedOut =
+      input.state === 'running' && input.timedOut && !existing.timedOut;
     const updated: BackgroundJobRecord = {
       ...existing,
       state: input.state,
@@ -226,7 +228,8 @@ export class BackgroundJobBoard implements BackgroundJobStore {
 
     this.jobs.set(input.taskID, updated);
     this.trimReusable(input.taskID);
-    if (notifyTerminal) this.notifyTerminalStateListeners(input.taskID);
+    if (notifyTerminal || notifyTimedOut)
+      this.notifyTerminalStateListeners(input.taskID);
     return updated;
   }
 

--- a/src/utils/background-job-board.ts
+++ b/src/utils/background-job-board.ts
@@ -524,10 +524,6 @@ export class BackgroundJobBoard implements BackgroundJobStore {
     return false; // ponytail: safe default - don't close
   }
 
-  retryDeferredClose(_sessionId: string): boolean {
-    return false; // Nothing deferred at board level
-  }
-
   clearDeferredClose(_sessionId: string): void {
     // No-op at board level
   }

--- a/src/utils/background-job-coordinator.test.ts
+++ b/src/utils/background-job-coordinator.test.ts
@@ -75,19 +75,19 @@ describe('BackgroundJobCoordinator', () => {
     expect(listener).toHaveBeenCalledWith('ses_123');
   });
 
-  test('handleTerminalState does not notify when not in deferred set', () => {
+  test('handleTerminalState notifies on terminal state even without prior defer', () => {
     const board = createMockBoard(false);
     const coordinator = new BackgroundJobCoordinator(board);
     const listener = mock(() => {});
 
     coordinator.addTerminalStateListener(listener);
 
-    // Simulate terminal state notification without deferring first
+    // Simulate terminal state notification without prior defer
     board.getState.mockReturnValue('completed');
     const boardListener = board.addTerminalStateListener.mock.calls[0]?.[0];
     boardListener?.('ses_123');
 
-    expect(listener).not.toHaveBeenCalled();
+    expect(listener).toHaveBeenCalledWith('ses_123');
   });
 
   test('full chain: board terminal → coordinator → listener for deferred job', () => {

--- a/src/utils/background-job-coordinator.test.ts
+++ b/src/utils/background-job-coordinator.test.ts
@@ -24,37 +24,7 @@ describe('BackgroundJobCoordinator', () => {
     expect(coordinator.deferIfRunning('ses_123')).toBe(true);
   });
 
-  test('retryDeferredClose returns false when not in deferred set', () => {
-    const board = createMockBoard(false);
-    const coordinator = new BackgroundJobCoordinator(board);
-    expect(coordinator.retryDeferredClose('ses_123')).toBe(false);
-  });
-
-  test('retryDeferredClose returns true after job completes', () => {
-    const board = createMockBoard(true);
-    const coordinator = new BackgroundJobCoordinator(board);
-
-    // First call defers (job running)
-    expect(coordinator.deferIfRunning('ses_123')).toBe(false);
-
-    // Now simulate job completion
-    board.isRunning.mockReturnValue(false);
-    expect(coordinator.retryDeferredClose('ses_123')).toBe(true);
-  });
-
-  test('clearDeferredClose removes from deferred set', () => {
-    const board = createMockBoard(true);
-    const coordinator = new BackgroundJobCoordinator(board);
-
-    coordinator.deferIfRunning('ses_123');
-    coordinator.clearDeferredClose('ses_123');
-
-    // Now retryDeferredClose should return false (not in set)
-    board.isRunning.mockReturnValue(false);
-    expect(coordinator.retryDeferredClose('ses_123')).toBe(false);
-  });
-
-  test('handleTerminalState notifies listeners when retryDeferredClose returns true', () => {
+  test('handleTerminalState notifies listeners for a deferred job', () => {
     const board = createMockBoard(true);
     const coordinator = new BackgroundJobCoordinator(board);
     const listener = mock(() => {});

--- a/src/utils/background-job-coordinator.ts
+++ b/src/utils/background-job-coordinator.ts
@@ -51,15 +51,11 @@ export class BackgroundJobCoordinator implements BackgroundJobStore {
    */
   private handleTerminalState(taskID: string): void {
     // Re-check board state to handle races
-    const state = this.board.getState(taskID);
-    if (state === undefined) return; // Job was already cleaned up
+    if (this.board.getState(taskID) === undefined) return;
 
-    // Check if this session should now close
-    if (this.retryDeferredClose(taskID)) {
-      // Notify listeners that session should close
-      for (const listener of this.terminalStateListeners) {
-        listener(taskID);
-      }
+    // Notify listeners on any terminal/timeout state
+    for (const listener of this.terminalStateListeners) {
+      listener(taskID);
     }
   }
 

--- a/src/utils/background-job-coordinator.ts
+++ b/src/utils/background-job-coordinator.ts
@@ -75,15 +75,6 @@ export class BackgroundJobCoordinator implements BackgroundJobStore {
   }
 
   /**
-   * Retry closing a deferred session. Called when a background job completes.
-   * Returns true if the session should now close.
-   */
-  retryDeferredClose(sessionId: string): boolean {
-    if (!this.deferredIdleCloses.has(sessionId)) return false;
-    return this.deferIfRunning(sessionId);
-  }
-
-  /**
    * Clear deferred close state for a session being deleted.
    */
   clearDeferredClose(sessionId: string): void {

--- a/src/utils/background-job-store.ts
+++ b/src/utils/background-job-store.ts
@@ -72,8 +72,6 @@ export interface BackgroundJobStore {
   /** Evaluate close policy. Returns true if session should close now.
    *  Mutates deferred state: adds to deferred set if running, removes if not. */
   deferIfRunning(sessionId: string): boolean;
-  /** Retry closing a deferred session. Returns true if session should now close. */
-  retryDeferredClose(sessionId: string): boolean;
   /** Clear deferred close state for a session being deleted. */
   clearDeferredClose(sessionId: string): void;
 }


### PR DESCRIPTION
## Summary
- close tracked multiplexer panes when background jobs complete, fail, cancel, or time out
- stop timed-out running jobs from deferring idle cleanup forever
- keep cleanup scoped to plugin-tracked pane/session IDs without broad process matching

## Validation
- bun test src/multiplexer/session-manager.test.ts
- bun test src/utils/background-job-board.test.ts
- bun test src/multiplexer/session-manager.test.ts src/utils/background-job-board.test.ts
- bun run typecheck
- bun run check:ci
- bun test

## Related issue
- #124