### PR TITLE
fix: add monthly usage limit pattern to foreground fallback

### DIFF
--- a/src/hooks/foreground-fallback/index.test.ts
+++ b/src/hooks/foreground-fallback/index.test.ts
@@ -89,6 +89,33 @@ describe('isRateLimitError', () => {
     expect(isRateLimitError({ message: 'Insufficient balance.' })).toBe(true);
   });
 
+  test('returns true for "Monthly usage limit reached"', () => {
+    expect(
+      isRateLimitError({
+        message:
+          'Monthly usage limit reached. Resets in X days.',
+      }),
+    ).toBe(true);
+  });
+
+  test('returns true for "5-hour usage limit reached"', () => {
+    expect(
+      isRateLimitError({
+        message:
+          '5-hour usage limit reached. Resets in 36min.',
+      }),
+    ).toBe(true);
+  });
+
+  test('returns true for "Weekly usage limit reached"', () => {
+    expect(
+      isRateLimitError({
+        message:
+          'Weekly usage limit reached. Resets in 2 days.',
+      }),
+    ).toBe(true);
+  });
+
   test('returns false for non-rate-limit error', () => {
     expect(isRateLimitError({ message: 'invalid API key' })).toBe(false);
   });

--- a/src/hooks/foreground-fallback/index.ts
+++ b/src/hooks/foreground-fallback/index.ts
@@ -42,6 +42,9 @@ const RATE_LIMIT_PATTERNS = [
   /insufficient.?(quota|balance)/i,
   /high concurrency/i,
   /reduce concurrency/i,
+  /monthly usage limit/i,
+  /5-hour usage limit/i,
+  /weekly usage limit/i,
 ];
 
 export function isRateLimitError(error: unknown): boolean {


### PR DESCRIPTION
What changed, and why was it needed?

The error string `"Monthly usage limit reached. Resets in N days."` from providers like opencode-go was not matched by any `RATE_LIMIT_PATTERNS` regex in `ForegroundFallbackManager`. This caused oracle and fixer agents to fail outright instead of falling through to the next model in their configured chain.

**Repro:** Configure an agent with a model array, exhaust the monthly usage limit on the first model, delegate a task — the session fails with `AI_APICallError: Monthly usage limit reached` and no fallback is attempted.

**Fix:** Add `/monthly usage limit/i` to `RATE_LIMIT_PATTERNS` + test case.

Fixes #620