### PR TITLE
docs: add skill references to preset docs (#690)

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,9 +166,16 @@ The default generated configuration includes both `openai` and `opencode-go` pre
 }
 ```
 
+### Preset Docs
+
+- **[OpenAI Preset](docs/openai-preset.md)** — the default generated preset; runs all agents on OpenAI models.
+- **[OpenCode Go Preset](docs/opencode-go-preset.md)** — runs the agents on OpenCode Go models; enables the Observer agent for visual analysis since its orchestrator model isn't multimodal.
+- **[Author's Preset](docs/authors-preset.md)** — the exact config the author runs day to day, with third-party skills.
+- **[$30 Preset](docs/thirty-dollars-preset.md)** — a mixed-provider setup built around Codex Plus and GitHub Copilot Pro for about $30/month.
+
 ### For Alternative Providers
 
-To use custom providers or a mixed-provider setup, use **[Configuration](docs/configuration.md)** for the full reference. If you want a ready-made starting point, check the **[Author's Preset](docs/authors-preset.md)**, **[$30 Preset](docs/thirty-dollars-preset.md)**, **[OpenAI Preset](docs/openai-preset.md)**, or **[OpenCode Go Preset](docs/opencode-go-preset.md)** - the `$30` preset is the best cheap setup.
+To use custom providers or a mixed-provider setup, use **[Configuration](docs/configuration.md)** for the full reference.
 
 ### ✅ Verify Your Setup
 

--- a/README.md
+++ b/README.md
@@ -168,10 +168,10 @@ The default generated configuration includes both `openai` and `opencode-go` pre
 
 ## Skill Reference
 
-| Skill | Description |
-| --- | --- |
-| `*` | All installed skills (wildcard) |
-| `simplify` | Code simplification |
+| Skill | Description | Source |
+| --- | --- | --- |
+| `*` | All installed skills (wildcard) | public |
+| `simplify` | Code simplification | public |
 
 ### For Alternative Providers
 

--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ The default generated configuration includes both `openai` and `opencode-go` pre
 - **[OpenCode Go Preset](docs/opencode-go-preset.md)** — runs the agents on OpenCode Go models; enables the Observer agent for visual analysis since its orchestrator model isn't multimodal.
 - **[Author's Preset](docs/authors-preset.md)** — the exact config the author runs day to day, with third-party skills.
 - **[$30 Preset](docs/thirty-dollars-preset.md)** — a mixed-provider setup built around Codex Plus and GitHub Copilot Pro for about $30/month.
+- **[OpenCode Zen Free Preset](docs/opencode-zen-free-preset.md)** — a fully free-tier preset; every agent runs on an \`opencode/...-free\` model, so it costs nothing.
 
 ### For Alternative Providers
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,13 @@ The default generated configuration includes both `openai` and `opencode-go` pre
 }
 ```
 
