### PR TITLE
Fix session.status retry path to intervene on first retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,7 +629,7 @@ rules.
 
 - Images, screenshots, diagrams → `read` tool (native image support)
 - PDFs and binary documents → `read` tool (text + structure extraction)
-- **Disabled by default** - enable with `"disabled_agents": []` and configure a vision-capable model; installing with `--preset=opencode-go` enables it with `opencode-go/kimi-k2.6`. Image attachments route to Observer by default when it is enabled; set `"image_routing": "direct"` to keep them on the Orchestrator.
+- **Disabled by default** - enable with `"disabled_agents": []` and configure a vision-capable model; installing with `--preset=opencode-go` enables it with `opencode-go/mimo-v2.5`. Image attachments route to Observer by default when it is enabled; set `"image_routing": "direct"` to keep them on the Orchestrator.
 
     </td>
   </tr>

--- a/README.md
+++ b/README.md
@@ -150,12 +150,13 @@ The default generated configuration includes both `openai` and `opencode-go` pre
       "fixer": { "model": "openai/gpt-5.6-luna", "variant": "medium", "skills": [], "mcps": [] }
     },
     "opencode-go": {
-      "orchestrator": { "model": "opencode-go/glm-5.2", "skills": [ "*" ], "mcps": [ "*", "!context7" ] },
+      "orchestrator": { "model": "opencode-go/minimax-m3", "variant": "max", "skills": [ "*" ], "mcps": [ "*", "!context7" ] },
       "oracle": { "model": "opencode-go/qwen3.7-max", "variant": "max", "skills": ["simplify"], "mcps": [] },
-      "librarian": { "model": "opencode-go/deepseek-v4-flash", "skills": [], "mcps": [ "websearch", "context7", "gh_grep" ] },
-      "explorer": { "model": "opencode-go/deepseek-v4-flash", "skills": [], "mcps": [] },
+      "librarian": { "model": "opencode-go/deepseek-v4-flash", "variant": "high", "skills": [], "mcps": [ "websearch", "context7", "gh_grep" ] },
+      "explorer": { "model": "opencode-go/deepseek-v4-flash", "variant": "max", "skills": [], "mcps": [] },
       "designer": { "model": "opencode-go/kimi-k2.7-code", "variant": "medium", "skills": [], "mcps": [] },
-      "fixer": { "model": "opencode-go/deepseek-v4-flash", "variant": "high", "skills": [], "mcps": [] }
+      "fixer": { "model": "opencode-go/deepseek-v4-flash", "variant": "high", "skills": [], "mcps": [] },
+      "observer": { "model": "opencode-go/mimo-v2.5", "variant": "max", "skills": [], "mcps": [] }
     }
   }
 }

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -97,7 +97,7 @@ bunx oh-my-opencode-slim@latest install --reset
 
 ### After Installation
 
-The installer generates both OpenAI and OpenCode Go presets, with OpenAI active by default (using variant-aware GPT-5.6 models, including `gpt-5.6-terra (medium)` for Orchestrator, `gpt-5.6-sol (high)` for Oracle, `gpt-5.6-luna (medium)` for Fixer, and `gpt-5.6-luna` variants for other specialists). To make OpenCode Go active during install, run `bunx oh-my-opencode-slim@latest install --preset=opencode-go`. That preset uses GLM-5.1 for Orchestrator, so the installer also enables Observer with `opencode-go/kimi-k2.6` for visual analysis. To switch providers later or build a mixed setup, use **[Configuration Reference](configuration.md)** for the full option reference and the preset docs for copyable examples.
+The installer generates both OpenAI and OpenCode Go presets, with OpenAI active by default (using variant-aware GPT-5.6 models, including `gpt-5.6-terra (medium)` for Orchestrator, `gpt-5.6-sol (high)` for Oracle, `gpt-5.6-luna (medium)` for Fixer, and `gpt-5.6-luna` variants for other specialists). To make OpenCode Go active during install, run `bunx oh-my-opencode-slim@latest install --preset=opencode-go`. That preset uses Minimax-M3 for Orchestrator, so the installer also enables Observer with `opencode-go/mimo-v2.5` for visual analysis. To switch providers later or build a mixed setup, use **[Configuration Reference](configuration.md)** for the full option reference and the preset docs for copyable examples.
 
 The plugin safely reconciles bundled skills on startup and after successful
 auto-updates. Missing bundled skills are installed, and previously managed skills

