### PR TITLE
refactor: remove dead code and unused exports

### DIFF
--- a/src/agents/index.test.ts
+++ b/src/agents/index.test.ts
@@ -12,7 +12,6 @@ import {
   createAgents,
   getAgentConfigs,
   getDisabledAgents,
-  getEnabledAgentNames,
   isSubagent,
 } from './index';
 
@@ -975,31 +974,6 @@ describe('disabled_agents', () => {
     expect(disabled.has('designer')).toBe(true);
     expect(disabled.has('orchestrator')).toBe(false);
     expect(disabled.has('councillor')).toBe(false);
-  });
-
-  test('getEnabledAgentNames filters correctly', () => {
-    const config: PluginConfig = {
-      disabled_agents: ['designer', 'fixer'],
-    };
-    const enabled = getEnabledAgentNames(config);
-    expect(enabled).not.toContain('designer');
-    expect(enabled).not.toContain('fixer');
-    expect(enabled).toContain('orchestrator');
-    expect(enabled).toContain('explorer');
-  });
-
-  test('getEnabledAgentNames includes enabled custom agents', () => {
-    const config: PluginConfig = {
-      disabled_agents: ['janitor'],
-      agents: {
-        janitor: { model: 'openai/gpt-5.6-luna' },
-        reviewer: { model: 'openai/gpt-5.6-luna' },
-      },
-    };
-
-    const enabled = getEnabledAgentNames(config);
-    expect(enabled).toContain('reviewer');
-    expect(enabled).not.toContain('janitor');
   });
 
   test('empty disabled_agents creates observer but not unconfigured council', () => {

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -729,23 +729,3 @@ export function getDisabledAgents(config?: PluginConfig): Set<string> {
   return disabled;
 }
 
-/**
- * Get the list of enabled (non-disabled) agent names.
- */
-export function getEnabledAgentNames(config?: PluginConfig): string[] {
-  const disabled = getDisabledAgents(config);
-  if (!config?.council) {
-    disabled.add('council');
-  }
-  const customAgentNames = getCustomAgentNames(config).filter(
-    (name) => !disabled.has(name),
-  );
-  const acpAgentNames = getAcpAgentNames(config).filter(
-    (name) => !disabled.has(name),
-  );
-  return [
-    ...ALL_AGENT_NAMES.filter((name) => !disabled.has(name)),
-    ...customAgentNames,
-    ...acpAgentNames,
-  ];
-}

--- a/src/multiplexer/factory.ts
+++ b/src/multiplexer/factory.ts
@@ -81,30 +81,6 @@ export function getMultiplexer(config: MultiplexerConfig): Multiplexer | null {
 }
 
 /**
- * Clear the multiplexer cache (useful for testing)
- */
-export function clearMultiplexerCache(): void {
-  // No-op: multiplexers are no longer cached.
-}
-
-/**
- * Get the effective multiplexer type for auto mode
- * Returns the actual type that would be used (tmux/zellij/herdr/none)
- */
-export function getAutoMultiplexerType(): 'tmux' | 'zellij' | 'herdr' | 'none' {
-  if (process.env.TMUX) {
-    return 'tmux';
-  }
-  if (process.env.ZELLIJ) {
-    return 'zellij';
-  }
-  if (process.env.HERDR_ENV || process.env.HERDR_PANE_ID) {
-    return 'herdr';
-  }
-  return 'none';
-}
-
-/**
  * Start background availability check for a multiplexer
  */
 export function startAvailabilityCheck(config: MultiplexerConfig): void {

--- a/src/multiplexer/index.ts
+++ b/src/multiplexer/index.ts
@@ -3,7 +3,6 @@
  */
 
 export {
-  clearMultiplexerCache,
   getMultiplexer,
   startAvailabilityCheck,
 } from './factory';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -3,7 +3,7 @@ export * from './background-job-board';
 export * from './background-job-coordinator';
 export * from './background-job-store';
 export * from './internal-initiator';
-export { getLogDir, initLogger, log } from './logger';
+export { initLogger, log } from './logger';
 export * from './polling';
 export * from './session';
 export * from './task';

--- a/src/utils/logger.test.ts
+++ b/src/utils/logger.test.ts
@@ -2,13 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import {
-  flushLoggerForTesting,
-  getLogDir,
-  initLogger,
-  log,
-  resetLogger,
-} from './logger';
+import { flushLoggerForTesting, initLogger, log, resetLogger } from './logger';
 
 describe('logger', () => {
   let tmpDir: string;
@@ -177,25 +171,6 @@ describe('logger', () => {
     const content = fs.readFileSync(logPath, 'utf-8');
     expect(content).toContain('circular data');
     expect(content).toContain('[unserializable]');
-  });
-
-  test('getLogDir returns OPENCODE_LOG_DIR when set', () => {
-    expect(getLogDir()).toBe(tmpDir);
-  });
-
-  test('getLogDir falls back to os.homedir when env not set', () => {
-    delete process.env.OPENCODE_LOG_DIR;
-    try {
-      expect(getLogDir()).toBe(
-        path.join(os.homedir(), '.local/share/opencode/log'),
-      );
-    } finally {
-      if (origLogDir === undefined) {
-        delete process.env.OPENCODE_LOG_DIR;
-      } else {
-        process.env.OPENCODE_LOG_DIR = origLogDir;
-      }
-    }
   });
 
   test('handles complex data structures', async () => {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -76,8 +76,6 @@ export function initLogger(sessionId: string): void {
   cleanupOldLogs(dir);
 }
 
-export { getLogDir };
-
 /** @internal Reset logger state for testing */
 export function resetLogger(): void {
   logFile = null;


### PR DESCRIPTION
## What changed, and why was it needed?

Exhaustive grep audit found 5 exported functions/values never imported by any production consumer:

- `clearMultiplexerCache` — already a no-op with comment "no longer cached"
- `getEnabledAgentNames` — exported, zero consumers outside its own test
- `getAutoMultiplexerType` — exported, never imported
- `getLogDir` — exported and re-exported from barrel, zero production consumers
- `resetMultiplexerSessionManagerState` — only used in tests; kept with `@internal` convention

### Changes
Removed 4 dead functions, kept `resetMultiplexerSessionManagerState` exported (required by Bun's ESM runtime for test isolation — cannot access non-exported module functions at runtime). Removed corresponding test cases.

### Verification
- `bun run check:ci` ✅
- `bun run typecheck` ✅
- `bun test` → 1447 pass (2 pre-existing timeouts unrelated)