### PR TITLE
fix(herdr): serialize concurrent spawnPane to prevent agentAreaPaneId race

### DIFF
--- a/src/multiplexer/herdr/index.test.ts
+++ b/src/multiplexer/herdr/index.test.ts
@@ -757,4 +757,48 @@ describe('HerdrMultiplexer', () => {
     // No CLI commands should be issued
     expect(commands()).toHaveLength(0);
   });
+
+  // Regression: concurrent spawns must not race on agentAreaPaneId (#762)
+  test('main-vertical: concurrent spawns produce one parent split + down splits', async () => {
+    let splitCount = 0;
+    crossSpawnMock.mockImplementation((command: string[]) => {
+      if (command[0] === 'which') {
+        return createSpawnResult(0, '/usr/bin/herdr\n');
+      }
+      if (command.includes('split')) {
+        splitCount++;
+        // Return sequential pane IDs so we can track which split is which
+        return createSpawnResult(
+          0,
+          `${createSplitResponse(`w1:p${splitCount + 1}`)}\n`,
+        );
+      }
+      return createSpawnResult();
+    });
+
+    const { HerdrMultiplexer } = await importFreshHerdr();
+    const herdr = new HerdrMultiplexer('main-vertical', 60);
+
+    // Fire both concurrently — before the fix, both would see
+    // agentAreaPaneId === null and split from the parent (w1:p1).
+    const [r1, r2] = await Promise.all([
+      herdr.spawnPane('s1', 'Agent 1', 'http://localhost:4096', '/repo'),
+      herdr.spawnPane('s2', 'Agent 2', 'http://localhost:4096', '/repo'),
+    ]);
+
+    expect(r1.success).toBe(true);
+    expect(r2.success).toBe(true);
+
+    const splitCommands = commands().filter((c) => c.includes('split'));
+    // Exactly 2 splits total
+    expect(splitCommands.length).toBe(2);
+
+    // First split: parent (w1:p1) → right
+    expect(splitCommands[0][3]).toBe('w1:p1');
+    expect(splitCommands[0]).toContain('right');
+
+    // Second split: agent area (w1:p2) → down
+    expect(splitCommands[1][3]).toBe('w1:p2');
+    expect(splitCommands[1]).toContain('down');
+  });
 });

--- a/src/multiplexer/herdr/index.ts
+++ b/src/multiplexer/herdr/index.ts
@@ -42,6 +42,8 @@ export class HerdrMultiplexer implements Multiplexer {
   private layout: MultiplexerLayout;
   private paneDirection: HerdrPaneDirection;
   private agentAreaPaneId: string | null = null;
+  // ponytail: serialize spawnPane to prevent concurrent races on agentAreaPaneId
+  private spawnMutex: Promise<unknown> = Promise.resolve();
 
   constructor(layout: MultiplexerLayout = 'main-vertical', mainPaneSize = 60) {
     // Herdr does not support exact main pane sizing like tmux.
@@ -66,6 +68,25 @@ export class HerdrMultiplexer implements Multiplexer {
   }
 
   async spawnPane(
+    sessionId: string,
+    description: string,
+    serverUrl: string,
+    directory: string,
+  ): Promise<PaneResult> {
+    // ponytail: serialize concurrent spawns to prevent races on agentAreaPaneId
+    const prev = this.spawnMutex;
+    let release!: () => void;
+    this.spawnMutex = new Promise<void>((r) => (release = r));
+    await prev;
+
+    try {
+      return await this.doSpawn(sessionId, description, serverUrl, directory);
+    } finally {
+      release();
+    }
+  }
+
+  private async doSpawn(
     sessionId: string,
     description: string,
     serverUrl: string,


### PR DESCRIPTION
## What problem are you solving?

Concurrent `spawnPane()` calls race on `agentAreaPaneId`. When two child sessions launch within ~74ms of each other, both read `agentAreaPaneId === null`, both split from the parent pane to the right, creating duplicate panes instead of stacking. ([#762](https://github.com/mhenke/oh-my-opencode-slim/issues/762), related to #668/#697)

## What does this change?

Adds a promise-based mutex around `spawnPane()` in `HerdrMultiplexer` so concurrent calls are serialized. The second call always sees the `agentAreaPaneId` set by the first and splits downward from it.

## Why this approach?

A simple promise chain is the minimal serialization for JS/TS — no external deps, no new abstraction. Alternatives: a `Mutex` class (heavier), a `Set` tracking in-flight promises (same idea, more code). The inline chain wins on simplicity.

## Related work

- [x] Checked open and closed PRs/issues for duplicates
- Related: #668, #697 (sequential agent-area tracking fix)

## AI assistance

- Model / harness: OpenCode (mimo-v2.5-free) with @explorer, @librarian, @fixer, @oracle, @designer, @observer, @council subagents
- Human reviewed the full diff? [x]

## Checklist

- [x] `bun run check:ci`, `bun run typecheck`, and `bun test` pass (1548 tests, 0 failures)
- [x] Docs updated if behavior changed — N/A, no user-facing behavior change
- [x] One logical change per PR
- [x] PR targets the `master` branch