### PR TITLE
docs: add triage tracker config (issue-tracker.md, domain.md, AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -285,3 +285,17 @@ Read-only dependency source repositories are available under
 - `.slim/clonedeps/repos/opencode/` - `https://github.com/anomalyco/opencode.git` at `dev@356f6841865d68adf6d0123c37357ad50814497a`; inspect `packages/opencode` for latest TypeScript runtime internals and experimental background subagent support.
 - `.slim/clonedeps/repos/modelcontextprotocol__typescript-sdk/` - `https://github.com/modelcontextprotocol/typescript-sdk.git` at `v1.29.0@e12cbd7078db388152f6e839abdbe09ba01f3f32`; inspect it for MCP protocol and server integration internals.
 - `.slim/clonedeps/repos/agentclientprotocol__agent-client-protocol/` - `https://github.com/agentclientprotocol/agent-client-protocol.git` at `main@8110fde4e8283b4bef1329d1ef7b074fd14cee1e`; inspect it for ACP protocol specification and schema details.
+
+## Agent skills
+
+### Issue tracker
+
+Issues and PRs are tracked on GitHub (`alvinunreal/oh-my-opencode-slim`); external PRs are a triage surface. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Canonical triage roles map to repo labels via `docs/agents/triage-labels.md` (e.g. `ready-for-agent` → `good-to-code`; `needs-triage` = unlabeled).
+
+### Domain docs
+
+Single-context repo: `CONTEXT.md` and `docs/adr/` at the root, plus `codemap.md`. See `docs/agents/domain.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -286,7 +286,7 @@ Read-only dependency source repositories are available under
 - `.slim/clonedeps/repos/modelcontextprotocol__typescript-sdk/` - `https://github.com/modelcontextprotocol/typescript-sdk.git` at `v1.29.0@e12cbd7078db388152f6e839abdbe09ba01f3f32`; inspect it for MCP protocol and server integration internals.
 - `.slim/clonedeps/repos/agentclientprotocol__agent-client-protocol/` - `https://github.com/agentclientprotocol/agent-client-protocol.git` at `main@8110fde4e8283b4bef1329d1ef7b074fd14cee1e`; inspect it for ACP protocol specification and schema details.
 
-## Agent skills
+## Agent Operating Context
 
 ### Issue tracker
 

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,25 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root — the project's domain glossary and architecture narrative.
+- **`docs/adr/`** at the repo root — read ADRs that touch the area you're about to work in.
+- **`codemap.md`** at the repo root — the repo's own architecture map (referenced by `AGENTS.md`); read it for module responsibilities and integration points before deep work in a folder.
+
+This is a **single-context** repo: one `CONTEXT.md` and one `docs/adr/` at the root. There is no `CONTEXT-MAP.md` and no per-context `CONTEXT.md`.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0001 (session reflection mode) — but worth reopening because…_

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -8,9 +8,7 @@ How the engineering skills should consume this repo's domain documentation when 
 - **`docs/adr/`** at the repo root — read ADRs that touch the area you're about to work in.
 - **`codemap.md`** at the repo root — the repo's own architecture map (referenced by `AGENTS.md`); read it for module responsibilities and integration points before deep work in a folder.
 
-This is a **single-context** repo: one `CONTEXT.md` and one `docs/adr/` at the root. There is no `CONTEXT-MAP.md` and no per-context `CONTEXT.md`.
-
-If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture` — external skills, not bundled in this repo) creates them lazily when terms or decisions actually get resolved.
 
 ## Use the glossary's vocabulary
 
@@ -22,4 +20,4 @@ If the concept you need isn't in the glossary yet, that's a signal — either yo
 
 If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
 
-> _Contradicts ADR-0001 (session reflection mode) — but worth reopening because…_
+> _Contradicts ADR-001 (session reflection mode) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -28,11 +28,11 @@ Guardrails (per council review):
 
 When enabled, PRs are labeled using the `gh pr` equivalents:
 
-- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
-- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,comments` to enumerate open PRs, then for each run `gh api repos/alvinunreal/oh-my-opencode-slim/pulls/<number> --jq '.author_association'` and keep only `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, `FIRST_TIMER`, `MANNEQUIN`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
-- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+- **Read a PR**: `gh pr view --repo alvinunreal/oh-my-opencode-slim <number> --comments` and `gh pr diff --repo alvinunreal/oh-my-opencode-slim <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --repo alvinunreal/oh-my-opencode-slim --state open --json number,title,body,labels,author,comments` to enumerate open PRs, then for each run `gh api repos/alvinunreal/oh-my-opencode-slim/pulls/<number> --jq '.author_association'` and keep only `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, `FIRST_TIMER`, `MANNEQUIN`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment --repo alvinunreal/oh-my-opencode-slim`, `gh pr edit --repo alvinunreal/oh-my-opencode-slim --add-label`/`--remove-label`, `gh pr close --repo alvinunreal/oh-my-opencode-slim`.
 
-GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view --repo alvinunreal/oh-my-opencode-slim 42` and fall back to `gh issue view 42`.
 
 ## When a skill says "publish to the issue tracker"
 

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -4,12 +4,12 @@ Issues and PRs for this repo live as GitHub issues. Use the `gh` CLI for all ope
 
 ## Conventions
 
-- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Create an issue**: `gh issue create --repo alvinunreal/oh-my-opencode-slim --title "..." --body "..."`. Use a heredoc for multi-line bodies.
 - **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
 - **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
-- **Comment on an issue**: `gh issue comment <number> --body "..."`
-- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
-- **Close**: `gh issue close <number> --comment "..."`
+- **Comment on an issue**: `gh issue comment --repo alvinunreal/oh-my-opencode-slim <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit --repo alvinunreal/oh-my-opencode-slim <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close --repo alvinunreal/oh-my-opencode-slim <number> --comment "..."`
 
 Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone. **Write operations (create / label / comment / close) must target the upstream tracker:** pass `--repo alvinunreal/oh-my-opencode-slim` (or set `GH_REPO=alvinunreal/oh-my-opencode-slim`). In a fork clone, a bare `gh` command would mutate your fork instead of the project tracker.
 
@@ -23,13 +23,13 @@ Guardrails (per council review):
 - Apply only `bug` or `enhancement` to PRs. Do not apply state labels (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`).
 - Never apply `good-to-code` to PRs — they are already code; the label is noise.
 - Never auto-close external PRs during triage. Closure stays in the review flow / maintainer decision.
-- Filter on `authorAssociation`, not PR content: keep CONTRIBUTOR / FIRST_TIME_CONTRIBUTOR / NONE (and any other non-collaborator association); drop OWNER / MEMBER / COLLABORATOR / FIRST_TIMER / MANNEQUIN.
+- Filter on `authorAssociation`, not PR content: keep CONTRIBUTOR / FIRST_TIME_CONTRIBUTOR / FIRST_TIMER / MANNEQUIN / NONE (all non-collaborator associations); drop OWNER / MEMBER / COLLABORATOR.
 - Keep PR triage out of issue metrics — don't mix PR counts into issue triage reporting.
 
 When enabled, PRs are labeled using the `gh pr` equivalents:
 
 - **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
-- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,comments` to enumerate open PRs, then for each run `gh pr view <number> --json authorAssociation` and keep only `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR` and any other non-collaborator association).
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,comments` to enumerate open PRs, then for each run `gh api repos/alvinunreal/oh-my-opencode-slim/pulls/<number> --jq '.author_association'` and keep only `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, `FIRST_TIMER`, `MANNEQUIN`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
 - **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
 
 GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,45 @@
+# Issue tracker: GitHub
+
+Issues and PRs for this repo live as GitHub issues. Use the `gh` CLI for all operations. The project repo is `alvinunreal/oh-my-opencode-slim`; the fork `mhenke/oh-my-opencode-slim` is used for PRs.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone. When working from the fork, pass `--repo alvinunreal/oh-my-opencode-slim` (or rely on the `GH_REPO` default).
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: yes.** This is an open-source repo; external PRs are feature requests with attached code and run through the same labels and states as issues. Collaborators' in-flight PRs are left alone.
+
+When enabled, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments` (or `gh pr view` for a PR).
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -15,9 +15,18 @@ Infer the repo from `git remote -v` — `gh` does this automatically when run in
 
 ## Pull requests as a triage surface
 
-**PRs as a request surface: yes.** This is an open-source repo; external PRs are feature requests with attached code and run through the same labels and states as issues. Collaborators' in-flight PRs are left alone.
+**PRs as a request surface: yes.** This is an open-source repo; external PRs are feature requests with attached code. They enter the triage queue for **category labeling only**, not the full state machine. Collaborators' in-flight PRs are excluded by the `authorAssociation` filter below.
 
-When enabled, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+**Scope: category labels only.** External PRs get a `bug` or `enhancement` category label based on the PR description or linked issue. They do **not** enter the triage state transitions and are **never** auto-closed during triage.
+
+Guardrails (per council review):
+- Apply only `bug` or `enhancement` to PRs. Do not apply state labels (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`).
+- Never apply `good-to-code` to PRs — they are already code; the label is noise.
+- Never auto-close external PRs during triage. Closure stays in the review flow / maintainer decision.
+- Filter on `authorAssociation`, not PR content: keep CONTRIBUTOR / FIRST_TIME_CONTRIBUTOR / NONE; drop OWNER / MEMBER / COLLABORATOR.
+- Keep PR triage out of issue metrics — don't mix PR counts into issue triage reporting.
+
+When enabled, PRs are labeled using the `gh pr` equivalents:
 
 - **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
 - **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,6 +1,6 @@
 # Issue tracker: GitHub
 
