### PR TITLE
fix(tui): use theme.text for badge to stay visible on transparent backgrounds (#582)

### DIFF
--- a/src/tui.ts
+++ b/src/tui.ts
@@ -177,7 +177,10 @@ function renderSidebar(
         [
           box(
             { paddingLeft: 1, paddingRight: 1, backgroundColor: theme.accent },
-            [text({ fg: theme.background }, ['OMO-Slim'])],
+            // Use theme.text, not theme.background: when the theme background is
+            // "none" (transparent) the foreground becomes RGBA(0,0,0,0) and the
+            // badge text vanishes. See #582.
+            [text({ fg: theme.text }, ['OMO-Slim'])],
           ),
           text({ fg: theme.textMuted }, [`v${version}`]),
         ],


### PR DESCRIPTION
The \`OMO-Slim\` badge in the TUI sidebar used \`theme.background\` as its text
color, drawn on top of a \`theme.accent\` background. When the theme background
is \`\"none\"\` (transparent), the foreground resolves to RGBA(0,0,0,0) and the
badge text disappears.

This uses \`theme.text\` instead, which is always a solid color, so the badge
stays visible on transparent-background themes without changing behavior
elsewhere.

Closes #582.