### PR TITLE
fix(background-job-board): prune leaked alias counters on job removal

### DIFF
--- a/src/utils/background-job-board.test.ts
+++ b/src/utils/background-job-board.test.ts
@@ -698,4 +698,82 @@ describe('BackgroundJobBoard', () => {
     const prompt = board.formatForPrompt('parent-1', 9_000);
     expect(prompt).toContain('running [resumed, 4s ago]');
   });
+
+  test('resets the alias counter after the last job for a prefix is dropped', () => {
+    const board = new BackgroundJobBoard();
+    const first = board.registerLaunch({
+      taskID: 'ses_1',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+    });
+    expect(first.alias).toBe('exp-1');
+
+    board.drop('ses_1');
+
+    // No explorer jobs remain for parent-1, so the counter is released and
+    // the next alias restarts at 1 instead of leaking to exp-2.
+    const second = board.registerLaunch({
+      taskID: 'ses_2',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+    });
+    expect(second.alias).toBe('exp-1');
+  });
+
+  test('keeps the alias counter while another job of the same prefix remains', () => {
+    const board = new BackgroundJobBoard();
+    board.registerLaunch({
+      taskID: 'ses_1',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+    });
+    board.registerLaunch({
+      taskID: 'ses_2',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+    });
+
+    // Dropping exp-1 while exp-2 is still live must NOT reset the counter,
+    // otherwise the next alias would collide with the live exp-2.
+    board.drop('ses_1');
+
+    const third = board.registerLaunch({
+      taskID: 'ses_3',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+    });
+    expect(third.alias).toBe('exp-3');
+  });
+
+  test('clearParent releases alias counters for that parent only', () => {
+    const board = new BackgroundJobBoard();
+    board.registerLaunch({
+      taskID: 'ses_1',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+    });
+    board.registerLaunch({
+      taskID: 'ses_2',
+      parentSessionID: 'parent-2',
+      agent: 'explorer',
+    });
+
+    board.clearParent('parent-1');
+
+    // parent-1's counter is released → restarts at exp-1.
+    const reused = board.registerLaunch({
+      taskID: 'ses_3',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+    });
+    expect(reused.alias).toBe('exp-1');
+
+    // parent-2 is untouched → continues from exp-2.
+    const other = board.registerLaunch({
+      taskID: 'ses_4',
+      parentSessionID: 'parent-2',
+      agent: 'explorer',
+    });
+    expect(other.alias).toBe('exp-2');
+  });
 });

--- a/src/utils/background-job-board.ts
+++ b/src/utils/background-job-board.ts
@@ -396,13 +396,20 @@ export class BackgroundJobBoard {
   }
 
   clearParent(parentSessionID: string): void {
+    const agents = new Set<string>();
     for (const job of this.list(parentSessionID)) {
+      agents.add(job.agent);
       this.jobs.delete(job.taskID);
+    }
+    for (const agent of agents) {
+      this.pruneCounter(parentSessionID, agent);
     }
   }
 
   drop(taskID: string): void {
+    const job = this.jobs.get(taskID);
     this.jobs.delete(taskID);
+    if (job) this.pruneCounter(job.parentSessionID, job.agent);
   }
 
   private trimReusable(taskID: string): void {
@@ -415,6 +422,7 @@ export class BackgroundJobBoard {
       .sort((a, b) => b.lastUsedAt - a.lastUsedAt);
     for (const stale of reusable.slice(this.maxReusablePerAgent)) {
       this.jobs.delete(stale.taskID);
+      this.pruneCounter(stale.parentSessionID, stale.agent);
     }
   }
 
@@ -436,13 +444,35 @@ export class BackgroundJobBoard {
   }
 
   private nextAlias(parentSessionID: string, agent: string): string {
-    const prefix = AGENT_PREFIX[agent] ?? (agent.slice(0, 3) || 'job');
+    const prefix = aliasPrefix(agent);
     const key = `${parentSessionID}:${prefix}`;
     const next = (this.counters.get(key) ?? 0) + 1;
     this.counters.set(key, next);
 
     return `${prefix}-${next}`;
   }
+
+  /**
+   * Release the alias counter for a parent/prefix once no jobs remain that
+   * could collide with a reset count. Without this, every (parent session ×
+   * agent prefix) pair leaks one counter entry for the life of the process,
+   * even after all its jobs have been dropped or cleared. Resetting the
+   * count is safe because aliases only need to stay unique among jobs that
+   * still exist for the parent.
+   */
+  private pruneCounter(parentSessionID: string, agent: string): void {
+    const prefix = aliasPrefix(agent);
+    const stillUsed = [...this.jobs.values()].some(
+      (job) =>
+        job.parentSessionID === parentSessionID &&
+        aliasPrefix(job.agent) === prefix,
+    );
+    if (!stillUsed) this.counters.delete(`${parentSessionID}:${prefix}`);
+  }
+}
+
+function aliasPrefix(agent: string): string {
+  return AGENT_PREFIX[agent] ?? (agent.slice(0, 3) || 'job');
 }
 
 export function deriveTaskSessionLabel(input: {


### PR DESCRIPTION
## Summary

Second-round resource fix following the audit in #597 and the follow-up tracker #600.

`BackgroundJobBoard` kept an alias `counters` Map keyed by `${parentSessionID}:${prefix}` that grew monotonically via `nextAlias()` and was **never pruned**. The job-deletion paths (`clearParent()`, `drop()`, `trimReusable()`) removed the job records but left the counter entries behind, leaking one entry per (parent session × agent prefix) for the life of long-running serve/dashboard processes.

This is the "background job-board alias-counter pruning" candidate listed in #600.

## Changes

- Extract prefix derivation into a shared `aliasPrefix()` helper.
- Add `pruneCounter(parentSessionID, agent)` that releases a counter entry **only when no remaining job shares that parent+prefix**. Resetting the count is safe under this invariant because aliases only need to stay unique among jobs that still exist — a reset count can never collide with a live alias.
- Wire pruning into all three job-deletion paths: `drop()`, `clearParent()` (collects distinct agents, prunes each), and `trimReusable()`.

## Tests

Added 3 focused regression tests (observable via alias numbering, since `counters` is private):
- Counter resets to `exp-1` after the last job for a prefix is dropped.
- Counter is preserved (`exp-3`) while another same-prefix job is still live — guards against alias collision.
- `clearParent` releases only that parent's counters, leaving sibling parents untouched.

## Validation

- `bun run typecheck` ✅
- `bun run check:ci` (biome) ✅
- `bun test src/utils/background-job-board.test.ts` → 34 pass ✅
- `bun test` (full suite) → 1217 pass / 0 fail ✅

## Scope

Intentionally one small chunk per #600's guidance. Remaining verified audit candidates left as follow-ups: interview-service record pruning (`interviewsById`/`browserOpened`), multiplexer `cleanup()` teardown + orphaned poll timer on re-init, and companion `process.on('exit')` listener accumulation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)