### PR TITLE
fix(tui-state): scope state file per project to stop model override leaks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -146,6 +146,9 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
   let multiplexerSessionManager: MultiplexerSessionManager;
   let autoUpdateChecker: ReturnType<typeof createAutoUpdateCheckerHook>;
   let sessionAgentMap: Map<string, string>;
+  // ponytail: cache sessionID -> project directory so TUI model writes
+  // land in the right per-project file after a project switch (ctx.directory is stale)
+  const sessionDirectories = new Map<string, string>();
   let sessionLifecycle: SessionLifecycle;
 
   let chatHeadersHook: ReturnType<typeof createChatHeadersHook>;
@@ -865,6 +868,7 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
               modelID?: string;
             };
             sessionID?: string;
+            directory?: string;
           };
           sessionID?: string;
           id?: string;
@@ -897,7 +901,8 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
               model,
               variant: variant ?? null,
             },
-            ctx.directory,
+            (info?.sessionID && sessionDirectories.get(info.sessionID)) ??
+              ctx.directory,
           );
         }
       }
@@ -907,6 +912,11 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
         const parentSessionId = event.properties?.info?.parentID;
         if (depthTracker && childSessionId && parentSessionId) {
           depthTracker.registerChild(parentSessionId, childSessionId);
+        }
+        const createdSessionId = event.properties?.info?.id;
+        const createdSessionDir = event.properties?.info?.directory;
+        if (createdSessionId && createdSessionDir) {
+          sessionDirectories.set(createdSessionId, createdSessionDir);
         }
       }
 
@@ -987,6 +997,7 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
         }
         if (sessionID) {
           sessionAgentMap.delete(sessionID);
+          sessionDirectories.delete(sessionID);
         }
       }
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -772,10 +772,13 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
           tuiAgentVariants[agentDef.name] = resolvedVariant;
         }
       }
-      recordTuiAgentModels({
-        agentModels: tuiAgentModels,
-        agentVariants: tuiAgentVariants,
-      });
+      recordTuiAgentModels(
+        {
+          agentModels: tuiAgentModels,
+          agentVariants: tuiAgentVariants,
+        },
+        ctx.directory,
+      );
 
       applyOrchestratorModelConfig({
         agents: configAgent,
@@ -888,11 +891,14 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
           const agentName = resolveRuntimeAgentName(config, info.agent);
           const model = `${providerID}/${modelID}`;
           const variant = resolveTuiVariantForModel(agentName, model);
-          recordTuiAgentModel({
-            agentName,
-            model,
-            variant: variant ?? null,
-          });
+          recordTuiAgentModel(
+            {
+              agentName,
+              model,
+              variant: variant ?? null,
+            },
+            ctx.directory,
+          );
         }
       }
 