+## Skill Reference
+
+| Skill | Description |
+| --- | --- |
+| `*` | All installed skills (wildcard) |
+| `simplify` | Code simplification |
+
 ### For Alternative Providers
 
 To use custom providers or a mixed-provider setup, use **[Configuration](docs/configuration.md)** for the full reference. If you want a ready-made starting point, check the **[Author's Preset](docs/authors-preset.md)** and **[$30 Preset](docs/thirty-dollars-preset.md)** - the `$30` preset is the best cheap setup.

--- a/README.md
+++ b/README.md
@@ -166,16 +166,9 @@ The default generated configuration includes both `openai` and `opencode-go` pre
 }
 ```
 
-## Skill Reference
-
-| Skill | Description | Source |
-| --- | --- | --- |
-| `*` | All installed skills (wildcard) | public |
-| `simplify` | Code simplification | public |
-
 ### For Alternative Providers
 
-To use custom providers or a mixed-provider setup, use **[Configuration](docs/configuration.md)** for the full reference. If you want a ready-made starting point, check the **[Author's Preset](docs/authors-preset.md)** and **[$30 Preset](docs/thirty-dollars-preset.md)** - the `$30` preset is the best cheap setup.
+To use custom providers or a mixed-provider setup, use **[Configuration](docs/configuration.md)** for the full reference. If you want a ready-made starting point, check the **[Author's Preset](docs/authors-preset.md)**, **[$30 Preset](docs/thirty-dollars-preset.md)**, **[OpenAI Preset](docs/openai-preset.md)**, or **[OpenCode Go Preset](docs/opencode-go-preset.md)** - the `$30` preset is the best cheap setup.
 
 ### ✅ Verify Your Setup
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ The default generated configuration includes both `openai` and `opencode-go` pre
 - **[OpenCode Go Preset](docs/opencode-go-preset.md)** — runs the agents on OpenCode Go models; enables the Observer agent for visual analysis since its orchestrator model isn't multimodal.
 - **[Author's Preset](docs/authors-preset.md)** — the exact config the author runs day to day, with third-party skills.
 - **[$30 Preset](docs/thirty-dollars-preset.md)** — a mixed-provider setup built around Codex Plus and GitHub Copilot Pro for about $30/month.
-- **[OpenCode Zen Free Preset](docs/opencode-zen-free-preset.md)** — a fully free-tier preset; every agent runs on an \`opencode/...-free\` model, so it costs nothing.
+- **[OpenCode Zen Free Preset](docs/opencode-zen-free-preset.md)** — every agent runs on an opencode free model; no usage cost.
 
 ### For Alternative Providers
 

--- a/docs/authors-preset.md
+++ b/docs/authors-preset.md
@@ -149,3 +149,5 @@ Each skill is listed with a short description and its source. The config block a
 | `websearch` | (MCP) web search | `public` |
 | `workers-best-practices` | Worker best practices | `author` |
 
+For the complete configuration reference, see [Configuration](configuration.md).
+

--- a/docs/authors-preset.md
+++ b/docs/authors-preset.md
@@ -4,6 +4,36 @@ This is the exact configuration the author runs day-to-day.
 
 ---
 
+## Skill Reference
+
+Each skill is listed with a short description. The config block above shows which agent uses it. These are the author's own third party skills and are not part of the plugin.
+
+| Skill | Description |
+| --- | --- |
+| `*` (excl. `!make-interfaces-feel-better`) | All installed skills except those explicitly excluded |
+| `better-icons` | Icon design |
+| `ce-brainstorm` | Brainstorming workflow |
+| `codegraph` | (MCP) code graph navigation |
+| `context7` | (MCP) library docs lookup |
+| `crawl4ai` | (MCP) web crawling |
+| `customer-research` | Customer research |
+| `gh_app` | (MCP) GitHub app access |
+| `image` | Image generation/editing |
+| `make-interfaces-feel-better` | UI/UX polish |
+| `marketing-psychology` | Marketing psychology |
+| `motion` | Animation/motion design |
+| `nuxt` | Nuxt framework |
+| `pnpm` | pnpm package manager |
+| `searxng` | (MCP) metasearch engine |
+| `tsdown` | tsdown bundler |
+| `video` | Video generation/editing |
+| `vitest` | Vitest test runner |
+| `vite` | Vite build tool |
+| `vue` | Vue framework |
+| `web-perf` | Web performance optimization |
+| `websearch` | (MCP) web search |
+| `workers-best-practices` | Worker best practices |
+
 ## The Config
 
 ```jsonc

--- a/docs/authors-preset.md
+++ b/docs/authors-preset.md
@@ -4,36 +4,6 @@ This is the exact configuration the author runs day-to-day.
 
 ---
 
