### PR TITLE
fix: resolve cmux test lint errors (noUnusedVariables, organizeImports)

### DIFF
--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -728,4 +728,3 @@ export function getDisabledAgents(config?: PluginConfig): Set<string> {
   }
   return disabled;
 }
-

--- a/src/multiplexer/cmux/index.test.ts
+++ b/src/multiplexer/cmux/index.test.ts
@@ -240,7 +240,6 @@ describe('CmuxMultiplexer', () => {
     const pane = await instance.spawnPane('s', 'agent', 'http://server', '/r');
     process.env.CMUX_SOCKET_PATH = '/tmp/socket-b';
     await instance.closePane(pane.paneId ?? '');
-    const close = calls.find((call) => call.includes('close-surface'));
     for (const operation of [
       'new-split',
       'respawn-pane',

--- a/src/multiplexer/cmux/session-lifecycle.test.ts
+++ b/src/multiplexer/cmux/session-lifecycle.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import type { Multiplexer } from '../types';
-import { CmuxSessionLifecycle } from './session-lifecycle';
 import { CmuxClosePolicy } from './close-policy';
+import { CmuxSessionLifecycle } from './session-lifecycle';
 import { CmuxSessionStore } from './session-state';
 
 function deferred<T>() {


### PR DESCRIPTION
## What problem are you solving?

`bun run check:ci` fails on two pre-existing lint errors in the cmux multiplexer test files (tracked in #759), which keeps CI red. This PR fixes those, plus one more unrelated lint error so the whole suite goes green.

## What does this change?

- `src/multiplexer/cmux/index.test.ts`: removes a dead `const close` variable that was assigned but never used (noUnusedVariables).
- `src/multiplexer/cmux/session-lifecycle.test.ts`: reorders imports (organizeImports).
- `src/agents/index.ts`: removes a trailing blank line at EOF that also failed check:ci.

## Why this approach?

All three are auto-fixable Biome violations. The unused `close` was redundant: the loop already asserts on `close-surface`. There were no real alternatives to weigh.

## Related work

- Checked open and closed PRs/issues for duplicates.
- Related: #759 (this PR resolves it).

## AI assistance (optional)

- Model / harness: OpenCode (hy3-free)
- Human reviewed the full diff? [ ] No — AI-assisted

## Checklist

- [x] `bun run check:ci` passes (all 253 files, 0 errors)
- [x] `bun run typecheck` passes
- [x] `bun test` passes (cmux suite: 32 pass, 0 fail)
- [x] One logical change per PR
- [x] PR targets the `master` branch