### PR TITLE
fix: fail over stalled subagent retries

### DIFF
--- a/src/hooks/foreground-fallback/index.test.ts
+++ b/src/hooks/foreground-fallback/index.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import { SessionLifecycle } from '../session-lifecycle';
-import { ForegroundFallbackManager, isRateLimitError } from './index';
+import {
+  ForegroundFallbackManager,
+  isFailoverError,
+  isRateLimitError,
+} from './index';
 
 type ForegroundFallbackClient = ConstructorParameters<
   typeof ForegroundFallbackManager
@@ -64,6 +68,10 @@ function makeChains(
 // ---------------------------------------------------------------------------
 
 describe('isRateLimitError', () => {
+  test('exports isFailoverError as the preferred classifier name', () => {
+    expect(typeof isFailoverError).toBe('function');
+  });
+
   test('returns true for 429 status code', () => {
     expect(isRateLimitError({ data: { statusCode: 429 } })).toBe(true);
   });
@@ -92,6 +100,87 @@ describe('isRateLimitError', () => {
 
   test('returns true for "Service Unavailable"', () => {
     expect(isRateLimitError({ message: 'Service Unavailable' })).toBe(true);
+  });
+
+  test('alias remains behaviorally compatible with isFailoverError', () => {
+    const controls = [
+      { data: { statusCode: 429 } },
+      { message: 'Rate limit exceeded' },
+      { message: 'internal server error' },
+      { data: { statusCode: 400, message: 'application invalid request' } },
+      { message: 'retried provider 503 times' },
+      null,
+      'string error',
+    ];
+
+    for (const error of controls) {
+      expect(isRateLimitError(error)).toBe(isFailoverError(error));
+    }
+  });
+
+  test('classifies textual provider outage errors as failover errors', () => {
+    for (const message of [
+      'internal server error',
+      'bad gateway',
+      'gateway timeout',
+    ]) {
+      expect(isFailoverError({ message })).toBe(true);
+    }
+  });
+
+  test('returns true for structured outage status codes', () => {
+    for (const statusCode of [500, 502, 503, 504]) {
+      expect(isRateLimitError({ data: { statusCode } })).toBe(true);
+    }
+  });
+
+  test('does not match outage status codes from arbitrary free text only', () => {
+    expect(isRateLimitError({ message: 'retried provider 503 times' })).toBe(
+      false,
+    );
+    expect(isFailoverError({ message: 'retried provider 503 times' })).toBe(
+      false,
+    );
+  });
+
+  test('returns true for transport-level provider errors', () => {
+    for (const error of [
+      { code: 'ECONNREFUSED', message: 'connect ECONNREFUSED 127.0.0.1' },
+      { code: 'ECONNRESET', message: 'socket hang up' },
+      { code: 'ENOTFOUND', message: 'getaddrinfo ENOTFOUND api.provider.test' },
+      { message: 'fetch failed' },
+      { message: 'provider request timeout' },
+    ]) {
+      expect(isRateLimitError(error)).toBe(true);
+    }
+  });
+
+  test('classifies nested transport cause codes as failover errors', () => {
+    expect(
+      isFailoverError({
+        message: 'wrapped provider failure',
+        cause: { code: 'ECONNREFUSED' },
+      }),
+    ).toBe(true);
+  });
+
+  test('returns false for HTTP 400 application invalid request', () => {
+    expect(
+      isRateLimitError({
+        data: {
+          statusCode: 400,
+          message: 'application invalid request: missing required field',
+        },
+      }),
+    ).toBe(false);
+    expect(
+      isFailoverError({
+        data: {
+          statusCode: 400,
+          message: 'application invalid request: missing required field',
+        },
+      }),
+    ).toBe(false);
   });
 
   test('returns true for "Monthly usage limit reached"', () => {
@@ -200,6 +289,39 @@ describe('ForegroundFallbackManager session.error', () => {
     ];
     expect(call[0].path.id).toBe('sess-1');
     // Should have picked the next model after anthropic/claude-opus-4-5
+    expect(call[0].body.model.providerID).toBe('openai');
+    expect(call[0].body.model.modelID).toBe('gpt-4o');
+  });
+
+  test('extracts session ID from properties.info.id on session.error', async () => {
+    await mgr.handleEvent({
+      type: 'message.updated',
+      properties: {
+        info: {
+          sessionID: 'sess-info-error',
+          providerID: 'anthropic',
+          modelID: 'claude-opus-4-5',
+          role: 'assistant',
+        },
+      },
+    });
+
+    await mgr.handleEvent({
+      type: 'session.error',
+      properties: {
+        info: { id: 'sess-info-error' },
+        error: { message: 'Rate limit exceeded' },
+      },
+    });
+
+    expect(mocks.promptAsync).toHaveBeenCalledTimes(1);
+    const call = mocks.promptAsync.mock.calls[0] as [
+      {
+        path: { id: string };
+        body: { model: { providerID: string; modelID: string } };
+      },
+    ];
+    expect(call[0].path.id).toBe('sess-info-error');
     expect(call[0].body.model.providerID).toBe('openai');
     expect(call[0].body.model.modelID).toBe('gpt-4o');
   });
@@ -408,6 +530,36 @@ describe('ForegroundFallbackManager session.status', () => {
     expect(mocks.promptAsync).toHaveBeenCalledTimes(1);
   });
 
+  test('extracts session ID from properties.info.id on session.status', async () => {
+    const { client, mocks } = createMockClient();
+    const mgr = new ForegroundFallbackManager(client, makeChains(), true, 1);
+
+    await mgr.handleEvent({
+      type: 'message.updated',
+      properties: {
+        info: {
+          sessionID: 'sess-info-status',
+          providerID: 'anthropic',
+          modelID: 'claude-opus-4-5',
+        },
+      },
+    });
+
+    await mgr.handleEvent({
+      type: 'session.status',
+      properties: {
+        info: { id: 'sess-info-status' },
+        status: { type: 'retry', message: 'usage limit reached, retrying...' },
+      },
+    });
+
+    expect(mocks.promptAsync).toHaveBeenCalledTimes(1);
+    const call = mocks.promptAsync.mock.calls[0] as [
+      { path: { id: string } },
+    ];
+    expect(call[0].path.id).toBe('sess-info-status');
+  });
+
   test('triggers fallback on retry status with insufficient balance message', async () => {
     const { client, mocks } = createMockClient();
     const mgr = new ForegroundFallbackManager(client, makeChains(), true, 1);
@@ -499,6 +651,145 @@ describe('ForegroundFallbackManager session.status', () => {
           type: 'retry',
           attempt: 3,
           message: 'rate limit, retrying...',
+        },
+      },
+    });
+    expect(mocks.promptAsync).toHaveBeenCalledTimes(1);
+  });
+
+  test('retry status with absent or unrecognized message still counts and triggers at maxRetries', async () => {
+    const { client, mocks } = createMockClient();
+    const mgr = new ForegroundFallbackManager(client, makeChains(), true, 3);
+
+    await mgr.handleEvent({
+      type: 'message.updated',
+      properties: {
+        info: {
+          sessionID: 'sess-retry-any-message',
+          providerID: 'anthropic',
+          modelID: 'claude-opus-4-5',
+        },
+      },
+    });
+
+    await mgr.handleEvent({
+      type: 'session.status',
+      properties: {
+        sessionID: 'sess-retry-any-message',
+        status: { type: 'retry' },
+      },
+    });
+    await mgr.handleEvent({
+      type: 'session.status',
+      properties: {
+        sessionID: 'sess-retry-any-message',
+        status: { type: 'retry', message: 'provider is trying again' },
+      },
+    });
+    expect(mocks.promptAsync).not.toHaveBeenCalled();
+
+    await mgr.handleEvent({
+      type: 'session.status',
+      properties: {
+        sessionID: 'sess-retry-any-message',
+        status: { type: 'retry' },
+      },
+    });
+
+    expect(mocks.promptAsync).toHaveBeenCalledTimes(1);
+  });
+
+  test('busy statuses between retries do not reset the retry budget', async () => {
+    const { client, mocks } = createMockClient();
+    const mgr = new ForegroundFallbackManager(client, makeChains(), true, 3);
+
+    await mgr.handleEvent({
+      type: 'message.updated',
+      properties: {
+        info: {
+          sessionID: 'sess-retry-busy-retry',
+          providerID: 'anthropic',
+          modelID: 'claude-opus-4-5',
+        },
+      },
+    });
+
+    for (const status of [
+      { type: 'retry' },
+      { type: 'busy' },
+      { type: 'retry' },
+      { type: 'busy' },
+    ]) {
+      await mgr.handleEvent({
+        type: 'session.status',
+        properties: {
+          sessionID: 'sess-retry-busy-retry',
+          status,
+        },
+      });
+    }
+    expect(mocks.promptAsync).not.toHaveBeenCalled();
+
+    await mgr.handleEvent({
+      type: 'session.status',
+      properties: {
+        sessionID: 'sess-retry-busy-retry',
+        status: { type: 'retry' },
+      },
+    });
+
+    expect(mocks.promptAsync).toHaveBeenCalledTimes(1);
+  });
+
+  test('debounces outage retry statuses before fallback', async () => {
+    const { client, mocks } = createMockClient();
+    const mgr = new ForegroundFallbackManager(client, makeChains(), true, 3);
+
+    await mgr.handleEvent({
+      type: 'message.updated',
+      properties: {
+        info: {
+          sessionID: 'sess-outage-retry',
+          providerID: 'anthropic',
+          modelID: 'claude-opus-4-5',
+        },
+      },
+    });
+
+    await mgr.handleEvent({
+      type: 'session.status',
+      properties: {
+        sessionID: 'sess-outage-retry',
+        status: {
+          type: 'retry',
+          attempt: 1,
+          message: 'service unavailable, retrying...',
+        },
+      },
+    });
+    expect(mocks.promptAsync).not.toHaveBeenCalled();
+
+    await mgr.handleEvent({
+      type: 'session.status',
+      properties: {
+        sessionID: 'sess-outage-retry',
+        status: {
+          type: 'retry',
+          attempt: 2,
+          message: 'service unavailable, retrying...',
+        },
+      },
+    });
+    expect(mocks.promptAsync).not.toHaveBeenCalled();
+
+    await mgr.handleEvent({
+      type: 'session.status',
+      properties: {
+        sessionID: 'sess-outage-retry',
+        status: {
+          type: 'retry',
+          attempt: 3,
+          message: 'service unavailable, retrying...',
         },
       },
     });
@@ -728,6 +1019,37 @@ describe('ForegroundFallbackManager subagent.session.created', () => {
     // primary is tried → fallback picks claude-haiku
     expect(call[0].body.model.providerID).toBe('anthropic');
     expect(call[0].body.model.modelID).toBe('claude-haiku');
+  });
+
+  test('child Oracle first provider outage uses only Oracle fallback chain', async () => {
+    const { client, mocks } = createMockClient();
+    const mgr = new ForegroundFallbackManager(
+      client,
+      {
+        orchestrator: ['google/gemini-2.5-pro', 'openai/gpt-4o'],
+        oracle: ['openai/gpt-4.1', 'anthropic/claude-sonnet-4-5'],
+      },
+      true,
+    );
+
+    mgr.registerSessionAgent('oracle-first-call', 'oracle');
+
+    await mgr.handleEvent({
+      type: 'session.error',
+      properties: {
+        sessionID: 'oracle-first-call',
+        error: { data: { statusCode: 503, message: 'upstream outage' } },
+      },
+    });
+
+    expect(mocks.promptAsync).toHaveBeenCalledTimes(1);
+    const call = mocks.promptAsync.mock.calls[0] as [
+      {
+        body: { model: { providerID: string; modelID: string } };
+      },
+    ];
+    expect(call[0].body.model.providerID).toBe('anthropic');
+    expect(call[0].body.model.modelID).toBe('claude-sonnet-4-5');
   });
 });
 

--- a/src/hooks/foreground-fallback/index.test.ts
+++ b/src/hooks/foreground-fallback/index.test.ts
@@ -504,6 +504,127 @@ describe('ForegroundFallbackManager message.updated', () => {
 // ---------------------------------------------------------------------------
 
 describe('ForegroundFallbackManager session.status', () => {
+  test('aborts active retry-budget-exhausted session before fallback re-prompt', async () => {
+    const calls: string[] = [];
+    const { client, mocks } = createMockClient({
+      abortImpl: async () => {
+        calls.push('abort');
+      },
+      promptAsyncImpl: async () => {
+        calls.push('promptAsync');
+        return {};
+      },
+    });
+    const mgr = new ForegroundFallbackManager(client, makeChains(), true, 3);
+
+    await mgr.handleEvent({
+      type: 'message.updated',
+      properties: {
+        info: {
+          sessionID: 'sess-retry-abort-before-prompt',
+          providerID: 'anthropic',
+          modelID: 'claude-opus-4-5',
+        },
+      },
+    });
+
+    for (const attempt of [1, 2, 3]) {
+      await mgr.handleEvent({
+        type: 'session.status',
+        properties: {
+          sessionID: 'sess-retry-abort-before-prompt',
+          status: {
+            type: 'retry',
+            attempt,
+            message: 'rate limit, retrying...',
+          },
+        },
+      });
+    }
+
+    expect(mocks.abort).toHaveBeenCalledTimes(1);
+    expect(mocks.promptAsync).toHaveBeenCalledTimes(1);
+    expect(calls).toEqual(['abort', 'promptAsync']);
+  });
+
+  test('keeps registered child agent identity sticky for retry fallback chain', async () => {
+    const { client, mocks } = createMockClient();
+    const mgr = new ForegroundFallbackManager(
+      client,
+      makeChains({
+        oracle: ['anthropic/claude-sonnet-4-5', 'openai/o3'],
+      }),
+      true,
+      1,
+    );
+
+    mgr.registerSessionAgent('child-oracle-sticky', 'oracle');
+    mgr.registerSessionAgent('child-oracle-sticky', 'orchestrator');
+    await mgr.handleEvent({
+      type: 'message.updated',
+      properties: {
+        info: {
+          sessionID: 'child-oracle-sticky',
+          providerID: 'anthropic',
+          modelID: 'claude-sonnet-4-5',
+        },
+      },
+    });
+
+    await mgr.handleEvent({
+      type: 'session.status',
+      properties: {
+        sessionID: 'child-oracle-sticky',
+        status: { type: 'retry', message: 'usage limit reached, retrying...' },
+      },
+    });
+
+    expect(mocks.promptAsync).toHaveBeenCalledTimes(1);
+    const call = mocks.promptAsync.mock.calls[0] as [
+      { body: { model: { providerID: string; modelID: string } } },
+    ];
+    expect(call[0].body.model).toEqual({ providerID: 'openai', modelID: 'o3' });
+  });
+
+  test('includes the sticky child agent in fallback promptAsync body', async () => {
+    const { client, mocks } = createMockClient();
+    const mgr = new ForegroundFallbackManager(
+      client,
+      makeChains({
+        oracle: ['anthropic/claude-sonnet-4-5', 'openai/o3'],
+      }),
+      true,
+      1,
+    );
+
+    mgr.registerSessionAgent('child-oracle-agent-body', 'oracle');
+    await mgr.handleEvent({
+      type: 'message.updated',
+      properties: {
+        info: {
+          sessionID: 'child-oracle-agent-body',
+          providerID: 'anthropic',
+          modelID: 'claude-sonnet-4-5',
+        },
+      },
+    });
+
+    await mgr.handleEvent({
+      type: 'session.status',
+      properties: {
+        sessionID: 'child-oracle-agent-body',
+        status: { type: 'retry', message: 'usage limit reached, retrying...' },
+      },
+    });
+
+    expect(mocks.promptAsync).toHaveBeenCalledTimes(1);
+    const call = mocks.promptAsync.mock.calls[0] as [
+      { body: { agent?: string; model: { providerID: string; modelID: string } } },
+    ];
+    expect(call[0].body.agent).toBe('oracle');
+    expect(call[0].body.model).toEqual({ providerID: 'openai', modelID: 'o3' });
+  });
+
   test('triggers fallback on retry status with rate limit message', async () => {
     const { client, mocks } = createMockClient();
     const mgr = new ForegroundFallbackManager(client, makeChains(), true, 1);

--- a/src/hooks/foreground-fallback/index.ts
+++ b/src/hooks/foreground-fallback/index.ts
@@ -44,27 +44,107 @@ const RATE_LIMIT_PATTERNS = [
   /insufficient.?(quota|balance)/i,
   /high concurrency/i,
   /reduce concurrency/i,
-  // ponytail: transient server errors mixed in; rename to isRetryableError
-  // and split from rate-limit detection when this list grows further
-  /service unavailable/i,
   /monthly usage limit/i,
   /5-hour usage limit/i,
   /weekly usage limit/i,
 ];
 
-export function isRateLimitError(error: unknown): boolean {
+const OUTAGE_STATUS_CODES = new Set([500, 502, 503, 504]);
+const TRANSPORT_CODES = new Set([
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'ENOTFOUND',
+  'ETIMEDOUT',
+  'EAI_AGAIN',
+]);
+const TRANSPORT_MESSAGE_PATTERNS = [
+  /^fetch failed$/i,
+  /^socket hang up$/i,
+  /^provider request timeout$/i,
+  /^request timeout$/i,
+  /^connect ECONNREFUSED\b/i,
+  /^getaddrinfo ENOTFOUND\b/i,
+];
+const PROVIDER_OUTAGE_PATTERNS = [
+  /\binternal server error\b/i,
+  /\bbad gateway\b/i,
+  /\bgateway timeout\b/i,
+  /\bservice unavailable\b/i,
+  /\bupstream outage\b/i,
+  /\bprovider outage\b/i,
+  /\bprovider unavailable\b/i,
+];
+
+function extractStatusCode(error: {
+  statusCode?: unknown;
+  data?: { statusCode?: unknown };
+}): number | undefined {
+  const value = error.statusCode ?? error.data?.statusCode;
+  return typeof value === 'number' ? value : undefined;
+}
+
+function eventSessionID(props: {
+  sessionID?: string;
+  info?: { id?: string };
+}): string | undefined {
+  return props.sessionID ?? props.info?.id;
+}
+
+export function isFailoverError(error: unknown): boolean {
   if (!error || typeof error !== 'object') return false;
   const err = error as {
+    code?: unknown;
+    cause?: { code?: unknown };
     message?: string;
-    data?: { statusCode?: number; message?: string; responseBody?: string };
+    statusCode?: number;
+    data?: {
+      code?: unknown;
+      statusCode?: number;
+      message?: string;
+      responseBody?: string;
+    };
   };
+  const statusCode = extractStatusCode(err);
+  if (statusCode === 429 || OUTAGE_STATUS_CODES.has(statusCode ?? 0)) {
+    return true;
+  }
+  if (statusCode === 400) return false;
+
+  if (
+    [err.code, err.cause?.code, err.data?.code].some(
+      (code) => typeof code === 'string' && TRANSPORT_CODES.has(code),
+    )
+  ) {
+    return true;
+  }
+
+  const messages = [
+    err.message ?? '',
+    err.data?.message ?? '',
+    err.data?.responseBody ?? '',
+  ];
+  if (
+    messages.some((message) =>
+      TRANSPORT_MESSAGE_PATTERNS.some((p) => p.test(message)),
+    )
+  ) {
+    return true;
+  }
+
   const text = [
     err.message ?? '',
-    String(err.data?.statusCode ?? ''),
     err.data?.message ?? '',
     err.data?.responseBody ?? '',
   ].join(' ');
-  return RATE_LIMIT_PATTERNS.some((p) => p.test(text));
+  return (
+    RATE_LIMIT_PATTERNS.some((p) => p.test(text)) ||
+    PROVIDER_OUTAGE_PATTERNS.some((p) => p.test(text))
+  );
+}
+
+/** @deprecated Use isFailoverError instead. */
+export function isRateLimitError(error: unknown): boolean {
+  return isFailoverError(error);
 }
 
 // ---------------------------------------------------------------------------
@@ -108,6 +188,11 @@ export class ForegroundFallbackManager {
    *  while a fallback abort/re-prompt is in flight for this session. */
   isFallbackInProgress(sessionID: string): boolean {
     return this.inProgress.has(sessionID);
+  }
+
+  registerSessionAgent(sessionID: string, agentName: string): void {
+    if (!sessionID || !agentName) return;
+    this.sessionAgent.set(sessionID, agentName);
   }
 
   constructor(
@@ -174,8 +259,8 @@ export class ForegroundFallbackManager {
             `${info.providerID}/${info.modelID}`,
           );
         }
-        // Rate-limit on an individual message
-        if (info.error && isRateLimitError(info.error)) {
+        // Failover-worthy error on an individual message
+        if (info.error && isFailoverError(info.error)) {
           if (this.shouldIntervene(sessionID)) {
             await this.tryFallback(sessionID);
           }
@@ -188,15 +273,17 @@ export class ForegroundFallbackManager {
 
       case 'session.error': {
         const props = event.properties as
-          | { sessionID?: string; error?: unknown }
+          | { sessionID?: string; info?: { id?: string }; error?: unknown }
           | undefined;
+        if (!props) break;
+        const sessionID = eventSessionID(props);
         if (
-          props?.sessionID &&
+          sessionID &&
           props.error &&
-          isRateLimitError(props.error) &&
-          this.shouldIntervene(props.sessionID)
+          isFailoverError(props.error) &&
+          this.shouldIntervene(sessionID)
         ) {
-          await this.tryFallback(props.sessionID);
+          await this.tryFallback(sessionID);
         }
         break;
       }
@@ -205,30 +292,45 @@ export class ForegroundFallbackManager {
         const props = event.properties as
           | {
               sessionID?: string;
+              info?: { id?: string };
               status?: { type?: string; message?: string; attempt?: number };
             }
           | undefined;
-        if (!props?.sessionID || !props.status?.message) break;
-        const msg = props.status.message.toLowerCase();
-        if (
-          msg.includes('rate limit') ||
-          msg.includes('usage limit') ||
-          msg.includes('usage exceeded') ||
-          msg.includes('quota exceeded') ||
-          msg.includes('exceededbudget') ||
-          msg.includes('over budget') ||
-          msg.includes('insufficient') ||
-          msg.includes('high concurrency') ||
-          msg.includes('reduce concurrency')
-        ) {
+        const sessionID = props ? eventSessionID(props) : undefined;
+        if (!sessionID) break;
+        if (props?.status?.type === 'retry') {
           // session.status retry path always counts toward the budget
           // — even the first retry is absorbed before intervening.
-          if (this.checkRetryBudget(props.sessionID)) {
-            await this.tryFallback(props.sessionID);
+          if (this.checkRetryBudget(sessionID)) {
+            await this.tryFallback(sessionID);
           }
-        } else {
-          // Non-rate-limit status: clear retry count (recovery).
-          this.sessionRetries.delete(props.sessionID);
+          break;
+        }
+
+        if (props?.status?.type === undefined && props?.status?.message) {
+          const msg = props.status.message.toLowerCase();
+          if (
+            isFailoverError({ message: props.status.message }) ||
+            msg.includes('rate limit') ||
+            msg.includes('usage limit') ||
+            msg.includes('usage exceeded') ||
+            msg.includes('quota exceeded') ||
+            msg.includes('exceededbudget') ||
+            msg.includes('over budget') ||
+            msg.includes('insufficient') ||
+            msg.includes('high concurrency') ||
+            msg.includes('reduce concurrency')
+          ) {
+            if (this.checkRetryBudget(sessionID)) {
+              await this.tryFallback(sessionID);
+            }
+          }
+          break;
+        }
+
+        if (this.isRecoveredStatus(props?.status?.type)) {
+          // Recovered/terminal status: clear retry count.
+          this.sessionRetries.delete(sessionID);
         }
         break;
       }
@@ -289,6 +391,16 @@ export class ForegroundFallbackManager {
     const tried = this.sessionRetries.get(sessionID) ?? 0;
     if (tried === 0) return true;
     return this.checkRetryBudget(sessionID);
+  }
+
+  private isRecoveredStatus(statusType: string | undefined): boolean {
+    return (
+      statusType === 'idle' ||
+      statusType === 'complete' ||
+      statusType === 'completed' ||
+      statusType === 'success' ||
+      statusType === 'terminal'
+    );
   }
 
   // ---------------------------------------------------------------------------

--- a/src/hooks/foreground-fallback/index.ts
+++ b/src/hooks/foreground-fallback/index.ts
@@ -191,8 +191,10 @@ export class ForegroundFallbackManager {
   }
 
   registerSessionAgent(sessionID: string, agentName: string): void {
-    if (!sessionID || !agentName) return;
-    this.sessionAgent.set(sessionID, agentName);
+    const normalizedAgentName = agentName.trim();
+    if (!sessionID || !normalizedAgentName) return;
+    if (this.sessionAgent.has(sessionID)) return;
+    this.sessionAgent.set(sessionID, normalizedAgentName);
   }
 
   constructor(
@@ -247,7 +249,7 @@ export class ForegroundFallbackManager {
         if (!sessionID) break;
         // Capture agent name when available (OpenCode includes it on subagent messages)
         if (typeof info.agent === 'string') {
-          this.sessionAgent.set(sessionID, info.agent);
+          this.registerSessionAgent(sessionID, info.agent);
         }
         // Track the model currently serving this session
         if (
@@ -302,7 +304,7 @@ export class ForegroundFallbackManager {
           // session.status retry path always counts toward the budget
           // — even the first retry is absorbed before intervening.
           if (this.checkRetryBudget(sessionID)) {
-            await this.tryFallback(sessionID);
+            await this.tryFallback(sessionID, { abortBeforePrompt: true });
           }
           break;
         }
@@ -322,7 +324,7 @@ export class ForegroundFallbackManager {
             msg.includes('reduce concurrency')
           ) {
             if (this.checkRetryBudget(sessionID)) {
-              await this.tryFallback(sessionID);
+              await this.tryFallback(sessionID, { abortBeforePrompt: true });
             }
           }
           break;
@@ -341,7 +343,7 @@ export class ForegroundFallbackManager {
           | { sessionID?: string; agentName?: unknown }
           | undefined;
         if (props?.sessionID && typeof props.agentName === 'string') {
-          this.sessionAgent.set(props.sessionID, props.agentName);
+          this.registerSessionAgent(props.sessionID, props.agentName);
         }
         break;
       }
@@ -407,7 +409,10 @@ export class ForegroundFallbackManager {
   // Core fallback logic
   // ---------------------------------------------------------------------------
 
-  private async tryFallback(sessionID: string): Promise<void> {
+  private async tryFallback(
+    sessionID: string,
+    options: { abortBeforePrompt?: boolean } = {},
+  ): Promise<void> {
     if (!sessionID) return;
     if (this.inProgress.has(sessionID)) return;
 
@@ -550,6 +555,7 @@ export class ForegroundFallbackManager {
         promptAsync?: (args: {
           path: { id: string };
           body: {
+            agent?: string;
             parts: unknown[];
             model: { providerID: string; modelID: string };
           };
@@ -560,25 +566,40 @@ export class ForegroundFallbackManager {
         return;
       }
 
-      // Try queuing the fallback prompt without aborting first. If OpenCode
-      // accepts it (204), the fallback model replaces the retry loop
-      // transparently — no dialog, no session error shown to the user.
-      // If promptAsync throws (e.g. session busy), fall back to abort+retry.
-      try {
-        await sessionClient.promptAsync({
-          path: { id: sessionID },
-          body: { parts: lastUser.parts, model: ref },
-        });
-      } catch (_promptErr) {
-        log('[foreground-fallback] promptAsync on busy session, aborting', {
-          sessionID,
-        });
+      const promptBody = {
+        parts: lastUser.parts,
+        model: ref,
+        ...(agentName ? { agent: agentName } : {}),
+      };
+
+      if (options.abortBeforePrompt) {
         await abortSessionWithTimeout(this.client, sessionID);
         await new Promise((r) => setTimeout(r, REPROMPT_DELAY_MS));
         await sessionClient.promptAsync({
           path: { id: sessionID },
-          body: { parts: lastUser.parts, model: ref },
+          body: promptBody,
         });
+      } else {
+        // Try queuing the fallback prompt without aborting first. If OpenCode
+        // accepts it (204), the fallback model replaces the retry loop
+        // transparently — no dialog, no session error shown to the user.
+        // If promptAsync throws (e.g. session busy), fall back to abort+retry.
+        try {
+          await sessionClient.promptAsync({
+            path: { id: sessionID },
+            body: promptBody,
+          });
+        } catch (_promptErr) {
+          log('[foreground-fallback] promptAsync on busy session, aborting', {
+            sessionID,
+          });
+          await abortSessionWithTimeout(this.client, sessionID);
+          await new Promise((r) => setTimeout(r, REPROMPT_DELAY_MS));
+          await sessionClient.promptAsync({
+            path: { id: sessionID },
+            body: promptBody,
+          });
+        }
       }
 
       this.sessionModel.set(sessionID, nextModel);

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -7,6 +7,7 @@ export { createDelegateTaskRetryHook } from './delegate-task-retry/hook';
 export { createFilterAvailableSkillsHook } from './filter-available-skills';
 export {
   ForegroundFallbackManager,
+  isFailoverError,
   isRateLimitError,
 } from './foreground-fallback';
 export { processImageAttachments } from './image-hook';

--- a/src/hooks/task-session-manager/index.ts
+++ b/src/hooks/task-session-manager/index.ts
@@ -11,7 +11,7 @@ import {
 } from '../../utils';
 import { isRecord as isObjectRecord } from '../../utils/guards';
 import { log } from '../../utils/logger';
-import { isRateLimitError } from '../foreground-fallback/index';
+import { isFailoverError } from '../foreground-fallback/index';
 import type { SessionLifecycle } from '../session-lifecycle';
 import {
   isUserMessageWithParts,
@@ -737,7 +737,7 @@ export function createTaskSessionManagerHook(
           const props = input.event.properties as
             | { error?: unknown }
             | undefined;
-          if (!props?.error || !isRateLimitError(props.error)) {
+          if (!props?.error || !isFailoverError(props.error)) {
             terminalJobsInjectedByParent.delete(sessionId);
           }
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1028,6 +1028,7 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
       }
 
       if (agent) {
+        foregroundFallback.registerSessionAgent(input.sessionID, agent);
         sessionAgentMap.set(input.sessionID, agent);
         // A chat message means this session is actively working. This also
         // covers the race where session.status busy fires before the


### PR DESCRIPTION
## Summary
- classify structured 500/502/503/504 and bounded transport failures as failover-worthy
- budget every OpenCode `session.status: retry` event while preserving retry counts across `busy`
- register the resolved agent before the first provider response so child fallback chains remain isolated
- preserve `isRateLimitError` as a deprecated compatibility alias for `isFailoverError`

## Why
OpenCode 1.17.18 can retry provider 5xx/transport failures indefinitely. OMO 2.1.1 only recognized a subset of retry messages, so a delegated child could remain busy without advancing its configured fallback chain.

Numeric 5xx matching remains structured-field-only; arbitrary free-text `503` does not trigger fallback. Explicit retry events are debounced by the existing `maxRetries` budget, and interleaved `busy` events no longer reset that budget.

## Validation
- `bun test src/hooks/foreground-fallback/index.test.ts` — 59 pass
- `bun test` — 1,439 pass
- `bun run typecheck`
- `bun run lint`
- `bun run build`

`fallback.timeoutMs` and `retryDelayMs` wiring is intentionally out of scope.