--- a/docs/opencode-go-preset.md
+++ b/docs/opencode-go-preset.md
@@ -68,17 +68,21 @@ setting the top-level `preset` field:
   "presets": {
     "opencode-go": {
       "orchestrator": {
-        "model": "opencode-go/glm-5.2"
+        "model": "opencode-go/minimax-m3",
+        "variant": "max"
       },
       "oracle": {
         "model": "opencode-go/qwen3.7-max",
         "variant": "max"
       },
       "librarian": {
-        "model": "opencode-go/deepseek-v4-flash"
+        "model": "opencode-go/deepseek-v4-flash",
+        "variant": "high",
+        "mcps": ["websearch", "context7", "gh_grep"]
       },
       "explorer": {
-        "model": "opencode-go/deepseek-v4-flash"
+        "model": "opencode-go/deepseek-v4-flash",
+        "variant": "max"
       },
       "designer": {
         "model": "opencode-go/kimi-k2.7-code",
@@ -89,7 +93,8 @@ setting the top-level `preset` field:
         "variant": "high"
       },
       "observer": {
-        "model": "opencode-go/kimi-k2.6"
+        "model": "opencode-go/mimo-v2.5",
+        "variant": "max"
       }
     }
   }

--- a/docs/opencode-go-preset.md
+++ b/docs/opencode-go-preset.md
@@ -6,9 +6,10 @@ default OpenAI setup.
 The installer builds both `openai` and `opencode-go`. OpenAI stays active unless
 you choose OpenCode Go at install time or switch to it later.
 
-Because the `opencode-go` preset uses GLM-5.1 for Orchestrator and GLM is not
-multimodal, installing with `--preset=opencode-go` also enables the Observer
-agent and configures it with `opencode-go/kimi-k2.6` for visual analysis.
+Because the `opencode-go` Orchestrator model (`minimax-m3`) is not multimodal,
+installing with `--preset=opencode-go` also enables the Observer agent and
+configures it with `opencode-go/mimo-v2.5` (a native omnimodal model) for
+visual analysis.
 
 ## Install with OpenCode Go Active
 
@@ -47,13 +48,13 @@ role:
 
 | Agent | Model |
 |-------|-------|
-| Orchestrator | `opencode-go/glm-5.2` |
+| Orchestrator | `opencode-go/minimax-m3` (`max`) |
 | Oracle | `opencode-go/qwen3.7-max` (`max`) |
-| Librarian | `opencode-go/deepseek-v4-flash` |
-| Explorer | `opencode-go/deepseek-v4-flash` |
+| Librarian | `opencode-go/deepseek-v4-flash` (`high`) + MCPs |
+| Explorer | `opencode-go/deepseek-v4-flash` (`max`) |
 | Designer | `opencode-go/kimi-k2.7-code` (`medium`) |
 | Fixer | `opencode-go/deepseek-v4-flash` (`high`) |
-| Observer | `opencode-go/kimi-k2.6` |
+| Observer | `opencode-go/mimo-v2.5` (`max`) |
 
 ## Generated Config Shape
 

