### PR TITLE
fix(fallback): prevent foreground fallback abort from prematurely cancelling background tasks

### DIFF
--- a/src/hooks/foreground-fallback/index.test.ts
+++ b/src/hooks/foreground-fallback/index.test.ts
@@ -1255,6 +1255,30 @@ describe('ForegroundFallbackManager session.deleted', () => {
     // Triggered (dedup was cleared by deletion)
     expect(mocks.promptAsync).toHaveBeenCalledTimes(1);
   });
+
+  test('does NOT clear inProgress when session.deleted fires', () => {
+    const coordinator = new SessionLifecycle(() => {});
+    const { client } = createMockClient();
+    const mgr = new ForegroundFallbackManager(
+      client,
+      makeChains(),
+      true,
+      3,
+      coordinator,
+    );
+
+    // Simulate: fallback is in progress
+    const sessionID = 'sess-inprog';
+    (mgr as any).inProgress.add(sessionID);
+    expect(mgr.isFallbackInProgress(sessionID)).toBe(true);
+
+    // Session deleted fires (as it does during abort in tryFallbackWithAbort)
+    coordinator.dispatchSessionDeleted(sessionID);
+
+    // inProgress must survive — the finally block of tryFallback/WithAbort
+    // manages it, not the session.deleted callback
+    expect(mgr.isFallbackInProgress(sessionID)).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/hooks/foreground-fallback/index.ts
+++ b/src/hooks/foreground-fallback/index.ts
@@ -241,7 +241,12 @@ export class ForegroundFallbackManager {
         this.sessionModel.delete(id);
         this.sessionAgent.delete(id);
         this.sessionTried.delete(id);
-        this.inProgress.delete(id);
+        // NOTE: inProgress is intentionally NOT cleared here —
+        // the finally blocks in tryFallback() and tryFallbackWithAbort()
+        // manage inProgress lifecycle. Clearing it here would make
+        // isFallbackInProgress() return false during the abort/re-prompt
+        // cycle, letting the task-session-manager treat the abort idle
+        // as a real completion and report a background task as cancelled.
         this.lastTrigger.delete(id);
         this.lastTriggerModel.delete(id);
         this.sessionRetries.delete(id);

--- a/src/hooks/task-session-manager/index.test.ts
+++ b/src/hooks/task-session-manager/index.test.ts
@@ -2150,6 +2150,56 @@ describe('task-session-manager hook', () => {
     expect(board.get('child-1')).toMatchObject({ state: 'running' });
   });
 
+  test('does NOT drop job from board on session.deleted when fallback in progress', async () => {
+    const coordinator = new SessionLifecycle(() => {});
+    const board = new BackgroundJobBoard();
+    board.registerLaunch({
+      taskID: 'child-1',
+      parentSessionID: 'parent-1',
+      agent: 'oracle',
+      description: 'architecture review',
+    });
+    expect(board.get('child-1')).toMatchObject({ state: 'running' });
+
+    createHook({
+      backgroundJobBoard: board,
+      coordinator,
+      isFallbackInProgress: (id) => id === 'child-1',
+    });
+
+    // Dispatch session.deleted while fallback is in progress
+    coordinator.dispatchSessionDeleted('child-1');
+
+    // Job must survive — the orchestrator needs to track it through the
+    // abort/re-prompt cycle
+    expect(board.get('child-1')).toBeDefined();
+    expect(board.get('child-1')).toMatchObject({ state: 'running' });
+  });
+
+  test('drops job from board on session.deleted when no fallback in progress', async () => {
+    const coordinator = new SessionLifecycle(() => {});
+    const board = new BackgroundJobBoard();
+    board.registerLaunch({
+      taskID: 'child-2',
+      parentSessionID: 'parent-1',
+      agent: 'oracle',
+      description: 'architecture review',
+    });
+    expect(board.get('child-2')).toMatchObject({ state: 'running' });
+
+    createHook({
+      backgroundJobBoard: board,
+      coordinator,
+      // isFallbackInProgress not set — no guard
+    });
+
+    // Dispatch session.deleted normally
+    coordinator.dispatchSessionDeleted('child-2');
+
+    // Job should be dropped
+    expect(board.get('child-2')).toBeUndefined();
+  });
+
   test('reconciles from idle when fallback guard passes', async () => {
     const board = new BackgroundJobBoard();
     board.registerLaunch({

--- a/src/hooks/task-session-manager/index.ts
+++ b/src/hooks/task-session-manager/index.ts
@@ -128,8 +128,15 @@ export function createTaskSessionManagerHook(
 
   if (options.coordinator) {
     options.coordinator.onSessionDeleted((sessionId) => {
-      backgroundJobBoard.drop(sessionId);
-      backgroundJobBoard.clearParent(sessionId);
+      // During a foreground fallback abort/re-prompt cycle, the session
+      // is being torn down and immediately recreated with a fallback model.
+      // Dropping the job from the board here would make the orchestrator
+      // lose track of the task and report it as cancelled even though the
+      // oracle actually completed.
+      if (!options.isFallbackInProgress?.(sessionId)) {
+        backgroundJobBoard.drop(sessionId);
+        backgroundJobBoard.clearParent(sessionId);
+      }
       terminalJobsInjectedByParent.delete(sessionId);
       taskContextTracker.clearSession(sessionId);
       taskContextTracker.prune(backgroundJobBoard);


### PR DESCRIPTION
## What changed, and why was it needed?

When a foreground agent hits a rate-limit and the fallback manager calls `tryFallbackWithAbort()`, the abort triggers a `session.deleted` lifecycle callback. Two things happened in those callbacks that shouldn't:

1. **`inProgress` was cleared** — the `onSessionDeleted` callback in `ForegroundFallbackManager` unconditionally called `this.inProgress.delete(id)`. This made `isFallbackInProgress()` return `false` during the abort idle window, causing the task-session-manager's idle reconciliation to treat the abort as a real completion instead of waiting for the fallback model to respond.

2. **The background job was dropped from the board** — the `onSessionDeleted` callback in `TaskSessionManager` unconditionally called `backgroundJobBoard.drop()`, permanently removing the job before `execFallback` could re-prompt with the fallback model via `promptAsync`. When the oracle actually completed with the new model, the board had no record of the task and the orchestrator reported it as cancelled.

The observable symptom: running `@oracle hello` would produce a response from the oracle but the orchestrator would report it as "Task cancelled" because `runningJobForSession` was `false` at idle time.

### Changes

**ForegroundFallbackManager:**
- Removed `this.inProgress.delete(id)` from the `onSessionDeleted` callback. The `finally` blocks of `tryFallback()` and `tryFallbackWithAbort()` already manage `inProgress` lifecycle correctly. The callback now only cleans up model/agent/tried/trigger metadata.

**TaskSessionManager:**
- Guarded `backgroundJobBoard.drop()` and `backgroundJobBoard.clearParent()` with `!options.isFallbackInProgress?.(sessionId)` — the same mechanism already wired in `src/index.ts:338-339` and used for idle reconciliation. When a foreground fallback is in progress, the job survives the abort and continues tracking through the re-prompt cycle.

Test coverage: 3 new tests — `inProgress` survival during `session.deleted`, job board drop suppression during fallback, and normal drop behavior preserved.

Closes #765