-Issues and PRs for this repo live as GitHub issues. Use the `gh` CLI for all operations. The project repo is `alvinunreal/oh-my-opencode-slim`; the fork `mhenke/oh-my-opencode-slim` is used for PRs.
+Issues and PRs for this repo live as GitHub issues. Use the `gh` CLI for all operations. The project repo is `alvinunreal/oh-my-opencode-slim`.
 
 ## Conventions
 
@@ -11,7 +11,7 @@ Issues and PRs for this repo live as GitHub issues. Use the `gh` CLI for all ope
 - **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
 - **Close**: `gh issue close <number> --comment "..."`
 
-Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone. When working from the fork, pass `--repo alvinunreal/oh-my-opencode-slim` (or rely on the `GH_REPO` default).
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone. **Write operations (create / label / comment / close) must target the upstream tracker:** pass `--repo alvinunreal/oh-my-opencode-slim` (or set `GH_REPO=alvinunreal/oh-my-opencode-slim`). In a fork clone, a bare `gh` command would mutate your fork instead of the project tracker.
 
 ## Pull requests as a triage surface
 
@@ -23,13 +23,13 @@ Guardrails (per council review):
 - Apply only `bug` or `enhancement` to PRs. Do not apply state labels (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`).
 - Never apply `good-to-code` to PRs — they are already code; the label is noise.
 - Never auto-close external PRs during triage. Closure stays in the review flow / maintainer decision.
-- Filter on `authorAssociation`, not PR content: keep CONTRIBUTOR / FIRST_TIME_CONTRIBUTOR / NONE; drop OWNER / MEMBER / COLLABORATOR.
+- Filter on `authorAssociation`, not PR content: keep CONTRIBUTOR / FIRST_TIME_CONTRIBUTOR / NONE (and any other non-collaborator association); drop OWNER / MEMBER / COLLABORATOR / FIRST_TIMER / MANNEQUIN.
 - Keep PR triage out of issue metrics — don't mix PR counts into issue triage reporting.
 
 When enabled, PRs are labeled using the `gh pr` equivalents:
 
 - **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
-- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,comments` to enumerate open PRs, then for each run `gh pr view <number> --json authorAssociation` and keep only `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR` and any other non-collaborator association).
 - **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
 
 GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
