### PR TITLE
fix(task-session-manager): record non-retryable session errors on job board

### DIFF
--- a/src/hooks/task-session-manager/index.test.ts
+++ b/src/hooks/task-session-manager/index.test.ts
@@ -1494,6 +1494,69 @@ describe('task-session-manager hook', () => {
     });
   });
 
+  test('non-retryable session.error marks running job as error on board', async () => {
+    const board = new BackgroundJobBoard();
+    const { hook } = createHook({ backgroundJobBoard: board });
+
+    board.registerLaunch({
+      taskID: 'child-1',
+      parentSessionID: 'parent-1',
+      agent: 'oracle',
+      description: 'review plan',
+    });
+    board.updateStatus({ taskID: 'child-1', state: 'running' });
+
+    await hook.event({
+      event: {
+        type: 'session.error',
+        properties: {
+          sessionID: 'child-1',
+          error: {
+            name: 'UnknownError',
+            message: 'LLM proxy connection refused',
+          },
+        },
+      },
+    });
+
+    const job = board.get('child-1');
+    expect(job?.state).toBe('error');
+    expect(job?.resultSummary).toBe('LLM proxy connection refused');
+  });
+
+  test('session.idle does not overwrite error state with completed', async () => {
+    const board = new BackgroundJobBoard();
+    const { hook } = createHook({ backgroundJobBoard: board });
+
+    board.registerLaunch({
+      taskID: 'child-1',
+      parentSessionID: 'parent-1',
+      agent: 'oracle',
+      description: 'review plan',
+    });
+    board.updateStatus({
+      taskID: 'child-1',
+      state: 'error',
+      resultSummary: 'connection refused',
+    });
+
+    const messages = createMessages('parent-1', 'continue');
+    await hook['experimental.chat.messages.transform']({}, messages);
+
+    await hook.event({
+      event: {
+        type: 'session.idle',
+        properties: {
+          info: { id: 'child-1', parentID: 'parent-1' },
+        },
+      },
+    });
+
+    const job = board.get('child-1');
+    expect(job?.state).toBe('error');
+    expect(job?.resultSummary).toBe('connection refused');
+  });
+
   test('completed reconciled job appears reusable and resumes via task', async () => {
     const board = new BackgroundJobBoard();
     const { hook } = createHook({ backgroundJobBoard: board });

--- a/src/hooks/task-session-manager/index.ts
+++ b/src/hooks/task-session-manager/index.ts
@@ -1051,7 +1051,7 @@ export function createTaskSessionManagerHook(
             // Record non-retryable errors on the job board so the
             // orchestrator sees the failure instead of a false completion.
             const job = backgroundJobBoard.get(sessionId);
-            if (job) {
+            if (job && job.state === 'running') {
               backgroundJobBoard.updateStatus({
                 taskID: sessionId,
                 state: 'error',

--- a/src/hooks/task-session-manager/index.ts
+++ b/src/hooks/task-session-manager/index.ts
@@ -1048,6 +1048,18 @@ export function createTaskSessionManagerHook(
             | undefined;
           if (!props?.error || !isFailoverError(props.error)) {
             terminalJobsInjectedByParent.delete(sessionId);
+            // Record non-retryable errors on the job board so the
+            // orchestrator sees the failure instead of a false completion.
+            const job = backgroundJobBoard.get(sessionId);
+            if (job) {
+              backgroundJobBoard.updateStatus({
+                taskID: sessionId,
+                state: 'error',
+                resultSummary:
+                  (props?.error as { message?: string } | undefined)?.message ??
+                  'Session error',
+              });
+            }
           }
         }
 


### PR DESCRIPTION
Fixes #478

## What problem are you solving?

When a subagent session hits a non-retryable error (LLM proxy failure, connection refused), the `session.error` handler clears timers but never updates the background job board. The job stays `running`. When `session.idle` fires later, it sees a `running` job and marks it `completed` with "Background task completed (reconciled from idle event)". The orchestrator reports the agent as having answered successfully when it actually errored.

## What does this change?

The `session.error` handler now records non-retryable errors on the job board with `state: 'error'` and the error message as the result summary. The existing idle handler guard (`job.state === 'running'`) naturally skips error-state jobs — no idle handler changes needed.

## Why this approach?

The board already supports `error` state. A single `updateStatus` call in the error handler is all that is needed — 8 lines. The idle handler's existing `job.state === 'running'` guard skips error jobs without any changes.

## Related work

- [x] I checked open AND closed PRs/issues for duplicates
- Related: #478

## AI assistance

- pi (Claude) — no subagents
- Human reviewed the full diff? [x]

## Checklist

- [x] `bun run check:ci`, `bun run typecheck`, and `bun test` pass
- [x] Docs: no behavior/command/config change
- [x] One logical change per PR
- [x] PR targets the `master` branch