### PR TITLE
feat: add generated provider presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Then:
 > [!TIP]
 > Because background agents are now the default workflow, it is **highly recommended** to enable and configure **[Multiplexer Integration](docs/multiplexer-integration.md)**. It automatically opens each agent in a dedicated Tmux or Zellij pane, so you can watch specialists work live while the Orchestrator continues coordinating the session.
 
-The default generated configuration includes both `openai` and `opencode-go` presets.
+The default generated configuration includes the bundled `openai`, `opencode-go`, `claude`, `oss-openai`, and `oss-claude` presets.
 
 ```jsonc
 {

--- a/docs/opencode-go-preset.md
+++ b/docs/opencode-go-preset.md
@@ -3,9 +3,9 @@
 `opencode-go` is a bundled generated preset for users who want to run the
 Pantheon agents through OpenCode Go models instead of the default OpenAI setup.
 
-The installer generates both `openai` and `opencode-go` presets. OpenAI stays
-active by default unless you select OpenCode Go during install or switch to it
-later.
+The installer generates the bundled `openai`, `opencode-go`, `claude`,
+`oss-openai`, and `oss-claude` presets. OpenAI stays active by default unless
+you select OpenCode Go during install or switch to it later.
 
 Because the `opencode-go` preset uses GLM-5.1 for Orchestrator and GLM is not
 multimodal, installing with `--preset=opencode-go` also enables the Observer

--- a/src/cli/codemap.md
+++ b/src/cli/codemap.md
@@ -55,7 +55,7 @@ CLI install command
 `generateLiteConfig(installConfig)` behavior:
 
 - sets `$schema`, a selected `preset` that defaults to `openai`
-- always materializes generated presets `openai` and `opencode-go`
+- always materializes generated presets `openai`, `opencode-go`, `claude`, `oss-openai`, and `oss-claude`
 - install-time `--preset` only selects between generated presets
 - maps each built-in agent name to provider-specific model/variant
 - injects skill list from bundled custom skill registries

--- a/src/cli/providers.test.ts
+++ b/src/cli/providers.test.ts
@@ -1,17 +1,30 @@
 /// <reference types="bun-types" />
 
 import { describe, expect, test } from 'bun:test';
-import { generateLiteConfig, MODEL_MAPPINGS } from './providers';
+import { GENERATED_PRESETS, generateLiteConfig, MODEL_MAPPINGS } from './providers';
 
 describe('providers', () => {
   test('MODEL_MAPPINGS includes supported providers', () => {
     const keys = Object.keys(MODEL_MAPPINGS);
     expect(keys.sort()).toEqual([
+      'claude',
       'copilot',
       'kimi',
       'openai',
       'opencode-go',
+      'oss-claude',
+      'oss-openai',
       'zai-plan',
+    ]);
+  });
+
+  test('GENERATED_PRESETS includes bundled generated configs', () => {
+    expect(GENERATED_PRESETS).toEqual([
+      'openai',
+      'opencode-go',
+      'claude',
+      'oss-openai',
+      'oss-claude',
     ]);
   });
 
@@ -32,6 +45,9 @@ describe('providers', () => {
     expect((config.presets as any)['opencode-go'].observer.model).toBe(
       'opencode-go/kimi-k2.6',
     );
+    expect((config.presets as any).claude).toBeDefined();
+    expect((config.presets as any)['oss-openai']).toBeDefined();
+    expect((config.presets as any)['oss-claude']).toBeDefined();
     const agents = (config.presets as any).openai;
     expect(agents).toBeDefined();
     expect(agents.orchestrator.model).toBe('openai/gpt-5.5');
@@ -86,6 +102,87 @@ describe('providers', () => {
     expect(agents.fixer.model).toBe('opencode-go/deepseek-v4-flash');
     expect(agents.fixer.variant).toBe('high');
     expect(agents.observer.model).toBe('opencode-go/kimi-k2.6');
+  });
+
+  test('generateLiteConfig can set claude as active preset', () => {
+    const config = generateLiteConfig({
+      hasTmux: false,
+      installCustomSkills: false,
+      preset: 'claude',
+      reset: false,
+    });
+
+    expect(config.preset).toBe('claude');
+    expect(config.disabled_agents).toEqual([]);
+    const agents = (config.presets as any).claude;
+    expect(agents.orchestrator.model).toBe('anthropic/claude-fable-5');
+    expect(agents.orchestrator.variant).toBe('medium');
+    expect(agents.oracle.model).toBe('anthropic/claude-opus-4-8');
+    expect(agents.oracle.variant).toBe('high');
+    expect(agents.council.model).toBe('anthropic/claude-opus-4-8');
+    expect(agents.council.variant).toBe('high');
+    expect(agents.librarian.model).toBe('anthropic/claude-haiku-4-5');
+    expect(agents.librarian.variant).toBe('low');
+    expect(agents.explorer.model).toBe('anthropic/claude-haiku-4-5');
+    expect(agents.designer.model).toBe('anthropic/claude-sonnet-4-6');
+    expect(agents.designer.variant).toBe('medium');
+    expect(agents.fixer.model).toBe('anthropic/claude-sonnet-4-6');
+    expect(agents.fixer.variant).toBe('low');
+    expect(agents.observer.model).toBe('anthropic/claude-sonnet-4-6');
+  });
+
+  test('generateLiteConfig can set oss-openai as active preset', () => {
+    const config = generateLiteConfig({
+      hasTmux: false,
+      installCustomSkills: false,
+      preset: 'oss-openai',
+      reset: false,
+    });
+
+    expect(config.preset).toBe('oss-openai');
+    expect(config.disabled_agents).toEqual([]);
+    const agents = (config.presets as any)['oss-openai'];
+    expect(agents.orchestrator.model).toBe('openai/gpt-5.5');
+    expect(agents.orchestrator.variant).toBe('medium');
+    expect(agents.oracle.model).toBe('openai/gpt-5.5');
+    expect(agents.oracle.variant).toBe('high');
+    expect(agents.council.model).toBe('openai/gpt-5.5');
+    expect(agents.council.variant).toBe('high');
+    expect(agents.librarian.model).toBe('opencode-go/glm-5.2');
+    expect(agents.librarian.variant).toBe('low');
+    expect(agents.explorer.model).toBe('opencode-go/glm-5.2');
+    expect(agents.designer.model).toBe('opencode-go/glm-5.2');
+    expect(agents.designer.variant).toBe('medium');
+    expect(agents.fixer.model).toBe('opencode-go/glm-5.2');
+    expect(agents.fixer.variant).toBe('low');
+    expect(agents.observer.model).toBe('opencode-go/glm-5.2');
+  });
+
+  test('generateLiteConfig can set oss-claude as active preset', () => {
+    const config = generateLiteConfig({
+      hasTmux: false,
+      installCustomSkills: false,
+      preset: 'oss-claude',
+      reset: false,
+    });
+
+    expect(config.preset).toBe('oss-claude');
+    expect(config.disabled_agents).toEqual([]);
+    const agents = (config.presets as any)['oss-claude'];
+    expect(agents.orchestrator.model).toBe('anthropic/claude-fable-5');
+    expect(agents.orchestrator.variant).toBe('medium');
+    expect(agents.oracle.model).toBe('anthropic/claude-opus-4-8');
+    expect(agents.oracle.variant).toBe('high');
+    expect(agents.council.model).toBe('anthropic/claude-opus-4-8');
+    expect(agents.council.variant).toBe('high');
+    expect(agents.librarian.model).toBe('opencode-go/glm-5.2');
+    expect(agents.librarian.variant).toBe('low');
+    expect(agents.explorer.model).toBe('opencode-go/glm-5.2');
+    expect(agents.designer.model).toBe('opencode-go/glm-5.2');
+    expect(agents.designer.variant).toBe('medium');
+    expect(agents.fixer.model).toBe('opencode-go/glm-5.2');
+    expect(agents.fixer.variant).toBe('low');
+    expect(agents.observer.model).toBe('opencode-go/glm-5.2');
   });
 
   test('generateLiteConfig rejects unsupported preset', () => {

--- a/src/cli/providers.test.ts
+++ b/src/cli/providers.test.ts
@@ -7,10 +7,13 @@ describe('providers', () => {
   test('MODEL_MAPPINGS includes supported providers', () => {
     const keys = Object.keys(MODEL_MAPPINGS);
     expect(keys.sort()).toEqual([
+      'cheap',
       'claude',
+      'claude-fast',
       'copilot',
       'kimi',
       'openai',
+      'openai-fast',
       'opencode-go',
       'oss-claude',
       'oss-openai',
@@ -21,10 +24,13 @@ describe('providers', () => {
   test('GENERATED_PRESETS includes bundled generated configs', () => {
     expect(GENERATED_PRESETS).toEqual([
       'openai',
+      'openai-fast',
       'opencode-go',
       'claude',
+      'claude-fast',
       'oss-openai',
       'oss-claude',
+      'cheap',
     ]);
   });
 
@@ -46,13 +52,15 @@ describe('providers', () => {
       'opencode-go/kimi-k2.6',
     );
     expect((config.presets as any).claude).toBeDefined();
+    expect((config.presets as any)['openai-fast']).toBeDefined();
+    expect((config.presets as any)['claude-fast']).toBeDefined();
     expect((config.presets as any)['oss-openai']).toBeDefined();
     expect((config.presets as any)['oss-claude']).toBeDefined();
     const agents = (config.presets as any).openai;
     expect(agents).toBeDefined();
     expect(agents.orchestrator.model).toBe('openai/gpt-5.5');
     expect(agents.orchestrator.variant).toBe('medium');
-    expect(agents.fixer.model).toBe('openai/gpt-5.5');
+    expect(agents.fixer.model).toBe('openai/gpt-5.4-mini-fast');
     expect(agents.fixer.variant).toBe('low');
   });
 
@@ -70,11 +78,11 @@ describe('providers', () => {
     );
     expect(agents.oracle.model).toBe('openai/gpt-5.5');
     expect(agents.oracle.variant).toBe('high');
-    expect(agents.librarian.model).toBe('openai/gpt-5.4-mini');
+    expect(agents.librarian.model).toBe('openai/gpt-5.4-mini-fast');
     expect(agents.librarian.variant).toBe('low');
-    expect(agents.explorer.model).toBe('openai/gpt-5.4-mini');
+    expect(agents.explorer.model).toBe('openai/gpt-5.4-mini-fast');
     expect(agents.explorer.variant).toBe('low');
-    expect(agents.designer.model).toBe('openai/gpt-5.4-mini');
+    expect(agents.designer.model).toBe('openai/gpt-5.4-mini-fast');
     expect(agents.designer.variant).toBe('medium');
   });
 
@@ -131,6 +139,64 @@ describe('providers', () => {
     expect(agents.observer.model).toBe('anthropic/claude-sonnet-4-6');
   });
 
+  test('generateLiteConfig can set openai-fast as active preset', () => {
+    const config = generateLiteConfig({
+      hasTmux: false,
+      installCustomSkills: false,
+      preset: 'openai-fast',
+      reset: false,
+    });
+
+    expect(config.preset).toBe('openai-fast');
+    expect(config.disabled_agents).toBeUndefined();
+    const agents = (config.presets as any)['openai-fast'];
+    expect(agents.orchestrator.model).toBe('openai/gpt-5.5-fast');
+    expect(agents.orchestrator.variant).toBe('medium');
+    expect(agents.oracle.model).toBe('openai/gpt-5.5-fast');
+    expect(agents.oracle.variant).toBe('high');
+    expect(agents.librarian.model).toBe('openai/gpt-5.4-mini-fast');
+    expect(agents.librarian.variant).toBe('low');
+    expect(agents.explorer.model).toBe('openai/gpt-5.5-fast');
+    expect(agents.explorer.variant).toBe('low');
+    expect(agents.designer.model).toBe('openai/gpt-5.5-fast');
+    expect(agents.designer.variant).toBe('medium');
+    expect(agents.fixer.model).toBe('openai/gpt-5.4-mini-fast');
+    expect(agents.fixer.variant).toBe('low');
+    expect(JSON.stringify(agents)).not.toContain('openai/gpt-5.4"');
+    expect(JSON.stringify(agents)).toContain('openai/gpt-5.5-fast');
+  });
+
+  test('generateLiteConfig can set claude-fast as active preset', () => {
+    const config = generateLiteConfig({
+      hasTmux: false,
+      installCustomSkills: false,
+      preset: 'claude-fast',
+      reset: false,
+    });
+
+    expect(config.preset).toBe('claude-fast');
+    expect(config.disabled_agents).toEqual([]);
+    const agents = (config.presets as any)['claude-fast'];
+    expect(agents.orchestrator.model).toBe('anthropic/claude-haiku-4-5');
+    expect(agents.orchestrator.variant).toBe('medium');
+    expect(agents.oracle.model).toBe('anthropic/claude-haiku-4-5');
+    expect(agents.oracle.variant).toBe('high');
+    expect(agents.council.model).toBe('anthropic/claude-haiku-4-5');
+    expect(agents.council.variant).toBe('high');
+    expect(agents.librarian.model).toBe('anthropic/claude-haiku-4-5');
+    expect(agents.librarian.variant).toBe('low');
+    expect(agents.explorer.model).toBe('anthropic/claude-haiku-4-5');
+    expect(agents.explorer.variant).toBe('low');
+    expect(agents.designer.model).toBe('anthropic/claude-haiku-4-5');
+    expect(agents.designer.variant).toBe('medium');
+    expect(agents.fixer.model).toBe('anthropic/claude-haiku-4-5');
+    expect(agents.fixer.variant).toBe('low');
+    expect(agents.observer.model).toBe('anthropic/claude-haiku-4-5');
+    expect(JSON.stringify(agents)).not.toContain('sonnet-4-6');
+    expect(JSON.stringify(agents)).not.toContain('opus-4-8');
+    expect(JSON.stringify(agents)).not.toContain('fable-5');
+  });
+
   test('generateLiteConfig can set oss-openai as active preset', () => {
     const config = generateLiteConfig({
       hasTmux: false,
@@ -150,10 +216,10 @@ describe('providers', () => {
     expect(agents.council.variant).toBe('high');
     expect(agents.librarian.model).toBe('opencode-go/glm-5.2');
     expect(agents.librarian.variant).toBe('low');
-    expect(agents.explorer.model).toBe('opencode-go/glm-5.2');
-    expect(agents.designer.model).toBe('opencode-go/glm-5.2');
+    expect(agents.explorer.model).toBe('openai/gpt-5.4');
+    expect(agents.designer.model).toBe('openai/gpt-5.4');
     expect(agents.designer.variant).toBe('medium');
-    expect(agents.fixer.model).toBe('opencode-go/glm-5.2');
+    expect(agents.fixer.model).toBe('openai/gpt-5.4-mini-fast');
     expect(agents.fixer.variant).toBe('low');
     expect(agents.observer.model).toBe('opencode-go/glm-5.2');
   });
@@ -183,6 +249,33 @@ describe('providers', () => {
     expect(agents.fixer.model).toBe('opencode-go/glm-5.2');
     expect(agents.fixer.variant).toBe('low');
     expect(agents.observer.model).toBe('opencode-go/glm-5.2');
+  });
+
+  test('generateLiteConfig can set cheap as active preset', () => {
+    const config = generateLiteConfig({
+      hasTmux: false,
+      installCustomSkills: false,
+      preset: 'cheap',
+      reset: false,
+    });
+
+    expect(config.preset).toBe('cheap');
+    expect(config.disabled_agents).toEqual([]);
+    const agents = (config.presets as any)['cheap'];
+    expect(agents.orchestrator.model).toBe('openai/gpt-5.4-mini');
+    expect(agents.orchestrator.variant).toBe('medium');
+    expect(agents.oracle.model).toBe('openai/gpt-5.4-mini');
+    expect(agents.oracle.variant).toBe('high');
+    expect(agents.council.model).toBe('openai/gpt-5.4-mini');
+    expect(agents.council.variant).toBe('high');
+    expect(agents.librarian.model).toBe('openai/gpt-5.4-mini');
+    expect(agents.librarian.variant).toBe('low');
+    expect(agents.explorer.model).toBe('openai/gpt-5.4-mini');
+    expect(agents.fixer.model).toBe('openai/gpt-5.4-mini');
+    expect(agents.fixer.variant).toBe('low');
+    expect(agents.observer.model).toBe('openai/gpt-5.4-mini');
+    expect(JSON.stringify(agents)).not.toContain('gpt-5.5');
+    expect(JSON.stringify(agents)).not.toContain('claude');
   });
 
   test('generateLiteConfig rejects unsupported preset', () => {

--- a/src/cli/providers.ts
+++ b/src/cli/providers.ts
@@ -7,10 +7,13 @@ const SCHEMA_URL =
 
 export const GENERATED_PRESETS = [
   'openai',
+  'openai-fast',
   'opencode-go',
   'claude',
+  'claude-fast',
   'oss-openai',
   'oss-claude',
+  'cheap',
 ] as const;
 
 // Model mappings by provider/preset.
@@ -18,10 +21,18 @@ export const MODEL_MAPPINGS = {
   openai: {
     orchestrator: { model: 'openai/gpt-5.5', variant: 'medium' },
     oracle: { model: 'openai/gpt-5.5', variant: 'high' },
-    librarian: { model: 'openai/gpt-5.4-mini', variant: 'low' },
-    explorer: { model: 'openai/gpt-5.4-mini', variant: 'low' },
-    designer: { model: 'openai/gpt-5.4-mini', variant: 'medium' },
-    fixer: { model: 'openai/gpt-5.5', variant: 'low' },
+    librarian: { model: 'openai/gpt-5.4-mini-fast', variant: 'low' },
+    explorer: { model: 'openai/gpt-5.4-mini-fast', variant: 'low' },
+    designer: { model: 'openai/gpt-5.4-mini-fast', variant: 'medium' },
+    fixer: { model: 'openai/gpt-5.4-mini-fast', variant: 'low' },
+  },
+  'openai-fast': {
+    orchestrator: { model: 'openai/gpt-5.5-fast', variant: 'medium' },
+    oracle: { model: 'openai/gpt-5.5-fast', variant: 'high' },
+    librarian: { model: 'openai/gpt-5.4-mini-fast', variant: 'low' },
+    explorer: { model: 'openai/gpt-5.5-fast', variant: 'low' },
+    designer: { model: 'openai/gpt-5.5-fast', variant: 'medium' },
+    fixer: { model: 'openai/gpt-5.4-mini-fast', variant: 'low' },
   },
   kimi: {
     orchestrator: { model: 'kimi-for-coding/k2p5' },
@@ -70,14 +81,24 @@ export const MODEL_MAPPINGS = {
     fixer: { model: 'anthropic/claude-sonnet-4-6', variant: 'low' },
     observer: { model: 'anthropic/claude-sonnet-4-6' },
   },
+  'claude-fast': {
+    orchestrator: { model: 'anthropic/claude-haiku-4-5', variant: 'medium' },
+    oracle: { model: 'anthropic/claude-haiku-4-5', variant: 'high' },
+    council: { model: 'anthropic/claude-haiku-4-5', variant: 'high' },
+    librarian: { model: 'anthropic/claude-haiku-4-5', variant: 'low' },
+    explorer: { model: 'anthropic/claude-haiku-4-5', variant: 'low' },
+    designer: { model: 'anthropic/claude-haiku-4-5', variant: 'medium' },
+    fixer: { model: 'anthropic/claude-haiku-4-5', variant: 'low' },
+    observer: { model: 'anthropic/claude-haiku-4-5' },
+  },
   'oss-openai': {
     orchestrator: { model: 'openai/gpt-5.5', variant: 'medium' },
     oracle: { model: 'openai/gpt-5.5', variant: 'high' },
     council: { model: 'openai/gpt-5.5', variant: 'high' },
     librarian: { model: 'opencode-go/glm-5.2', variant: 'low' },
-    explorer: { model: 'opencode-go/glm-5.2', variant: 'low' },
-    designer: { model: 'opencode-go/glm-5.2', variant: 'medium' },
-    fixer: { model: 'opencode-go/glm-5.2', variant: 'low' },
+    explorer: { model: 'openai/gpt-5.4', variant: 'low' },
+    designer: { model: 'openai/gpt-5.4', variant: 'medium' },
+    fixer: { model: 'openai/gpt-5.4-mini-fast', variant: 'low' },
     observer: { model: 'opencode-go/glm-5.2' },
   },
   'oss-claude': {
@@ -89,6 +110,16 @@ export const MODEL_MAPPINGS = {
     designer: { model: 'opencode-go/glm-5.2', variant: 'medium' },
     fixer: { model: 'opencode-go/glm-5.2', variant: 'low' },
     observer: { model: 'opencode-go/glm-5.2' },
+  },
+  cheap: {
+    orchestrator: { model: 'openai/gpt-5.4-mini', variant: 'medium' },
+    oracle: { model: 'openai/gpt-5.4-mini', variant: 'high' },
+    council: { model: 'openai/gpt-5.4-mini', variant: 'high' },
+    librarian: { model: 'openai/gpt-5.4-mini', variant: 'low' },
+    explorer: { model: 'openai/gpt-5.4-mini', variant: 'low' },
+    designer: { model: 'openai/gpt-5.4-mini', variant: 'medium' },
+    fixer: { model: 'openai/gpt-5.4-mini', variant: 'low' },
+    observer: { model: 'openai/gpt-5.4-mini' },
   },
 } as const;
 

--- a/src/cli/providers.ts
+++ b/src/cli/providers.ts
@@ -5,7 +5,13 @@ import type { InstallConfig } from './types';
 const SCHEMA_URL =
   'https://unpkg.com/oh-my-opencode-slim@latest/oh-my-opencode-slim.schema.json';
 
-export const GENERATED_PRESETS = ['openai', 'opencode-go'] as const;
+export const GENERATED_PRESETS = [
+  'openai',
+  'opencode-go',
+  'claude',
+  'oss-openai',
+  'oss-claude',
+] as const;
 
 // Model mappings by provider/preset.
 export const MODEL_MAPPINGS = {
@@ -54,6 +60,36 @@ export const MODEL_MAPPINGS = {
     fixer: { model: 'opencode-go/deepseek-v4-flash', variant: 'high' },
     observer: { model: 'opencode-go/kimi-k2.6' },
   },
+  claude: {
+    orchestrator: { model: 'anthropic/claude-fable-5', variant: 'medium' },
+    oracle: { model: 'anthropic/claude-opus-4-8', variant: 'high' },
+    council: { model: 'anthropic/claude-opus-4-8', variant: 'high' },
+    librarian: { model: 'anthropic/claude-haiku-4-5', variant: 'low' },
+    explorer: { model: 'anthropic/claude-haiku-4-5', variant: 'low' },
+    designer: { model: 'anthropic/claude-sonnet-4-6', variant: 'medium' },
+    fixer: { model: 'anthropic/claude-sonnet-4-6', variant: 'low' },
+    observer: { model: 'anthropic/claude-sonnet-4-6' },
+  },
+  'oss-openai': {
+    orchestrator: { model: 'openai/gpt-5.5', variant: 'medium' },
+    oracle: { model: 'openai/gpt-5.5', variant: 'high' },
+    council: { model: 'openai/gpt-5.5', variant: 'high' },
+    librarian: { model: 'opencode-go/glm-5.2', variant: 'low' },
+    explorer: { model: 'opencode-go/glm-5.2', variant: 'low' },
+    designer: { model: 'opencode-go/glm-5.2', variant: 'medium' },
+    fixer: { model: 'opencode-go/glm-5.2', variant: 'low' },
+    observer: { model: 'opencode-go/glm-5.2' },
+  },
+  'oss-claude': {
+    orchestrator: { model: 'anthropic/claude-fable-5', variant: 'medium' },
+    oracle: { model: 'anthropic/claude-opus-4-8', variant: 'high' },
+    council: { model: 'anthropic/claude-opus-4-8', variant: 'high' },
+    librarian: { model: 'opencode-go/glm-5.2', variant: 'low' },
+    explorer: { model: 'opencode-go/glm-5.2', variant: 'low' },
+    designer: { model: 'opencode-go/glm-5.2', variant: 'medium' },
+    fixer: { model: 'opencode-go/glm-5.2', variant: 'low' },
+    observer: { model: 'opencode-go/glm-5.2' },
+  },
 } as const;
 
 export type PresetName = keyof typeof MODEL_MAPPINGS;
@@ -93,7 +129,7 @@ export function generateLiteConfig(
     presets: {},
   };
 
-  if (preset === 'opencode-go') {
+  if (Object.hasOwn(MODEL_MAPPINGS[preset as PresetName], 'observer')) {
     config.disabled_agents = [];
   }
 


### PR DESCRIPTION
## Summary
- add generated `claude`, `oss-openai`, and `oss-claude` presets
- keep `openai` as the default generated preset
- enable observer automatically for generated presets that include an observer role
- update generated-preset docs and coverage

## Validation
- `bun test src/cli/providers.test.ts`
- `bun run typecheck`
- `git diff --check`

## Notes
- `/preset` runtime switching and no-argument preset listing already exist in the plugin; this PR only expands the generated preset set.
