### PR TITLE
fix: abort child session on signal cancel + early-register board job from session.created

### DIFF
--- a/src/hooks/task-session-manager/index.test.ts
+++ b/src/hooks/task-session-manager/index.test.ts
@@ -2281,6 +2281,50 @@ describe('task-session-manager hook', () => {
     });
   });
 
+  test('session.created early-registers board job so after-hook cancellation cannot orphan the child', async () => {
+    // Reproduces #765: parent tool may be cancelled before tool.execute.after,
+    // so the job never lands on the board. Early registration from
+    // session.created keeps runningJobForSession true and lets idle reconcile.
+    const board = new BackgroundJobBoard();
+    const { hook } = createHook({ backgroundJobBoard: board });
+
+    await hook['tool.execute.before'](
+      { tool: 'task', sessionID: 'parent-1', callID: 'call-1' },
+      {
+        args: {
+          subagent_type: 'oracle',
+          description: 'loss design review',
+        },
+      },
+    );
+
+    // Child session is created while the parent tool is still in flight.
+    await hook.event({
+      event: {
+        type: 'session.created',
+        properties: { info: { id: 'child-1', parentID: 'parent-1' } },
+      },
+    });
+
+    expect(board.get('child-1')).toMatchObject({
+      state: 'running',
+      agent: 'oracle',
+      parentSessionID: 'parent-1',
+      description: 'loss design review',
+    });
+
+    // Simulate parent tool never firing tool.execute.after (cancelled).
+    // Child goes idle after finishing — board must still reconcile.
+    await hook.event({
+      event: { type: 'session.idle', properties: { sessionID: 'child-1' } },
+    });
+
+    expect(board.get('child-1')).toMatchObject({
+      state: 'reconciled',
+      terminalState: 'completed',
+    });
+  });
+
   test('cancelled job is not reconciled from idle', async () => {
     const board = new BackgroundJobBoard();
     board.registerLaunch({

--- a/src/hooks/task-session-manager/index.ts
+++ b/src/hooks/task-session-manager/index.ts
@@ -660,6 +660,35 @@ export function createTaskSessionManagerHook(
           options.shouldManageSession(info.parentID)
         ) {
           taskContextTracker.pendingManagedTaskIds.add(info.id);
+          // Early board registration: if the parent tool call is cancelled
+          // before tool.execute.after (e.g. foreground fallback abort), the
+          // after-hook never fires and the job is never tracked — idle then
+          // reports runningJobForSession:false and the orchestrator sees
+          // "Task cancelled" while the child is still working (#765).
+          // Peek (don't take) so tool.execute.after can still re-register.
+          const pending = pendingCallTracker.peekByParent(info.parentID);
+          if (
+            pending &&
+            !pending.resumedTaskId &&
+            !backgroundJobBoard.get(info.id)
+          ) {
+            const record = backgroundJobBoard.registerLaunch({
+              taskID: info.id,
+              parentSessionID: pending.parentSessionId,
+              agent: pending.agentType,
+              description: pending.label,
+              objective: pending.label,
+            });
+            log(
+              '[task-session-manager] early board registration from session.created',
+              {
+                taskID: record.taskID,
+                alias: record.alias,
+                parentSessionID: record.parentSessionID,
+                agent: record.agent,
+              },
+            );
+          }
         }
         return;
       }

--- a/src/hooks/task-session-manager/pending-call-tracker.ts
+++ b/src/hooks/task-session-manager/pending-call-tracker.ts
@@ -39,6 +39,14 @@ export function createPendingCallTracker() {
       return pending;
     },
 
+    /** Peek oldest pending call for a parent without removing it. */
+    peekByParent(parentSessionId: string) {
+      for (const call of pendingCalls.values()) {
+        if (call.parentSessionId === parentSessionId) return call;
+      }
+      return undefined;
+    },
+
     clearSession(sessionId: string) {
       for (const [callId, pending] of pendingCalls.entries()) {
         if (pending.parentSessionId === sessionId) {

--- a/src/utils/session.test.ts
+++ b/src/utils/session.test.ts
@@ -55,6 +55,10 @@ describe('session utilities', () => {
     await expect(
       promptWithTimeout(client, { path: { id: 's1' }, body: { parts: [] } }, 5),
     ).rejects.toThrow('Prompt timed out after 5ms');
+
+    // Abort must still be attempted even though it threw; the original
+    // timeout error is preserved.
+    expect(abort).toHaveBeenCalledWith({ path: { id: 's1' } });
   });
 
   test('promptWithTimeout honors abort signal when timeout is disabled', async () => {
@@ -78,6 +82,11 @@ describe('session utilities', () => {
         controller.signal,
       ),
     ).rejects.toThrow('Prompt cancelled');
+
+    // Signal cancel must abort the server-side session, same as timeout.
+    // Without this, the parent tool returns cancelled while the child keeps
+    // running (orphan session).
+    expect(abort).toHaveBeenCalledWith({ path: { id: 's1' } });
   });
 
   test('promptWithTimeout returns when prompt resolves with no timeout', async () => {

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -142,11 +142,17 @@ export async function promptWithTimeout(
 
     await Promise.race(racers);
   } catch (error) {
-    if (error instanceof OperationTimeoutError) {
+    // Abort the server-side session on timeout OR signal cancel. Without
+    // the signal branch, a cancelled parent tool leaves the child running
+    // as an orphan ("Task cancelled" to the orchestrator, child still
+    // working). Match by error identity, not `signal.aborted`, so an
+    // unrelated rejection overlapping a signal abort does not fire an
+    // extra abort round-trip.
+    if (isPromptCancellationError(error)) {
       try {
         await abortSessionWithTimeout(client, sessionId);
       } catch {
-        // Best-effort cleanup: preserve the original prompt timeout error.
+        // Best-effort: preserve the original error.
       }
     }
     throw error;
@@ -154,6 +160,12 @@ export async function promptWithTimeout(
     clearTimeout(timer);
     if (onAbort) signal?.removeEventListener('abort', onAbort);
   }
+}
+
+/** OperationTimeoutError or our own "Prompt cancelled" Error. */
+function isPromptCancellationError(error: unknown): boolean {
+  if (error instanceof OperationTimeoutError) return true;
+  return error instanceof Error && error.message === 'Prompt cancelled';
 }
 
 /**


### PR DESCRIPTION
## What changed, and why was it needed?

Two related causes of the **"Task cancelled" while the child session is still running** symptom (#765 still reproduces after #769; also observed on v2.2.2 in real orchestrator sessions).

### 1. `promptWithTimeout` does not abort the child session on signal cancel

`src/utils/session.ts` aborted the server-side session on **timeout** (`OperationTimeoutError`) but **not** on `AbortSignal` cancel — it only rejected the local race with `"Prompt cancelled"`. Since `client.session.prompt(args)` runs server-side, the child session keeps working after the parent tool call returns cancelled. Result: an **orphan session** that is still running in the Background Job Board while the orchestrator has already moved on.

The repo already does the right thing elsewhere (`src/tools/acp-run.ts` registers `ctx.abort.addEventListener('abort', () => client.close())`); this aligns `promptWithTimeout` with that pattern.

**Fix:** also call `abortSessionWithTimeout` when `signal?.aborted === true`. Best-effort, preserves the original error.

### 2. Job never reaches the board when `tool.execute.after` is skipped

#765 was traced (see issue comments by @mhenke) to the case where a foreground-fallback abort cancels the parent tool call **before** `tool.execute.after` fires. The after-hook is the only place the job is registered on `BackgroundJobBoard`, so `runningJobForSession` is `false` at idle time and the task is reported cancelled even though the child is actively working. #769 guarded the case where the job was registered and then dropped; this is the case where it was **never** registered.

**Fix:** in the `session.created` event handler, **peek** (not take) the pending call for the parent and early-register the job. Peeking means `tool.execute.after` can still `registerLaunch` / `updateStatus` later (`BackgroundJobBoard.registerLaunch` is idempotent). If the after-hook fires, nothing changes; if it is skipped, the job is already tracked and idle reconciliation works.

## Changes

- `src/utils/session.ts`: extend the `catch` to abort on `signal.aborted` as well as `OperationTimeoutError`.
- `src/utils/session.test.ts`: assert `abort` is called on signal-driven cancel.
- `src/hooks/task-session-manager/pending-call-tracker.ts`: add `peekByParent(parentSessionId)`.
- `src/hooks/task-session-manager/index.ts`: in `session.created`, if a pending call exists for the parent and the board has no entry for the new child id, `registerLaunch` it early.
- `src/hooks/task-session-manager/index.test.ts`: regression test — `session.created` keeps the job tracked through idle even when `tool.execute.after` is never called.

## Validation

- `bun test` — 1594 pass / 0 fail (incl. new regression test).
- `bun run typecheck` — clean.
- `bun run check:ci` — clean.

Refs #765.