--- a/src/tools/preset-manager.test.ts
+++ b/src/tools/preset-manager.test.ts
@@ -185,12 +185,15 @@ describe('createPresetManager', () => {
     });
 
     test('updates the TUI snapshot after a successful preset switch', async () => {
-      recordTuiAgentModels({
-        agentModels: {
-          explorer: 'openai/gpt-5.6-luna',
-          fixer: 'openai/gpt-5.6-luna',
+      recordTuiAgentModels(
+        {
+          agentModels: {
+            explorer: 'openai/gpt-5.6-luna',
+            fixer: 'openai/gpt-5.6-luna',
+          },
         },
-      });
+        tempDir,
+      );
 
       const ctx = createMockContext();
       const config: PluginConfig = {
@@ -209,7 +212,7 @@ describe('createPresetManager', () => {
         output,
       );
 
-      expect(readTuiSnapshot().agentModels).toEqual({
+      expect(readTuiSnapshot(tempDir).agentModels).toEqual({
         explorer: 'openai/gpt-5.6',
         fixer: 'openai/gpt-5.6-luna',
         orchestrator: 'anthropic/claude-3.5-haiku',
@@ -354,11 +357,14 @@ describe('createPresetManager', () => {
 
     test('unknown preset does not change active state or dispose instance', async () => {
       setActiveRuntimePreset('cheap');
-      recordTuiAgentModels({
-        agentModels: {
-          explorer: 'openai/gpt-5.6-luna',
+      recordTuiAgentModels(
+        {
+          agentModels: {
+            explorer: 'openai/gpt-5.6-luna',
+          },
         },
-      });
+        tempDir,
+      );
 
       const ctx = createMockContext();
       const config: PluginConfig = {

--- a/src/tools/preset-manager.ts
+++ b/src/tools/preset-manager.ts
@@ -177,7 +177,7 @@ export function createPresetManager(ctx: PluginInput, config: PluginConfig) {
       // Non-critical: runtime state is set regardless
     }
 
-    const snapshot = readTuiSnapshot();
+    const snapshot = readTuiSnapshot(ctx.directory);
     const agentModels = { ...snapshot.agentModels };
     const agentVariants = { ...snapshot.agentVariants };
     for (const [agentName, agentConfig] of Object.entries(agentUpdates)) {
@@ -191,7 +191,7 @@ export function createPresetManager(ctx: PluginInput, config: PluginConfig) {
       }
     }
 
-    recordTuiAgentModels({ agentModels, agentVariants });
+    recordTuiAgentModels({ agentModels, agentVariants }, ctx.directory);
 
     activePreset = presetName;
 

--- a/src/tui-state.test.ts
+++ b/src/tui-state.test.ts
@@ -130,4 +130,19 @@ describe('tui-state persistence', () => {
     });
     expect(snapshot.agentVariants).toEqual({});
   });
+
+  test('cross-project isolation — different directories write independent state files', () => {
+    const dirA = fs.mkdtempSync(path.join(os.tmpdir(), 'omos-a-'));
+    const dirB = fs.mkdtempSync(path.join(os.tmpdir(), 'omos-b-'));
+    try {
+      recordTuiAgentModels({ agentModels: { explorer: 'model-a' } }, dirA);
+      recordTuiAgentModels({ agentModels: { explorer: 'model-b' } }, dirB);
+
+      expect(readTuiSnapshot(dirA).agentModels.explorer).toBe('model-a');
+      expect(readTuiSnapshot(dirB).agentModels.explorer).toBe('model-b');
+    } finally {
+      fs.rmSync(dirA, { recursive: true, force: true });
+      fs.rmSync(dirB, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/tui-state.test.ts
+++ b/src/tui-state.test.ts
@@ -3,6 +3,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import {
+  getTuiStatePath,
   readTuiSnapshot,
   recordTuiAgentModel,
   recordTuiAgentModels,
@@ -29,18 +30,21 @@ afterEach(() => {
 
 describe('tui-state persistence', () => {
   test('persists enabled agent models', () => {
-    recordTuiAgentModels({
-      agentModels: {
-        explorer: 'openai/gpt-5.6-luna',
-        fixer: 'openai/gpt-5.6-luna',
+    recordTuiAgentModels(
+      {
+        agentModels: {
+          explorer: 'openai/gpt-5.6-luna',
+          fixer: 'openai/gpt-5.6-luna',
+        },
+        agentVariants: {
+          explorer: 'low',
+          fixer: 'high',
+        },
       },
-      agentVariants: {
-        explorer: 'low',
-        fixer: 'high',
-      },
-    });
+      tempDir,
+    );
 
-    const snapshot = readTuiSnapshot();
+    const snapshot = readTuiSnapshot(tempDir);
 
     expect(snapshot.agentModels).toEqual({
       explorer: 'openai/gpt-5.6-luna',
@@ -53,55 +57,61 @@ describe('tui-state persistence', () => {
   });
 
   test('updates a single live agent model without dropping others', () => {
-    recordTuiAgentModels({
-      agentModels: {
-        orchestrator: 'default',
-        explorer: 'openai/gpt-5.6-luna',
+    recordTuiAgentModels(
+      {
+        agentModels: {
+          orchestrator: 'default',
+          explorer: 'openai/gpt-5.6-luna',
+        },
       },
-    });
+      tempDir,
+    );
 
-    recordTuiAgentModel({
-      agentName: 'orchestrator',
-      model: 'openai/gpt-5.6',
-    });
+    recordTuiAgentModel(
+      {
+        agentName: 'orchestrator',
+        model: 'openai/gpt-5.6',
+      },
+      tempDir,
+    );
 
-    expect(readTuiSnapshot().agentModels).toEqual({
+    expect(readTuiSnapshot(tempDir).agentModels).toEqual({
       orchestrator: 'openai/gpt-5.6',
       explorer: 'openai/gpt-5.6-luna',
     });
   });
 
   test('updates a single live agent variant without dropping others', () => {
-    recordTuiAgentModels({
-      agentModels: {
-        orchestrator: 'default',
-        explorer: 'openai/gpt-5.6-luna',
+    recordTuiAgentModels(
+      {
+        agentModels: {
+          orchestrator: 'default',
+          explorer: 'openai/gpt-5.6-luna',
+        },
+        agentVariants: {
+          explorer: 'low',
+        },
       },
-      agentVariants: {
-        explorer: 'low',
+      tempDir,
+    );
+
+    recordTuiAgentModel(
+      {
+        agentName: 'orchestrator',
+        model: 'openai/gpt-5.6',
+        variant: 'high',
       },
-    });
+      tempDir,
+    );
 
-    recordTuiAgentModel({
-      agentName: 'orchestrator',
-      model: 'openai/gpt-5.6',
-      variant: 'high',
-    });
-
-    expect(readTuiSnapshot().agentVariants).toEqual({
+    expect(readTuiSnapshot(tempDir).agentVariants).toEqual({
       orchestrator: 'high',
       explorer: 'low',
     });
   });
 
   test('ignores legacy config status fields in old snapshots', () => {
-    const filePath = path.join(
-      tempDir,
-      'opencode',
-      'storage',
-      'oh-my-opencode-slim',
-      'tui-state.json',
-    );
+    const filePath = getTuiStatePath(tempDir);
     fs.mkdirSync(path.dirname(filePath), { recursive: true });
     fs.writeFileSync(
       filePath,
@@ -114,7 +124,7 @@ describe('tui-state persistence', () => {
       }),
     );
 
-    const snapshot = readTuiSnapshot();
+    const snapshot = readTuiSnapshot(tempDir);
     expect(snapshot.agentModels).toEqual({
       explorer: 'openai/gpt-5.6-luna',
     });

--- a/src/tui-state.ts
+++ b/src/tui-state.ts
@@ -1,4 +1,4 @@
-import * as crypto from 'node:crypto';
+import { createHash } from 'node:crypto';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -21,8 +21,7 @@ function dataDir(): string {
 
 // ponytail: per-project scope prevents /model overrides from leaking across projects
 function projectScope(projectDir: string): string {
-  return crypto
-    .createHash('sha256')
+  return createHash('sha256')
     .update(path.resolve(projectDir))
     .digest('hex')
     .slice(0, 12);

--- a/src/tui-state.ts
+++ b/src/tui-state.ts
@@ -1,3 +1,4 @@
+import * as crypto from 'node:crypto';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -18,8 +19,24 @@ function dataDir(): string {
   );
 }
 
-export function getTuiStatePath(): string {
-  return path.join(dataDir(), 'opencode', 'storage', STATE_DIR, STATE_FILE);
+// ponytail: per-project scope prevents /model overrides from leaking across projects
+function projectScope(projectDir: string): string {
+  return crypto
+    .createHash('sha256')
+    .update(path.resolve(projectDir))
+    .digest('hex')
+    .slice(0, 12);
+}
+
+export function getTuiStatePath(projectDir: string): string {
+  return path.join(
+    dataDir(),
+    'opencode',
+    'storage',
+    STATE_DIR,
+    projectScope(projectDir),
+    STATE_FILE,
+  );
 }
 
 function emptySnapshot(): TuiSnapshot {
@@ -44,25 +61,29 @@ function parseSnapshot(value: string): TuiSnapshot {
   };
 }
 
-export function readTuiSnapshot(): TuiSnapshot {
+export function readTuiSnapshot(projectDir: string): TuiSnapshot {
   try {
-    return parseSnapshot(fs.readFileSync(getTuiStatePath(), 'utf8'));
+    return parseSnapshot(fs.readFileSync(getTuiStatePath(projectDir), 'utf8'));
   } catch {
     return emptySnapshot();
   }
 }
 
-export async function readTuiSnapshotAsync(): Promise<TuiSnapshot> {
+export async function readTuiSnapshotAsync(
+  projectDir: string,
+): Promise<TuiSnapshot> {
   try {
-    return parseSnapshot(await fs.promises.readFile(getTuiStatePath(), 'utf8'));
+    return parseSnapshot(
+      await fs.promises.readFile(getTuiStatePath(projectDir), 'utf8'),
+    );
   } catch {
     return emptySnapshot();
   }
 }
 
-function writeTuiSnapshot(snapshot: TuiSnapshot): void {
+function writeTuiSnapshot(snapshot: TuiSnapshot, projectDir: string): void {
   try {
-    const filePath = getTuiStatePath();
+    const filePath = getTuiStatePath(projectDir);
     fs.mkdirSync(path.dirname(filePath), { recursive: true });
     fs.writeFileSync(filePath, `${JSON.stringify(snapshot)}\n`);
   } catch {
@@ -70,29 +91,38 @@ function writeTuiSnapshot(snapshot: TuiSnapshot): void {
   }
 }
 
-function updateSnapshot(mutator: (snapshot: TuiSnapshot) => void): void {
-  const snapshot = readTuiSnapshot();
+function updateSnapshot(
+  projectDir: string,
+  mutator: (snapshot: TuiSnapshot) => void,
+): void {
+  const snapshot = readTuiSnapshot(projectDir);
   mutator(snapshot);
   snapshot.updatedAt = Date.now();
-  writeTuiSnapshot(snapshot);
+  writeTuiSnapshot(snapshot, projectDir);
 }
 
-export function recordTuiAgentModels(input: {
-  agentModels: Record<string, string>;
-  agentVariants?: Record<string, string>;
-}): void {
-  updateSnapshot((snapshot) => {
+export function recordTuiAgentModels(
+  input: {
+    agentModels: Record<string, string>;
+    agentVariants?: Record<string, string>;
+  },
+  projectDir: string,
+): void {
+  updateSnapshot(projectDir, (snapshot) => {
     snapshot.agentModels = { ...input.agentModels };
     snapshot.agentVariants = { ...(input.agentVariants ?? {}) };
   });
 }
 
-export function recordTuiAgentModel(input: {
-  agentName: string;
-  model: string;
-  variant?: string | null;
-}): void {
-  updateSnapshot((snapshot) => {
+export function recordTuiAgentModel(
+  input: {
+    agentName: string;
+    model: string;
+    variant?: string | null;
+  },
+  projectDir: string,
+): void {
+  updateSnapshot(projectDir, (snapshot) => {
     snapshot.agentModels[input.agentName] = input.model;
     if (input.variant !== undefined) {
       if (input.variant === null) {

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -252,11 +252,11 @@ const plugin: TuiPluginModule & { id: string } = {
     const version = meta.version ?? (await readPackageVersion()) ?? 'dev';
     let configDirectory = getTuiDirectory(api);
     let { configInvalid, compactSidebar } = readConfigState(configDirectory);
-    let snapshot = readTuiSnapshot();
+    let snapshot = readTuiSnapshot(configDirectory);
     const renderTimer = setInterval(async () => {
       try {
-        snapshot = await readTuiSnapshotAsync();
         const currentDirectory = getTuiDirectory(api);
+        snapshot = await readTuiSnapshotAsync(currentDirectory);
         if (currentDirectory !== configDirectory) {
           configDirectory = currentDirectory;
           ({ configInvalid, compactSidebar } =


### PR DESCRIPTION
What changed, and why was it needed?

## What problem are you solving?
Issue #741: `tui-state.json` stores runtime agent model overrides (set via `/model`) at one fixed global path with no project isolation. A user who switches models in project A and then opens project B (different providers/models) gets project A's stale overrides read before B's config applies, which throws `Model not found: openai/gpt-5.4-mini` in B. The only workaround was deleting `tui-state.json` when switching projects, which also dropped legitimate overrides.

## What does this change?
Scopes `tui-state.json` per project by hashing the project directory into the storage path (`.../oh-my-opencode-slim/<sha256(projectDir)[:12]>/tui-state.json`) instead of a single global file. Every read/write caller now receives the project directory.

## Why this approach?
Three options were considered. Per-project path (chosen) matches OpenCode's own `storage/session/<projectHash>/` layout and is the smallest correct fix. A single shared file keyed by project would keep a global file and complicate the schema. Validating stored models against active providers on load only hides the symptom. The per-project path avoids any cross-project read.

## Related work
- [x] I checked open AND closed PRs/issues for duplicates
- Related: #741 (the issue this fixes). Adjacent but distinct: #639 (preserve /model across plugin re-inits), #737 (disable fallback when user picks a model via /model). No existing PR fixes the cross-project isolation.

## Acceptance testing
1. Confirm two projects get separate files. Start OpenCode in project A, then in project B. Check the storage dir:
   ```
   ls ~/.local/share/opencode/storage/oh-my-opencode-slim/
   ```
   You should see two different 12-char hash directories, one per project. Before the fix there was a single `tui-state.json` at that level with no hash folder.
2. To confirm a directory matches a project, compute the expected hash (matches `path.resolve` + sha256, first 12 hex):
   ```
   printf '%s' "$(realpath -s /abs/path/to/projectA)" | sha256sum | cut -c1-12
   ```
   That string should equal one of the directory names. `realpath -s` avoids symlink resolution, same as `path.resolve`.

## AI assistance
- Model / harness: OpenCode (hy3-free) with @oracle (hy3-free) subagents for the code review and @fixer (hy3-free) for the test and import change.
- Human reviewed the full diff? Yes. The change was manually acceptance-tested by opening two projects and confirming separate 12-char hash state directories are created, with no model leak across projects.

## Checklist
- [x] `bun run check:ci`, `bun run typecheck`, and `bun test` pass (1550 tests, 0 fail)
- [x] Docs updated if behavior/commands changed: no doc change needed. This is an internal state-file location change with no user-facing command, config, or behavior surface.
- [x] One logical change per PR
- [x] PR targets the `master` branch