-## Skill Reference
-
-Each skill is listed with a short description. The config block above shows which agent uses it. These are the author's own third party skills and are not part of the plugin.
-
-| Skill | Description |
-| --- | --- |
-| `*` (excl. `!make-interfaces-feel-better`) | All installed skills except those explicitly excluded |
-| `better-icons` | Icon design |
-| `ce-brainstorm` | Brainstorming workflow |
-| `codegraph` | (MCP) code graph navigation |
-| `context7` | (MCP) library docs lookup |
-| `crawl4ai` | (MCP) web crawling |
-| `customer-research` | Customer research |
-| `gh_app` | (MCP) GitHub app access |
-| `image` | Image generation/editing |
-| `make-interfaces-feel-better` | UI/UX polish |
-| `marketing-psychology` | Marketing psychology |
-| `motion` | Animation/motion design |
-| `nuxt` | Nuxt framework |
-| `pnpm` | pnpm package manager |
-| `searxng` | (MCP) metasearch engine |
-| `tsdown` | tsdown bundler |
-| `video` | Video generation/editing |
-| `vitest` | Vitest test runner |
-| `vite` | Vite build tool |
-| `vue` | Vue framework |
-| `web-perf` | Web performance optimization |
-| `websearch` | (MCP) web search |
-| `workers-best-practices` | Worker best practices |
-
 ## The Config
 
 ```jsonc
@@ -148,3 +118,34 @@ Each skill is listed with a short description. The config block above shows whic
 }
 
 ```
+
+## Skill Reference
+
+Each skill is listed with a short description and its source. The config block above shows which agent uses it. `author` means the author's own third party skill (not part of the plugin); `public` means a public tool, framework, or MCP server.
+
+| Skill | Description | Source |
+| --- | --- | --- |
+| `*` (excl. `!make-interfaces-feel-better`) | All installed skills except those explicitly excluded | `author` |
+| `better-icons` | Icon design | `author` |
+| `ce-brainstorm` | Brainstorming workflow | `author` |
+| `codegraph` | (MCP) code graph navigation | `public` |
+| `context7` | (MCP) library docs lookup | `public` |
+| `crawl4ai` | (MCP) web crawling | `public` |
+| `customer-research` | Customer research | `author` |
+| `gh_app` | (MCP) GitHub app access | `public` |
+| `image` | Image generation/editing | `author` |
+| `make-interfaces-feel-better` | UI/UX polish | `author` |
+| `marketing-psychology` | Marketing psychology | `author` |
+| `motion` | Animation/motion design | `author` |
+| `nuxt` | Nuxt framework | `public` |
+| `pnpm` | pnpm package manager | `public` |
+| `searxng` | (MCP) metasearch engine | `public` |
+| `tsdown` | tsdown bundler | `public` |
+| `video` | Video generation/editing | `author` |
+| `vitest` | Vitest test runner | `public` |
+| `vite` | Vite build tool | `public` |
+| `vue` | Vue framework | `public` |
+| `web-perf` | Web performance optimization | `author` |
+| `websearch` | (MCP) web search | `public` |
+| `workers-best-practices` | Worker best practices | `author` |
+

