### PR TITLE
feat: detect and abort stuck cmux background agents

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -146,6 +146,9 @@ Presets can also be switched at runtime without restarting using the `/preset` c
 | `backgroundJobs.maxSessionsPerAgent` | integer | `2` | Maximum completed/reconciled reusable child sessions per specialist type in the current orchestrator session (1–10) |
 | `backgroundJobs.readContextMinLines` | integer | `10` | Minimum number of lines read from a file before it appears in reusable background-job context (0–1000) |
 | `backgroundJobs.readContextMaxFiles` | integer | `8` | Maximum number of recent read-context files shown per reusable child session (0–50) |
+| `stuckAgent.enabled` | boolean | `true` | Detect and abort background subagent sessions that stay busy without activity (cmux multiplexer only) |
+| `stuckAgent.timeoutMs` | number | `180000` | Inactivity (ms) before a busy session is considered stuck (30000–600000) |
+| `stuckAgent.graceMs` | number | `30000` | Minimum session age (ms) before stuck detection activates (5000–60000) |
 | `disabled_mcps` | string[] | `[]` | MCP server IDs to disable globally |
 | `fallback.enabled` | boolean | `true` | Enable model failover on timeout/error |
 | `fallback.timeoutMs` | number | `15000` | Time before aborting and trying next model |

--- a/oh-my-opencode-slim.schema.json
+++ b/oh-my-opencode-slim.schema.json
@@ -363,6 +363,27 @@
         }
       }
     },
+    "stuckAgent": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "default": true,
+          "type": "boolean"
+        },
+        "timeoutMs": {
+          "default": 180000,
+          "type": "integer",
+          "minimum": 30000,
+          "maximum": 600000
+        },
+        "graceMs": {
+          "default": 30000,
+          "type": "integer",
+          "minimum": 5000,
+          "maximum": 60000
+        }
+      }
+    },
     "fallback": {
       "type": "object",
       "properties": {

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -47,6 +47,10 @@ export const POLL_INTERVAL_BACKGROUND_MS = 2000;
 // Timeouts
 export const MAX_POLL_TIME_MS = 5 * 60 * 1000; // 5 minutes
 
+// Stuck agent detection
+export const STUCK_AGENT_TIMEOUT_MS = 180_000; // 3 min
+export const STUCK_AGENT_GRACE_MS = 30_000; // 30 s
+
 // Subagent depth limits
 export const DEFAULT_MAX_SUBAGENT_DEPTH = 3;
 

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -234,6 +234,10 @@ export function mergePluginConfigs(
       base.companion as Record<string, unknown> | undefined,
       override.companion as Record<string, unknown> | undefined,
     ) as PluginConfig['companion'],
+    stuckAgent: deepMerge(
+      base.stuckAgent as Record<string, unknown> | undefined,
+      override.stuckAgent as Record<string, unknown> | undefined,
+    ) as PluginConfig['stuckAgent'],
   };
 }
 

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -52,10 +52,21 @@ const PROMPTS_DIR_NAME = 'oh-my-opencode-slim';
  * @param onWarning - Optional callback for warnings
  * @returns Validated config object, or null if loading failed
  */
