### PR TITLE
docs: make triage-labels.md the label source of truth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -294,7 +294,10 @@ Issues and PRs are tracked on GitHub (`alvinunreal/oh-my-opencode-slim`); extern
 
 ### Triage labels
 
-Canonical triage roles map to repo labels via `docs/agents/triage-labels.md` (e.g. `ready-for-agent` → `good-to-code`; `needs-triage` = unlabeled).
+Canonical triage roles map to repo labels via `docs/agents/triage-labels.md`
+(e.g. `ready-for-agent` → `good-to-code`; `needs-triage` = unlabeled). Install
+the `triage` skill (command in `docs/maintainers.md`). Community preset
+submissions use the `community-preset` label (see `docs/maintainers.md`).
 
 ### Domain docs
 

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -16,6 +16,12 @@ When your output names a domain concept (in an issue title, a refactor proposal,
 
 If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
 
+## Triage and labels
+
+Operational triage roles and their repo labels are documented in
+`docs/agents/triage-labels.md` (source of truth) and `docs/maintainers.md`.
+The external-PR triage policy lives in `docs/agents/issue-tracker.md`.
+
 ## Flag ADR conflicts
 
 If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -5,6 +5,9 @@ Maps the **canonical triage roles** (defined in the `triage` skill from
 issue tracker. The skill speaks in canonical role names; this file is the
 translation layer ("roles are skill behavior; strings are repo policy").
 
+> **See also:** [`docs/maintainers.md`](../maintainers.md) — triage workflow
+> procedure (how to apply labels, when to close, etc.).
+
 | Label in `mattpocock/skills` | Label in our tracker | Meaning |
 | ---------------------------- | -------------------- | ------- |
 | `bug`                        | `bug`                | Something is broken |
@@ -26,8 +29,7 @@ translation layer ("roles are skill behavior; strings are repo policy").
   issues that still need implementation.
 - The following repo labels are intentionally **outside** the triage taxonomy
   and should not be applied by `/triage`:
-  - `confirmed` — maintainer-acknowledged signal after `needs-triage`
   - `status:in-review` — human review state (optional overlay on `good-to-code`)
-  - `P0` — priority overlay; apply manually alongside any role for urgent items
   - `release` — release management
   - `Share Your Thoughts` — open-ended community feedback
+  - `community-preset` — community submission (applied via `preset_submission.yml` form)

--- a/docs/maintainers.md
+++ b/docs/maintainers.md
@@ -4,10 +4,9 @@ This document is the source of truth for issue triage and lightweight repo maint
 
 ## Goals
 
-- Keep bug reports actionable.
-- Keep issue filing lightweight.
-- Keep support out of the issue tracker.
-- Keep maintainer decisions fast and consistent.
+- Bug reports stay actionable; filing stays lightweight.
+- Support questions go to Telegram, not the issue tracker.
+- Maintainers decide quickly and apply the same standard each time.
 
 ## Where Different Things Go
 
@@ -27,7 +26,7 @@ Use the Telegram channel for:
 - general support
 - open-ended usage questions
 
-If an issue is really a support request, reply briefly and redirect the user to Telegram.
+If an issue is really a support request, reply briefly and redirect the user to [Telegram](https://t.me/boringdystopiadevelopment).
 
 ## Issue Forms
 
@@ -54,45 +53,44 @@ Feature requests should stay lightweight and focus on:
 - the requested change
 - optional extra context
 
+### Community preset submission
+
+Community preset submissions use a separate form (`preset_submission.yml`).
+These require preset name, GitHub handle, config block, supported providers, and
+intended use case. Label with `community-preset` and review for clarity and
+validity before merging.
+
 ## Labels
 
-Only use these labels:
-
-- `bug` - bug report
-- `enhancement` - feature request or improvement
-- `needs-info` - cannot act yet because key details are missing
-- `confirmed` - a maintainer confirmed the issue or agrees the request is valid
-- `P0` - highest priority
-- `Share Your Thoughts` - open-ended feedback from the community
-
-If a label does not help triage or prioritization, do not add it.
+The canonical label taxonomy is defined in
+[`docs/agents/triage-labels.md`](agents/triage-labels.md). This section covers
+triage procedure only.
 
 ## Triage Flow
 
-For each new issue, make a quick first decision:
+Requires the `triage` skill from `mattpocock/skills`.
 
-1. Is it a bug report, a feature request, or support?
-2. Is there enough information to act on it?
-3. Is it confirmed?
+**Install the skill:** `npx skills add https://github.com/mattpocock/skills --skill triage`
 
-### Bug reports
+The label mapping the skill expects is already provided in
+[`docs/agents/triage-labels.md`](agents/triage-labels.md). You do **not** need to
+run `/setup-matt-pocock-skills` for this repo.
 
-- Add `bug` if needed.
-- Add `needs-info` if required details are missing.
-- Add `confirmed` once a maintainer reproduces it or agrees it is valid and actionable.
-- Add `P0` only for the highest-priority problems.
+Route each new issue:
 
-### Feature requests
+1. **Bug report or feature request?** → run `/triage`. Canonical roles and their
+   GitHub label mappings live in
+   [`docs/agents/triage-labels.md`](agents/triage-labels.md); the skill owns the
+   role model and state transitions.
+2. **Support request?** → reply briefly, redirect to [Telegram](https://t.me/boringdystopiadevelopment), close if needed.
 
-- Add `enhancement` if needed.
-- Add `confirmed` when maintainers agree it is a valid direction worth tracking.
-- Add `P0` only if it is truly urgent.
+**PRs are a separate surface.** External PRs get category labels only
+(`bug`/`enhancement`) and do not enter the triage state machine. See
+[`docs/agents/issue-tracker.md`](agents/issue-tracker.md) for the full PR
+triage policy.
 
-### Support issues
-
-- Reply briefly.
-- Redirect the user to Telegram.
-- Close if needed.
+This guide covers only repo-specific routing. The `triage` skill and
+`triage-labels.md` handle label application and state transitions.
 
 ## Closing Policy
 


### PR DESCRIPTION
What changed, and why was it needed?

The label taxonomy was split across `maintainers.md`, `triage-labels.md`, and `AGENTS.md` with no clear owner, and two GitHub labels (`confirmed`, `P0`) existed but were undocumented and only ever used on closed issues. This PR makes `docs/agents/triage-labels.md` the single source of truth, reconciles `docs/maintainers.md` to it, and removes the dead labels.

## What problem are you solving?

The triage label taxonomy had no single owner: `maintainers.md` listed labels (including the dead `confirmed`/`P0`), `triage-labels.md` listed them as "outside taxonomy", and `AGENTS.md`'s triage section was thin and omitted `community-preset`, the `triage` skill install command, and the PR policy pointer. `confirmed`/`P0` were ghost labels — present in the tracker but undocumented and unused on any open issue (only on closed ones).

## What does this change?

`docs/agents/triage-labels.md` is now the canonical label taxonomy (source of truth); `docs/maintainers.md` routes to it instead of duplicating the list, its triage flow is rewritten (issues → `/triage`, PRs → `issue-tracker.md`), `confirmed`/`P0` are dropped, `community-preset` submission is documented, and prose is humanized. `AGENTS.md` triage section and `docs/agents/domain.md` are updated to cross-reference the source of truth.

## Why this approach?

Picking one file as the source of truth removes the drift that caused the inconsistency; the other docs defer to it. Deleting `confirmed`/`P0` (only on closed issues, no open triage impact) is the minimal cleanup. No alternative was seriously considered — the goal was purely to stop duplicating the label list across files.

## Related work

- [x] I checked open AND closed PRs/issues for duplicates
- Related: builds on merged #706 (domain glossary + triage label mapping) and #760 (triage tracker config); no open duplicate found.

## AI assistance (optional)

- Model / harness: OpenCode (hy3-free) with @oracle (hy3-free) code review and @skeptic (hy3-free) receiving-code-review subagents; ponytail skill active.
- Human reviewed the full diff? [x] — approved by user before submission.

## Checklist

- [x] `bun run check:ci`, `bun run typecheck`, and `bun test` pass
- [x] Docs updated if behavior/commands changed — no behavior/command/config change; docs-only, so no README update required (stated explicitly)
- [x] One logical change per PR
- [x] PR targets the `master` branch

See CONTRIBUTING.md for full contribution guidance.
