### PR TITLE
fix: add stripOrchestratorModel flag to preserve runtime /model picks

### DIFF
--- a/oh-my-opencode-slim.schema.json
+++ b/oh-my-opencode-slim.schema.json
@@ -12,6 +12,10 @@
       "description": "Use the compact TUI sidebar layout. Defaults to true; set false to use the expanded layout.",
       "type": "boolean"
     },
+    "stripOrchestratorModel": {
+      "description": "When true, delete orchestrator.model from the SDK config after resolution. This forces OpenCode to fall back to session.model (the user's runtime /model pick) when resuming the orchestrator after subagent dispatch, preventing the silent flip to the config default. Defaults to false (off). When false, the orchestrator uses its configured model and runtime /model picks may be silently overwritten on subagent dispatch.",
+      "type": "boolean"
+    },
     "autoUpdate": {
       "description": "Disable automatic installation of plugin updates when false. Defaults to true.",
       "type": "boolean"
@@ -376,6 +380,11 @@
         "retry_on_empty": {
           "default": true,
           "description": "When true (default), empty provider responses are treated as failures, triggering fallback/retry. Set to false to treat them as successes.",
+          "type": "boolean"
+        },
+        "runtimeOverride": {
+          "default": true,
+          "description": "When true (default), a runtime model selected via /model that is outside the configured fallback chain will still trigger the chain on rate-limit errors. When false, out-of-chain runtime picks are respected and the error surfaces instead of silently falling back to the chain. Models that are members of the chain always fall back regardless of this setting.",
           "type": "boolean"
         }
       },

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -310,6 +310,17 @@ export const PluginConfigSchema = z
       .describe(
         'Use the compact TUI sidebar layout. Defaults to true; set false to use the expanded layout.',
       ),
+    stripOrchestratorModel: z
+      .boolean()
+      .optional()
+      .describe(
+        'When true, delete orchestrator.model from the SDK config after resolution. ' +
+          'This forces OpenCode to fall back to session.model (the user\'s runtime /model pick) ' +
+          'when resuming the orchestrator after subagent dispatch, preventing the silent ' +
+          'flip to the config default. Defaults to false (off). When false, the orchestrator ' +
+          'uses its configured model and runtime /model picks may be silently overwritten ' +
+          'on subagent dispatch.',
+      ),
     autoUpdate: z
       .boolean()
       .optional()

--- a/src/index.ts
+++ b/src/index.ts
@@ -561,7 +561,7 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
       // Runtime failover on API errors (e.g. rate limits
       // mid-conversation) is handled separately by
       // ForegroundFallbackManager via the event hook.
-      log('[plugin] config() hook running (LOCAL BUILD v2.1.0-hotfix)', {
+      log('[plugin] config() hook running', {
         agentKeys: Object.keys(configAgent),
         orchestratorEntry: configAgent.orchestrator,
       });
@@ -723,21 +723,27 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
         }
       }
 