-function loadConfigFromPath(
+/**
+ * Load raw plugin configuration from a specific file path.
+ * Supports both .json and .jsonc formats (JSON with comments).
+ * Returns null if the file doesn't exist, is invalid, or cannot be read.
+ * Does NOT apply schema validation or defaults — callers must validate
+ * the merged result so defaults don't override explicit user values.
+ *
+ * @param configPath - Absolute path to the config file
+ * @param onWarning - Optional callback for warnings
+ * @returns Raw config object, or null if loading failed
+ */
+function loadRawConfigFromPath(
   configPath: string,
   options?: LoadPluginConfigOptions,
-): PluginConfig | null {
+): Record<string, unknown> | null {
   try {
     const content = fs.readFileSync(configPath, 'utf-8');
     // Use stripJsonComments to support JSONC format (comments and trailing commas)
@@ -83,23 +94,10 @@ function loadConfigFromPath(
       }
       return null;
     }
-    const result = PluginConfigSchema.safeParse(rawConfig);
-
-    if (!result.success) {
-      options?.onWarning?.({
-        path: configPath,
-        kind: 'invalid-schema',
-        message: 'Config does not match schema',
-        formatted: result.error.format(),
-      });
-      if (!options?.silent) {
-        console.warn(`[oh-my-opencode-slim] Invalid config at ${configPath}:`);
-        console.warn(result.error.format());
-      }
+    if (rawConfig === null || typeof rawConfig !== 'object') {
       return null;
     }
-
-    return result.data;
+    return rawConfig as Record<string, unknown>;
   } catch (error) {
     // File doesn't exist or isn't readable - this is expected and fine
     if (
@@ -303,16 +301,40 @@ export function loadPluginConfig(
   const { userConfigPath, projectConfigPath } =
     findPluginConfigPaths(directory);
 
-  let config: PluginConfig = userConfigPath
-    ? (loadConfigFromPath(userConfigPath, options) ?? {})
-    : {};
-
-  const projectConfig = projectConfigPath
-    ? loadConfigFromPath(projectConfigPath, options)
+  // Load raw configs (no schema validation/defaults) so merging preserves
+  // explicit user values. Schema defaults are applied AFTER merging.
+  const userRaw = userConfigPath
+    ? loadRawConfigFromPath(userConfigPath, options)
     : null;
-  if (projectConfig) {
-    config = mergePluginConfigs(config, projectConfig);
+  const projectRaw = projectConfigPath
+    ? loadRawConfigFromPath(projectConfigPath, options)
+    : null;
+
+  // Merge raw configs before applying defaults
+  // Use deepMerge so nested objects (agents, tmux, stuckAgent, etc.) merge
+  // field-by-field rather than being replaced entirely.
+  const mergedRaw: Record<string, unknown> =
+    deepMerge(userRaw ?? {}, projectRaw ?? {}) ?? {};
+
+  // Validate merged config and apply defaults
+  const result = PluginConfigSchema.safeParse(mergedRaw);
+  if (!result.success) {
+    options?.onWarning?.({
+      path: projectConfigPath ?? userConfigPath ?? '',
+      kind: 'invalid-schema',
+      message: 'Config does not match schema',
+      formatted: result.error.format(),
+    });
+    if (!options?.silent) {
+      console.warn(
+        `[oh-my-opencode-slim] Invalid config at ${projectConfigPath ?? userConfigPath ?? ''}:`,
+      );
+      console.warn(result.error.format());
+    }
+    return {};
   }
+
+  let config: PluginConfig = result.data;
 
   // Migrate legacy tmux config to multiplexer config for backward compatibility
   config = migrateTmuxToMultiplexer(config);

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -176,6 +176,15 @@ export const BackgroundJobsConfigSchema = z.object({
 
 export type BackgroundJobsConfig = z.infer<typeof BackgroundJobsConfigSchema>;
 
+export const StuckAgentConfigSchema = z
+  .object({
+    enabled: z.boolean().default(true),
+    timeoutMs: z.number().int().min(30_000).max(600_000).default(180_000),
+    graceMs: z.number().int().min(5_000).max(60_000).default(30_000),
+  })
+  .optional();
+export type StuckAgentConfig = z.infer<typeof StuckAgentConfigSchema>;
+
 export const FailoverConfigSchema = z
   .object({
     enabled: z.boolean().default(true),
@@ -372,6 +381,7 @@ export const PluginConfigSchema = z
     websearch: WebsearchConfigSchema.optional(),
     interview: InterviewConfigSchema.optional(),
     backgroundJobs: BackgroundJobsConfigSchema.optional(),
+    stuckAgent: StuckAgentConfigSchema.optional(),
     fallback: FailoverConfigSchema.optional(),
     council: CouncilConfigSchema.optional(),
     companion: CompanionConfigSchema.optional(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,8 @@ import {
   DEFAULT_READ_CONTEXT_MAX_FILES,
   DEFAULT_READ_CONTEXT_MIN_LINES,
   resolveImageRouting,
+  STUCK_AGENT_GRACE_MS,
+  STUCK_AGENT_TIMEOUT_MS,
 } from './config/constants';
 import {
   getActiveRuntimePreset,
@@ -282,10 +284,21 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
 
     // Initialize MultiplexerSessionManager to handle OpenCode's built-in
     // Task tool sessions
+    const stuckAgentEnabled = config.stuckAgent?.enabled ?? true;
     multiplexerSessionManager = new MultiplexerSessionManager(
       ctx,
       multiplexerConfig,
       backgroundJobCoordinator,
+      {
+        stuckThresholdMs: stuckAgentEnabled
+          ? (config.stuckAgent?.timeoutMs ?? STUCK_AGENT_TIMEOUT_MS)
+          : Infinity,
+        stuckGraceMs: config.stuckAgent?.graceMs ?? STUCK_AGENT_GRACE_MS,
+        // ponytail: isFallbackInProgress guard is not wired in Phase 1
+        // because foregroundFallback is initialized after this point.
+        // The skip is safe: isFallbackInProgress defaults to undefined,
+        // meaning stuck detection always proceeds for busy sessions.
+      },
     );
     backgroundJobCoordinator.addTerminalStateListener((taskID) => {
       void multiplexerSessionManager.closeSessionFromCoordinator(taskID);

--- a/src/multiplexer/cmux/close-policy.test.ts
+++ b/src/multiplexer/cmux/close-policy.test.ts
@@ -22,6 +22,26 @@ describe('CmuxClosePolicy', () => {
     });
   });
 
+  test('activity cancels idle but not stuck', () => {
+    const policy = new CmuxClosePolicy();
+    expect(policy.activity(policy.request('idle', 1, 0))).toBeUndefined();
+    expect(policy.activity(policy.request('stuck', 1, 0))?.reason).toBe(
+      'stuck',
+    );
+  });
+
+  test('stuck upgrades idle and refreshes its retry budget', () => {
+    const policy = new CmuxClosePolicy(100, 2);
+    const idle = policy.failed(policy.request('idle', 1, 0), 1);
+    const stuck = policy.request('stuck', 2, 50, idle);
+    expect(stuck).toMatchObject({
+      reason: 'stuck',
+      attempts: 0,
+      deadline: 150,
+      nextAttemptAt: 50,
+    });
+  });
+
   test('exhaustion enters 30 then 60 second tracked cooldown', () => {
     const policy = new CmuxClosePolicy(100, 1);
     const first = policy.failed(policy.request('cleanup', 0, 0), 1);

--- a/src/multiplexer/cmux/close-policy.ts
+++ b/src/multiplexer/cmux/close-policy.ts
@@ -1,4 +1,4 @@
-export type CmuxCloseReason = 'idle' | 'deleted' | 'cleanup';
+export type CmuxCloseReason = 'idle' | 'deleted' | 'cleanup' | 'stuck';
 export interface CmuxCloseIntent {
   reason: CmuxCloseReason;
   expectedActivityVersion: number;
@@ -20,7 +20,11 @@ export class CmuxClosePolicy {
     now: number,
     current?: CmuxCloseIntent,
   ): CmuxCloseIntent {
-    if (!current || (reason === 'deleted' && current.reason === 'idle')) {
+    if (
+      !current ||
+      ((reason === 'deleted' || reason === 'stuck') &&
+        current.reason === 'idle')
+    ) {
       return {
         reason,
         expectedActivityVersion: version,

--- a/src/multiplexer/cmux/session-lifecycle.test.ts
+++ b/src/multiplexer/cmux/session-lifecycle.test.ts
@@ -341,3 +341,220 @@ describe('CmuxSessionLifecycle races', () => {
     ).toBe(true);
   });
 });
+
+describe('CmuxSessionLifecycle stuck detection', () => {
+  const store = new CmuxSessionStore();
+  beforeEach(() => store.resetForTests());
+
+  function busyStatuses(
+    ...sessions: string[]
+  ): () => Promise<Record<string, { type: string }>> {
+    const map: Record<string, { type: string }> = {};
+    for (const s of sessions) map[s] = { type: 'busy' };
+    return async () => map;
+  }
+
+  test('stuck triggers when busy with no activityVersion change for > threshold', async () => {
+    let now = 0;
+    const mux = multiplexer();
+    const abort = mock(() => Promise.resolve());
+    const markCancelled = mock(() => {});
+    const lifecycle = new CmuxSessionLifecycle(
+      'owner',
+      mux,
+      () => 'http://server',
+      '/repo',
+      {
+        deferIfRunning: () => true,
+        clearDeferredClose: () => {},
+        markCancelled,
+      },
+      {
+        now: () => now,
+        stuckThresholdMs: 100,
+        stuckGraceMs: 10,
+        client: { session: { abort } },
+        isServerRunning: async () => true,
+        fetchStatuses: busyStatuses('stuck-1'),
+        delay: async () => {},
+      },
+    );
+    await lifecycle.onSessionCreated({
+      type: 'session.created',
+      properties: { info: { id: 'stuck-1', parentID: 'p' } },
+    });
+
+    // First poll: snapshot stuckCheckVersion (no activity - version stays 0)
+    now = 1_000;
+    await lifecycle.pollOnce();
+    expect(abort).not.toHaveBeenCalled();
+
+    // Second poll past threshold + grace: version still 0, stuck detected
+    now = 2_000;
+    await lifecycle.pollOnce();
+    expect(abort).toHaveBeenCalledTimes(1);
+    expect(mux.closePane).toHaveBeenCalledTimes(1);
+    await lifecycle.cleanup();
+  });
+
+  test('stuck does NOT trigger during grace period', async () => {
+    let now = 0;
+    const mux = multiplexer();
+    const abort = mock(() => Promise.resolve());
+    const lifecycle = new CmuxSessionLifecycle(
+      'owner',
+      mux,
+      () => 'http://server',
+      '/repo',
+      undefined,
+      {
+        now: () => now,
+        stuckThresholdMs: 100,
+        stuckGraceMs: 500_000, // very long grace
+        client: { session: { abort } },
+        isServerRunning: async () => true,
+        fetchStatuses: busyStatuses('grace'),
+        delay: async () => {},
+      },
+    );
+    await lifecycle.onSessionCreated({
+      type: 'session.created',
+      properties: { info: { id: 'grace', parentID: 'p' } },
+    });
+
+    now = 1_000;
+    await lifecycle.pollOnce(); // snapshot
+    now = 10_000;
+    await lifecycle.pollOnce(); // past threshold, but not grace
+    expect(abort).not.toHaveBeenCalled();
+    await lifecycle.cleanup();
+  });
+
+  test('stuck resets when activity fires between polls', async () => {
+    let now = 0;
+    const mux = multiplexer();
+    const abort = mock(() => Promise.resolve());
+    const lifecycle = new CmuxSessionLifecycle(
+      'owner',
+      mux,
+      () => 'http://server',
+      '/repo',
+      undefined,
+      {
+        now: () => now,
+        stuckThresholdMs: 300,
+        stuckGraceMs: 10,
+        client: { session: { abort } },
+        isServerRunning: async () => true,
+        fetchStatuses: busyStatuses('reset-me'),
+        delay: async () => {},
+      },
+    );
+    await lifecycle.onSessionCreated({
+      type: 'session.created',
+      properties: { info: { id: 'reset-me', parentID: 'p' } },
+    });
+
+    // Initial poll snapshots version
+    now = 10;
+    await lifecycle.pollOnce();
+
+    // Activity fires (content event) - resets stuck state (clears
+    // stuckCheckVersion + updates lastActivityAt)
+    now = 20;
+    await lifecycle.onSessionStatus({
+      type: 'message.updated',
+      properties: { sessionID: 'reset-me' },
+    });
+
+    // First poll after activity: snapshots the new version. Threshold has
+    // barely elapsed (noActivityMs = 10 < 300), so no stuck.
+    now = 30;
+    await lifecycle.pollOnce();
+    expect(abort).not.toHaveBeenCalled();
+
+    // Second poll after activity: version still same, threshold still not
+    // reached (noActivityMs = 40 - 20 = 20 < 300). No stuck.
+    now = 40;
+    await lifecycle.pollOnce();
+    expect(abort).not.toHaveBeenCalled();
+
+    // Enough time passes: now threshold exceeded
+    now = 500;
+    await lifecycle.pollOnce();
+    expect(abort).toHaveBeenCalledTimes(1);
+    await lifecycle.cleanup();
+  });
+
+  test('stuck does NOT trigger for idle sessions', async () => {
+    let now = 0;
+    const mux = multiplexer();
+    const abort = mock(() => Promise.resolve());
+    const lifecycle = new CmuxSessionLifecycle(
+      'owner',
+      mux,
+      () => 'http://server',
+      '/repo',
+      undefined,
+      {
+        now: () => now,
+        stuckThresholdMs: 100,
+        stuckGraceMs: 10,
+        client: { session: { abort } },
+        isServerRunning: async () => true,
+        fetchStatuses: async () => ({ nope: { type: 'idle' } }),
+        delay: async () => {},
+      },
+    );
+    await lifecycle.onSessionCreated({
+      type: 'session.created',
+      properties: { info: { id: 'nope', parentID: 'p' } },
+    });
+
+    now = 50_000;
+    await lifecycle.pollOnce();
+    expect(abort).not.toHaveBeenCalled();
+    await lifecycle.cleanup();
+  });
+
+  test('abort + close are invoked on a stuck session', async () => {
+    let now = 0;
+    const mux = multiplexer();
+    const abort = mock(() => Promise.resolve());
+    const markCancelled = mock(() => {});
+    const lifecycle = new CmuxSessionLifecycle(
+      'owner',
+      mux,
+      () => 'http://server',
+      '/repo',
+      {
+        deferIfRunning: () => true,
+        clearDeferredClose: () => {},
+        markCancelled,
+      },
+      {
+        now: () => now,
+        stuckThresholdMs: 50,
+        stuckGraceMs: 10,
+        client: { session: { abort } },
+        isServerRunning: async () => true,
+        fetchStatuses: busyStatuses('abort-me'),
+        delay: async () => {},
+      },
+    );
+    await lifecycle.onSessionCreated({
+      type: 'session.created',
+      properties: { info: { id: 'abort-me', parentID: 'p' } },
+    });
+
+    now = 500;
+    await lifecycle.pollOnce(); // snapshot
+    now = 10_000;
+    await lifecycle.pollOnce(); // stuck triggers
+    expect(abort).toHaveBeenCalledTimes(1);
+    expect(mux.closePane).toHaveBeenCalledTimes(1);
+    expect(markCancelled).toHaveBeenCalledWith('abort-me', 'stuck');
+    expect(store.get('abort-me')?.stuckDetectedAt).toBe(10_000);
+    await lifecycle.cleanup();
+  });
+});

--- a/src/multiplexer/cmux/session-lifecycle.ts
+++ b/src/multiplexer/cmux/session-lifecycle.ts
@@ -1,5 +1,10 @@
-import { POLL_INTERVAL_BACKGROUND_MS } from '../../config';
+import {
+  POLL_INTERVAL_BACKGROUND_MS,
+  STUCK_AGENT_GRACE_MS,
+  STUCK_AGENT_TIMEOUT_MS,
+} from '../../config';
 import { log } from '../../utils/logger';
+import { abortSessionWithTimeout } from '../../utils/session';
 import type { Multiplexer } from '../types';
 import { isServerRunning } from '../types';
 import { CmuxClosePolicy, type CmuxCloseReason } from './close-policy';
@@ -24,6 +29,7 @@ export interface CmuxSessionEvent {
 interface BackgroundJobs {
   deferIfRunning(session: string): boolean;
   clearDeferredClose(session: string): void;
+  markCancelled?(taskID: string, reason?: string): void;
 }
 
 export interface CmuxSessionLifecycleOptions {
@@ -39,6 +45,12 @@ export interface CmuxSessionLifecycleOptions {
   shutdownTimeoutMs?: number;
   isServerRunning?: (url: string) => Promise<boolean>;
   fetchStatuses?: () => Promise<Record<string, { type: string }>>;
+  /** Client for aborting stuck sessions. */
+  client?: Parameters<typeof abortSessionWithTimeout>[0];
+  /** Milliseconds of inactivity before a busy session is considered stuck. */
+  stuckThresholdMs?: number;
+  /** Minimum time a session must exist before stuck detection activates. */
+  stuckGraceMs?: number;
 }
 
 const ACTIVITY_EVENTS = new Set([
@@ -73,6 +85,9 @@ export class CmuxSessionLifecycle {
   private readonly fetchStatuses: () => Promise<
     Record<string, { type: string }>
   >;
+  private readonly client?: Parameters<typeof abortSessionWithTimeout>[0];
+  private readonly stuckThresholdMs: number;
+  private readonly stuckGraceMs: number;
   private pollTimer?: ReturnType<typeof setInterval>;
   private polling = false;
   private cleanupPromise?: Promise<void>;
@@ -98,6 +113,9 @@ export class CmuxSessionLifecycle {
     this.missingGraceMs = options.missingGraceMs ?? 30_000;
     this.closeRetryMs = options.closeRetryMs ?? 1_000;
     this.shutdownTimeoutMs = options.shutdownTimeoutMs ?? 5_000;
+    this.client = options.client;
+    this.stuckThresholdMs = options.stuckThresholdMs ?? STUCK_AGENT_TIMEOUT_MS;
+    this.stuckGraceMs = options.stuckGraceMs ?? STUCK_AGENT_GRACE_MS;
     this.policy = new CmuxClosePolicy(
       options.closeRetryTtlMs,
       options.closeRetryMaxAttempts,
@@ -326,6 +344,9 @@ export class CmuxSessionLifecycle {
     if (!next && record.closeIntent) record.closeTimer?.cancel();
     record.closeIntent = next;
     if (!next) record.closeTimer = undefined;
+    // Clear stuck detection on any real activity
+    record.stuckDetectedAt = undefined;
+    record.stuckCheckVersion = undefined;
   }
 
   private async requestClose(
@@ -450,6 +471,35 @@ export class CmuxSessionLifecycle {
           }
         }
         if (status) record.statusMissingSince = undefined;
+        if (status && status.type === 'busy') {
+          // ---- Stuck detection for busy sessions ----
+          // Cancel idle close intents without resetting activity timestamps
+          // so lastActivityAt stays valid for stuck detection.
+          if (record.closeIntent?.reason === 'idle') {
+            record.closeTimer?.cancel();
+            record.closeTimer = undefined;
+            record.closeIntent = undefined;
+          }
+
+          if (this.stuckThresholdMs < Infinity && !record.stuckDetectedAt) {
+            const now = this.now();
+            const noActivityMs = now - record.lastActivityAt;
+
+            if (
+              noActivityMs > this.stuckThresholdMs &&
+              record.stuckCheckVersion !== undefined &&
+              now - (record.attachedAt ?? record.lastActivityAt) >
+                this.stuckGraceMs
+            ) {
+              await this.handleStuckSession(record);
+              continue;
+            }
+          }
+
+          // Record current version for next tick's comparison
+          record.stuckCheckVersion = record.activityVersion;
+          continue;
+        }
         if (status && status.type !== 'idle') {
           this.activity(record.session);
           continue;
@@ -480,6 +530,30 @@ export class CmuxSessionLifecycle {
     } finally {
       this.polling = false;
     }
+  }
+
+  private async handleStuckSession(record: CmuxSessionRecord): Promise<void> {
+    const now = this.now();
+    const noActivityMs = now - record.lastActivityAt;
+    log('[cmux-session-lifecycle] stuck session detected, aborting', {
+      session: record.session,
+      activityVersion: record.activityVersion,
+      lastActivityAt: record.lastActivityAt,
+      noActivityMs,
+      stuckThresholdMs: this.stuckThresholdMs,
+    });
+    record.stuckDetectedAt = now;
+
+    // Abort the session via the OpenCode client
+    if (this.client) {
+      await abortSessionWithTimeout(this.client, record.session, 1_000);
+    }
+
+    // Mark the background job as cancelled with stuck reason
+    this.backgroundJobs?.markCancelled?.(record.session, 'stuck');
+
+    // Request pane close with stuck reason
+    await this.requestClose(record, 'stuck');
   }
 
   private startPolling(): void {

--- a/src/multiplexer/cmux/session-lifecycle.ts
+++ b/src/multiplexer/cmux/session-lifecycle.ts
@@ -544,9 +544,18 @@ export class CmuxSessionLifecycle {
     });
     record.stuckDetectedAt = now;
 
-    // Abort the session via the OpenCode client
+    // Abort the session via the OpenCode client (best-effort — must not block cleanup)
     if (this.client) {
-      await abortSessionWithTimeout(this.client, record.session, 1_000);
+      try {
+        await abortSessionWithTimeout(this.client, record.session, 1_000);
+      } catch {
+        log(
+          '[cmux-session-lifecycle] abortSessionWithTimeout failed, continuing cleanup',
+          {
+            session: record.session,
+          },
+        );
+      }
     }
 
     // Mark the background job as cancelled with stuck reason

--- a/src/multiplexer/cmux/session-lifecycle.ts
+++ b/src/multiplexer/cmux/session-lifecycle.ts
@@ -542,7 +542,6 @@ export class CmuxSessionLifecycle {
       noActivityMs,
       stuckThresholdMs: this.stuckThresholdMs,
     });
-    record.stuckDetectedAt = now;
 
     // Abort the session via the OpenCode client (best-effort — must not block cleanup)
     if (this.client) {
@@ -558,11 +557,21 @@ export class CmuxSessionLifecycle {
       }
     }
 
-    // Mark the background job as cancelled with stuck reason
-    this.backgroundJobs?.markCancelled?.(record.session, 'stuck');
+    // Mark the background job as cancelled with stuck reason (best-effort)
+    try {
+      this.backgroundJobs?.markCancelled?.(record.session, 'stuck');
+    } catch (err) {
+      log('[cmux-session-lifecycle] markCancelled failed, continuing cleanup', {
+        session: record.session,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
 
     // Request pane close with stuck reason
     await this.requestClose(record, 'stuck');
+
+    // Set detection latch AFTER cleanup steps so a throw above allows retry on next poll
+    record.stuckDetectedAt = now;
   }
 
   private startPolling(): void {

--- a/src/multiplexer/cmux/session-state.ts
+++ b/src/multiplexer/cmux/session-state.ts
@@ -28,6 +28,10 @@ export interface CmuxSessionRecord {
   closeIntent?: CmuxCloseIntent;
   closeTimer?: { cancel(): void };
   spawnPromise?: Promise<PaneResult>;
+  /** activityVersion captured at the last stuck check tick. */
+  stuckCheckVersion?: number;
+  /** Timestamp when stuck was first confirmed (prevents repeated aborts). */
+  stuckDetectedAt?: number;
 }
 
 const STORE_KEY = Symbol.for('oh-my-opencode-slim.cmux-session-store');

--- a/src/multiplexer/session-manager.ts
+++ b/src/multiplexer/session-manager.ts
@@ -180,7 +180,7 @@ export class MultiplexerSessionManager {
         this.resolveServerUrl,
         this.directory,
         this.backgroundJobBoard,
-        options,
+        { ...options, client: ctx.client },
       );
     }
 


### PR DESCRIPTION
> **⚠️ Disclaimer:** I was not able to test the cmux multiplexer changes end-to-end. The stuck agent detection, close policy, and cmux session lifecycle logic were developed and verified via unit tests only. Manual testing of cmux pane spawning, stuck detection firing on a real busy session, and pane cleanup was not performed. Please review with extra scrutiny on the cmux-specific paths.

Closes #67

## What changed, and why was it needed?

### What problem are you solving?

Background subagent sessions that crash or hang without emitting a terminal event (e.g. `session.deleted`, `session.idle`) leave their cmux panes open indefinitely, leaking resources. This is the remaining gap from #124 (closed). There is no automatic stuck/hang/freeze detection anywhere in the multiplexer lifecycle.

### What does this change?

Adds stuck agent detection to `CmuxSessionLifecycle`: busy sessions with no activity version change past a configurable threshold (default 3 min, configurable via `stuckAgent.timeoutMs`) are auto-aborted, marked cancelled, and their panes closed. Also fixes a foreground-fallback race where stale retry events from a previous model could trigger duplicate fallbacks after a model switch.

### Why this approach?

Alternatives considered:
- **Poll-based health checks**: Would require a separate health endpoint on the agent, adding complexity. Stuck detection via activity version comparison is simpler and reuses existing polling infrastructure.
- **Heartbeat from agents**: Would require agent cooperation. The proposed approach works passively by observing existing status events.
- **Longer timeouts only**: Not sufficient — a truly stuck session needs active intervention, not just longer waiting.

The activity-version-based approach is minimal: it reuses the existing poll loop, only checks busy sessions, and respects a grace period to avoid false positives on newly created sessions.

### Related work

- [x] I checked open AND closed PRs/issues for duplicates
- Related: #67 (original issue), #124 (closed, partial fix)

### AI assistance (optional)

- Model / harness: OpenCode (mimo-v2.5-free) with @explorer, @fixer subagents
- Human reviewed the full diff? [ ] (N/A if no AI assistance)

### Checklist

- [x] `bun run check:ci`, `bun run typecheck`, and `bun test` pass
- [x] Docs (README.md, docs/) updated — `docs/configuration.md` updated with `stuckAgent` config options
- [x] One logical change per PR
- [x] PR targets the `master` branch