--- a/docs/openai-preset.md
+++ b/docs/openai-preset.md
@@ -1,0 +1,108 @@
+# OpenAI Preset
+
+`openai` is the bundled default generated preset. The installer generates both
+`openai` and `opencode-go` presets; OpenAI is active by default.
+
+## Install with OpenAI Active
+
+```bash
+bunx oh-my-opencode-slim@latest install
+```
+
+Then authenticate and refresh models:
+
+```bash
+opencode auth login
+opencode models --refresh
+```
+
+## Switch at Runtime
+
+If both presets are already in your config, switch from inside OpenCode:
+
+```text
+/preset openai
+```
+
+See [Preset Switching](preset-switching.md) for the full runtime switching
+workflow.
+
+## Bundled Model Mapping
+
+The generated `openai` preset maps each specialist to an OpenAI model tuned for
+its role:
+
+| Agent | Model |
+|-------|-------|
+| Orchestrator | `openai/gpt-5.5` (`medium`) |
+| Oracle | `openai/gpt-5.5` (`high`) |
+| Librarian | `openai/gpt-5.4-mini` (`low`) |
+| Explorer | `openai/gpt-5.4-mini` (`low`) |
+| Designer | `openai/gpt-5.4-mini` (`medium`) |
+| Fixer | `openai/gpt-5.5` (`low`) |
+
+## Generated Config Shape
+
+Your generated config includes `openai` under `presets` and activates it by
+setting the top-level `preset` field:
+
+```jsonc
+{
+  "preset": "openai",
+  "presets": {
+    "openai": {
+      "orchestrator": {
+        "model": "openai/gpt-5.5",
+        "variant": "medium",
+        "skills": ["*"],
+        "mcps": ["*", "!context7"]
+      },
+      "oracle": {
+        "model": "openai/gpt-5.5",
+        "variant": "high",
+        "skills": ["simplify"],
+        "mcps": []
+      },
+      "librarian": {
+        "model": "openai/gpt-5.4-mini",
+        "variant": "low",
+        "skills": [],
+        "mcps": ["websearch", "context7", "gh_grep"]
+      },
+      "explorer": {
+        "model": "openai/gpt-5.4-mini",
+        "variant": "low",
+        "skills": [],
+        "mcps": []
+      },
+      "designer": {
+        "model": "openai/gpt-5.4-mini",
+        "variant": "medium",
+        "skills": [],
+        "mcps": []
+      },
+      "fixer": {
+        "model": "openai/gpt-5.5",
+        "variant": "low",
+        "skills": [],
+        "mcps": []
+      }
+    }
+  }
+}
+```
+
+## Skill Reference
+
+Each skill is listed with a short description and its source. The config block
+above shows which agent uses it. `author` means the author's own third party
+skill (not part of the plugin); `public` means a public tool, framework, or MCP
+server.
+
+| Skill | Description | Source |
+| --- | --- | --- |
+| `*` | All installed skills (wildcard) | public |
+| `simplify` | Code simplification | public |
+
+For the complete configuration reference, see
+[Configuration](configuration.md).

--- a/docs/openai-preset.md
+++ b/docs/openai-preset.md
@@ -1,7 +1,7 @@
 # OpenAI Preset
 
-`openai` is the bundled default generated preset. The installer generates both
-`openai` and `opencode-go` presets; OpenAI is active by default.
+`openai` is the default generated preset. The installer builds both `openai`
+and `opencode-go`; OpenAI is the one that runs unless you pick the other.
 
 ## Install with OpenAI Active
 
@@ -29,8 +29,7 @@ workflow.
 
 ## Bundled Model Mapping
 
-The generated `openai` preset maps each specialist to an OpenAI model tuned for
-its role:
+The generated `openai` preset assigns each specialist an OpenAI model:
 
 | Agent | Model |
 |-------|-------|

--- a/docs/openai-preset.md
+++ b/docs/openai-preset.md
@@ -100,8 +100,8 @@ server.
 
 | Skill | Description | Source |
 | --- | --- | --- |
-| `*` | All installed skills (wildcard) | public |
-| `simplify` | Code simplification | public |
+| `*` | All installed skills (wildcard) | `public` |
+| `simplify` | Code simplification | `public` |
 
 For the complete configuration reference, see
 [Configuration](configuration.md).

--- a/docs/opencode-go-preset.md
+++ b/docs/opencode-go-preset.md
@@ -101,7 +101,7 @@ This preset defines no per-agent `skills` or `mcps`. All agents use whatever ski
 
 | Skill | Description | Source |
 | --- | --- | --- |
-| `*` | All installed skills (wildcard) | public |
+| `*` | All installed skills (wildcard) | `public` |
 
 For the complete configuration reference, see
 [Configuration](configuration.md).

