### PR TITLE
fix(council): respect council.default_preset by not hardcoding "default"

### DIFF
--- a/src/agents/council.ts
+++ b/src/agents/council.ts
@@ -19,7 +19,7 @@ orchestration system that runs consensus across multiple models.
 
 **Usage**:
 1. Call the \`council_session\` tool with the user's prompt
-2. Optionally specify a preset (default: "default")
+2. Optionally specify a preset (omit to use the configured default)
 3. Receive the councillor responses formatted for synthesis
 4. Follow the Synthesis Process below
 5. Present the result to the user

--- a/src/tools/council.test.ts
+++ b/src/tools/council.test.ts
@@ -99,6 +99,18 @@ describe('council_session tool', () => {
       expect(tools.council_session.args.preset).toBeDefined();
       expect(tools.council_session.args).toHaveProperty('preset');
     });
+
+    test('preset description does not hardcode the "default" preset', () => {
+      const ctx = createMockPluginContext();
+      const councilManager = createMockCouncilManager();
+      const tools = createCouncilTool(ctx, councilManager);
+
+      const description = (tools.council_session.args.preset as any)
+        .description;
+      expect(description).toBeDefined();
+      expect(description).not.toContain('(default: "default")');
+      expect(description).toContain('configured default');
+    });
   });
 
   describe('execute', () => {

--- a/src/tools/council.ts
+++ b/src/tools/council.ts
@@ -46,7 +46,7 @@ Returns the councillor responses with a summary footer.`,
         .string()
         .optional()
         .describe(
-          'Council preset to use (default: "default"). Must match a preset in the council config.',
+          'Council preset to use. Omit to use the configured default. Must match a preset in the council config.',
         ),
     },
     async execute(args, toolContext) {


### PR DESCRIPTION
## Summary

The council agent was being told the default preset was literally `"default"`. That wording made it pass `preset: "default"` explicitly, which short-circuits the manager's `presetName ?? councilConfig.default_preset ?? 'default'` chain and silently ignores a configured `council.default_preset`.

This rewords the council agent prompt and the `council_session` tool description so the agent omits the preset to use the configured default. No logic change — the manager resolution was already correct. Adds a regression test on the tool description.

Closes #479
