### PR TITLE
docs: add TakoAPI directory badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Listed on TakoAPI](https://takoapi.com/api/badge/alvinunreal-oh-my-opencode-slim)](https://takoapi.com/agents/alvinunreal-oh-my-opencode-slim)
+
 <div align="center">
   <a href="https://github.com/alvinunreal/oh-my-opencode-slim/stargazers">
     <img src="img/v2.webp" alt="oh-my-opencode-slim V2 Release" style="border-radius: 10px;">


### PR DESCRIPTION
Hi! 👋 **oh-my-opencode-slim** is listed in the [TakoAPI](https://takoapi.com) open agent directory — a free, open catalog that helps people discover AI-agent projects ("one API to discover all agents").

Your listing: https://takoapi.com/agents/alvinunreal-oh-my-opencode-slim

This PR adds a small badge near the top of the README that links back to that listing, so visitors can find the directory entry. It's entirely optional — if you'd prefer not to include it, just close this PR (no hard feelings, and apologies for the noise).

No tracking and no obligations. Thanks for building oh-my-opencode-slim! 🙏