### PR TITLE
fix(cli): use node shebang so npx/npm install works without bun

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,13 @@ Install and configure oh-my-opencode-slim: https://raw.githubusercontent.com/alv
 bunx oh-my-opencode-slim@latest install
 ```
 
+The published CLI is a Node-compatible bundle, so `npx` works too if you don't
+have Bun installed:
+
+```bash
+npx oh-my-opencode-slim@latest install
+```
+
 ### Run from Master
 
 Use this if you want the latest code, easier bug fixes, or a local setup for

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env bun
+#!/usr/bin/env node
 import { doctor, parseDoctorArgs } from './doctor';
 import { install } from './install';
 import { getGeneratedPresetNames, isGeneratedPresetName } from './providers';


### PR DESCRIPTION
## What changed, and why was it needed?

Running the installer without Bun fails at the shebang:

```
$ npx oh-my-opencode-slim@latest install
/usr/bin/env: 'bun': No such file or directory
```

The only thing forcing a Bun runtime is the `#!/usr/bin/env bun` shebang on the CLI entrypoint (`src/cli/index.ts`). The CLI bundle itself is already Node-compatible:

- It's built with `bun build src/cli/index.ts --target node --format esm`.
- No Bun-specific runtime is used in the CLI path. `Bun.*` only appears in `src/tui.ts` (the plugin TUI, a separate bundle) and a comment in `src/utils/compat.ts`; `bun:test` / `bun:sqlite` only appear in tests and skill docs.
- Verified locally: `node dist/cli/index.js install` completes all 9 install steps on a machine with no Bun installed.

This PR switches the entrypoint shebang to `node`. Bun's bundler preserves the entrypoint shebang, so the published `dist` picks this up automatically on the next build — no build-config change needed. The CLI stays fully compatible with Bun (`bunx` still works).

Also documents the `npx` install path in the README next to the existing `bunx` one.

### Scope

- `src/cli/index.ts` — shebang `bun` → `node` (1 line)
- `README.md` — add `npx` install snippet

`prepare: bun run build` is intentionally left as-is: it only runs for git/source installs (a dev-time build chain), while registry installs via npx/npm ship the prebuilt `dist` and never invoke it.