### PR TITLE
fix: track busy Herdr subagents without known agent name

### DIFF
--- a/src/companion/manager.test.ts
+++ b/src/companion/manager.test.ts
@@ -202,12 +202,36 @@ describe('CompanionManager', () => {
     expect(readState().sessions[0].active_agents).toEqual(['intro']);
   });
 
-  it('ignores status events without agent or with unknown status', () => {
+  it('ignores status events with unknown status but tracks busy without agent', () => {
     const m = make();
     m.onLoad();
     m.onSessionStatus({ sessionId: 'ses_x', agent: undefined, status: 'busy' });
     m.onSessionStatus({ sessionId: 'ses_y', agent: 'fixer', status: 'retry' });
+    // ses_x is now tracked because Herdr subagents often lack
+    // the agent field; the session ID is used as a fallback name.
+    expect(readState().sessions[0].active_agents).toEqual(['ses_x']);
+  });
+
+  it('accepts busy sessions from agents without a known name (Herdr subagents)', () => {
+    const m = make();
+    m.onLoad();
+    // Simulate a Herdr subagent: busy event fires but agent is undefined
+    m.onSessionStatus({
+      sessionId: 'herdr_ses',
+      agent: undefined,
+      status: 'busy',
+    });
+    expect(readState().sessions[0].active_agents).toEqual(['herdr_ses']);
+    // The overall status stays 'idle' — only the orchestrator drives
+    // that field. Herdr subagents appear in active_agents.
+    // When the session goes idle it is removed even without a known agent name
+    m.onSessionStatus({
+      sessionId: 'herdr_ses',
+      agent: undefined,
+      status: 'idle',
+    });
     expect(readState().sessions[0].active_agents).toEqual(['intro']);
+    expect(readState().sessions[0].status).toBe('idle');
   });
 
   it('shows input gif while waiting for user input', () => {

--- a/src/companion/manager.ts
+++ b/src/companion/manager.ts
@@ -310,8 +310,10 @@ export class CompanionManager {
     }
 
     if (status === 'busy') {
-      if (!agent) return;
-      this.busyAgentSessions.set(sessionId, agent);
+      // Accept busy sessions even without a known agent name — Herdr
+      // subagents (spawned via opencode attach) often lack the agent
+      // field, and dropping the event leaves them shown as idle.
+      this.busyAgentSessions.set(sessionId, agent ?? sessionId);
     } else {
       // Remove by session even when the agent name is unknown, so a
       // finished specialist can never get stuck on screen.


### PR DESCRIPTION
## What changed, and why was it needed?

`CompanionManager.onSessionStatus` dropped every `busy` event that arrived without an `agent` field. Herdr subagents — spawned via `opencode attach` — often lack the `agent` property in `chat.message`, so `sessionAgentMap` never knows about them. When `session.status` fires as `busy`, the companion ignores it and the pane stays idle even though the agent is actively working.

The `idle` path already handles `undefined` agent correctly: it removes the entry by session ID regardless of agent name. The `busy` path was the only one with the early return.

### Fix
Accept busy sessions without a known agent name by falling back to `sessionId` as the map value. This makes Herdr subagents appear in `active_agents` as expected. Updated the test that previously asserted the broken behavior and added a dedicated test for the Herdr scenario.

Closes #669