### PR TITLE
Rename the session when /interview starts

### DIFF
--- a/src/interview/interview.test.ts
+++ b/src/interview/interview.test.ts
@@ -174,6 +174,55 @@ describe('interview service', () => {
       await fs.rm(tempDir, { recursive: true, force: true });
     });
 
+    test('renames session with interview title on creation', async () => {
+      const tempDir = await fs.mkdtemp('/tmp/interview-test-');
+      const ctx = createMockContext({ directory: tempDir });
+      const service = createInterviewService(ctx);
+      service.setBaseUrlResolver(async () => 'http://localhost:9999');
+      const output = { parts: [] as Array<{ type: string; text?: string }> };
+
+      await service.handleCommandExecuteBefore(
+        {
+          command: 'interview',
+          sessionID: 'session-rename',
+          arguments: 'build a task manager',
+        },
+        output,
+      );
+
+      expect(ctx.client.session.update).toHaveBeenCalledTimes(1);
+      expect(ctx.client.session.update.mock.calls[0][0]).toEqual({
+        path: { id: 'session-rename' },
+        body: { title: 'Interview: build a task manager' },
+      });
+
+      await fs.rm(tempDir, { recursive: true, force: true });
+    });
+
+    test('truncates session title to 50 chars with ellipsis', async () => {
+      const tempDir = await fs.mkdtemp('/tmp/interview-test-');
+      const ctx = createMockContext({ directory: tempDir });
+      const service = createInterviewService(ctx);
+      service.setBaseUrlResolver(async () => 'http://localhost:9999');
+      const output = { parts: [] as Array<{ type: string; text?: string }> };
+
+      const longIdea = 'a'.repeat(60);
+      await service.handleCommandExecuteBefore(
+        {
+          command: 'interview',
+          sessionID: 'session-truncate',
+          arguments: longIdea,
+        },
+        output,
+      );
+
+      const title = ctx.client.session.update.mock.calls[0][0].body.title;
+      expect(title.length).toBe(50);
+      expect(title.endsWith('…')).toBe(true);
+
+      await fs.rm(tempDir, { recursive: true, force: true });
+    });
+
     test('creates markdown file with slug-only filename (no timestamp prefix)', async () => {
       const tempDir = await fs.mkdtemp('/tmp/interview-test-');
       const ctx = createMockContext({ directory: tempDir });

--- a/src/interview/interview.test.ts
+++ b/src/interview/interview.test.ts
@@ -40,6 +40,7 @@ function createMockContext(overrides?: {
           }
           return {};
         }),
+        update: mock(async () => ({})),
       },
     },
     directory: overrides?.directory ?? '/test/directory',

--- a/src/interview/manager.test.ts
+++ b/src/interview/manager.test.ts
@@ -48,6 +48,7 @@ function createMockContext(overrides?: {
           }
           return {};
         }),
+        update: mock(async () => ({})),
       },
     },
     directory: overrides?.directory ?? '/test/directory',

--- a/src/interview/service.ts
+++ b/src/interview/service.ts
@@ -688,24 +688,17 @@ export function createInterviewService(
     );
 
     // best-effort: rename the session so it's identifiable in the session list.
-    // strip a leading imperative verb (e.g. "build a") and cap length so the
-    // title stays short in the session list. never block interview creation
-    // if the rename fails.
-    const titleIdea = idea.replace(
-      /^(build|create|make|write|design|implement|add|set up)\s+(a|an|the)\s+/i,
-      '',
-    );
-    let sessionTitle = `Interview: ${titleIdea}`;
-    const MAX_TITLE = 50;
-    if (sessionTitle.length > MAX_TITLE) {
-      sessionTitle = `${sessionTitle.slice(0, MAX_TITLE - 1)}…`;
+    // never block interview creation if the rename fails.
+    let sessionTitle = `Interview: ${idea}`;
+    if (sessionTitle.length > 50) {
+      sessionTitle = `${sessionTitle.slice(0, 49)}…`;
     }
     ctx.client.session
-      .update({
+      .update?.({
         path: { id: input.sessionID },
         body: { title: sessionTitle },
       })
-      .catch(() => {});
+      ?.catch(() => {});
   }
 
   async function handleEvent(input: {

--- a/src/interview/service.ts
+++ b/src/interview/service.ts
@@ -686,6 +686,26 @@ export function createInterviewService(
     output.parts.push(
       createInternalAgentTextPart(buildKickoffPrompt(idea, maxQuestions)),
     );
+
+    // best-effort: rename the session so it's identifiable in the session list.
+    // strip a leading imperative verb (e.g. "build a") and cap length so the
+    // title stays short in the session list. never block interview creation
+    // if the rename fails.
+    const titleIdea = idea.replace(
+      /^(build|create|make|write|design|implement|add|set up)\s+(a|an|the)\s+/i,
+      '',
+    );
+    let sessionTitle = `Interview: ${titleIdea}`;
+    const MAX_TITLE = 50;
+    if (sessionTitle.length > MAX_TITLE) {
+      sessionTitle = `${sessionTitle.slice(0, MAX_TITLE - 1)}…`;
+    }
+    ctx.client.session
+      .update({
+        path: { id: input.sessionID },
+        body: { title: sessionTitle },
+      })
+      .catch(() => {});
   }
 
   async function handleEvent(input: {


### PR DESCRIPTION
Closes #485.

Running `/interview <idea>` used to leave the current session titled "New Session...", which made interview sessions hard to tell apart in the session list. Now the session is renamed to `Interview: <idea>` as soon as the interview is created.

A leading imperative verb is dropped from the idea so the title stays short. For example, `/interview build a requirements interview workflow` gives the session the title `Interview: requirements interview workflow`.

This was previously marked as blocked by the SDK, but `client.session.update` (PATCH /session/{id}) has been available since SDK v1.4.3, and the plugin already calls `ctx.client.session.*` elsewhere. The fix is a single best-effort call placed after the interview is created, wrapped in `.catch` so a failed rename never blocks the interview.

Verified with a real opencode run: the session title updates as expected.
