### PR TITLE
chore: prepare 2.0.6 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,8 @@ verification while specialists do the work in their own lanes.
 - **[oh-my-opencode-slim skill](#oh-my-opencode-slim-skill)** — a bundled
   configuration skill that helps tune models, prompts, custom agents, MCP access,
   presets, and plugin behavior safely.
+- **Release Smoke Test** — validates packed release candidates and bugfixes
+  before public publish with isolated OpenCode runtime smokes.
 
 #### Background Agents
 
@@ -662,7 +664,7 @@ Use this section as a map: start with installation, then jump to features, confi
 | **[Configuration](docs/configuration.md)** | Config file locations, JSONC support, prompt overrides, and full option reference |
 | **[Background Orchestration](docs/background-orchestration.md)** | Scheduler-first orchestrator model built around native background subagents |
 | **[Maintainer Guide](docs/maintainers.md)** | Issue triage rules, label meanings, support routing, and repo maintenance workflow |
-| **[Skills](docs/skills.md)** | Bundled skills such as `simplify`, `codemap`, `clonedeps`, `deepwork`, `reflect`, `worktrees`, and `oh-my-opencode-slim` |
+| **[Skills](docs/skills.md)** | Bundled skills such as `simplify`, `codemap`, `clonedeps`, `deepwork`, `reflect`, `worktrees`, `release-smoke-test`, and `oh-my-opencode-slim` |
 | **[MCPs](docs/mcps.md)** | `websearch`, `context7`, `gh_grep`, and how MCP permissions work per agent |
 | **[Tools](docs/tools.md)** | Built-in tool capabilities like `webfetch`, LSP tools, code search, and formatters |
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -18,6 +18,7 @@ Bundled skills are installed by the `oh-my-opencode-slim` installer.
 | [`deepwork`](#deepwork) | Heavy/complex coding sessions workflow | `orchestrator` |
 | [`reflect`](#reflect) | Review repeated work and suggest reusable workflow improvements | `orchestrator` |
 | [`worktrees`](#worktrees) | Safe Git worktree lane management | `orchestrator` |
+| [`release-smoke-test`](#release-smoke-test) | Packed release-candidate and bugfix smoke validation | `orchestrator` |
 | [`oh-my-opencode-slim`](#oh-my-opencode-slim) | Plugin configuration and self-improvement guidance | `orchestrator` |
 
 ---
@@ -207,6 +208,32 @@ After config changes, expect guidance like:
 ```text
 This should apply on the next OpenCode run; restart OpenCode if you need it immediately.
 ```
+
+---
+
+## release-smoke-test
+
+**Validate packed release candidates and bugfixes before public publish.**
+
+`release-smoke-test` is an orchestrator-only skill for proving a release branch
+works as an installed package artifact. It builds and packs the candidate,
+installs the tarball into a throwaway app, runs OpenCode with a sanitized
+temporary config, verifies the active `plugin_origins`, and searches isolated
+logs for the crash signature being fixed.
+
+Use it for release hardening, runtime compatibility checks, and model-specific
+smokes such as OpenCode 1.17.11 malformed message transform regressions.
+
+Typical request:
+
+```text
+Use release-smoke-test to validate this release candidate before npm publish.
+```
+
+The skill distinguishes fully isolated smokes from host-provider smokes. If a
+model such as GPT-5.5 Fast needs provider aliases from the current machine, the
+skill records that limitation instead of treating it as equivalent to a clean
+`env -i` smoke.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode-slim",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Lightweight agent orchestration plugin for OpenCode - a slimmed-down fork of oh-my-opencode",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/scripts/verify-release-artifact.ts
+++ b/scripts/verify-release-artifact.ts
@@ -37,6 +37,7 @@ const packagedRequiredFiles = [
   'src/skills/deepwork/SKILL.md',
   'src/skills/reflect/SKILL.md',
   'src/skills/oh-my-opencode-slim/SKILL.md',
+  'src/skills/release-smoke-test/SKILL.md',
   'src/skills/worktrees/SKILL.md',
 ];
 

--- a/src/agents/index.test.ts
+++ b/src/agents/index.test.ts
@@ -296,6 +296,7 @@ describe('skill permissions', () => {
     // CUSTOM_SKILLS loop must also add a named codemap entry for orchestrator
     expect(skillPerm?.codemap).toBe('allow');
     expect(skillPerm?.clonedeps).toBe('allow');
+    expect(skillPerm?.['release-smoke-test']).toBe('allow');
   });
 
   test('fixer does not get codemap skill allowed by default', () => {

--- a/src/cli/custom-skills.ts
+++ b/src/cli/custom-skills.ts
@@ -68,6 +68,13 @@ export const CUSTOM_SKILLS: CustomSkill[] = [
     sourcePath: 'src/skills/oh-my-opencode-slim',
   },
   {
+    name: 'release-smoke-test',
+    description:
+      'Validate packed release candidates and bugfixes before public publish',
+    allowedAgents: ['orchestrator'],
+    sourcePath: 'src/skills/release-smoke-test',
+  },
+  {
     name: 'worktrees',
     description:
       'Manage Git worktrees as OMO safe isolated coding lanes for complex/risky/parallel work',

--- a/src/cli/skills.test.ts
+++ b/src/cli/skills.test.ts
@@ -25,6 +25,7 @@ describe('skills permissions', () => {
     expect(orchestratorPerms.clonedeps).toBe('allow');
     expect(orchestratorPerms.deepwork).toBe('allow');
     expect(orchestratorPerms.reflect).toBe('allow');
+    expect(orchestratorPerms['release-smoke-test']).toBe('allow');
     expect(orchestratorPerms.worktrees).toBe('allow');
     expect(orchestratorPerms['oh-my-opencode-slim']).toBe('allow');
   });

--- a/src/hooks/filter-available-skills/index.ts
+++ b/src/hooks/filter-available-skills/index.ts
@@ -119,9 +119,9 @@ export function createFilterAvailableSkillsHook(
       _input: Record<string, never>,
       output: { messages?: unknown },
     ): Promise<void> => {
-      const messages = (Array.isArray(output.messages) ? output.messages : []).filter(
-        isMessageWithParts,
-      );
+      const messages = (
+        Array.isArray(output.messages) ? output.messages : []
+      ).filter(isMessageWithParts);
       if (messages.length === 0) {
         return;
       }

--- a/src/hooks/phase-reminder/index.ts
+++ b/src/hooks/phase-reminder/index.ts
@@ -7,7 +7,7 @@
  */
 import { PHASE_REMINDER } from '../../config/constants';
 import { SLIM_INTERNAL_INITIATOR_MARKER } from '../../utils';
-import { isUserMessageWithParts, type MessageWithParts } from '../types';
+import { isUserMessageWithParts } from '../types';
 
 export { PHASE_REMINDER };
 

--- a/src/hooks/task-session-manager/index.test.ts
+++ b/src/hooks/task-session-manager/index.test.ts
@@ -55,7 +55,9 @@ describe('task-session-manager hook', () => {
     const messages = {
       messages: [
         {},
-        { info: { role: 'user', agent: 'orchestrator', sessionID: 'parent-1' } },
+        {
+          info: { role: 'user', agent: 'orchestrator', sessionID: 'parent-1' },
+        },
         { parts: [{ type: 'text', text: 'missing info' }] },
         {
           info: { role: 'assistant' },

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -25,7 +25,9 @@ export type MessageWithParts = {
   parts: MessagePart[];
 };
 
-export function isMessageWithParts(message: unknown): message is MessageWithParts {
+export function isMessageWithParts(
+  message: unknown,
+): message is MessageWithParts {
   if (!message || typeof message !== 'object') {
     return false;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,11 +32,7 @@ import {
   ForegroundFallbackManager,
 } from './hooks';
 import { processImageAttachments } from './hooks/image-hook';
-import {
-  isMessageWithParts,
-  isUserMessageWithParts,
-  type MessageWithParts,
-} from './hooks/types';
+import { isMessageWithParts, isUserMessageWithParts } from './hooks/types';
 import { createInterviewManager } from './interview';
 import { createBuiltinMcps } from './mcp';
 import {
@@ -1037,9 +1033,9 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
       input: Record<string, never>,
       output: { messages?: unknown },
     ): Promise<void> => {
-      const messages = (Array.isArray(output.messages) ? output.messages : []).filter(
-        isMessageWithParts,
-      );
+      const messages = (
+        Array.isArray(output.messages) ? output.messages : []
+      ).filter(isMessageWithParts);
 
       for (const message of messages) {
         if (!isUserMessageWithParts(message)) {
@@ -1069,10 +1065,9 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
         input,
         { messages },
       );
-      await phaseReminderHook['experimental.chat.messages.transform'](
-        input,
-        { messages },
-      );
+      await phaseReminderHook['experimental.chat.messages.transform'](input, {
+        messages,
+      });
       await filterAvailableSkillsHook['experimental.chat.messages.transform'](
         input,
         { messages },

--- a/src/skills/codemap.md
+++ b/src/skills/codemap.md
@@ -22,6 +22,7 @@
   - `src/skills/reflect/` (orchestrator-only workflow for learning from repeated work and suggesting reusable improvements)
   - `src/skills/worktrees/` (orchestrator-only workflow for safe Git worktree lanes)
   - `src/skills/oh-my-opencode-slim/` (orchestrator-only plugin configuration and self-improvement guidance)
+  - `src/skills/release-smoke-test/` (orchestrator-only workflow for packed release-candidate runtime validation)
 - Files are considered static runtime payload. No plugin TS module in `src/` imports these files directly; they
   are loaded by OpenCode via filesystem installation.
 
@@ -44,6 +45,7 @@
   bundled skill payloads such as `src/skills/simplify/SKILL.md`,
   `src/skills/codemap/SKILL.md`, `src/skills/clonedeps/SKILL.md`, and
   `src/skills/deepwork/SKILL.md`, `src/skills/reflect/SKILL.md`,
-  `src/skills/worktrees/SKILL.md`, plus `src/skills/oh-my-opencode-slim/SKILL.md`,
+  `src/skills/worktrees/SKILL.md`, `src/skills/release-smoke-test/SKILL.md`,
+  plus `src/skills/oh-my-opencode-slim/SKILL.md`,
   are present in the tarball.
 - `package.json` scripts (`verify:release`, `build`) rely on these assets to ensure install-time skill availability.

--- a/src/skills/release-smoke-test/SKILL.md
+++ b/src/skills/release-smoke-test/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: release-smoke-test
+description: Test an oh-my-opencode-slim release candidate or bugfix before publishing. Use when validating a packed plugin artifact, release branch, crash fix, OpenCode runtime compatibility, or model-specific smoke test such as OpenCode 1.17.11 message transform regressions.
+---
+
+# Release Smoke Test
+
+Use this skill to validate an `oh-my-opencode-slim` release candidate before
+public npm publish. Test the packed artifact, not `@latest` and not the source
+tree.
+
+## Core Workflow
+
+1. Start from the release-prep branch or commit.
+2. Build and pack the candidate.
+3. Install the tarball into a throwaway app.
+4. Create an isolated OpenCode config pointing at the installed
+   `node_modules/oh-my-opencode-slim/dist/index.js`.
+5. Run `opencode debug config` and verify `plugin_origins` contains only the
+   intended plugin when doing an isolation smoke.
+6. Run non-pure `opencode run --print-logs --log-level DEBUG`.
+7. Search isolated logs for the original crash signature.
+8. Record exact artifact, model, OpenCode version, command shape, result, and
+   limitations on the release issue or PR.
+
+## Pack Candidate
+
+Use a temp directory so release validation never depends on the local package
+cache.
+
+```bash
+SMOKE=/tmp/oh-my-opencode-slim-release-smoke
+rm -rf "$SMOKE"
+mkdir -p "$SMOKE/pkg" "$SMOKE/app" "$SMOKE/home" "$SMOKE/xdg/opencode" "$SMOKE/run"
+
+bun run build
+npm pack --pack-destination "$SMOKE/pkg"
+```
+
+Install the tarball:
+
+```bash
+cd "$SMOKE/app"
+bun init -y
+bun add "$SMOKE/pkg"/oh-my-opencode-slim-*.tgz
+node -p "require('./node_modules/oh-my-opencode-slim/package.json').version"
+```
+
+## Isolated Config
+
+Write the minimal OpenCode config:
+
+```bash
+cat > "$SMOKE/xdg/opencode/opencode.json" <<EOF
+{
+  "model": "opencode/deepseek-v4-flash-free",
+  "plugin": [
+    "file://$SMOKE/app/node_modules/oh-my-opencode-slim/dist/index.js"
+  ],
+  "agent": {
+    "orchestrator": {
+      "model": "opencode/deepseek-v4-flash-free"
+    }
+  }
+}
+EOF
+```
+
+Use `env -i` for the cleanest smoke. This strips host `OPENCODE_*`, `ORCA_*`,
+and project overlay variables that can silently add plugins or provider aliases.
+
+```bash
+env -i PATH="$PATH" HOME="$SMOKE/home" XDG_CONFIG_HOME="$SMOKE/xdg" \
+  opencode debug config
+```
+
+Confirm:
+
+- `plugin_origins` has exactly one entry.
+- That entry points to the temp app's packed `dist/index.js`.
+- The model is the one intended for the smoke.
+
+If OpenCode needs provider aliases from the host environment, run a second
+non-isolated model-specific smoke and clearly label it as weaker isolation.
+
+## Runtime Smoke
+
+Run the actual prompt with timeout:
+
+```bash
+env -i PATH="$PATH" HOME="$SMOKE/home" XDG_CONFIG_HOME="$SMOKE/xdg" \
+  timeout 120 \
+  opencode run --print-logs --log-level DEBUG "Say OK only."
+```
+
+Expected result:
+
+```text
+OK
+```
+
+Search logs for the bug signature. For the OpenCode 1.17.11 malformed-message
+crash, use:
+
+```bash
+rg "message\\.info\\.role|undefined is not an object|Cannot read properties of undefined|TypeError" \
+  "$SMOKE/home/.local/share/opencode/log" -n 2>/dev/null || true
+```
+
+No matches should appear.
+
+## OpenAI / Host-Provider Smoke
+
+If the fully isolated environment cannot resolve OpenAI provider aliases, run a
+separate host-provider smoke while keeping the plugin path pointed at the
+tarball install.
+
+```bash
+mkdir -p "$SMOKE/config"
+cat > "$SMOKE/config/opencode.json" <<EOF
+{
+  "model": "openai/gpt-5.5-fast",
+  "plugin": [
+    "file://$SMOKE/app/node_modules/oh-my-opencode-slim/dist/index.js"
+  ],
+  "agent": {
+    "orchestrator": {
+      "model": "openai/gpt-5.5-fast"
+    }
+  }
+}
+EOF
+
+OPENCODE_CONFIG_DIR="$SMOKE/config" \
+  timeout 120 \
+  opencode run --print-logs --log-level DEBUG "Say OK only."
+```
+
+Report this as a host-provider smoke because existing project, user, or Orca
+OpenCode config may still merge in. Use `opencode debug config` to disclose
+what else loaded.
+
+## Reporting Template
+
+```markdown
+## Release-candidate smoke validation
+
+- Commit under test:
+- Tarball:
+- Installed package version:
+- OpenCode version:
+- Config isolation: sanitized `env -i` / host-provider
+- Plugin origin:
+- Model:
+- Command:
+- Result:
+- Crash signature search:
+- Limitations:
+```
+


### PR DESCRIPTION
## Summary

- Bump `oh-my-opencode-slim` to `2.0.6` for the malformed OpenCode message transform crash fix merged in PR #625
- Keep the release branch plugin-only: no companion version or manifest changes
- Apply the Biome formatting/import cleanup required by release validation after PR #625
- Add the bundled `release-smoke-test` skill so future release candidates and bugfixes can be validated from a packed tarball before public npm publish
- Register `release-smoke-test` for `orchestrator`, document it, and require it in release artifact verification

## Release tracking

Tracks #629.

Related bug issue: #628.
Related fix PR: #625.

## Runtime smoke validation

Validated the release candidate from the packed tarball, not from the source tree:

- Built and packed `oh-my-opencode-slim-2.0.6.tgz`
- Installed the tarball into a throwaway app
- Verified installed package version reads back as `2.0.6`
- Verified isolated OpenCode config loaded only the temp package plugin origin
- Ran non-pure `opencode run --print-logs --log-level DEBUG "Say OK only."`
- Searched isolated logs for `message.info.role`, `undefined is not an object`, `Cannot read properties of undefined`, and `TypeError`; no crash signature found
- Also ran a host-provider smoke with `openai/gpt-5.5-fast`, which returned `OK` with no crash signature in logs

Notes are recorded on #629:

- https://github.com/alvinunreal/oh-my-opencode-slim/issues/629#issuecomment-4826086968
- https://github.com/alvinunreal/oh-my-opencode-slim/issues/629#issuecomment-4826092429

## Validation

Run from clean worktree `/tmp/oh-my-opencode-slim-release-2.0.6`:

- `bun run check:ci`
- `bun run typecheck`
- `bun test src/cli/skills.test.ts src/cli/providers.test.ts src/agents/index.test.ts` (`105 pass, 0 fail`)
- `bun run build && bun run verify:release`
- `bun test` (`1219 pass, 0 fail`)
- `git diff --check`

## Publish note

Do not publish npm from this PR. After merge, tag `v2.0.6`, create GitHub release notes from the actual diff since `v2.0.5`, and publish npm only after explicit approval.
