### PR TITLE
fix: place AGENTS.md before orchestrator prompt in system order

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1126,12 +1126,12 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
             s.includes('orchestrator'),
         );
         if (!alreadyInjected) {
-          // Prepend the orchestrator prompt to the system array. Use the
-          // resolved prompt from the orchestrator agent definition (which
-          // includes any custom replacement or append from orchestrator.md
-          // / orchestrator_append.md) Fall back to
-          // buildOrchestratorPrompt only if the resolved prompt is
-          // missing.
+          // Place the orchestrator prompt after AGENTS.md so the user's
+          // behavioral rules (language, code conventions, etc.) retain
+          // their intended priority. AGENTS.md is injected by OpenCode
+          // core into system[0]; prepending the orchestrator prompt before
+          // it buries user-defined rules under thousands of lines of
+          // orchestration instructions.
           const orchestratorDef = agentDefs.find(
             (a) => a.name === 'orchestrator',
           );
@@ -1140,8 +1140,8 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
               ? orchestratorDef.config.prompt
               : buildOrchestratorPrompt(disabledAgents);
           output.system[0] =
-            orchestratorPrompt +
-            (output.system[0] ? `\n\n${output.system[0]}` : '');
+            (output.system[0] || '') +
+            `\n\n${orchestratorPrompt}`;
         }
       }
 


### PR DESCRIPTION
## Problem

The `experimental.chat.system.transform` hook in `src/index.ts` prepends the orchestrator prompt to `output.system[0]`, which at that point contains the user's AGENTS.md — injected by OpenCode core as the highest-priority behavioral ruleset. By prepending the orchestrator prompt (~250 lines of English orchestration instructions), the plugin buries the user's explicitly-declared rules under thousands of tokens of its own directives.

This is not a language-specific issue. It affects all users regardless of whether their AGENTS.md is written in English or any other language. The user's code conventions, commit message formats, comment strategies, and other behavioral rules are attentionally diluted by the orchestrator prompt sitting above them.

## Fix

Append the orchestrator prompt after `output.system[0]` instead of prepending it. One-line change: swap concatenation order.

```typescript
// Before:
output.system[0] = orchestratorPrompt + (output.system[0] ? `\n\n${output.system[0]}` : '');

// After:
output.system[0] = (output.system[0] || '') + `\n\n${orchestratorPrompt}`;
```

## Risk Assessment

- The orchestrator prompt remains fully intact, just positioned after AGENTS.md instead of before it.
- The orchestrator's `&lt;Role&gt;` assignment is explicit and unambiguous regardless of position.
- Users who override the orchestrator prompt via `orchestrator.md` are unaffected — the hook already reads the resolved prompt from `agentDefs` (fixed in PR #332).
- No functional change to the hook logic — only the concatenation order is reversed.