### PR TITLE
fix(multiplexer): normalize Windows backslash paths in attach --dir (#568)

### DIFF
--- a/src/multiplexer/herdr/index.ts
+++ b/src/multiplexer/herdr/index.ts
@@ -83,6 +83,7 @@ export class HerdrMultiplexer implements Multiplexer {
         '--direction',
         this.paneDirection,
         '--cwd',
+        // Normalize Windows backslashes→/ so sh -lc (MSYS2) doesn't corrupt --cwd (issue #568)
         process.platform === 'win32'
           ? directory.replace(/\\/g, '/')
           : directory,

--- a/src/multiplexer/herdr/index.ts
+++ b/src/multiplexer/herdr/index.ts
@@ -19,6 +19,7 @@ import {
   buildOpencodeAttachCommand,
   findBinary,
   gracefulClosePane,
+  normalizePathForShell,
 } from '../shared';
 import type { Multiplexer, PaneResult } from '../types';
 
@@ -74,6 +75,10 @@ export class HerdrMultiplexer implements Multiplexer {
     }
 
     try {
+      // Normalize Windows backslashes→/ so sh -lc (MSYS2) doesn't
+      // corrupt --cwd (issue #568).
+      const attachDir = normalizePathForShell(directory);
+
       // 1. Split the parent pane to create a new one
       const splitArgs = [
         herdr,
@@ -83,10 +88,7 @@ export class HerdrMultiplexer implements Multiplexer {
         '--direction',
         this.paneDirection,
         '--cwd',
-        // Normalize Windows backslashes→/ so sh -lc (MSYS2) doesn't corrupt --cwd (issue #568)
-        process.platform === 'win32'
-          ? directory.replace(/\\/g, '/')
-          : directory,
+        attachDir,
         '--no-focus',
       ];
 
@@ -128,7 +130,7 @@ export class HerdrMultiplexer implements Multiplexer {
       const opencodeCmd = buildOpencodeAttachCommand(
         sessionId,
         serverUrl,
-        directory,
+        attachDir,
       );
 
       log('[herdr] spawnPane: running attach command', {

--- a/src/multiplexer/herdr/index.ts
+++ b/src/multiplexer/herdr/index.ts
@@ -83,7 +83,9 @@ export class HerdrMultiplexer implements Multiplexer {
         '--direction',
         this.paneDirection,
         '--cwd',
-        directory,
+        process.platform === 'win32'
+          ? directory.replace(/\\/g, '/')
+          : directory,
         '--no-focus',
       ];
 

--- a/src/multiplexer/shared.test.ts
+++ b/src/multiplexer/shared.test.ts
@@ -41,8 +41,7 @@ describe('gracefulClosePane', () => {
       };
     });
 
-    const { gracefulClosePane } =
-      await importShared();
+    const { gracefulClosePane } = await importShared();
     const ok = await gracefulClosePane('tmux', '%1', {
       ctrlC: ['send-keys', '-t', '%1', 'C-c'],
       close: ['kill-pane', '-t', '%1'],
@@ -101,5 +100,35 @@ describe('gracefulClosePane', () => {
       close: ['y'],
     });
     expect(ok).toBe(false);
+  });
+});
+
+describe('buildOpencodeAttachCommand', () => {
+  test('normalizes Windows backslash paths to forward slashes', async () => {
+    const original = process.platform;
+    Object.defineProperty(process, 'platform', {
+      value: 'win32',
+      configurable: true,
+    });
+    try {
+      const { buildOpencodeAttachCommand } = await importShared();
+      const cmd = buildOpencodeAttachCommand(
+        'sess',
+        'url',
+        'C:\\Users\\foo\\repo',
+      );
+      expect(cmd).toContain('C:/Users/foo/repo');
+    } finally {
+      Object.defineProperty(process, 'platform', {
+        value: original,
+        configurable: true,
+      });
+    }
+  });
+
+  test('leaves non-Windows paths unchanged', async () => {
+    const { buildOpencodeAttachCommand } = await importShared();
+    const cmd = buildOpencodeAttachCommand('sess', 'url', '/home/user/repo');
+    expect(cmd).toContain('/home/user/repo');
   });
 });

--- a/src/multiplexer/shared.test.ts
+++ b/src/multiplexer/shared.test.ts
@@ -127,8 +127,20 @@ describe('buildOpencodeAttachCommand', () => {
   });
 
   test('leaves non-Windows paths unchanged', async () => {
-    const { buildOpencodeAttachCommand } = await importShared();
-    const cmd = buildOpencodeAttachCommand('sess', 'url', '/home/user/repo');
-    expect(cmd).toContain('/home/user/repo');
+    const original = process.platform;
+    Object.defineProperty(process, 'platform', {
+      value: 'linux',
+      configurable: true,
+    });
+    try {
+      const { buildOpencodeAttachCommand } = await importShared();
+      const cmd = buildOpencodeAttachCommand('sess', 'url', '/home/user/repo');
+      expect(cmd).toContain('/home/user/repo');
+    } finally {
+      Object.defineProperty(process, 'platform', {
+        value: original,
+        configurable: true,
+      });
+    }
   });
 });

--- a/src/multiplexer/shared.ts
+++ b/src/multiplexer/shared.ts
@@ -17,6 +17,8 @@ export function buildOpencodeAttachCommand(
   serverUrl: string,
   directory: string,
 ): string {
+  const attachDir =
+    process.platform === 'win32' ? directory.replace(/\\/g, '/') : directory;
   return [
     'opencode',
     'attach',
@@ -24,7 +26,7 @@ export function buildOpencodeAttachCommand(
     '--session',
     quoteShellArg(sessionId),
     '--dir',
-    quoteShellArg(directory),
+    quoteShellArg(attachDir),
   ].join(' ');
 }
 

--- a/src/multiplexer/shared.ts
+++ b/src/multiplexer/shared.ts
@@ -12,16 +12,19 @@ export function quoteShellArg(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
+/** Normalize Windows backslashes to / so sh -lc (MSYS2/Git Bash) doesn't treat them as escape chars. */
+export function normalizePathForShell(directory: string): string {
+  return process.platform === 'win32'
+    ? directory.replace(/\\/g, '/')
+    : directory;
+}
+
 export function buildOpencodeAttachCommand(
   sessionId: string,
   serverUrl: string,
   directory: string,
 ): string {
-  // Normalize backslashes to forward slashes on Windows: when the command runs
-  // under sh -lc (MSYS2/Git Bash), backslashes are treated as escape chars and
-  // corrupt the --dir path (issue #568).
-  const attachDir =
-    process.platform === 'win32' ? directory.replace(/\\/g, '/') : directory;
+  const attachDir = normalizePathForShell(directory);
   return [
     'opencode',
     'attach',

--- a/src/multiplexer/shared.ts
+++ b/src/multiplexer/shared.ts
@@ -17,6 +17,9 @@ export function buildOpencodeAttachCommand(
   serverUrl: string,
   directory: string,
 ): string {
+  // Normalize backslashes to forward slashes on Windows: when the command runs
+  // under sh -lc (MSYS2/Git Bash), backslashes are treated as escape chars and
+  // corrupt the --dir path (issue #568).
   const attachDir =
     process.platform === 'win32' ? directory.replace(/\\/g, '/') : directory;
   return [


### PR DESCRIPTION
On Windows, launching a background subagent pane (Zellij/MSYS2) corrupted the
\`--dir\` path: backslashes in the project directory were passed straight through
\`sh -lc\`, where MSYS2 treats \`\\\` as an escape character — producing a broken path
like \`C:\Users\example\Usersexample\`.

This normalizes backslashes to forward slashes for \`win32\` before building the
attach command in \`buildOpencodeAttachCommand\` (shared by the tmux and zellij
backends) and in herdr's \`--cwd\`. Non-Windows paths are left untouched, so there's
no behavior change elsewhere.

Closes #568.