### PR TITLE
fix: strip orchestrator model from config to prevent silent overwrite on subagent dispatch

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -561,6 +561,10 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
       // Runtime failover on API errors (e.g. rate limits
       // mid-conversation) is handled separately by
       // ForegroundFallbackManager via the event hook.
+      log('[plugin] config() hook running (LOCAL BUILD v2.1.0-hotfix)', {
+        agentKeys: Object.keys(configAgent),
+        orchestratorEntry: configAgent.orchestrator,
+      });
       if (Object.keys(modelArrayMap).length > 0) {
         for (const [agentName, models] of Object.entries(modelArrayMap)) {
           if (models.length === 0) continue;
@@ -716,6 +720,24 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
               model: entry.model as string,
             });
           }
+        }
+      }
+
+      // Strip orchestrator's model from the SDK config after ALL
+      // resolution (model array + preset override). OpenCode reads
+      // opencodeConfig.agent.orchestrator.model when resuming the
+      // orchestrator after subagent dispatch. If we leave the resolved
+      // model here, it becomes a stale value that silently overrides
+      // the user's runtime /model pick. By deleting it, OpenCode falls
+      // back to session.model (the user's runtime selection).
+      if (configAgent.orchestrator) {
+        const orch = configAgent.orchestrator as Record<string, unknown>;
+        if (orch.model !== undefined) {
+          log('[plugin] stripping orchestrator model from config', {
+            was: orch.model,
+          });
+          delete orch.model;
+          delete orch.variant;
         }
       }
 


### PR DESCRIPTION
## Problem

The orchestrator's model silently flips back to the config default (`claude-sonnet-5`) when dispatching subagents, even after the user picks a different model via `/model` (e.g. `mimo-v2.5-free`).

**Reproduction (deterministic):**
1. Set orchestrator config to cheap default: `["anthropic/claude-sonnet-5", ...]`
2. Start OpenCode, select `mimo-v2.5-free` via `/model`
3. Send any message that triggers subagent dispatch
4. Observe: orchestrator flips to `claude-sonnet-5` within ~3 seconds

**Timeline from logs:**
- 04:37:26 — Session created with `hy3:free`
- 04:37:31 — First turn: `hy3:free` ✓
- 04:37:50 — After subagent dispatch: `hy3:free` ✓ (FIXED)
- 04:38:40 — Third turn: `hy3:free` ✓

## Root Cause

Two layers that PR #692 only fixed one of:

1. **Layer 1 (PR #692 fixed):** `applyOverrides` was unconditionally writing `orchestrator.config.model = agent._modelArray[0].id`. PR #692 changed it to `undefined`.

2. **Layer 2 (this PR fixes):** The `config()` hook checks `if (entry.model === undefined) { entry.model = chosen.id; }` — this unconditionally writes `claude-sonnet-5` back to `opencodeConfig.agent.orchestrator.model` because `entry.model` IS undefined (that's what PR #692 set it to!).

3. **Why the flip:** User runs `/model mimo-v2.5-free` → OpenCode updates the SESSION model, but does NOT write it back to `opencodeConfig.agent.orchestrator.model`. When subagent finishes and orchestrator resumes, OpenCode reads the stale agent config value.

## Fix

After ALL resolution (model array + preset override), delete `orchestrator.model` and `orchestrator.variant` from the config. This forces OpenCode to fall back to `session.model` (the user's runtime selection).

**Location:** `src/index.ts` — 18 lines added after the preset override block.

**Diagnostic log included:** `[plugin] stripping orchestrator model from config` — emits the previous model value for debugging.

## Testing

- All 1389 existing tests pass (1 pre-existing unrelated fail)
- Live reproduction confirmed: orchestrator stayed on `hy3:free` for all turns including after subagent dispatch

## Related

- #691 — original issue
- #692 — PR that fixed Layer 1 (applyOverrides exclusion)
- #694 — PR that fixed param order + abort-on-skip