-      // Strip orchestrator's model from the SDK config after ALL
-      // resolution (model array + preset override). OpenCode reads
-      // opencodeConfig.agent.orchestrator.model when resuming the
-      // orchestrator after subagent dispatch. If we leave the resolved
-      // model here, it becomes a stale value that silently overrides
-      // the user's runtime /model pick. By deleting it, OpenCode falls
-      // back to session.model (the user's runtime selection).
-      if (configAgent.orchestrator) {
-        const orch = configAgent.orchestrator as Record<string, unknown>;
-        if (orch.model !== undefined) {
-          log('[plugin] stripping orchestrator model from config', {
-            was: orch.model,
-          });
-          delete orch.model;
-          delete orch.variant;
+      // Optional: strip orchestrator's model from the SDK config.
+      // When stripOrchestratorModel is true, delete orchestrator.model
+      // and orchestrator.variant after ALL resolution (model array +
+      // preset override). This forces OpenCode to fall back to
+      // session.model (the user's runtime /model pick) when resuming
+      // the orchestrator after subagent dispatch, preventing the
+      // silent flip to the config default.
+      //
+      // Off by default. When false, the orchestrator uses its
+      // configured model and runtime /model picks may be silently
+      // overwritten on subagent dispatch.
+      if (config.stripOrchestratorModel === true) {
+        if (configAgent.orchestrator) {
+          const orch = configAgent.orchestrator as Record<string, unknown>;
+          if (orch.model !== undefined) {
+            log('[plugin] stripping orchestrator model from config', {
+              was: orch.model,
+            });
+            delete orch.model;
+            delete orch.variant;
+          }
         }
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -561,6 +561,10 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
       // Runtime failover on API errors (e.g. rate limits
       // mid-conversation) is handled separately by
       // ForegroundFallbackManager via the event hook.
+      log('[plugin] config() hook running (LOCAL BUILD v2.1.0-hotfix)', {
+        agentKeys: Object.keys(configAgent),
+        orchestratorEntry: configAgent.orchestrator,
+      });
       if (Object.keys(modelArrayMap).length > 0) {
         for (const [agentName, models] of Object.entries(modelArrayMap)) {
           if (models.length === 0) continue;
@@ -716,6 +720,24 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
               model: entry.model as string,
             });
           }
+        }
+      }
+
+      // Strip orchestrator's model from the SDK config after ALL
+      // resolution (model array + preset override). OpenCode reads
+      // opencodeConfig.agent.orchestrator.model when resuming the
+      // orchestrator after subagent dispatch. If we leave the resolved
+      // model here, it becomes a stale value that silently overrides
+      // the user's runtime /model pick. By deleting it, OpenCode falls
+      // back to session.model (the user's runtime selection).
+      if (configAgent.orchestrator) {
+        const orch = configAgent.orchestrator as Record<string, unknown>;
+        if (orch.model !== undefined) {
+          log('[plugin] stripping orchestrator model from config', {
+            was: orch.model,
+          });
+          delete orch.model;
+          delete orch.variant;
         }
       }
 


### PR DESCRIPTION
## Problem

The orchestrator's model silently flips back to the config default during subagent runs, after the user picks a different model via `/model`.

**Reproduction (deterministic):**
1. Set orchestrator config to any model
2. Start OpenCode, select a different model via `/model` that is not your config model nor in the fallback chain
3. Send any message that triggers subagent dispatch
4. Observe: orchestrator flips to the config default during the subagent run

## Root Cause

The plugin's `config()` hook writes the resolved model to `opencodeConfig.agent.orchestrator.model` at startup. OpenCode reads this value once and sets the agent definition. After that, the agent definition is static.

When the user picks a model via `/model`, OpenCode updates the session model but does NOT update the agent definition. When the orchestrator resumes during a subagent run, OpenCode reads the stale agent definition (config default) instead of the session model (user's pick).

## Fix

Add a `stripOrchestratorModel` config option (default `false`). When `true`, the plugin deletes `orchestrator.model` and `orchestrator.variant` from the SDK config after ALL resolution (model array + preset override). This forces OpenCode to fall back to `session.model` (the user's runtime `/model` pick) when the orchestrator resumes during a subagent run.

**Location:** `src/index.ts` lines 726-748

## Trade-off

When `stripOrchestratorModel: true`:
- Orchestrator's model is deleted from the SDK config at runtime
- OpenCode falls back to `session.model` (user's `/model` pick)
- If the user doesn't pick a model via `/model`, OpenCode uses the global default from `opencode.json`
- Other orchestrator fields (temperature, prompt, permissions) are preserved
- Presets still work (they override the model when active)
- Fallback chain still works (built from `_modelArray`)

When `false` (default):
- Orchestrator uses its configured model
- Runtime `/model` picks may be silently overwritten during subagent runs (existing behavior)

## Usage

```jsonc
{
  "agents": {
    "orchestrator": {
      "model": ["<your-default-model>", "<your-fallback-model>"],
      "temperature": 0.1
    }
  },
  "stripOrchestratorModel": true
}
```

## Diagnostic Log

When the flag is enabled, the plugin emits:
```
[plugin] stripping orchestrator model from config {"was":"<previous-model-value>"}
```

This confirms the strip is firing and shows the previous model value.

## Testing

- All 1389 existing tests pass (1 pre-existing unrelated fail)
- Live reproduction confirmed: orchestrator stayed on user's pick for all turns including during subagent runs

## Related

- #691 — original issue
- #692 — PR that fixed `applyOverrides` exclusion
- #694 — PR that fixed param order + abort-on-skip