### PR TITLE
feat: add /report-issue skill for filing GitHub issues with scrubbed logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ companion/target/
 .codegraph/
 companion/VIDEOS/
 .worktrees/
+
+# Skill eval artifacts (benchmark outputs, not source)
+src/skills/*/evals/

--- a/codemap.md
+++ b/codemap.md
@@ -53,6 +53,7 @@ This codemap covers the plugin repository itself and excludes the nested `openco
 | `src/skills/codemap/` | Repository-mapping skill package and codemap state-management script. | [View Map](src/skills/codemap/codemap.md) |
 | `src/skills/clonedeps/` | Workflow-only dependency source mirroring skill that routes discovery/ref resolution through librarian and direct orchestrator git operations. | [View Map](src/skills/clonedeps/codemap.md) |
 | `src/skills/simplify/` | Behavior-preserving simplification skill package. | [View Map](src/skills/simplify/codemap.md) |
+| `src/skills/report-issue/` | Files a GitHub issue for this plugin with environment info and model-scrubbed logs. | [View Map](src/skills/report-issue/SKILL.md) |
 | `src/tools/` | Tool and runtime-command export surface for AST-grep, smartfetch, council orchestration, and `/preset` switching. | [View Map](src/tools/codemap.md) |
 | `src/tools/ast-grep/` | AST-grep binary management and AST-aware search/replace tool flow. | [View Map](src/tools/ast-grep/codemap.md) |
 | `src/tools/smartfetch/` | Fetch/extract/cache pipeline for web content and secondary-model summarization. | [View Map](src/tools/smartfetch/codemap.md) |

--- a/src/cli/custom-skills-registry.ts
+++ b/src/cli/custom-skills-registry.ts
@@ -74,7 +74,7 @@ export const CUSTOM_SKILLS: CustomSkill[] = [
     name: 'report-issue',
     description:
       'File a GitHub issue for oh-my-opencode-slim with environment info and scrubbed logs',
-    allowedAgents: ['*'],
+    allowedAgents: ['orchestrator'],
     sourcePath: 'src/skills/report-issue',
   },
 ];

--- a/src/cli/custom-skills-registry.ts
+++ b/src/cli/custom-skills-registry.ts
@@ -74,7 +74,7 @@ export const CUSTOM_SKILLS: CustomSkill[] = [
     name: 'report-issue',
     description:
       'File a GitHub issue for oh-my-opencode-slim with environment info and scrubbed logs',
-    allowedAgents: ['orchestrator'],
+    allowedAgents: ['*'],
     sourcePath: 'src/skills/report-issue',
   },
 ];

--- a/src/cli/custom-skills-registry.ts
+++ b/src/cli/custom-skills-registry.ts
@@ -70,4 +70,11 @@ export const CUSTOM_SKILLS: CustomSkill[] = [
     allowedAgents: ['orchestrator'],
     sourcePath: 'src/skills/worktrees',
   },
+  {
+    name: 'report-issue',
+    description:
+      'File a GitHub issue for oh-my-opencode-slim with environment info and scrubbed logs',
+    allowedAgents: ['orchestrator'],
+    sourcePath: 'src/skills/report-issue',
+  },
 ];

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -16,5 +16,6 @@ export { createLoopCommandHook } from './loop-command';
 export { createPhaseReminderHook } from './phase-reminder';
 export { createPostFileToolNudgeHook } from './post-file-tool-nudge';
 export { createReflectCommandHook } from './reflect';
+export { createReportIssueCommandHook } from './report-issue-command';
 export { SessionLifecycle } from './session-lifecycle';
 export { createTaskSessionManagerHook } from './task-session-manager';

--- a/src/hooks/report-issue-command/index.ts
+++ b/src/hooks/report-issue-command/index.ts
@@ -6,8 +6,8 @@ const COMMAND_NAME = 'report-issue';
 function activationPrompt(text: string): string {
   return [
     'The user ran `/report-issue`. Follow the `report-issue` skill',
-    'instructions (gather environment + plugin logs first, scrub secrets,',
-    'draft, confirm before submitting).',
+    'instructions (finalize issue details first, then collect environment +',
+    'relevant plugin log, scrub secrets, draft, confirm before submitting).',
     '',
     `User's request: ${text}`,
   ].join('\n');

--- a/src/hooks/report-issue-command/index.ts
+++ b/src/hooks/report-issue-command/index.ts
@@ -1,0 +1,59 @@
+import { createInternalAgentTextPart } from '../../utils';
+import { registerCommandHook } from '../command-hook-utils';
+
+const COMMAND_NAME = 'report-issue';
+
+function activationPrompt(text: string): string {
+  return [
+    'The user ran `/report-issue`. Follow the `report-issue` skill',
+    'instructions (gather environment + plugin logs first, scrub secrets,',
+    'draft, confirm before submitting).',
+    '',
+    `User's request: ${text}`,
+  ].join('\n');
+}
+
+function helpPrompt(): string {
+  return [
+    'Usage: `/report-issue <description>`',
+    '',
+    'File a GitHub issue for oh-my-opencode-slim with scrubbed logs.',
+    '',
+    'Examples:',
+    '  `/report-issue the council summary is too verbose`',
+    '  `/report-issue feature: add a dry-run flag to /preset`',
+    '  `/report-issue bug: /reflect hangs on large conversations`',
+  ].join('\n');
+}
+
+export function createReportIssueCommandHook(): {
+  registerCommand: (config: Record<string, unknown>) => void;
+  handleCommandExecuteBefore: (
+    input: { command: string; sessionID: string; arguments: string },
+    output: { parts: Array<{ type: string; text?: string }> },
+  ) => Promise<void>;
+} {
+  return {
+    registerCommand: (opencodeConfig) => {
+      registerCommandHook(
+        opencodeConfig,
+        COMMAND_NAME,
+        'File a GitHub issue for oh-my-opencode-slim with scrubbed logs',
+        'Collect env + logs, scrub secrets, draft, confirm, submit via issue form.',
+      );
+    },
+
+    handleCommandExecuteBefore: async (input, output) => {
+      if (input.command !== COMMAND_NAME) return;
+
+      output.parts.length = 0;
+      const args = input.arguments.trim();
+      if (!args) {
+        output.parts.push(createInternalAgentTextPart(helpPrompt()));
+        return;
+      }
+
+      output.parts.push({ type: 'text', text: activationPrompt(args) });
+    },
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ import {
   createPhaseReminderHook,
   createPostFileToolNudgeHook,
   createReflectCommandHook,
+  createReportIssueCommandHook,
   createTaskSessionManagerHook,
   ForegroundFallbackManager,
   SessionLifecycle,
@@ -156,6 +157,7 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
   let deepworkCommandHook: ReturnType<typeof createDeepworkCommandHook>;
   let reflectCommandHook: ReturnType<typeof createReflectCommandHook>;
   let loopCommandHook: ReturnType<typeof createLoopCommandHook>;
+  let reportIssueCommandHook: ReturnType<typeof createReportIssueCommandHook>;
   let taskSessionManagerHook: ReturnType<typeof createTaskSessionManagerHook>;
   let phaseReminder: ReturnType<typeof createPhaseReminderHook>;
   let filterAvailableSkills: ReturnType<typeof createFilterAvailableSkillsHook>;
@@ -320,6 +322,7 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
     deepworkCommandHook = createDeepworkCommandHook();
     reflectCommandHook = createReflectCommandHook();
     loopCommandHook = createLoopCommandHook();
+    reportIssueCommandHook = createReportIssueCommandHook();
     taskSessionManagerHook = createTaskSessionManagerHook(ctx, {
       maxSessionsPerAgent:
         config.backgroundJobs?.maxSessionsPerAgent ??
@@ -865,6 +868,7 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
       deepworkCommandHook.registerCommand(opencodeConfig);
       reflectCommandHook.registerCommand(opencodeConfig);
       loopCommandHook.registerCommand(opencodeConfig);
+      reportIssueCommandHook.registerCommand(opencodeConfig);
       presetManager.registerCommand(opencodeConfig);
     },
 
@@ -1057,6 +1061,15 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
       );
 
       await loopCommandHook.handleCommandExecuteBefore(
+        input as {
+          command: string;
+          sessionID: string;
+          arguments: string;
+        },
+        output as { parts: Array<{ type: string; text?: string }> },
+      );
+
+      await reportIssueCommandHook.handleCommandExecuteBefore(
         input as {
           command: string;
           sessionID: string;

--- a/src/skills/report-issue/SKILL.md
+++ b/src/skills/report-issue/SKILL.md
@@ -58,7 +58,8 @@ some of it):
 Tell the user up front: **do not paste API keys, tokens, or passwords into the
 description.** The scrubber only protects the plugin log, not free text. Also
 warn that the issue is filed on a **public** repo, so review the draft for
-secrets before approving.
+secrets before approving. Likewise avoid absolute file paths (e.g.
+`/Users/john/...`) in the description — use relative paths or `~`.
 
 ### 3. Scrub the log
 
@@ -83,7 +84,8 @@ draft before submit, but you are the first line of defense.
 
 ### 4. Draft the issue body
 
-Write the draft to a temp file (e.g. `/tmp/omos-issue.md`) using this template:
+Write the draft to a unique temp file (e.g. `/tmp/omos-issue-$(date +%s).md`)
+to avoid clobbering a prior draft, using this template:
 
 ```markdown
 ## Description
@@ -135,12 +137,16 @@ approve, edit, or cancel. Do not run `gh` until they approve.
 
 If `gh` is available and the user approved:
 
+Check `gh auth status` first. If not authenticated, tell the user to run
+`gh auth login` (or paste the draft manually at the URL below) — do not attempt
+the create.
+
 ```bash
 gh issue create \
   --repo alvinunreal/oh-my-opencode-slim \
   --title "<title>" \
   --label "<type>" \
-  --body-file /tmp/omos-issue.md
+  --body-file /tmp/omos-issue-$(date +%s).md
 ```
 
 - `<type>` is `bug` or `enhancement` from step 1; the label carries the

--- a/src/skills/report-issue/SKILL.md
+++ b/src/skills/report-issue/SKILL.md
@@ -25,12 +25,39 @@ draft. That confirm step is the safety net — do not skip it.
 
 ## Workflow
 
-Start the collection work immediately — gather environment and plugin logs
-**before** or alongside asking the user for details. This way the draft (and
-secret redaction) is always reached even in a single-shot turn, and you are not
-blocked waiting on the user's title.
+Get the issue clear first, then pull the supporting context. This keeps the
+log relevant to what the user is actually reporting, and still reaches a draft
+in a single shot (the user's first message is usually the description).
 
-### 1. Collect environment and logs (do this first)
+### 1. Finalize the issue details (do this first)
+
+Get these four fields settled **before** moving on to logs — they shape the
+whole draft and tell you which log lines matter:
+
+- **Description** — what happened and reproduction steps. For a `bug`, also ask
+  for expected vs actual behavior; for an `enhancement`, ask what behavior the
+  user wants. This is the core of the report.
+- **Title** — short, specific, actionable summary (under ~72 chars). No need
+  for a `[Bug]`/`[Feature]` prefix; the type label carries that.
+- **Type** — `bug` or `enhancement`.
+- **Skill/command** — which omos agent, skill, or command was in use when it
+  broke (helps triage; optional).
+
+Do not proceed to log collection until these are finalized. **Never assume any
+of the four** — if a field is missing or ambiguous, ask for that one field
+specifically (one question at a time), and wait for the answer before asking the
+next. Do not invent a title, guess a type, or infer a description from context.
+Only once all four are explicitly confirmed by the user do you move to logs.
+
+Tell the user up front: **do not paste API keys, tokens, or passwords into the
+description.** The scrubber only protects the plugin log, not free text. Also
+warn that the issue is filed on a **public** repo, so review the draft for
+secrets before approving. Likewise avoid absolute file paths (e.g.
+`/Users/john/...`) in the description — use relative paths or `~`.
+
+### 2. Collect environment and the relevant plugin log
+
+Now that you know what broke, gather the supporting context:
 
 Gather the environment yourself — OS, OpenCode version, this plugin's version,
 Node/Bun versions, and the shell. Run whatever command fits the platform; if a
@@ -39,27 +66,11 @@ value is unavailable, record `unknown` rather than failing.
 Locate the most recent plugin log. The directory is `$OPENCODE_LOG_DIR` if set,
 otherwise `~/.local/share/opencode/log` (macOS/Linux) or
 `%USERPROFILE%\.local\share\opencode\log` (Windows). Pick the newest
-`oh-my-opencode-slim.*.log`. If none exists, note `[no plugin log found]`.
-
-### 2. Gather user input
-
-Ask for what you still need (one message; the user may have already volunteered
-some of it):
-
-- **Title** — short, specific, actionable summary (under ~72 chars). No need
-  for a `[Bug]`/`[Feature]` prefix; the type label carries that.
-- **Type** — `bug` or `enhancement`.
-- **Description** — what happened and reproduction steps. For a `bug`, also ask
-  for expected vs actual behavior; for an `enhancement`, ask what behavior the
-  user wants.
-- **Skill/command** — which omos agent, skill, or command was in use when it
-  broke (helps triage; optional).
-
-Tell the user up front: **do not paste API keys, tokens, or passwords into the
-description.** The scrubber only protects the plugin log, not free text. Also
-warn that the issue is filed on a **public** repo, so review the draft for
-secrets before approving. Likewise avoid absolute file paths (e.g.
-`/Users/john/...`) in the description — use relative paths or `~`.
+`oh-my-opencode-slim.*.log`. If none exists, that's fine — note
+`[no plugin log found]` and continue; the issue can still be filed without it.
+Prefer the log segment around when the reported problem occurred; if the user
+named a skill/command (step 1), scan for that in the log to pull the relevant
+lines rather than dumping the whole file.
 
 ### 3. Scrub the log
 
@@ -126,24 +137,35 @@ hundred lines is plenty for a bug report) and append
 cut at line boundaries — never split a line in half, since that can split a
 secret mid-token.
 
-### 5. Confirm
+### 5. The Iron Rule gate (approve / revise / deny)
 
-Show the **raw** draft to the user (verbatim markdown, not a rendered preview).
-State explicitly if truncation happened, and remind them the issue is filed on
-a **public** repo — review for any secrets before approving. Ask the user to
-approve, edit, or cancel. Do not run `gh` until they approve.
+This is the **only** point where the user decides. Everything above is
+automatic — you fill in env, logs, and the draft. Then present the **raw**
+draft (verbatim markdown, not a rendered preview) and offer exactly three
+choices:
 
-### 6. Submit
+- **Approve** — publish the issue to GitHub.
+- **Revise** — tell you what to change (or edit inline); you re-draft and show
+  the gate again.
+- **Deny** — discard; nothing is sent.
+
+Rules for this gate:
+
+- State explicitly if truncation happened, and remind them the issue is filed on
+  a **public** repo — review for any secrets before approving.
+- **`gh` is never run unless the user picks Approve.** No exceptions, no
+  "just creating it now", no silent submit.
+- If the user approves, only then proceed to Submit.
+
+### 6. Submit (only after explicit Approve)
 
 This repo uses GitHub **issue forms** (`.github/ISSUE_TEMPLATE/bug-report.yml`
 and `feature-request.yml`), and blank issues are disabled. So file through the
 form template, not a free-form body — a plain `--body` is rejected.
 
-If `gh` is available and the user approved:
-
-Check `gh auth status` first. If not authenticated, tell the user to run
-`gh auth login` (or paste the draft manually at the URL below) — do not attempt
-the create.
+Check `gh auth status` first. If not authenticated, do **not** attempt the
+create — tell the user to run `gh auth login` (or paste the draft manually at
+the URL below).
 
 **Bug** → use `bug-report.yml` and map fields:
 
@@ -188,7 +210,8 @@ is needed — just ask or note it.
 
 ## Safety Rules
 
-- Never run `gh issue create` without explicit user approval of the draft.
+- **Iron rule: `gh` is never called unless the user explicitly picks Approve at
+  the gate.** No publish, no draft creation, no silent submit — ever.
 - Embed the log **verbatim** after scrubbing — never paraphrase it (paraphrasing
   bypasses the scrubber).
 - The PEM tripwire refuses embedding; it does not try to scrub a key.

--- a/src/skills/report-issue/SKILL.md
+++ b/src/skills/report-issue/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: report-issue
+description: >
+  File a GitHub issue for oh-my-opencode-slim, collecting environment info and
+  recent plugin logs, scrubbing secrets, and drafting the body for confirmation
+  before submitting. Use when the user says "report an issue", "file a bug",
+  "open a GitHub issue for omos", or wants to submit a bug report or feature
+  request for this plugin — even if they don't name the skill explicitly.
+---
+
+# Report an Issue (oh-my-opencode-slim)
+
+Help the user open a well-formed GitHub issue for oh-my-opencode-slim. The point
+is a good bug report: environment + recent plugin logs + a clear description,
+with secrets scrubbed and the user confirming before anything is submitted.
+
+`gh issue create` is **never** run without the user explicitly approving the
+draft. That confirm step is the safety net — do not skip it.
+
+## When to Use
+
+- "report an issue", "file a bug", "open a GitHub issue for omos"
+- User describes a problem with the plugin and wants to submit it upstream
+- User wants to propose an enhancement to oh-my-opencode-slim
+
+## Workflow
+
+### 1. Gather user input
+
+Ask for three things (one message, can be combined if the user volunteers them):
+
+- **Title** — short, specific, actionable summary (under ~72 chars). No need
+  for a `[Bug]`/`[Feature]` prefix; the type label carries that.
+- **Type** — `bug` or `enhancement`.
+- **Description** — what happened and reproduction steps. For a `bug`, also ask
+  for expected vs actual behavior; for an `enhancement`, ask what behavior the
+  user wants.
+- **Skill/command** — which omos agent, skill, or command was in use when it
+  broke (helps triage; optional).
+
+Tell the user up front: **do not paste API keys, tokens, or passwords into the
+description.** The scrubber only protects the plugin log, not free text. Also
+warn that the issue is filed on a **public** repo, so review the draft for
+secrets before approving.
+
+### 2. Collect environment
+
+Run these and capture the output:
+
+```bash
+echo "OS: $(uname -a 2>/dev/null || echo unknown)"
+echo "OpenCode: $(opencode --version 2>/dev/null || echo unknown)"
+echo "Plugin: $(bun -e 'import {readFileSync}from"node:fs";try{const p=JSON.parse(readFileSync("package.json","utf8"));console.log(p.version)}catch{console.log("unknown")}' 2>/dev/null || echo unknown)"
+echo "Node: $(node --version 2>/dev/null || echo unknown)"
+echo "Bun: $(bun --version 2>/dev/null || echo unknown)"
+echo "Shell: $SHELL"
+```
+
+If a command is unavailable, record `unknown` rather than failing the whole step.
+
+### 3. Collect plugin logs
+
+Resolve the log directory, then take the most recent plugin log:
+
+```bash
+LOG_DIR="${OPENCODE_LOG_DIR:-$HOME/.local/share/opencode/log}"
+LOG_FILE=$(ls -t "$LOG_DIR"/oh-my-opencode-slim.*.log 2>/dev/null | head -n1)
+```
+
+- If no log file exists, set logs to `[no plugin log found]` and continue.
+- Tail the last 500 lines: `tail -n 500 "$LOG_FILE"`.
+
+Windows path note: on Windows the default is
+`%USERPROFILE%\.local\share\opencode\log`. This skill targets macOS/Linux; if
+the user is on Windows and `OPENCODE_LOG_DIR` is unset, ask them for the path.
+
+### 4. Scrub the log
+
+Run the tail through a single-pass scrubber. Use `bun -e` so no extra file is
+needed:
+
+```bash
+tail -n 500 "$LOG_FILE" | bun -e '
+const lines = require("node:fs").readFileSync(0,"utf8").split("\n");
+const home = require("node:os").homedir();
+const rules = [
+  [/(sk-[A-Za-z0-9]{20,})/g, "<REDACTED:OPENAI_KEY>"],
+  [/(xai-[A-Za-z0-9]{20,})/g, "<REDACTED:XAI_KEY>"],
+  [/(exa[A-Za-z0-9_-]*key[=:]\s*["'"'"']?[A-Za-z0-9_-]{12,})/gi, "exaApiKey=<REDACTED:EXA_KEY>"],
+  [/(Bearer\s+[A-Za-z0-9._-]{12,})/g, "Bearer <REDACTED:TOKEN>"],
+  [/(?:[\?&](?:token|access_token|auth)=)([A-Za-z0-9._-]{12,})/gi, "$1=<REDACTED:URL_TOKEN>"],
+  [/(eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,})/g, "<REDACTED:JWT>"],
+  [/(?:mongodb(?:\+srv)?|postgres(?:ql)?|mysql|redis|amqp):\/\/[^\s"'"]+/gi, "<REDACTED:DB_CONNSTR>"],
+  [/(?:ANTHROPIC_API_KEY|OPENAI_API_KEY|XAI_API_KEY|GITHUB_TOKEN|AWS_[A-Z_]+|[^A-Za-z]SECRET|[^A-Za-z]TOKEN|[^A-Za-z]KEY)\s*=\s*["'"'"']?[A-Za-z0-9\/+._-]{12,}/g, "$1=<REDACTED:SECRET>"],
+  [/(?:[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})/g, "<REDACTED:EMAIL>"],
+  [/\b(?:\d{1,3}\.){3}\d{1,3}\b/g, "<REDACTED:IP>"],
+  [/\b(?:(?:[0-9a-fA-F]{1,4}:){2,7}[0-9a-fA-F]{1,4})\b/g, "<REDACTED:IPV6>"],
+];
+let out = lines.map(l => rules.reduce((s,[re,rep]) => s.replace(re,rep), l));
+// home dir redaction (covers expanded paths the $HOME pattern misses)
+if (home) out = out.map(l => l.split(home).join("~"));
+process.stdout.write(out.join("\n"));
+'
+```
+
+**PEM tripwire (run before scrubbing):** if the raw tail contains
+`-----BEGIN (RSA |EC |DSA |OPENSSH |ENCRYPTED )?PRIVATE KEY-----`, do **not**
+embed the log. Tell the user a private key was detected, refuse to include the
+log, and continue with `Logs: [skipped — private key detected in log]`.
+
+### 5. Draft the issue body
+
+Write the draft to a temp file (e.g. `/tmp/omos-issue.md`) using this template:
+
+```markdown
+## Description
+
+<user description / repro steps>
+
+## Skill / Command
+
+<skill or command in use when it broke, or N/A>
+
+## Environment
+
+- OS: <os>
+- OpenCode: <opencode version>
+- Plugin: <plugin version>
+- Node: <node version>
+- Bun: <bun version>
+- Shell: <shell>
+
+## Plugin Logs (last 500 lines, scrubbed)
+
+<details>
+<summary>Click to expand — scrubbed plugin log</summary>
+
+```log
+<scrubbed log, or [no plugin log found] / [skipped — private key detected in log]>
+```
+
+</details>
+
+---
+🤖 This issue was created using the /report-issue skill.
+```
+
+If `--no-logs` was requested, put `Logs: [skipped by user]` in the details block
+instead of log content.
+
+Truncate at **line boundaries only**: if the scrubbed log exceeds ~6000
+characters, keep whole lines up to that limit and append
+`\n... [truncated — review may be incomplete; attach raw log manually]`. Never
+cut a line in half (that can split a secret mid-token).
+
+### 6. Confirm
+
+Show the **raw** draft to the user (verbatim markdown, not a rendered preview).
+State explicitly if truncation happened, and remind them the issue is filed on
+a **public** repo — review for any secrets before approving. Ask the user to
+approve, edit, or cancel. Do not run `gh` until they approve.
+
+### 7. Submit
+
+If `gh` is available and the user approved:
+
+```bash
+gh issue create \
+  --repo alvinunreal/oh-my-opencode-slim \
+  --title "<title>" \
+  --label "<type>" \
+  --body-file /tmp/omos-issue.md
+```
+
+- `<type>` is `bug` or `enhancement` from step 1; the label carries the
+  categorization, so the title stays prefix-free.
+- If `gh` is not installed or not authenticated, do **not** fail silently: print
+  the full draft and tell the user to paste it at
+  `https://github.com/alvinunreal/oh-my-opencode-slim/issues/new`.
+
+## Flags
+
+- `--no-logs` — skip log collection; the details block shows
+  `Logs: [skipped by user]`.
+
+## Safety Rules
+
+- Never run `gh issue create` without explicit user approval of the draft.
+- Embed the log **verbatim** after scrubbing — never paraphrase it (paraphrasing
+  bypasses the scrubber).
+- The PEM tripwire refuses embedding; it does not try to scrub a key.
+- Secrets in the user's free-text description are not scrubbed — warn upfront.

--- a/src/skills/report-issue/SKILL.md
+++ b/src/skills/report-issue/SKILL.md
@@ -31,7 +31,7 @@ in a single shot (the user's first message is usually the description).
 
 ### 1. Finalize the issue details (do this first)
 
-Get these four fields settled **before** moving on to logs — they shape the
+Get these five fields settled **before** moving on to logs — they shape the
 whole draft and tell you which log lines matter:
 
 - **Description** — what happened and reproduction steps. For a `bug`, also ask
@@ -51,7 +51,7 @@ Do not proceed to log collection until these are finalized. **Never assume any
 of the five** — if a field is missing or ambiguous, ask for that one field
 specifically (one question at a time), and wait for the answer before asking the
 next. Do not invent a title, guess a type, or infer a description from context.
-Only once all four are explicitly confirmed by the user do you move to logs.
+Only once all five are explicitly confirmed by the user do you move to logs.
 
 Tell the user up front: **do not paste API keys, tokens, or passwords into the
 description.** The scrubber only protects the plugin log, not free text. Also
@@ -168,9 +168,10 @@ Rules for this gate:
 
 ### 6. Submit (only after explicit Approve)
 
-This repo uses GitHub **issue forms** (`.github/ISSUE_TEMPLATE/bug-report.yml`
-and `feature-request.yml`), and blank issues are disabled. So file through the
-form template, not a free-form body — a plain `--body` is rejected.
+This repo provides GitHub **issue forms** (`.github/ISSUE_TEMPLATE/bug-report.yml`
+and `feature-request.yml`). We file with `--body-file` (no `--template`) so the
+label carries the categorization; a plain `--body` works via the API but the
+form-based path keeps the issue consistent with the repo's templates.
 
 Check `gh auth status` first. If not authenticated, do **not** attempt the
 create — tell the user to run `gh auth login` (or paste the draft manually at

--- a/src/skills/report-issue/SKILL.md
+++ b/src/skills/report-issue/SKILL.md
@@ -42,9 +42,13 @@ whole draft and tell you which log lines matter:
 - **Type** — `bug` or `enhancement`.
 - **Skill/command** — which omos agent, skill, or command was in use when it
   broke (helps triage; optional).
+- **Screenshots** — ask if the user has any screenshots (error UI, terminal
+  output, behavior). `gh` cannot attach files, so if they have them, they drag
+  them into the GitHub issue after it's created. Note `screenshots: <yes, drag
+  into issue> / <none>` so the user knows to attach them.
 
 Do not proceed to log collection until these are finalized. **Never assume any
-of the four** — if a field is missing or ambiguous, ask for that one field
+of the five** — if a field is missing or ambiguous, ask for that one field
 specifically (one question at a time), and wait for the answer before asking the
 next. Do not invent a title, guess a type, or infer a description from context.
 Only once all four are explicitly confirmed by the user do you move to logs.
@@ -95,8 +99,8 @@ draft before submit, but you are the first line of defense.
 
 ### 4. Draft the issue body
 
-Write the draft to a unique temp file (e.g. `/tmp/omos-issue-$(date +%s).md`)
-to avoid clobbering a prior draft, using this template:
+Prepare the draft as markdown to show the user at the Iron Rule gate (step 5),
+using this template:
 
 ```markdown
 ## Description
@@ -115,27 +119,17 @@ to avoid clobbering a prior draft, using this template:
 - Node: <node version>
 - Bun: <bun version>
 - Shell: <shell>
-
-## Plugin Logs (scrubbed)
-
-<details>
-<summary>Click to expand — scrubbed plugin log</summary>
-
-```log
-<scrubbed log, or [no plugin log found] / [skipped — private key detected in log] / [skipped by user]>
-```
-
-</details>
+- Screenshots: <yes — drag into the issue after it's created / none>
 
 ---
 🤖 This issue was created using the /report-issue skill.
 ```
 
-If the log is very long, keep it readable: trim to a sensible tail (a few
-hundred lines is plenty for a bug report) and append
-`... [truncated — review may be incomplete; attach raw log manually]`. Always
-cut at line boundaries — never split a line in half, since that can split a
-secret mid-token.
+The scrubbed plugin log is **not** inlined here — it is posted as a separate
+comment after the issue is created (see step 6), so the issue body stays
+readable. If no log was found or the user skipped it, note
+`[no plugin log found]` / `[skipped by user]` in the Environment section
+instead.
 
 ### 5. The Iron Rule gate (approve / revise / deny)
 
@@ -167,35 +161,148 @@ Check `gh auth status` first. If not authenticated, do **not** attempt the
 create — tell the user to run `gh auth login` (or paste the draft manually at
 the URL below).
 
-**Bug** → use `bug-report.yml` and map fields:
+**Bug** → use `bug-report.yml` and map fields. The log is **not** inlined
+here — put a short pointer in the logs field and post the full log as a comment
+after creation (see below):
+
+**Important — `gh` version reality:** many `gh` builds reject `--field` and
+reject `--template` together with `--body-file`. The reliable cross-version
+pattern is to write the form's fields as **YAML front matter** in a body file
+and create with `--body-file` (no `--template`, no `--field`), then apply the
+label manually. The form's field IDs are `problem` + `context`
+(`feature-request.yml`) and `what_happened`/`steps`/`config`/`opencode_version`/
+`plugin_version`/`operating_system`/`logs` (`bug-report.yml`) — but since we
+post the log as a comment, the bug form's `logs` field just gets a pointer.
+
+Write the body to a temp file, then:
+
+**Bug** → `/tmp/omos-issue-<ts>.md`:
+
+```markdown
+---
+name: Bug report
+what_happened: |-
+  <description + expected/actual>
+steps: |-
+  <repro steps>
+config: |-
+  <oh-my-opencode.json or 'omitted'>
+opencode_version: "<version>"
+plugin_version: "<plugin version>"
+operating_system: "<os>"
+logs: |-
+  Scrubbed plugin log posted as a comment below.
+---
+
+## Description
+
+<user description / repro steps>
+
+## Skill / Command
+
+<skill or command in use when it broke, or N/A>
+
+## Environment
+
+- OS: <os>
+- OpenCode: <opencode version>
+- Plugin: <plugin version>
+- Node: <node version>
+- Bun: <bun version>
+- Shell: <shell>
+- Screenshots: <yes — drag into the issue after it's created / none>
+
+---
+🤖 This issue was created using the /report-issue skill.
+```
 
 ```bash
 gh issue create \
   --repo alvinunreal/oh-my-opencode-slim \
-  --template bug-report.yml \
   --title "<title>" \
-  --field "What happened, and what did you expect?"="<description + expected/actual>" \
-  --field "Steps to reproduce"="<repro steps>" \
-  --field "oh-my-opencode.json"="<config or 'omitted'>" \
-  --field "OpenCode version"="<version>" \
-  --field "oh-my-opencode-slim version"="<plugin version>" \
-  --field "Operating system"="<os>" \
-  --field "Logs, screenshots, or extra context"="<scrubbed plugin log>"
+  --body-file /tmp/omos-issue-<ts>.md \
+  --label bug
 ```
 
-**Enhancement** → use `feature-request.yml`:
+**Enhancement** → `/tmp/omos-issue-<ts>.md`:
+
+```markdown
+---
+name: Feature request
+problem: |-
+  <what you want and why>
+context: |-
+  <optional examples/links>
+---
+
+## Description
+
+<what you want and why>
+
+## Skill / Command
+
+<skill or command, or N/A>
+
+## Environment
+
+- OS: <os>
+- OpenCode: <opencode version>
+- Plugin: <plugin version>
+- Node: <node version>
+- Bun: <bun version>
+- Shell: <shell>
+- Screenshots: <yes — drag into the issue after it's created / none>
+
+---
+🤖 This issue was created using the /report-issue skill.
+```
 
 ```bash
 gh issue create \
   --repo alvinunreal/oh-my-opencode-slim \
-  --template feature-request.yml \
   --title "<title>" \
-  --field "Description"="<what you want and why>" \
-  --field "Extra context"="<optional examples/links>"
+  --body-file /tmp/omos-issue-<ts>.md \
+  --label enhancement
 ```
 
-- The `--title` should be prefix-free (no `[Bug]`/`[Feature]`); the form's
-  `title:` prefix and `labels:` are applied by the template automatically.
+After the issue is created, post the scrubbed plugin log as a **separate
+comment** (this keeps the issue body clean and the log out of the form fields).
+Format it with the first log row shown as a visible example, then the full log
+in a collapsible block, and a clear note explaining what the comment is:
+
+```bash
+gh issue comment <issue-number> --repo alvinunreal/oh-my-opencode-slim --body-file /tmp/omos-issue-log-<ts>.md
+```
+
+Where `/tmp/omos-issue-log-<ts>.md` contains:
+
+```markdown
+> 📎 **Scrubbed plugin log** — posted as a separate comment so the issue body
+> stays readable. Secrets were redacted by the /report-issue skill. The first
+> row is shown as an example; expand below for the full log.
+
+First row (example):
+```
+<first scrubbed log line>
+```
+
+<details>
+<summary>Full scrubbed plugin log (click to expand)</summary>
+
+```log
+<scrubbed log, or [no plugin log found] / [skipped — private key detected in log] / [skipped by user]>
+```
+
+</details>
+```
+
+If no log was found or the user skipped it, post a one-line comment
+(`[no plugin log found]` / `[skipped by user]`) instead of the block above.
+
+- The `--title` should be prefix-free (no `[Bug]`/`[Feature]`); the `--label`
+  flag applies the categorization since we don't use `--template`.
+- Both `gh` calls (create + comment) are gated by the Approve choice — neither
+  runs without it.
 - If `gh` is not installed or not authenticated, do **not** fail silently: print
   the full draft and tell the user to paste it at
   `https://github.com/alvinunreal/oh-my-opencode-slim/issues/new?template=bug-report.yml`
@@ -204,9 +311,9 @@ gh issue create \
 ## Skipping logs
 
 Logs are included by default, but they are optional. If the user says not to
-include logs (or you judge them irrelevant for the report), put
-`Logs: [skipped by user]` in the details block instead of log content. No flag
-is needed — just ask or note it.
+include logs (or you judge them irrelevant for the report), skip the log comment
+and note `[skipped by user]` in the Environment section. No flag is needed —
+just ask or note it.
 
 ## Safety Rules
 

--- a/src/skills/report-issue/SKILL.md
+++ b/src/skills/report-issue/SKILL.md
@@ -67,46 +67,49 @@ LOG_DIR="${OPENCODE_LOG_DIR:-$HOME/.local/share/opencode/log}"
 LOG_FILE=$(ls -t "$LOG_DIR"/oh-my-opencode-slim.*.log 2>/dev/null | head -n1)
 ```
 
-- If no log file exists, set logs to `[no plugin log found]` and continue.
-- Tail the last 500 lines: `tail -n 500 "$LOG_FILE"`.
-
 Windows path note: on Windows the default is
 `%USERPROFILE%\.local\share\opencode\log`. This skill targets macOS/Linux; if
 the user is on Windows and `OPENCODE_LOG_DIR` is unset, ask them for the path.
 
 ### 4. Scrub the log
 
-Run the tail through a single-pass scrubber. Use `bun -e` so no extra file is
-needed:
+You are an AI model — redact secrets by reading the tailed log and applying the
+checklist below. Do **not** rely on a regex script; redact inline as you prepare
+the draft. This avoids brittle escaping and lets you catch shapes regex misses.
+
+First read the tail:
 
 ```bash
-tail -n 500 "$LOG_FILE" | bun -e '
-const lines = require("node:fs").readFileSync(0,"utf8").split("\n");
-const home = require("node:os").homedir();
-const rules = [
-  [/(sk-[A-Za-z0-9]{20,})/g, "<REDACTED:OPENAI_KEY>"],
-  [/(xai-[A-Za-z0-9]{20,})/g, "<REDACTED:XAI_KEY>"],
-  [/(exa[A-Za-z0-9_-]*key[=:]\s*["'"'"']?[A-Za-z0-9_-]{12,})/gi, "exaApiKey=<REDACTED:EXA_KEY>"],
-  [/(Bearer\s+[A-Za-z0-9._-]{12,})/g, "Bearer <REDACTED:TOKEN>"],
-  [/(?:[\?&](?:token|access_token|auth)=)([A-Za-z0-9._-]{12,})/gi, "$1=<REDACTED:URL_TOKEN>"],
-  [/(eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,})/g, "<REDACTED:JWT>"],
-  [/(?:mongodb(?:\+srv)?|postgres(?:ql)?|mysql|redis|amqp):\/\/[^\s"'"]+/gi, "<REDACTED:DB_CONNSTR>"],
-  [/(?:ANTHROPIC_API_KEY|OPENAI_API_KEY|XAI_API_KEY|GITHUB_TOKEN|AWS_[A-Z_]+|[^A-Za-z]SECRET|[^A-Za-z]TOKEN|[^A-Za-z]KEY)\s*=\s*["'"'"']?[A-Za-z0-9\/+._-]{12,}/g, "$1=<REDACTED:SECRET>"],
-  [/(?:[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})/g, "<REDACTED:EMAIL>"],
-  [/\b(?:\d{1,3}\.){3}\d{1,3}\b/g, "<REDACTED:IP>"],
-  [/\b(?:(?:[0-9a-fA-F]{1,4}:){2,7}[0-9a-fA-F]{1,4})\b/g, "<REDACTED:IPV6>"],
-];
-let out = lines.map(l => rules.reduce((s,[re,rep]) => s.replace(re,rep), l));
-// home dir redaction (covers expanded paths the $HOME pattern misses)
-if (home) out = out.map(l => l.split(home).join("~"));
-process.stdout.write(out.join("\n"));
-'
+if [ -z "$LOG_FILE" ]; then
+  echo "[no plugin log found]"
+else
+  tail -n 500 "$LOG_FILE"
+fi
 ```
 
-**PEM tripwire (run before scrubbing):** if the raw tail contains
-`-----BEGIN (RSA |EC |DSA |OPENSSH |ENCRYPTED )?PRIVATE KEY-----`, do **not**
-embed the log. Tell the user a private key was detected, refuse to include the
-log, and continue with `Logs: [skipped — private key detected in log]`.
+**PEM tripwire (check first):** If the log contains
+`-----BEGIN ... PRIVATE KEY-----` (any variant: RSA, EC, DSA, OPENSSH,
+ENCRYPTED), do **not** embed the log. Tell the user a private key was detected,
+refuse to include it, and use `Logs: [skipped — private key detected in log]`.
+
+Otherwise, redact these from the log before embedding. Replace the value with
+the marker shown — never paraphrase or summarize the log (paraphrasing bypasses
+redaction):
+
+- API keys: `sk-…`, `xai-…`, `exaApiKey=…` → `<REDACTED:API_KEY>`
+- Bearer / session tokens, and `?token=` / `?access_token=` / `?auth=` URL
+  params → `<REDACTED:TOKEN>`
+- JWTs (`eyJ… . … . …`) → `<REDACTED:JWT>`
+- DB connection strings (`mongodb://`, `postgres://`, `redis://`, etc.) →
+  `<REDACTED:DB_CONNSTR>`
+- Explicit secret env vars: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `XAI_API_KEY`,
+  `GITHUB_TOKEN`, `AWS_*` → `<REDACTED:SECRET>`
+- Absolute paths containing the user's home directory → replace with `~`
+- Any other credential-shaped value you recognize (long base64/hex strings in
+  auth contexts, passwords, tokens) → `<REDACTED:SECRET>`
+
+When in doubt, redact. The user reviews the draft before submit, but the model
+is the first line of defense.
 
 ### 5. Draft the issue body
 
@@ -178,10 +181,12 @@ gh issue create \
   the full draft and tell the user to paste it at
   `https://github.com/alvinunreal/oh-my-opencode-slim/issues/new`.
 
-## Flags
+## Skipping logs
 
-- `--no-logs` — skip log collection; the details block shows
-  `Logs: [skipped by user]`.
+Logs are included by default, but they are optional. If the user says not to
+include logs (or you judge them irrelevant for the report), put
+`Logs: [skipped by user]` in the details block instead of log content. No flag
+is needed — just ask or note it.
 
 ## Safety Rules
 

--- a/src/skills/report-issue/SKILL.md
+++ b/src/skills/report-issue/SKILL.md
@@ -45,71 +45,37 @@ secrets before approving.
 
 ### 2. Collect environment
 
-Run these and capture the output:
-
-```bash
-echo "OS: $(uname -a 2>/dev/null || echo unknown)"
-echo "OpenCode: $(opencode --version 2>/dev/null || echo unknown)"
-echo "Plugin: $(bun -e 'import {readFileSync}from"node:fs";try{const p=JSON.parse(readFileSync("package.json","utf8"));console.log(p.version)}catch{console.log("unknown")}' 2>/dev/null || echo unknown)"
-echo "Node: $(node --version 2>/dev/null || echo unknown)"
-echo "Bun: $(bun --version 2>/dev/null || echo unknown)"
-echo "Shell: $SHELL"
-```
-
-If a command is unavailable, record `unknown` rather than failing the whole step.
+Gather the environment yourself — OS, OpenCode version, this plugin's version,
+Node/Bun versions, and the shell. Run whatever command fits the platform; if a
+value is unavailable, record `unknown` rather than failing.
 
 ### 3. Collect plugin logs
 
-Resolve the log directory, then take the most recent plugin log:
-
-```bash
-LOG_DIR="${OPENCODE_LOG_DIR:-$HOME/.local/share/opencode/log}"
-LOG_FILE=$(ls -t "$LOG_DIR"/oh-my-opencode-slim.*.log 2>/dev/null | head -n1)
-```
-
-Windows path note: on Windows the default is
-`%USERPROFILE%\.local\share\opencode\log`. This skill targets macOS/Linux; if
-the user is on Windows and `OPENCODE_LOG_DIR` is unset, ask them for the path.
+Locate the most recent plugin log. The directory is `$OPENCODE_LOG_DIR` if set,
+otherwise `~/.local/share/opencode/log` (macOS/Linux) or
+`%USERPROFILE%\.local\share\opencode\log` (Windows). Pick the newest
+`oh-my-opencode-slim.*.log`. If none exists, note `[no plugin log found]`.
 
 ### 4. Scrub the log
 
-You are an AI model — redact secrets by reading the tailed log and applying the
-checklist below. Do **not** rely on a regex script; redact inline as you prepare
-the draft. This avoids brittle escaping and lets you catch shapes regex misses.
-
-First read the tail:
-
-```bash
-if [ -z "$LOG_FILE" ]; then
-  echo "[no plugin log found]"
-else
-  tail -n 500 "$LOG_FILE"
-fi
-```
+You are an AI model — redact secrets by reading the log and applying judgment.
+Do **not** run a regex script; redact inline as you prepare the draft. This
+avoids brittle escaping and lets you catch shapes regex misses.
 
 **PEM tripwire (check first):** If the log contains
 `-----BEGIN ... PRIVATE KEY-----` (any variant: RSA, EC, DSA, OPENSSH,
 ENCRYPTED), do **not** embed the log. Tell the user a private key was detected,
 refuse to include it, and use `Logs: [skipped — private key detected in log]`.
 
-Otherwise, redact these from the log before embedding. Replace the value with
-the marker shown — never paraphrase or summarize the log (paraphrasing bypasses
-redaction):
-
-- API keys: `sk-…`, `xai-…`, `exaApiKey=…` → `<REDACTED:API_KEY>`
-- Bearer / session tokens, and `?token=` / `?access_token=` / `?auth=` URL
-  params → `<REDACTED:TOKEN>`
-- JWTs (`eyJ… . … . …`) → `<REDACTED:JWT>`
-- DB connection strings (`mongodb://`, `postgres://`, `redis://`, etc.) →
-  `<REDACTED:DB_CONNSTR>`
-- Explicit secret env vars: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `XAI_API_KEY`,
-  `GITHUB_TOKEN`, `AWS_*` → `<REDACTED:SECRET>`
-- Absolute paths containing the user's home directory → replace with `~`
-- Any other credential-shaped value you recognize (long base64/hex strings in
-  auth contexts, passwords, tokens) → `<REDACTED:SECRET>`
-
-When in doubt, redact. The user reviews the draft before submit, but the model
-is the first line of defense.
+Otherwise, redact credential-shaped content before embedding: API keys
+(`sk-…`, `xai-…`, `exaApiKey=…`), bearer/session tokens and `?token=` /
+`?access_token=` / `?auth=` URL params, JWTs, DB connection strings, explicit
+secret env vars (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `XAI_API_KEY`,
+`GITHUB_TOKEN`, `AWS_*`), home-directory paths (→ `~`), and anything else that
+looks like a secret. Replace each value with a `<REDACTED:…>` marker. Never
+paraphrase or summarize the log — embed it verbatim after redaction
+(paraphrasing bypasses redaction). When in doubt, redact; the user reviews the
+draft before submit, but you are the first line of defense.
 
 ### 5. Draft the issue body
 
@@ -133,13 +99,13 @@ Write the draft to a temp file (e.g. `/tmp/omos-issue.md`) using this template:
 - Bun: <bun version>
 - Shell: <shell>
 
-## Plugin Logs (last 500 lines, scrubbed)
+## Plugin Logs (scrubbed)
 
 <details>
 <summary>Click to expand — scrubbed plugin log</summary>
 
 ```log
-<scrubbed log, or [no plugin log found] / [skipped — private key detected in log]>
+<scrubbed log, or [no plugin log found] / [skipped — private key detected in log] / [skipped by user]>
 ```
 
 </details>
@@ -148,13 +114,11 @@ Write the draft to a temp file (e.g. `/tmp/omos-issue.md`) using this template:
 🤖 This issue was created using the /report-issue skill.
 ```
 
-If `--no-logs` was requested, put `Logs: [skipped by user]` in the details block
-instead of log content.
-
-Truncate at **line boundaries only**: if the scrubbed log exceeds ~6000
-characters, keep whole lines up to that limit and append
-`\n... [truncated — review may be incomplete; attach raw log manually]`. Never
-cut a line in half (that can split a secret mid-token).
+If the log is very long, keep it readable: trim to a sensible tail (a few
+hundred lines is plenty for a bug report) and append
+`... [truncated — review may be incomplete; attach raw log manually]`. Always
+cut at line boundaries — never split a line in half, since that can split a
+secret mid-token.
 
 ### 6. Confirm
 

--- a/src/skills/report-issue/SKILL.md
+++ b/src/skills/report-issue/SKILL.md
@@ -72,18 +72,23 @@ otherwise `~/.local/share/opencode/log` (macOS/Linux) or
 `%USERPROFILE%\.local\share\opencode\log` (Windows). Logs are named
 `oh-my-opencode-slim.<timestamp>.log` and only the most recent 10 are kept.
 
-**The newest log is not always the right one.** The bug usually happened in a
-specific session, not the most recent startup. Ask the user which log is
-relevant — list the available `oh-my-opencode-slim.*.log` files with
-timestamps and let them pick, or accept "newest" if they don't care. If none
-exists, that's fine — note `[no plugin log found]` and continue; the issue can
+**The newest log is almost never the right one.** The bug happened in a
+specific session, not the most recent startup — the newest log is usually just
+an unrelated init/health-check dump. You MUST ask the user which log is
+relevant; do NOT silently default to the newest file.
+
+List the available `oh-my-opencode-slim.*.log` files with timestamps and ask
+the user to pick the one from when the problem occurred (or say "none / skip").
+This is a **blocking question** — wait for the answer before proceeding, just
+like the field questions in step 1. If the user says none exists or to skip,
+note `[no plugin log found]` / `[skipped by user]` and continue; the issue can
 still be filed without it.
 
 Once the log is chosen, **pull only the segment around the reported problem** —
 not the whole file. If the user named a skill/command in step 1, grep the log
 for that to find the relevant lines, then include a window of context around
-them (e.g. ±30 lines). A raw init/health-check dump is noise and should not be
-the default. If the relevant segment can't be found, say so and include the
+them (e.g. ±30 lines). A raw init/health-check dump is noise and must never be
+posted as "the log." If the relevant segment can't be found, say so and include the
 tail of the log instead of the entire file.
 
 ### 3. Scrub the log
@@ -301,9 +306,11 @@ If no log was found or the user skipped it, post a one-line comment
 ## Skipping logs
 
 Logs are included by default, but they are optional. If the user says not to
-include logs (or you judge them irrelevant for the report), skip the log comment
-and note `[skipped by user]` in the Environment section. No flag is needed —
-just ask or note it.
+include logs (or you judge them irrelevant for the report — e.g. an acceptance
+test with no real failure, where every available log is just init noise), skip
+the log comment and note `[skipped by user]` in the Environment section. No flag
+is needed — just ask or note it. Never post an unrelated init/health-check dump
+just to have a log.
 
 ## Safety Rules
 

--- a/src/skills/report-issue/SKILL.md
+++ b/src/skills/report-issue/SKILL.md
@@ -167,36 +167,24 @@ after creation (see below):
 
 **Important — `gh` version reality:** many `gh` builds reject `--field` and
 reject `--template` together with `--body-file`. The reliable cross-version
-pattern is to write the form's fields as **YAML front matter** in a body file
-and create with `--body-file` (no `--template`, no `--field`), then apply the
-label manually. The form's field IDs are `problem` + `context`
-(`feature-request.yml`) and `what_happened`/`steps`/`config`/`opencode_version`/
-`plugin_version`/`operating_system`/`logs` (`bug-report.yml`) — but since we
-post the log as a comment, the bug form's `logs` field just gets a pointer.
+pattern is to write a **plain markdown body** to a file and create with
+`--body-file` (no `--template`, no `--field`), then apply the label manually.
+`gh` does NOT parse YAML front matter from `--body-file` — it renders the whole
+file verbatim — so do NOT include front matter. The body below is the full
+issue body; the structured form fields are not populated, which is fine.
 
 Write the body to a temp file, then:
 
 **Bug** → `/tmp/omos-issue-<ts>.md`:
 
 ```markdown
----
-name: Bug report
-what_happened: |-
-  <description + expected/actual>
-steps: |-
-  <repro steps>
-config: |-
-  <oh-my-opencode.json or 'omitted'>
-opencode_version: "<version>"
-plugin_version: "<plugin version>"
-operating_system: "<os>"
-logs: |-
-  Scrubbed plugin log posted as a comment below.
----
-
 ## Description
 
-<user description / repro steps>
+<user description + expected vs actual>
+
+## Repro Steps
+
+<numbered repro steps>
 
 ## Skill / Command
 
@@ -227,14 +215,6 @@ gh issue create \
 **Enhancement** → `/tmp/omos-issue-<ts>.md`:
 
 ```markdown
----
-name: Feature request
-problem: |-
-  <what you want and why>
-context: |-
-  <optional examples/links>
----
-
 ## Description
 
 <what you want and why>

--- a/src/skills/report-issue/SKILL.md
+++ b/src/skills/report-issue/SKILL.md
@@ -67,14 +67,24 @@ Gather the environment yourself — OS, OpenCode version, this plugin's version,
 Node/Bun versions, and the shell. Run whatever command fits the platform; if a
 value is unavailable, record `unknown` rather than failing.
 
-Locate the most recent plugin log. The directory is `$OPENCODE_LOG_DIR` if set,
+Locate the relevant plugin log. The directory is `$OPENCODE_LOG_DIR` if set,
 otherwise `~/.local/share/opencode/log` (macOS/Linux) or
-`%USERPROFILE%\.local\share\opencode\log` (Windows). Pick the newest
-`oh-my-opencode-slim.*.log`. If none exists, that's fine — note
-`[no plugin log found]` and continue; the issue can still be filed without it.
-Prefer the log segment around when the reported problem occurred; if the user
-named a skill/command (step 1), scan for that in the log to pull the relevant
-lines rather than dumping the whole file.
+`%USERPROFILE%\.local\share\opencode\log` (Windows). Logs are named
+`oh-my-opencode-slim.<timestamp>.log` and only the most recent 10 are kept.
+
+**The newest log is not always the right one.** The bug usually happened in a
+specific session, not the most recent startup. Ask the user which log is
+relevant — list the available `oh-my-opencode-slim.*.log` files with
+timestamps and let them pick, or accept "newest" if they don't care. If none
+exists, that's fine — note `[no plugin log found]` and continue; the issue can
+still be filed without it.
+
+Once the log is chosen, **pull only the segment around the reported problem** —
+not the whole file. If the user named a skill/command in step 1, grep the log
+for that to find the relevant lines, then include a window of context around
+them (e.g. ±30 lines). A raw init/health-check dump is noise and should not be
+the default. If the relevant segment can't be found, say so and include the
+tail of the log instead of the entire file.
 
 ### 3. Scrub the log
 
@@ -267,10 +277,10 @@ First row (example):
 ```
 
 <details>
-<summary>Full scrubbed plugin log (click to expand)</summary>
+<summary>Scrubbed plugin log segment (click to expand)</summary>
 
 ```log
-<scrubbed log, or [no plugin log found] / [skipped — private key detected in log] / [skipped by user]>
+<relevant scrubbed segment, or [no plugin log found] / [skipped — private key detected in log] / [skipped by user]>
 ```
 
 </details>

--- a/src/skills/report-issue/SKILL.md
+++ b/src/skills/report-issue/SKILL.md
@@ -135,25 +135,49 @@ approve, edit, or cancel. Do not run `gh` until they approve.
 
 ### 6. Submit
 
+This repo uses GitHub **issue forms** (`.github/ISSUE_TEMPLATE/bug-report.yml`
+and `feature-request.yml`), and blank issues are disabled. So file through the
+form template, not a free-form body — a plain `--body` is rejected.
+
 If `gh` is available and the user approved:
 
 Check `gh auth status` first. If not authenticated, tell the user to run
 `gh auth login` (or paste the draft manually at the URL below) — do not attempt
 the create.
 
+**Bug** → use `bug-report.yml` and map fields:
+
 ```bash
 gh issue create \
   --repo alvinunreal/oh-my-opencode-slim \
+  --template bug-report.yml \
   --title "<title>" \
-  --label "<type>" \
-  --body-file /tmp/omos-issue-$(date +%s).md
+  --field "What happened, and what did you expect?"="<description + expected/actual>" \
+  --field "Steps to reproduce"="<repro steps>" \
+  --field "oh-my-opencode.json"="<config or 'omitted'>" \
+  --field "OpenCode version"="<version>" \
+  --field "oh-my-opencode-slim version"="<plugin version>" \
+  --field "Operating system"="<os>" \
+  --field "Logs, screenshots, or extra context"="<scrubbed plugin log>"
 ```
 
-- `<type>` is `bug` or `enhancement` from step 1; the label carries the
-  categorization, so the title stays prefix-free.
+**Enhancement** → use `feature-request.yml`:
+
+```bash
+gh issue create \
+  --repo alvinunreal/oh-my-opencode-slim \
+  --template feature-request.yml \
+  --title "<title>" \
+  --field "Description"="<what you want and why>" \
+  --field "Extra context"="<optional examples/links>"
+```
+
+- The `--title` should be prefix-free (no `[Bug]`/`[Feature]`); the form's
+  `title:` prefix and `labels:` are applied by the template automatically.
 - If `gh` is not installed or not authenticated, do **not** fail silently: print
   the full draft and tell the user to paste it at
-  `https://github.com/alvinunreal/oh-my-opencode-slim/issues/new`.
+  `https://github.com/alvinunreal/oh-my-opencode-slim/issues/new?template=bug-report.yml`
+  (or `feature-request.yml`).
 
 ## Skipping logs
 

--- a/src/skills/report-issue/SKILL.md
+++ b/src/skills/report-issue/SKILL.md
@@ -25,9 +25,26 @@ draft. That confirm step is the safety net — do not skip it.
 
 ## Workflow
 
-### 1. Gather user input
+Start the collection work immediately — gather environment and plugin logs
+**before** or alongside asking the user for details. This way the draft (and
+secret redaction) is always reached even in a single-shot turn, and you are not
+blocked waiting on the user's title.
 
-Ask for three things (one message, can be combined if the user volunteers them):
+### 1. Collect environment and logs (do this first)
+
+Gather the environment yourself — OS, OpenCode version, this plugin's version,
+Node/Bun versions, and the shell. Run whatever command fits the platform; if a
+value is unavailable, record `unknown` rather than failing.
+
+Locate the most recent plugin log. The directory is `$OPENCODE_LOG_DIR` if set,
+otherwise `~/.local/share/opencode/log` (macOS/Linux) or
+`%USERPROFILE%\.local\share\opencode\log` (Windows). Pick the newest
+`oh-my-opencode-slim.*.log`. If none exists, note `[no plugin log found]`.
+
+### 2. Gather user input
+
+Ask for what you still need (one message; the user may have already volunteered
+some of it):
 
 - **Title** — short, specific, actionable summary (under ~72 chars). No need
   for a `[Bug]`/`[Feature]` prefix; the type label carries that.
@@ -43,20 +60,7 @@ description.** The scrubber only protects the plugin log, not free text. Also
 warn that the issue is filed on a **public** repo, so review the draft for
 secrets before approving.
 
-### 2. Collect environment
-
-Gather the environment yourself — OS, OpenCode version, this plugin's version,
-Node/Bun versions, and the shell. Run whatever command fits the platform; if a
-value is unavailable, record `unknown` rather than failing.
-
-### 3. Collect plugin logs
-
-Locate the most recent plugin log. The directory is `$OPENCODE_LOG_DIR` if set,
-otherwise `~/.local/share/opencode/log` (macOS/Linux) or
-`%USERPROFILE%\.local\share\opencode\log` (Windows). Pick the newest
-`oh-my-opencode-slim.*.log`. If none exists, note `[no plugin log found]`.
-
-### 4. Scrub the log
+### 3. Scrub the log
 
 You are an AI model — redact secrets by reading the log and applying judgment.
 Do **not** run a regex script; redact inline as you prepare the draft. This
@@ -77,7 +81,7 @@ paraphrase or summarize the log — embed it verbatim after redaction
 (paraphrasing bypasses redaction). When in doubt, redact; the user reviews the
 draft before submit, but you are the first line of defense.
 
-### 5. Draft the issue body
+### 4. Draft the issue body
 
 Write the draft to a temp file (e.g. `/tmp/omos-issue.md`) using this template:
 
@@ -120,14 +124,14 @@ hundred lines is plenty for a bug report) and append
 cut at line boundaries — never split a line in half, since that can split a
 secret mid-token.
 
-### 6. Confirm
+### 5. Confirm
 
 Show the **raw** draft to the user (verbatim markdown, not a rendered preview).
 State explicitly if truncation happened, and remind them the issue is filed on
 a **public** repo — review for any secrets before approving. Ask the user to
 approve, edit, or cancel. Do not run `gh` until they approve.
 
-### 7. Submit
+### 6. Submit
 
 If `gh` is available and the user approved:
 


### PR DESCRIPTION
Fixes #779

## What problem are you solving?

Filing a GitHub issue for this plugin requires manually gathering environment info, locating the right plugin log, scrubbing secrets, and formatting the body — easy to get wrong or leak secrets. Issue #779 asked for a `/report-issue` skill that does this reliably.

## What does this change?

Adds a `report-issue` skill (src/skills/report-issue/SKILL.md) plus a `/report-issue` slash-command hook that activates it. The skill finalizes issue fields, collects env + the relevant plugin log, scrubs secrets by model judgment (with a PEM tripwire), shows a raw draft at an Iron Rule gate, then submits via `gh issue create --body-file` + posts the log as a separate comment.

## Why this approach?

- Plain `--body-file` markdown (no YAML front matter — `gh` 2.45.0 renders front matter verbatim) + `--label` is the reliable cross-version path; `--field` and `--template`+`--body-file` are rejected by many builds.
- Log selection is a blocking question: the newest log is usually unrelated init noise, so the agent lists logs and waits for the user's pick, then pulls only the segment around the problem.
- No new dependencies; reuses existing `gh` CLI and the established command-hook pattern (mirrors `loop-command`).

## Related work

Checked open/closed issues — #779 is the originating request. No duplicate PR found.

## AI assistance

- Harness: OpenCode (oh-my-opencode-slim plugin).
- Orchestrator: `opencode/hy3-free` (active preset primary).
- `@oracle` (used for code review): `opencode/big-pickle` (active preset primary).
- `@skeptic` (used for receiving-code-review): `opencode/big-pickle` (active preset primary).
- Human reviewed the full diff: approved by user.

Note: supersedes the closed #806 (that PR's branch history was rewritten, making #806 unrecoverable; this PR points at the same cleaned branch `feat/779-report-issue-skill`).

## Docs

No user-facing command/behavior change outside the new skill; README not updated (skill is self-documenting via its SKILL.md). Eval artifacts are gitignored and excluded from the PR.

