### PR TITLE
fix(windows): detect opencode installed via .cmd shims and add Windows install paths

### DIFF
--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -126,15 +126,30 @@ async function checkOpenCodeInstalled(): Promise<{
 }> {
   const installed = await isOpenCodeInstalled();
   if (!installed) {
+    const isWindows = process.platform === 'win32';
     printError('OpenCode is not installed on this system.');
     printInfo('Install it with:');
-    console.log(
-      `     ${BLUE}curl -fsSL https://opencode.ai/install | bash${RESET}`,
-    );
-    console.log();
-    printInfo('Or if already installed, add it to your PATH:');
-    console.log(`     ${BLUE}export PATH="$HOME/.local/bin:$PATH"${RESET}`);
-    console.log(`     ${BLUE}export PATH="$HOME/.opencode/bin:$PATH"${RESET}`);
+    if (isWindows) {
+      console.log(
+        `     ${BLUE}powershell -NoProfile -ExecutionPolicy Bypass -Command "irm https://opencode.ai/install.ps1 | iex"${RESET}`,
+      );
+      console.log();
+      printInfo('Or with winget:');
+      console.log(`     ${BLUE}winget install opencode${RESET}`);
+      console.log();
+      printInfo('Or if already installed, add it to your PATH:');
+      console.log(
+        `     ${BLUE}setx PATH "%PATH%;%LOCALAPPDATA%\\Programs\\opencode"${RESET}`,
+      );
+    } else {
+      console.log(
+        `     ${BLUE}curl -fsSL https://opencode.ai/install | bash${RESET}`,
+      );
+      console.log();
+      printInfo('Or if already installed, add it to your PATH:');
+      console.log(`     ${BLUE}export PATH="$HOME/.local/bin:$PATH"${RESET}`);
+      console.log(`     ${BLUE}export PATH="$HOME/.opencode/bin:$PATH"${RESET}`);
+    }
     return { ok: false };
   }
   const version = await getOpenCodeVersion();

--- a/src/cli/system.ts
+++ b/src/cli/system.ts
@@ -9,23 +9,41 @@ function resolvePathCommand(
   environment: NodeJS.ProcessEnv = process.env,
 ): string | null {
   try {
-    const resolver = process.platform === 'win32' ? 'where' : 'which';
+    const isWindows = process.platform === 'win32';
+    const resolver = isWindows ? 'where' : 'which';
     const result = spawnSync(resolver, [command], {
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'ignore'],
       env: environment,
+      // On Windows, `where opencode` returns multiple shims (opencode, opencode.cmd,
+      // opencode.ps1). Node's spawnSync cannot execute an extensionless npm shim,
+      // and since Node's CVE-2024-27980 patch .cmd/.bat files also require a shell.
+      shell: isWindows,
     });
 
     if (result.status !== 0) {
       return null;
     }
 
-    const resolved = result.stdout
+    const lines = result.stdout
       .split(/\r?\n/)
       .map((line) => line.trim())
-      .find(Boolean);
+      .filter(Boolean);
 
-    return resolved ?? null;
+    if (lines.length === 0) {
+      return null;
+    }
+
+    // On Windows, prefer executable shims (.cmd, .exe, .ps1) over the
+    // extensionless npm wrapper that Node cannot spawn directly.
+    if (isWindows) {
+      const executable = lines.find((line) =>
+        /\.(cmd|exe|ps1|bat)$/i.test(line),
+      );
+      return executable ?? lines[0];
+    }
+
+    return lines[0];
   } catch {
     return null;
   }
@@ -37,9 +55,13 @@ function canExecute(
   environment: NodeJS.ProcessEnv = process.env,
 ): boolean {
   try {
+    const isWindows = process.platform === 'win32';
     const result = spawnSync(command, args, {
       stdio: 'ignore',
       env: environment,
+      // Required on Windows to execute .cmd/.bat shims produced by npm/pnpm/yarn
+      // (Node's CVE-2024-27980 patch blocks them without a shell).
+      shell: isWindows,
     });
     return result.status === 0;
   } catch {
@@ -51,10 +73,35 @@ function getOpenCodePaths(
   environment: NodeJS.ProcessEnv = process.env,
 ): string[] {
   const home = environment.HOME || environment.USERPROFILE || '';
+  const isWindows = process.platform === 'win32';
+  const appData =
+    environment.APPDATA || `${home}\\AppData\\Roaming`;
+  const localAppData =
+    environment.LOCALAPPDATA || `${home}\\AppData\\Local`;
+
+  const windowsPaths = isWindows
+    ? [
+        // npm global shims (created as .cmd on Windows)
+        `${appData}\\npm\\opencode.cmd`,
+        `${appData}\\npm\\opencode.ps1`,
+        // pnpm global
+        `${localAppData}\\pnpm\\opencode.cmd`,
+        // Yarn global
+        `${localAppData}\\Yarn\\bin\\opencode.cmd`,
+        // opencode.ai/install .exe location
+        `${localAppData}\\Programs\\opencode\\opencode.exe`,
+        // Scoop
+        `${home}\\scoop\\shims\\opencode.exe`,
+        `${home}\\scoop\\apps\\opencode\\current\\bin\\opencode.exe`,
+        // Chocolatey
+        `C:\\ProgramData\\chocolatey\\bin\\opencode.exe`,
+      ]
+    : [];
 
   return [
     // PATH (try this first)
     'opencode',
+    ...windowsPaths,
     // User local installations (Linux & macOS)
     `${home}/.local/bin/opencode`,
     `${home}/.opencode/bin/opencode`,


### PR DESCRIPTION
## Problem

On Windows, `bunx oh-my-opencode-slim install` fails immediately after the companion prompt with:

```
[x] OpenCode is not installed on this system.
```

even when opencode is installed and running. This is reported by users running opencode right now — the check is wrong, not the install.

## Root cause

The check in `src/cli/system.ts` (`isOpenCodeInstalled` -> `resolvePathCommand` + `canExecute`) breaks on Windows in three compounding ways:

1. **`where opencode` returns multiple shims** (`opencode`, `opencode.cmd`, `opencode.ps1`). The code picked the first line via `.find(Boolean)`, which is the **extensionless npm wrapper** that Node cannot spawn on Windows.
2. **Node's CVE-2024-27980 patch blocks `.cmd`/`.bat` via `spawnSync` without `shell: true`**, throwing `Error: spawn EINVAL`. The `try/catch` swallows it and returns `false`.
3. **The fallback `getOpenCodePaths` list had zero Windows entries** (only Unix paths: `~/.local/bin`, homebrew, snap, nix, cargo, npm-global…), so the check never recovered.

The flow in `src/cli/install.ts` is:

```ts
const companionInstall = await shouldInstallCompanion(config); // asks companion? y/n
...
const { ok } = await checkOpenCodeInstalled();                 // broken check runs next
if (!ok) return 1;                                             // exits 1
```

So answering `y` to the companion prompt is immediately followed by the broken detection, which exits. The companion answer doesn't gate the check — it just happens to be the preceding step.

## Fix

- `resolvePathCommand`: pass `shell: true` to `spawnSync` on win32, and prefer executable shims (`.cmd`/`.exe`/`.ps1`/`.bat`) over the extensionless npm wrapper when parsing `where` output.
- `canExecute`: pass `shell: true` to `spawnSync` on win32 so `.cmd` shims can execute.
- `getOpenCodePaths`: add Windows install paths (npm `%APPDATA%\npm`, pnpm, yarn, opencode.ai installer at `%LOCALAPPDATA%\Programs\opencode`, Scoop, Chocolatey).
- `checkOpenCodeInstalled` in `install.ts`: print Windows-specific install hints (PowerShell `irm | iex`, `winget install opencode`) instead of the Unix-only `curl | bash` / `export PATH=...`.

## Verification

- `bunx tsc --noEmit` -> exit 0, no errors.
- `bunx @biomejs/biome lint src/cli/system.ts src/cli/install.ts` -> clean.
- Full `bun run build` fails on Windows for a **pre-existing, unrelated** reason (the `--external @opencode-ai/plugin/*` glob in `build:plugin` doesn't expand on Windows shells), so it's not in scope here.

## Impact

Unblocks Windows installs. Without this fix, no Windows user can pass the `checkOpenCodeInstalled` step when opencode is installed via npm/pnpm/yarn/scoop/chocolatey — the installer always exits 1 right after the companion prompt.