--- a/docs/opencode-go-preset.md
+++ b/docs/opencode-go-preset.md
@@ -88,5 +88,7 @@ setting the top-level `preset` field:
 }
 ```
 
+This preset defines no `skills` or `mcps` per agent. It relies on model selection only (see [Bundled Model Mapping](#bundled-model-mapping)); agents use whatever skills are globally installed.
+
 For the complete configuration reference, see
 [Configuration](configuration.md).

--- a/docs/opencode-go-preset.md
+++ b/docs/opencode-go-preset.md
@@ -1,11 +1,10 @@
 # OpenCode Go Preset
 
-`opencode-go` is a bundled generated preset for users who want to run the
-Pantheon agents through OpenCode Go models instead of the default OpenAI setup.
+`opencode-go` runs the Pantheon agents on OpenCode Go models instead of the
+default OpenAI setup.
 
-The installer generates both `openai` and `opencode-go` presets. OpenAI stays
-active by default unless you select OpenCode Go during install or switch to it
-later.
+The installer builds both `openai` and `opencode-go`. OpenAI stays active unless
+you choose OpenCode Go at install time or switch to it later.
 
 Because the `opencode-go` preset uses GLM-5.1 for Orchestrator and GLM is not
 multimodal, installing with `--preset=opencode-go` also enables the Observer
@@ -67,13 +66,19 @@ setting the top-level `preset` field:
   "disabled_agents": [],
   "presets": {
     "opencode-go": {
-      "orchestrator": { "model": "opencode-go/glm-5.2" },
+      "orchestrator": {
+        "model": "opencode-go/glm-5.2"
+      },
       "oracle": {
         "model": "opencode-go/qwen3.7-max",
         "variant": "max"
       },
-      "librarian": { "model": "opencode-go/deepseek-v4-flash" },
-      "explorer": { "model": "opencode-go/deepseek-v4-flash" },
+      "librarian": {
+        "model": "opencode-go/deepseek-v4-flash"
+      },
+      "explorer": {
+        "model": "opencode-go/deepseek-v4-flash"
+      },
       "designer": {
         "model": "opencode-go/kimi-k2.7-code",
         "variant": "medium"
@@ -82,13 +87,21 @@ setting the top-level `preset` field:
         "model": "opencode-go/deepseek-v4-flash",
         "variant": "high"
       },
-      "observer": { "model": "opencode-go/kimi-k2.6" }
+      "observer": {
+        "model": "opencode-go/kimi-k2.6"
+      }
     }
   }
 }
 ```
 
