### PR TITLE
fix: preserve user /model selection across plugin re-inits

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -514,9 +514,15 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
             | Record<string, unknown>
             | undefined;
           if (entry) {
-            entry.model = chosen.id;
-            if (chosen.variant) {
-              entry.variant = chosen.variant;
+            // Only apply model array resolution if no user-selected model
+            // exists. A user-selected model (via /model command) takes
+            // precedence over the config's fallback chain to preserve
+            // runtime selections and avoid breaking provider cache.
+            if (entry.model === undefined) {
+              entry.model = chosen.id;
+              if (chosen.variant) {
+                entry.variant = chosen.variant;
+              }
             }
           } else {
             // Agent exists in slim but not in opencodeConfig.agent —


### PR DESCRIPTION
## Problem

When a user selects a model via /model in OpenCode, that selection is overwritten after spawning a subagent. This happens because:

1. Subagent spawn triggers client.config.update() → Instance.dispose() → plugin re-init
2. The config() hook re-runs and the model array resolution block unconditionally overwrites entry.model with the first model from the config array
3. The user runtime /model selection (preserved in opencodeConfig) is lost

This breaks provider cache (increases API cost) and overrides the user explicit runtime model selection.

## Root Cause

The model array resolution block in src/index.ts (line 517) does:

```
entry.model = chosen.id;
```

This runs unconditionally on every config hook re-init, regardless of whether the user already selected a model at runtime via /model.

## Solution

Guard the model array resolution to only apply when entry.model is undefined (first init or array config with no prior selection). When the user has already selected a model via /model, the merge at line 482-484 preserves it (...existing wins), and the model array resolution now skips it.

### Changes
- In model array resolution block, check entry.model === undefined before overwriting
- Skip resolution when user /model selection is already present
- Add comment explaining the guard

## Testing

- Existing tests pass (model-resolution, agents/index)
- Manual testing: select model via /model → spawn subagent → model should persist
- First init still works: model array resolution applies when no user selection exists

## Notes

- This fix is minimal — 9 lines changed, only the model array resolution guard
- The runtime preset override block (/preset) is unaffected — it explicitly overrides models as a user action
- Config-file models serve as defaults when no user selection exists