@@ -42,13 +42,3 @@ Create a GitHub issue.
 
 Run `gh issue view <number> --comments` (or `gh pr view` for a PR).
 
-## Wayfinding operations
-
-Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
-
-- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
-- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
-- **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
-- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
-- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
-- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.


### PR DESCRIPTION
## What problem are you solving?

The triage workflow's issue-tracker backend and label mapping were implicit/inferred rather than declared. There was no single source of truth for: which GitHub repo hosts issues/PRs, that external PRs are a triage surface, the scope of PR triage (category labels only), and how engineering skills should consume the repo's domain docs. This left triage behavior undocumented and easy to get wrong.

## What does this change?

Adds `docs/agents/issue-tracker.md` (GitHub backend + PRs-as-triage-surface guardrails), `docs/agents/domain.md` (single-context domain-doc consumption guide), and an `## Agent skills` block in `AGENTS.md` pointing to both. Docs-only; no code or behavior change.

## Why this approach?

Follows the repo's existing convention — the `setup-matt-pocock-skills` pattern writes MD files under `docs/agents/` and `triage-labels.md` already existed. The PRs-as-triage-surface scope was set by a council review (issue #758) to category labeling only, encoded as explicit guardrails. No alternatives beyond documenting the existing inferred behavior were considered.

## Related work

- [x] I checked open AND closed PRs/issues for duplicates
- Related: #758 (council decision tracking), #759 (cmux test lint — resolved via #761, no longer blocks `check:ci`)

## AI assistance (optional)

- Model / harness: OpenCode (hy3-free) with @oracle / @council / @explorer subagents
- Human reviewed the full diff? [ ] No — AI-assisted; user authorized "open as is"

## Checklist

- [x] `bun run check:ci`, `bun run typecheck`, and `bun test` pass — all three green on this branch (0 commits behind master); #759 cmux test lint is resolved via #761, so `check:ci` now passes.
- [x] Docs (README.md, docs/) updated if behavior/commands changed — this PR is docs; README unchanged (no behavior change).
- [x] One logical change per PR
- [x] PR targets the `master` branch
