### PR TITLE
fix: guard message-transform against malformed messages

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ import {
   SessionLifecycle,
 } from './hooks';
 import { processImageAttachments } from './hooks/image-hook';
-import type { MessageWithParts } from './hooks/types';
+import { isMessageWithParts, type MessageWithParts } from './hooks/types';
 import { createInterviewManager } from './interview';
 import { createBuiltinMcps } from './mcp';
 import {
@@ -1103,6 +1103,9 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
       const typedOutput = output as { messages: MessageWithParts[] };
 
       for (const message of typedOutput.messages) {
+        if (!isMessageWithParts(message)) {
+          continue;
+        }
         if (message.info.role !== 'user') {
           continue;
         }


### PR DESCRIPTION
## What changed, and why was it needed?

The `experimental.chat.messages.transform` handler in `src/index.ts` iterated over messages with an unsafe type cast (`as MessageWithParts[]`) and accessed `message.info.role` and `message.parts` without checking that the message had those properties.

Every sub-hook that processes messages (`phase-reminder`, `filter-available-skills`, `task-session-manager`) already guards with `isMessageWithParts` before accessing `.info.role` or `.parts`. The main handler was the exception — if a message lacked either property, it would throw at runtime.

### Fix
Import `isMessageWithParts` from `hooks/types` and apply it as a guard before the role/parts access, consistent with how the sub-hooks do it.

Closes #679