-This preset defines no `skills` or `mcps` per agent. It relies on model selection only (see [Bundled Model Mapping](#bundled-model-mapping)); agents use whatever skills are globally installed.
+## Skill Reference
+
+This preset defines no per-agent `skills` or `mcps`. All agents use whatever skills are globally installed (the `*` wildcard).
+
+| Skill | Description | Source |
+| --- | --- | --- |
+| `*` | All installed skills (wildcard) | public |
 
 For the complete configuration reference, see
 [Configuration](configuration.md).

--- a/docs/opencode-zen-free-preset.md
+++ b/docs/opencode-zen-free-preset.md
@@ -1,0 +1,75 @@
+# OpenCode Zen Free Preset
+
+This preset is a **fully free-tier** setup — every agent uses an `opencode/...-free`
+model, so it costs nothing to run.
+
+No subscriptions, no API keys, no billing. Just configure the preset and go.
+
+---
+
+## The Config
+
+```jsonc
+{
+  "preset": "opencode-zen-free",
+  "presets": {
+    "opencode-zen-free": {
+      "orchestrator": {
+        "model": "opencode/hy3-free",
+        "temperature": 0.4,
+        "skills": ["*"],
+        "mcps": ["*", "!context7"]
+      },
+      "oracle": {
+        "model": "opencode/big-pickle",
+        "temperature": 0.4,
+        "variant": "max",
+        "skills": ["simplify"],
+        "mcps": []
+      },
+      "explorer": {
+        "model": "opencode/north-mini-code-free",
+        "temperature": 0.2,
+        "skills": [],
+        "mcps": []
+      },
+      "librarian": {
+        "model": "opencode/deepseek-v4-flash-free",
+        "temperature": 0.2,
+        "skills": [],
+        "mcps": ["websearch", "context7", "gh_grep"]
+      },
+      "designer": {
+        "model": "opencode/mimo-v2.5-free",
+        "temperature": 0.3,
+        "variant": "medium",
+        "skills": [],
+        "mcps": []
+      },
+      "fixer": {
+        "model": "opencode/deepseek-v4-flash-free",
+        "temperature": 0.2,
+        "variant": "high",
+        "skills": [],
+        "mcps": []
+      },
+      "observer": {
+        "model": "opencode/north-mini-code-free",
+        "temperature": 0.2,
+        "variant": "low",
+        "skills": [],
+        "mcps": []
+      }
+    }
+  }
+}
+```
+
+## Skill Reference
+
+| Skill | Description | Source |
+| --- | --- | --- |
+| `*` | All installed skills (wildcard) | public |
+| `simplify` | Code simplification | public |
+
+For the complete configuration reference, see [Configuration](configuration.md).

--- a/docs/opencode-zen-free-preset.md
+++ b/docs/opencode-zen-free-preset.md
@@ -1,9 +1,9 @@
 # OpenCode Zen Free Preset
 
-This preset is a **fully free-tier** setup — every agent uses an `opencode/...-free`
-model, so it costs nothing to run.
+This preset runs entirely on free-tier models. Every agent uses an `opencode/...-free`
+model, so there is no cost.
 
-No subscriptions, no API keys, no billing. Just configure the preset and go.
+No subscription or API key required. Set the preset and start.
 
 ---
 

--- a/docs/opencode-zen-free-preset.md
+++ b/docs/opencode-zen-free-preset.md
@@ -53,7 +53,7 @@ You need an API key for the `opencode` provider. Sign up at [OpenCode Zen](https
         "mcps": []
       },
       "observer": {
-        "model": "opencode/north-mini-code-free",
+        "model": "opencode/mimo-v2.5-free",
         "temperature": 0.2,
         "variant": "low",
         "skills": [],

--- a/docs/opencode-zen-free-preset.md
+++ b/docs/opencode-zen-free-preset.md
@@ -1,7 +1,6 @@
 # OpenCode Zen Free Preset
 
-This preset runs entirely on free-tier models. Every agent uses an `opencode/...-free`
-model, so there is no usage cost.
+Every agent runs on an opencode free model; no usage cost.
 
 You need an API key for the `opencode` provider. Sign up at [OpenCode Zen](https://opencode.ai/zen) (skip billing; the free models need no balance) and connect it with `/connect`.
 

--- a/docs/opencode-zen-free-preset.md
+++ b/docs/opencode-zen-free-preset.md
@@ -68,7 +68,7 @@ You need an API key for the `opencode` provider. Sign up at [OpenCode Zen](https
 
 | Skill | Description | Source |
 | --- | --- | --- |
-| `*` | All installed skills (wildcard) | public |
-| `simplify` | Code simplification | public |
+| `*` | All installed skills (wildcard) | `public` |
+| `simplify` | Code simplification | `public` |
 
 For the complete configuration reference, see [Configuration](configuration.md).

--- a/docs/opencode-zen-free-preset.md
+++ b/docs/opencode-zen-free-preset.md
@@ -3,7 +3,7 @@
 This preset runs entirely on free-tier models. Every agent uses an `opencode/...-free`
 model, so there is no usage cost.
 
-You still need an API key for the `opencode` provider, but the free models themselves are free to use. Set the preset and start.
+You need an API key for the `opencode` provider. Sign up at [OpenCode Zen](https://opencode.ai/zen) (skip billing; the free models need no balance) and connect it with `/connect`.
 
 ---
 

--- a/docs/opencode-zen-free-preset.md
+++ b/docs/opencode-zen-free-preset.md
@@ -1,9 +1,9 @@
 # OpenCode Zen Free Preset
 
 This preset runs entirely on free-tier models. Every agent uses an `opencode/...-free`
-model, so there is no cost.
+model, so there is no usage cost.
 
-No subscription or API key required. Set the preset and start.
+You still need an API key for the `opencode` provider, but the free models themselves are free to use. Set the preset and start.
 
 ---
 

--- a/docs/thirty-dollars-preset.md
+++ b/docs/thirty-dollars-preset.md
@@ -1,8 +1,8 @@
 # $30 Preset
 
-This preset is for people who want a strong setup built around **Codex Plus ($20/month)** and **GitHub Copilot Pro ($10/month)**.
+This preset pairs **Codex Plus ($20/month)** with **GitHub Copilot Pro ($10/month)**.
 
-It uses Codex Plus for the OpenAI models and GitHub Copilot for the premium design models, giving you a mixed-provider setup for about **$30/month total**.
+Codex Plus covers the OpenAI models and Copilot covers the design models, so you get a mixed-provider setup for about **$30/month total**.
 
 ---
 
@@ -25,6 +25,8 @@ It uses Codex Plus for the OpenAI models and GitHub Copilot for the premium desi
 
 ## Skill Reference
 
-| Skill | Description |
-| --- | --- |
-| `*` | All installed skills (wildcard) |
+| Skill | Description | Source |
+| --- | --- | --- |
+| `*` | All installed skills (wildcard) | public |
+
+For the complete configuration reference, see [Configuration](configuration.md).

--- a/docs/thirty-dollars-preset.md
+++ b/docs/thirty-dollars-preset.md
@@ -6,6 +6,12 @@ It uses Codex Plus for the OpenAI models and GitHub Copilot for the premium desi
 
 ---
 
+## Skill Reference
+
+| Skill | Description |
+| --- | --- |
+| `*` | All installed skills (wildcard) |
+
 ## The Config
 
 ```jsonc

--- a/docs/thirty-dollars-preset.md
+++ b/docs/thirty-dollars-preset.md
@@ -6,12 +6,6 @@ It uses Codex Plus for the OpenAI models and GitHub Copilot for the premium desi
 
 ---
 
-## Skill Reference
-
-| Skill | Description |
-| --- | --- |
-| `*` | All installed skills (wildcard) |
-
 ## The Config
 
 ```jsonc
@@ -28,3 +22,9 @@ It uses Codex Plus for the OpenAI models and GitHub Copilot for the premium desi
     }
   }
 ```
+
+## Skill Reference
+
+| Skill | Description |
+| --- | --- |
+| `*` | All installed skills (wildcard) |

--- a/docs/thirty-dollars-preset.md
+++ b/docs/thirty-dollars-preset.md
@@ -27,6 +27,6 @@ Codex Plus covers the OpenAI models and Copilot covers the design models, so you
 
 | Skill | Description | Source |
 | --- | --- | --- |
-| `*` | All installed skills (wildcard) | public |
+| `*` | All installed skills (wildcard) | `public` |
 
 For the complete configuration reference, see [Configuration](configuration.md).


### PR DESCRIPTION
## Summary
Closes #690. The preset docs now list which skills each preset uses, and the four preset pages follow a consistent layout.

- `docs/authors-preset.md` — `## Skill Reference` (Skill | Description | Source) for the author's third-party skills, placed after the config block.
- `docs/openai-preset.md` — new page mirroring the opencode-go layout, with a `## Skill Reference` covering `*` and `simplify` (both `public`).
- `docs/opencode-go-preset.md` — added `## Skill Reference` (notes that it sets no per-agent skills); config block reformatted to the expanded style.
- `docs/thirty-dollars-preset.md` — `## Skill Reference` now has the Source column, plus a link to Configuration.
- `README.md` — dropped the duplicated skill table and added a `### Preset Docs` section with a one-line blurb and link for each preset, above `### For Alternative Providers`.

## Decisions
- Tables use Skill | Description | Source. No Agent column, since the config block already shows which agent uses each skill.
- The Source column marks `author` (third-party) or `public` (tool, framework, or MCP).
- No URLs. Most of these skills are the author's private files with no public source, and the tool-named ones are the author's wrappers, not the frameworks themselves.
- Left out any write-up of model choice. Model names change every few months and the config block already pairs each model with its role.

## Verification
- `bun run check:ci` passes on every doc touched here. One unrelated error in `src/hooks/foreground-fallback/index.ts` is already in the tree and is not part of this branch.