### PR TITLE
fix(deepwork): enforce saving deliverables outside internal .slim scratchpad

### DIFF
--- a/src/hooks/deepwork/index.test.ts
+++ b/src/hooks/deepwork/index.test.ts
@@ -69,6 +69,7 @@ describe('deepwork command hook', () => {
     );
     expect(output.parts[0].text).toContain('git-local yet OpenCode-readable');
     expect(output.parts[0].text).toContain('.slim/deepwork/');
+    expect(output.parts[0].text).toContain('save code/doc deliverables');
     expect(output.parts[0].text).toContain('@oracle');
     expect(output.parts[0].text).toContain('simplify/readability');
     expect(output.parts[0].text).toContain('refactor scheduler state');

--- a/src/hooks/deepwork/index.ts
+++ b/src/hooks/deepwork/index.ts
@@ -10,6 +10,7 @@ function activationPrompt(task: string): string {
     'Deepwork requirements:',
     '- before planning, delegation, or creating state, inspect existing `.gitignore` and `.ignore`; add only missing entries without duplicates: `.gitignore` must contain `.slim/deepwork/`, and `.ignore` must contain `!.slim/deepwork/` and `!.slim/deepwork/**`; this keeps state git-local yet OpenCode-readable;',
     '- create/update a `.slim/deepwork/` progress file;',
+    '- save code/doc deliverables to project paths (e.g. `src/`, `docs/`); reserve `.slim/deepwork/` strictly for progress files;',
     '- keep OpenCode todos synced with the current phase;',
     '- draft a plan and get `@oracle` review before implementation;',
     '- create and review a phased implementation/delegation plan;',

--- a/src/skills/deepwork/SKILL.md
+++ b/src/skills/deepwork/SKILL.md
@@ -27,6 +27,8 @@ Required behavior:
   `!.slim/deepwork/` and `!.slim/deepwork/**`;
 - keep OpenCode todos aligned with the active deepwork phase;
 - create and maintain a local markdown progress file under `.slim/deepwork/`;
+- save code/doc deliverables to project paths (e.g. `src/`, `docs/`); reserve
+  `.slim/deepwork/` strictly for progress files;
 - write valuable research findings into that file as confirmed research context
   when they are received and reconciled;
 - draft a plan before implementation;


### PR DESCRIPTION
## Overview

During high-risk coding sessions using `/deepwork`, agents managed progress by updating internal files under `.slim/deepwork/`. However, the prompt lacked clear directives distinguishing internal progress state files from final session deliverables. As a result, agents occasionally left finished deliverables exclusively inside the `.slim/deepwork/` scratchpad or under draft filenames instead of writing them to actual project target paths (e.g., `src/`, `docs/`).

This PR adds a concise, non-suppressive prompt rule to both the Deepwork activation prompt (`src/hooks/deepwork/index.ts`) and the Deepwork skill card (`src/skills/deepwork/SKILL.md`) to explicitly direct deliverables to project paths while reserving `.slim/deepwork/` strictly for progress tracking.

## Changes Included

- **`src/hooks/deepwork/index.ts`**: Updated `activationPrompt` requirement list with concise, role-budgeted directive:
  `- save code/doc deliverables to project paths (e.g. \`src/\`, \`docs/\`); reserve \`.slim/deepwork/\` strictly for progress files;`
- **`src/skills/deepwork/SKILL.md`**: Updated required behavior under Core Contract to match prompt convention and line formatting limits.
- **`src/hooks/deepwork/index.test.ts`**: Updated unit tests to assert the new activation prompt requirement.

## Verification

- `bun run check:ci` (Biome linters and code formatters) passed without errors.
- `bun run typecheck` (TypeScript) passed without errors.
- `bun test` passed 1,562 tests across 92 test files.