### PR TITLE
fix: gate internal_reminders on deepwork sessions

### DIFF
--- a/src/hooks/phase-reminder/index.ts
+++ b/src/hooks/phase-reminder/index.ts
@@ -12,12 +12,28 @@ import { isUserMessageWithParts } from '../types';
 
 export { PHASE_REMINDER };
 
+interface PhaseReminderOptions {
+  /** If provided, only inject when this returns true for the session. */
+  shouldInject?: (sessionID: string) => boolean;
+  coordinator?: SessionLifecycle;
+}
+
 /**
  * Creates the experimental.chat.messages.transform hook for phase reminder injection.
  * This hook runs right before sending to API, so it doesn't affect UI display.
  * Only injects for the orchestrator agent.
  */
-export function createPhaseReminderHook(coordinator?: SessionLifecycle) {
+export function createPhaseReminderHook(
+  options: PhaseReminderOptions | SessionLifecycle = {},
+) {
+  // Backward-compatible: if called with a SessionLifecycle directly, treat as coordinator
+  const opts: PhaseReminderOptions =
+    typeof options === 'object' && 'coordinator' in options
+      ? (options as PhaseReminderOptions)
+      : typeof options === 'object' && 'onSessionDeleted' in options
+        ? { coordinator: options as SessionLifecycle }
+        : {};
+  const { coordinator, shouldInject } = opts;
   return {
     'experimental.chat.messages.transform': async (
       _input: Record<string, never>,
@@ -51,10 +67,14 @@ export function createPhaseReminderHook(coordinator?: SessionLifecycle) {
         return;
       }
 
-      // If post-file-tool-nudge is pending for this session, it handles
-      // injection via system prompt — skip message-level injection.
       const sessionId = (lastUserMessage as { info?: { sessionID?: string } })
         ?.info?.sessionID;
+      if (sessionId && shouldInject && !shouldInject(sessionId)) {
+        return;
+      }
+
+      // If post-file-tool-nudge is pending for this session, it handles
+      // injection via system prompt — skip message-level injection.
       if (sessionId && coordinator?.hasPendingSession(sessionId)) {
         return;
       }

--- a/src/hooks/phase-reminder/index.ts
+++ b/src/hooks/phase-reminder/index.ts
@@ -28,11 +28,9 @@ export function createPhaseReminderHook(
 ) {
   // Backward-compatible: if called with a SessionLifecycle directly, treat as coordinator
   const opts: PhaseReminderOptions =
-    typeof options === 'object' && 'coordinator' in options
-      ? (options as PhaseReminderOptions)
-      : typeof options === 'object' && 'onSessionDeleted' in options
-        ? { coordinator: options as SessionLifecycle }
-        : {};
+    typeof options === 'object' && 'onSessionDeleted' in options
+      ? { coordinator: options as SessionLifecycle }
+      : (options as PhaseReminderOptions);
   const { coordinator, shouldInject } = opts;
   return {
     'experimental.chat.messages.transform': async (
@@ -69,7 +67,7 @@ export function createPhaseReminderHook(
 
       const sessionId = (lastUserMessage as { info?: { sessionID?: string } })
         ?.info?.sessionID;
-      if (sessionId && shouldInject && !shouldInject(sessionId)) {
+      if (shouldInject && (!sessionId || !shouldInject(sessionId))) {
         return;
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -139,6 +139,7 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
   let multiplexerSessionManager: MultiplexerSessionManager;
   let autoUpdateChecker: ReturnType<typeof createAutoUpdateCheckerHook>;
   let sessionAgentMap: Map<string, string>;
+  let deepworkSessions: Set<string>;
   let sessionLifecycle: SessionLifecycle;
 
   let chatHeadersHook: ReturnType<typeof createChatHeadersHook>;
@@ -289,6 +290,10 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
     // Track session → agent mapping for serve-mode system prompt injection
     sessionAgentMap = new Map<string, string>();
 
+    // Track sessions that have a deepwork file (.slim/deepwork/*.md).
+    // Phase reminders are only injected when a deepwork session is active.
+    deepworkSessions = new Set<string>();
+
     chatHeadersHook = createChatHeadersHook(ctx);
 
     // Initialize foreground fallback manager for runtime model switching.
@@ -346,13 +351,17 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
       };
     };
 
-    phaseReminder = createPhaseReminderHook(sessionLifecycle);
+    phaseReminder = createPhaseReminderHook({
+      shouldInject: (sessionID) => deepworkSessions.has(sessionID),
+      coordinator: sessionLifecycle,
+    });
 
     filterAvailableSkills = createFilterAvailableSkillsHook(ctx, config);
 
     postFileToolNudge = createPostFileToolNudgeHook({
       shouldInject: (sessionID) =>
-        sessionAgentMap.get(sessionID) === 'orchestrator',
+        sessionAgentMap.get(sessionID) === 'orchestrator' &&
+        deepworkSessions.has(sessionID),
       coordinator: sessionLifecycle,
     });
 
@@ -943,6 +952,7 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
         }
         if (sessionID) {
           sessionAgentMap.delete(sessionID);
+          deepworkSessions.delete(sessionID);
         }
       }
     },
@@ -982,6 +992,16 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
         },
         output as { parts: Array<{ type: string; text?: string }> },
       );
+
+      // Mark the session as a deepwork session so phase/post-file-tool-nudge
+      // reminders are enabled for the orchestrator.
+      if (
+        input.command === 'deepwork' &&
+        input.arguments.trim().length > 0 &&
+        input.sessionID
+      ) {
+        deepworkSessions.add(input.sessionID);
+      }
 
       await reflectCommandHook.handleCommandExecuteBefore(
         input as {

--- a/src/index.ts
+++ b/src/index.ts
@@ -290,7 +290,7 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
     // Track session → agent mapping for serve-mode system prompt injection
     sessionAgentMap = new Map<string, string>();
 
-    // Track sessions that have a deepwork file (.slim/deepwork/*.md).
+    // Track sessions where /deepwork was invoked this run.
     // Phase reminders are only injected when a deepwork session is active.
     deepworkSessions = new Set<string>();
 


### PR DESCRIPTION
## Problem

The ~100-word scheduler instruction block (`PHASE_REMINDER`) is injected on **every** orchestrator turn via two hooks:

1. **`phase-reminder`** — appended as a message part after the last user message (`experimental.chat.messages.transform`)
2. **`post-file-tool-nudge`** — injected into the system prompt after file reads/writes (`experimental.chat.system.transform`)

## Why this matters

The reminder text is designed for **scheduler discipline** during heavy, multi-phase work:

> *"plan lanes/dependencies → dispatch background specialists → track task IDs → wait for hook-driven completion → reconcile terminal results → verify. Do not poll running jobs, consume running-job output, or advance dependent work."*

This is essential guidance during `/deepwork` sessions where the orchestrator must function as a scheduler rather than the default implementation worker. But on routine turns — a quick file fix, a documentation edit, a codebase question — it wastes ~100 tokens of context every single turn, and pushes the orchestrator toward background-task coordination patterns that are often unnecessary overhead.

When a user has not initiated a deepwork session, the orchestrator should stay lean. The `internal_reminder` was "[originally intended for deepwork sessions only]" — constraining it to that scope makes the default experience lighter while preserving the scheduling guidance where it adds real value.

## Fix

**2 files changed, 45 insertions, 5 deletions**

### `src/hooks/phase-reminder/index.ts`
- Added `shouldInject` option to `createPhaseReminderHook`
- Backward-compatible: existing callers passing a `SessionLifecycle` directly still work

### `src/index.ts`
- Tracks deepwork sessions in a `Set<string>` (`deepworkSessions`)
- Session is marked as deepwork when `/deepwork <task>` is invoked (non-empty args)
- Session is cleaned up on `session.deleted`
- Both hooks gate on `deepworkSessions.has(sessionID)` — reminders only fire during deepwork sessions

## Verification

- ✅ `bun run check:ci` — clean (233 files, no fixes)
- ✅ `bun run typecheck` — clean
- ✅ `bun run build` — clean
- ✅ `bun test` — 1381 pass, 2 pre-existing failures (dashboard timeout, fish XDG path):