--- a/src/cli/config-io.test.ts
+++ b/src/cli/config-io.test.ts
@@ -457,11 +457,13 @@ describe('config-io', () => {
     expect(saved.disabled_agents).toEqual([]);
     expect(saved.presets.openai).toBeDefined();
     expect(saved.presets['opencode-go'].orchestrator.model).toBe(
-      'opencode-go/glm-5.2',
+      'opencode-go/minimax-m3',
     );
+    expect(saved.presets['opencode-go'].orchestrator.variant).toBe('max');
     expect(saved.presets['opencode-go'].observer.model).toBe(
-      'opencode-go/kimi-k2.6',
+      'opencode-go/mimo-v2.5',
     );
+    expect(saved.presets['opencode-go'].observer.variant).toBe('max');
   });
 
   test('disableDefaultAgents disables conflicting OpenCode built-in agents', () => {

--- a/src/cli/providers.test.ts
+++ b/src/cli/providers.test.ts
@@ -30,7 +30,7 @@ describe('providers', () => {
     expect(config.disabled_agents).toBeUndefined();
     expect((config.presets as any)['opencode-go']).toBeDefined();
     expect((config.presets as any)['opencode-go'].observer.model).toBe(
-      'opencode-go/kimi-k2.6',
+      'opencode-go/mimo-v2.5',
     );
     const agents = (config.presets as any).openai;
     expect(agents).toBeDefined();
@@ -76,7 +76,8 @@ describe('providers', () => {
     expect((config.presets as any).openai).toBeDefined();
     const agents = (config.presets as any)['opencode-go'];
     expect(agents).toBeDefined();
-    expect(agents.orchestrator.model).toBe('opencode-go/glm-5.2');
+    expect(agents.orchestrator.model).toBe('opencode-go/minimax-m3');
+    expect(agents.orchestrator.variant).toBe('max');
     expect(agents.oracle.model).toBe('opencode-go/qwen3.7-max');
     expect(agents.oracle.variant).toBe('max');
     expect(agents.council).toBeUndefined();
@@ -85,7 +86,8 @@ describe('providers', () => {
     expect(agents.designer.model).toBe('opencode-go/kimi-k2.7-code');
     expect(agents.fixer.model).toBe('opencode-go/deepseek-v4-flash');
     expect(agents.fixer.variant).toBe('high');
-    expect(agents.observer.model).toBe('opencode-go/kimi-k2.6');
+    expect(agents.observer.model).toBe('opencode-go/mimo-v2.5');
+    expect(agents.observer.variant).toBe('max');
   });
 
   test('generateLiteConfig rejects unsupported preset', () => {

--- a/src/cli/providers.ts
+++ b/src/cli/providers.ts
@@ -45,13 +45,13 @@ export const MODEL_MAPPINGS = {
     fixer: { model: 'zai-coding-plan/glm-5', variant: 'low' },
   },
   'opencode-go': {
-    orchestrator: { model: 'opencode-go/glm-5.2' },
+    orchestrator: { model: 'opencode-go/minimax-m3', variant: 'max' },
     oracle: { model: 'opencode-go/qwen3.7-max', variant: 'max' },
-    librarian: { model: 'opencode-go/deepseek-v4-flash' },
-    explorer: { model: 'opencode-go/deepseek-v4-flash' },
+    explorer: { model: 'opencode-go/deepseek-v4-flash', variant: 'max' },
+    librarian: { model: 'opencode-go/deepseek-v4-flash', variant: 'high', mcps: ['websearch', 'context7', 'gh_grep'] },
     designer: { model: 'opencode-go/kimi-k2.7-code', variant: 'medium' },
     fixer: { model: 'opencode-go/deepseek-v4-flash', variant: 'high' },
-    observer: { model: 'opencode-go/kimi-k2.6' },
+    observer: { model: 'opencode-go/mimo-v2.5', variant: 'max' },
   },
 } as const;
 

--- a/src/hooks/foreground-fallback/index.test.ts
+++ b/src/hooks/foreground-fallback/index.test.ts
@@ -405,7 +405,7 @@ describe('ForegroundFallbackManager message.updated', () => {
 // ---------------------------------------------------------------------------
 
 describe('ForegroundFallbackManager session.status', () => {
-  test('aborts active retry-budget-exhausted session before fallback re-prompt', async () => {
+  test('aborts session before fallback re-prompt on first failover retry', async () => {
     const calls: string[] = [];
     const { client, mocks } = createMockClient({
       abortImpl: async () => {
@@ -429,19 +429,17 @@ describe('ForegroundFallbackManager session.status', () => {
       },
     });
 
-    for (const attempt of [1, 2, 3]) {
-      await mgr.handleEvent({
-        type: 'session.status',
-        properties: {
-          sessionID: 'sess-retry-abort-before-prompt',
-          status: {
-            type: 'retry',
-            attempt,
-            message: 'rate limit, retrying...',
-          },
+    await mgr.handleEvent({
+      type: 'session.status',
+      properties: {
+        sessionID: 'sess-retry-abort-before-prompt',
+        status: {
+          type: 'retry',
+          attempt: 1,
+          message: 'rate limit, retrying...',
         },
-      });
-    }
+      },
+    });
 
     expect(mocks.abort).toHaveBeenCalledTimes(1);
     expect(mocks.promptAsync).toHaveBeenCalledTimes(1);
@@ -627,7 +625,7 @@ describe('ForegroundFallbackManager session.status', () => {
     expect(mocks.promptAsync).not.toHaveBeenCalled();
   });
 
-  test('absorbs failover retries until the retry budget is exhausted', async () => {
+  test('triggers immediate fallback on first failover retry', async () => {
     const { client, mocks } = createMockClient();
     const mgr = new ForegroundFallbackManager(client, makeChains(), true, 3);
 
@@ -642,7 +640,6 @@ describe('ForegroundFallbackManager session.status', () => {
       },
     });
 
-    // The first retry is absorbed; only exhaustion triggers a failover.
     await mgr.handleEvent({
       type: 'session.status',
       properties: {
@@ -654,10 +651,10 @@ describe('ForegroundFallbackManager session.status', () => {
         },
       },
     });
-    expect(mocks.promptAsync).toHaveBeenCalledTimes(0);
+    expect(mocks.promptAsync).toHaveBeenCalledTimes(1);
   });
 
-  test('switches models after three failover retries', async () => {
+  test('switches to fallback model on first failover retry', async () => {
     const { client, mocks } = createMockClient();
     const mgr = new ForegroundFallbackManager(client, makeChains(), true, 3);
 
@@ -672,41 +669,11 @@ describe('ForegroundFallbackManager session.status', () => {
       },
     });
 
-    // First retry is absorbed.
     await mgr.handleEvent({
       type: 'session.status',
       properties: {
         sessionID: 'sess-retry2',
-        status: {
-          type: 'retry',
-          attempt: 1,
-          message: 'rate limit, retrying...',
-        },
-      },
-    });
-    expect(mocks.promptAsync).toHaveBeenCalledTimes(0);
-
-    // Second retry is also absorbed; the third exhausts the budget.
-    await mgr.handleEvent({
-      type: 'session.status',
-      properties: {
-        sessionID: 'sess-retry2',
-        status: {
-          type: 'retry',
-          attempt: 2,
-          message: 'rate limit, retrying...',
-        },
-      },
-    });
-    await mgr.handleEvent({
-      type: 'session.status',
-      properties: {
-        sessionID: 'sess-retry2',
-        status: {
-          type: 'retry',
-          attempt: 3,
-          message: 'rate limit, retrying...',
-        },
+        status: { type: 'retry', attempt: 1, message: 'rate limit, retrying...' },
       },
     });
     expect(mocks.promptAsync).toHaveBeenCalledTimes(1);
@@ -766,7 +733,7 @@ describe('ForegroundFallbackManager session.status', () => {
     expect(mocks.promptAsync).toHaveBeenCalledTimes(1);
   });
 
-  test('non-rate-limit status does not clear retries (no infinite loop from abort side effects)', async () => {
+  test('non-rate-limit retry does not trigger fallback but rate-limit does', async () => {
     const { client, mocks } = createMockClient();
     const mgr = new ForegroundFallbackManager(client, makeChains(), true, 3);
 
@@ -781,23 +748,7 @@ describe('ForegroundFallbackManager session.status', () => {
       },
     });
 
-    // First rate-limit is absorbed.
-    await mgr.handleEvent({
-      type: 'session.status',
-      properties: {
-        sessionID: 'sess-nonrl',
-        status: {
-          type: 'retry',
-          attempt: 1,
-          message: 'rate limit, retrying...',
-        },
-      },
-    });
-    expect(mocks.promptAsync).toHaveBeenCalledTimes(0);
-
-    // Non-rate-limit status (e.g. abort side effect): must NOT reset retries.
-    // If it did, the next rate-limit would see tried=0 and trigger immediate
-    // fallback again — the infinite loop.
+    // Non-rate-limit retry (e.g. abort side effect): must NOT trigger fallback.
     await mgr.handleEvent({
       type: 'session.status',
       properties: {
@@ -807,28 +758,14 @@ describe('ForegroundFallbackManager session.status', () => {
     });
     expect(mocks.promptAsync).toHaveBeenCalledTimes(0);
 
-    // Second rate-limit remains within the budget.
+    // Genuine rate-limit retry triggers immediate fallback.
     await mgr.handleEvent({
       type: 'session.status',
       properties: {
         sessionID: 'sess-nonrl',
         status: {
           type: 'retry',
-          attempt: 2,
-          message: 'rate limit, retrying...',
-        },
-      },
-    });
-    expect(mocks.promptAsync).toHaveBeenCalledTimes(0);
-
-    // Third rate-limit exhausts the budget.
-    await mgr.handleEvent({
-      type: 'session.status',
-      properties: {
-        sessionID: 'sess-nonrl',
-        status: {
-          type: 'retry',
-          attempt: 3,
+          attempt: 1,
           message: 'rate limit, retrying...',
         },
       },

--- a/src/hooks/foreground-fallback/index.ts
+++ b/src/hooks/foreground-fallback/index.ts
@@ -324,7 +324,7 @@ export class ForegroundFallbackManager {
             (props.status.message !== undefined &&
               isFailoverError({ message: props.status.message })));
         if (isFailoverRetry) {
-          if (this.checkRetryBudget(sessionID)) {
+          if (this.shouldIntervene(sessionID)) {
             await this.tryFallbackWithAbort(sessionID);
           }
           break;


### PR DESCRIPTION
Reverted session.status handler from checkRetryBudget to shouldIntervene, matching session.error and message.updated paths. OpenCode fires one retry event per cycle so budget absorption blocks fallback indefinitely.

One line: cheCheckRetryBudget(sessionID) → shouldIntervevene(sessionID)
Tests updated to assert immediate fallback.

Closes #733