### PR TITLE
fix: append background job board to task output so model sees active jobs

### DIFF
--- a/src/hooks/task-session-manager/index.ts
+++ b/src/hooks/task-session-manager/index.ts
@@ -489,6 +489,14 @@ export function createTaskSessionManagerHook(
           launch.taskID,
           taskContextTracker.contextFilesForPrompt(launch.taskID),
         );
+        // Append the background job board to the task output so the model
+        // sees the active job immediately and knows to wait for completion.
+        const board = backgroundJobBoard.formatForPrompt(
+          pending.parentSessionId,
+        );
+        if (board) {
+          output.output = `${output.output}\n\n${board}`;
+        }
         return;
       }
 


### PR DESCRIPTION
When the task tool returns `<task state="running">`, the model doesn't know to wait for the background job and immediately reports 'cancelled'.

This appends the background job board to the task output so the model sees the active job and knows to wait for completion.

Fixes #765