### PR TITLE
docs(readme): add issue #823 models to per-agent recommended ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Recommended Models:</b> <code>gpt-5.6-terra</code> <code>claude-fable-5</code> <code>claude-opus-4-8</code> <code>glm-5.2</code> <code>minimax-m3</code> <code>qwen3.7-plus</code> <code>mimo-v2.5</code>
+      <b>Recommended Models:</b> <code>claude-fable-5</code> <code>claude-opus-4-8</code> <code>glm-5.2</code> <code>gpt-5.6-terra</code> <code>mimo-v2.5</code> <code>minimax-m3</code> <code>qwen3.7-plus</code>
     </td>
   </tr>
   <tr>
@@ -301,7 +301,7 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Recommended Models:</b> <code>gpt-5.3-codex</code> <code>zai-glm-4.7</code> <code>kimi-k2p6-turbo</code> <code>kimi-k2.6</code> <code>deepseek-v4-flash</code> <code>north-mini-code</code>
+      <b>Recommended Models:</b> <code>deepseek-v4-flash</code> <code>gpt-5.3-codex</code> <code>kimi-k2.6</code> <code>kimi-k2p6-turbo</code> <code>north-mini-code</code> <code>zai-glm-4.7</code>
       </td>
    </tr>
    <tr>
@@ -342,7 +342,7 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Recommended Models:</b> <code>gpt-5.6-sol</code> <code>claude-fable-5</code> <code>claude-opus-4-8</code> <code>deepseek-v4-pro</code> <code>qwen3.7-max</code> <code>mimo-v2.5-pro</code> <code>glm-5.2</code> <code>big-pickle</code>
+      <b>Recommended Models:</b> <code>big-pickle</code> <code>claude-fable-5</code> <code>claude-opus-4-8</code> <code>deepseek-v4-pro</code> <code>glm-5.2</code> <code>gpt-5.6-sol</code> <code>mimo-v2.5-pro</code> <code>qwen3.7-max</code>
     </td>
   </tr>
   <tr>
@@ -432,7 +432,7 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Recommended Models:</b> <code>gpt-5.3-codex</code> <code>zai-glm-4.7</code> <code>kimi-k2p6-turbo</code> <code>kimi-k2.6</code> <code>deepseek-v4-flash</code> <code>mimo-v2.5</code> <code>north-mini-code</code> <code>minimax-m2.7</code>
+      <b>Recommended Models:</b> <code>deepseek-v4-flash</code> <code>gpt-5.3-codex</code> <code>kimi-k2.6</code> <code>kimi-k2p6-turbo</code> <code>mimo-v2.5</code> <code>minimax-m2.7</code> <code>north-mini-code</code> <code>zai-glm-4.7</code>
       </td>
    </tr>
    <tr>
@@ -514,7 +514,7 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Recommended Models:</b> <code>gpt-5.6-luna</code> <code>claude-sonnet-4-6</code> <code>kimi-k2.7-code</code> <code>deepseek-v4-flash</code> <code>north-mini-code</code>
+      <b>Recommended Models:</b> <code>claude-sonnet-4-6</code> <code>deepseek-v4-flash</code> <code>gpt-5.6-luna</code> <code>kimi-k2.7-code</code> <code>north-mini-code</code>
     </td>
   </tr>
   <tr>

--- a/README.md
+++ b/README.md
@@ -302,11 +302,11 @@ If any agent fails to respond, check your provider authentication and config fil
   <tr>
     <td colspan="2">
       <b>Recommended Models:</b> <code>deepseek-v4-flash</code> <code>gpt-5.3-codex</code>
-      </td>
-   </tr>
-   <tr>
-      <td colspan="2">
-         <b>Model Guidance:</b> Choose a fast, low-cost model. Explorer handles broad scouting work, so speed and efficiency usually matter more than using your strongest reasoning model.
+    </td>
+  </tr>
+  <tr>
+    <td colspan="2">
+      <b>Model Guidance:</b> Choose a fast, low-cost model. Explorer handles broad scouting work, so speed and efficiency usually matter more than using your strongest reasoning model.
     </td>
   </tr>
 </table>
@@ -433,11 +433,11 @@ If any agent fails to respond, check your provider authentication and config fil
   <tr>
     <td colspan="2">
       <b>Recommended Models:</b> <code>deepseek-v4-flash</code> <code>gpt-5.3-codex</code> <code>mimo-v2.5</code> <code>minimax-m2.7</code>
-      </td>
-   </tr>
-   <tr>
-      <td colspan="2">
-         <b>Model Guidance:</b> Choose a fast, low-cost model. Librarian handles research and documentation lookups, so speed and efficiency usually matter more than using your strongest reasoning model.
+    </td>
+  </tr>
+  <tr>
+    <td colspan="2">
+      <b>Model Guidance:</b> Choose a fast, low-cost model. Librarian handles research and documentation lookups, so speed and efficiency usually matter more than using your strongest reasoning model.
     </td>
   </tr>
 </table>
@@ -557,16 +557,16 @@ If any agent fails to respond, check your provider authentication and config fil
   <tr>
     <td colspan="2">
       <b>Default Model:</b> <code>openai/gpt-5.6-luna</code> - <i>configure a vision-capable model to enable</i>
-      </td>
-   </tr>
-   <tr>
-      <td colspan="2">
-         <b>Recommended Models:</b> <code>mimo-v2.5</code> <code>qwen3.5-plus</code>
-      </td>
-   </tr>
-   <tr>
-      <td colspan="2">
-         <b>Model Guidance:</b> Choose a vision-capable model if you want the agent to read screenshots, images, PDFs, and other visual files.
+    </td>
+  </tr>
+  <tr>
+    <td colspan="2">
+      <b>Recommended Models:</b> <code>mimo-v2.5</code> <code>qwen3.5-plus</code>
+    </td>
+  </tr>
+  <tr>
+    <td colspan="2">
+      <b>Model Guidance:</b> Choose a vision-capable model if you want the agent to read screenshots, images, PDFs, and other visual files.
     </td>
   </tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Recommended Models:</b> <code>openai/gpt-5.6-terra (medium)</code> <code>anthropic/claude-fable-5</code> <code>anthropic/claude-opus-4-8</code> <code>opencode-go/glm-5.2</code> <code>opencode-go/minimax-m3</code> <code>opencode-go/qwen3.7-plus</code>
+      <b>Recommended Models:</b> <code>openai/gpt-5.6-terra (medium)</code> <code>anthropic/claude-fable-5</code> <code>anthropic/claude-opus-4-8</code> <code>opencode-go/glm-5.2</code> <code>opencode-go/minimax-m3</code> <code>opencode-go/qwen3.7-plus</code> <code>opencode/mimo-v2.5</code> <code>opencode/nemotron-3-ultra</code>
     </td>
   </tr>
   <tr>
@@ -301,7 +301,7 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Recommended Models:</b> <code>openai/gpt-5.3-codex</code> <code>cerebras/zai-glm-4.7</code> <code>fireworks-ai/accounts/fireworks/routers/kimi-k2p6-turbo</code> <code>opencode-go/kimi-k2.6</code> <code>opencode-go/deepseek-v4-flash</code>
+      <b>Recommended Models:</b> <code>openai/gpt-5.3-codex</code> <code>cerebras/zai-glm-4.7</code> <code>fireworks-ai/accounts/fireworks/routers/kimi-k2p6-turbo</code> <code>opencode-go/kimi-k2.6</code> <code>opencode-go/deepseek-v4-flash</code> <code>opencode/north-mini-code</code>
       </td>
    </tr>
    <tr>
@@ -342,7 +342,7 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Recommended Models:</b> <code>openai/gpt-5.6-sol (xhigh)</code> <code>anthropic/claude-fable-5</code> <code>anthropic/claude-opus-4-8 (xhigh)</code> <code>opencode-go/deepseek-v4-pro</code> <code>opencode-go/qwen3.7-max</code> <code>opencode-go/mimo-v2.5-pro</code> <code>opencode-go/glm-5.2</code>
+      <b>Recommended Models:</b> <code>openai/gpt-5.6-sol (xhigh)</code> <code>anthropic/claude-fable-5</code> <code>anthropic/claude-opus-4-8 (xhigh)</code> <code>opencode-go/deepseek-v4-pro</code> <code>opencode-go/qwen3.7-max</code> <code>opencode-go/mimo-v2.5-pro</code> <code>opencode-go/glm-5.2</code> <code>opencode/big-pickle</code>
     </td>
   </tr>
   <tr>
@@ -432,7 +432,7 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Recommended Models:</b> <code>openai/gpt-5.3-codex</code> <code>cerebras/zai-glm-4.7</code> <code>fireworks-ai/accounts/fireworks/routers/kimi-k2p6-turbo</code> <code>opencode-go/kimi-k2.6</code> <code>opencode-go/deepseek-v4-flash</code> <code>opencode-go/mimo-v2.5</code>
+      <b>Recommended Models:</b> <code>openai/gpt-5.3-codex</code> <code>cerebras/zai-glm-4.7</code> <code>fireworks-ai/accounts/fireworks/routers/kimi-k2p6-turbo</code> <code>opencode-go/kimi-k2.6</code> <code>opencode-go/deepseek-v4-flash</code> <code>opencode-go/mimo-v2.5</code> <code>opencode/north-mini-code</code> <code>opencode/minimax-m2.7</code>
       </td>
    </tr>
    <tr>
@@ -514,7 +514,7 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Recommended Models:</b> <code>openai/gpt-5.6-luna (medium)</code> <code>anthropic/claude-sonnet-4-6</code> <code>opencode-go/kimi-k2.7-code</code> <code>opencode-go/deepseek-v4-flash</code>
+      <b>Recommended Models:</b> <code>openai/gpt-5.6-luna (medium)</code> <code>anthropic/claude-sonnet-4-6</code> <code>opencode-go/kimi-k2.7-code</code> <code>opencode-go/deepseek-v4-flash</code> <code>opencode/north-mini-code</code>
     </td>
   </tr>
   <tr>
@@ -561,7 +561,7 @@ If any agent fails to respond, check your provider authentication and config fil
    </tr>
    <tr>
       <td colspan="2">
-         <b>Recommended Models:</b> <code>opencode-go/mimo-v2.5</code> <code>opencode-go/mimo-v2.5-pro</code>
+         <b>Recommended Models:</b> <code>opencode-go/mimo-v2.5</code> <code>opencode-go/mimo-v2.5-pro</code> <code>opencode/qwen3.5-plus</code>
       </td>
    </tr>
    <tr>

--- a/README.md
+++ b/README.md
@@ -473,7 +473,7 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Recommended Models:</b> <code>gemini-3.5-flash</code> <code>kimi-k2.7-code</code> <code>kimi-k2.7-code</code> <code>minimax-m3</code>
+      <b>Recommended Models:</b> <code>gemini-3.5-flash</code> <code>kimi-k2.7-code</code> <code>minimax-m3</code>
     </td>
   </tr>
   <tr>

--- a/README.md
+++ b/README.md
@@ -307,8 +307,8 @@ If any agent fails to respond, check your provider authentication and config fil
    <tr>
       <td colspan="2">
          <b>Model Guidance:</b> Choose a fast, low-cost model. Explorer handles broad scouting work, so speed and efficiency usually matter more than using your strongest reasoning model.
-      </td>
-   </tr>
+    </td>
+  </tr>
 </table>
 
 ---
@@ -438,8 +438,8 @@ If any agent fails to respond, check your provider authentication and config fil
    <tr>
       <td colspan="2">
          <b>Model Guidance:</b> Choose a fast, low-cost model. Librarian handles research and documentation lookups, so speed and efficiency usually matter more than using your strongest reasoning model.
-      </td>
-   </tr>
+    </td>
+  </tr>
 </table>
 
 ---
@@ -567,7 +567,7 @@ If any agent fails to respond, check your provider authentication and config fil
    <tr>
       <td colspan="2">
          <b>Model Guidance:</b> Choose a vision-capable model if you want the agent to read screenshots, images, PDFs, and other visual files.
-      </td>
+    </td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Recommended Models:</b> <code>deepseek-v4-flash</code> <code>gpt-5.3-codex</code> <code>kimi-k2.6</code> <code>kimi-k2p6-turbo</code> <code>north-mini-code</code> <code>zai-glm-4.7</code>
+      <b>Recommended Models:</b> <code>deepseek-v4-flash</code> <code>gpt-5.3-codex</code>
       </td>
    </tr>
    <tr>
@@ -342,7 +342,7 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Recommended Models:</b> <code>big-pickle</code> <code>claude-fable-5</code> <code>claude-opus-4-8</code> <code>deepseek-v4-pro</code> <code>glm-5.2</code> <code>gpt-5.6-sol</code> <code>mimo-v2.5-pro</code> <code>qwen3.7-max</code>
+      <b>Recommended Models:</b> <code>claude-fable-5</code> <code>claude-opus-4-8</code> <code>deepseek-v4-pro</code> <code>glm-5.2</code> <code>gpt-5.6-sol</code> <code>qwen3.7-max</code>
     </td>
   </tr>
   <tr>
@@ -432,7 +432,7 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Recommended Models:</b> <code>deepseek-v4-flash</code> <code>gpt-5.3-codex</code> <code>kimi-k2.6</code> <code>kimi-k2p6-turbo</code> <code>mimo-v2.5</code> <code>minimax-m2.7</code> <code>north-mini-code</code> <code>zai-glm-4.7</code>
+      <b>Recommended Models:</b> <code>deepseek-v4-flash</code> <code>gpt-5.3-codex</code> <code>mimo-v2.5</code> <code>minimax-m2.7</code>
       </td>
    </tr>
    <tr>
@@ -514,7 +514,7 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Recommended Models:</b> <code>claude-sonnet-4-6</code> <code>deepseek-v4-flash</code> <code>gpt-5.6-luna</code> <code>kimi-k2.7-code</code> <code>north-mini-code</code>
+      <b>Recommended Models:</b> <code>claude-sonnet-4-6</code> <code>deepseek-v4-flash</code> <code>gpt-5.6-luna</code> <code>kimi-k2.7-code</code>
     </td>
   </tr>
   <tr>
@@ -561,7 +561,7 @@ If any agent fails to respond, check your provider authentication and config fil
    </tr>
    <tr>
       <td colspan="2">
-         <b>Recommended Models:</b> <code>mimo-v2.5</code> <code>mimo-v2.5-pro</code> <code>qwen3.5-plus</code>
+         <b>Recommended Models:</b> <code>mimo-v2.5</code> <code>qwen3.5-plus</code>
       </td>
    </tr>
    <tr>

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Recommended Models:</b> <code>openai/gpt-5.6-terra (medium)</code> <code>claude-fable-5</code> <code>claude-opus-4-8</code> <code>glm-5.2</code> <code>mimo-v2.5</code> <code>minimax-m3</code> <code>qwen3.7-plus</code>
+      <b>Recommended Models:</b> <code>claude-fable-5</code> <code>claude-opus-4-8</code> <code>glm-5.2</code> <code>gpt-5.6-terra</code> <code>mimo-v2.5</code> <code>minimax-m3</code> <code>qwen3.7-plus</code>
     </td>
   </tr>
   <tr>
@@ -301,7 +301,7 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Recommended Models:</b> <code>deepseek-v4-flash</code> <code>openai/gpt-5.3-codex</code>
+      <b>Recommended Models:</b> <code>deepseek-v4-flash</code> <code>gpt-5.3-codex</code>
       </td>
    </tr>
    <tr>
@@ -342,7 +342,7 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Recommended Models:</b> <code>claude-fable-5</code> <code>claude-opus-4-8</code> <code>deepseek-v4-pro</code> <code>glm-5.2</code> <code>openai/gpt-5.6-sol (xhigh)</code> <code>qwen3.7-max</code>
+      <b>Recommended Models:</b> <code>claude-fable-5</code> <code>claude-opus-4-8</code> <code>deepseek-v4-pro</code> <code>glm-5.2</code> <code>gpt-5.6-sol</code> <code>qwen3.7-max</code>
     </td>
   </tr>
   <tr>
@@ -432,7 +432,7 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Recommended Models:</b> <code>deepseek-v4-flash</code> <code>openai/gpt-5.3-codex</code> <code>mimo-v2.5</code> <code>minimax-m2.7</code>
+      <b>Recommended Models:</b> <code>deepseek-v4-flash</code> <code>gpt-5.3-codex</code> <code>mimo-v2.5</code> <code>minimax-m2.7</code>
       </td>
    </tr>
    <tr>
@@ -473,7 +473,7 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Recommended Models:</b> <code>google/gemini-3.5-flash</code> <code>kimi-k2.7-code</code> <code>minimax-m3</code>
+      <b>Recommended Models:</b> <code>gemini-3.5-flash</code> <code>kimi-k2.7-code</code> <code>minimax-m3</code>
     </td>
   </tr>
   <tr>
@@ -514,7 +514,7 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Recommended Models:</b> <code>claude-sonnet-4-6</code> <code>deepseek-v4-flash</code> <code>openai/gpt-5.6-luna (medium)</code> <code>kimi-k2.7-code</code>
+      <b>Recommended Models:</b> <code>claude-sonnet-4-6</code> <code>deepseek-v4-flash</code> <code>gpt-5.6-luna</code> <code>kimi-k2.7-code</code>
     </td>
   </tr>
   <tr>
@@ -561,7 +561,7 @@ If any agent fails to respond, check your provider authentication and config fil
    </tr>
    <tr>
       <td colspan="2">
-         <b>Recommended Models:</b> <code>mimo-v2.5</code> <code>openai/gpt-5.6-luna</code> <code>qwen3.5-plus</code>
+         <b>Recommended Models:</b> <code>mimo-v2.5</code> <code>qwen3.5-plus</code>
       </td>
    </tr>
    <tr>

--- a/README.md
+++ b/README.md
@@ -255,12 +255,12 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Default Model:</b> <code>openai/gpt-5.6-terra (medium)</code>
+      <b>Default Model:</b> <code>gpt-5.6-terra (medium)</code>
     </td>
   </tr>
   <tr>
     <td colspan="2">
-      <b>Recommended Models:</b> <code>openai/gpt-5.6-terra (medium)</code> <code>anthropic/claude-fable-5</code> <code>anthropic/claude-opus-4-8</code> <code>opencode-go/glm-5.2</code> <code>opencode-go/minimax-m3</code> <code>opencode-go/qwen3.7-plus</code> <code>opencode/mimo-v2.5</code>
+      <b>Recommended Models:</b> <code>gpt-5.6-terra (medium)</code> <code>claude-fable-5</code> <code>claude-opus-4-8</code> <code>glm-5.2</code> <code>minimax-m3</code> <code>qwen3.7-plus</code> <code>mimo-v2.5</code>
     </td>
   </tr>
   <tr>
@@ -296,12 +296,12 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Default Model:</b> <code>openai/gpt-5.6-luna</code>
+      <b>Default Model:</b> <code>gpt-5.6-luna</code>
     </td>
   </tr>
   <tr>
     <td colspan="2">
-      <b>Recommended Models:</b> <code>openai/gpt-5.3-codex</code> <code>cerebras/zai-glm-4.7</code> <code>fireworks-ai/accounts/fireworks/routers/kimi-k2p6-turbo</code> <code>opencode-go/kimi-k2.6</code> <code>opencode-go/deepseek-v4-flash</code> <code>opencode/north-mini-code</code>
+      <b>Recommended Models:</b> <code>gpt-5.3-codex</code> <code>zai-glm-4.7</code> <code>kimi-k2p6-turbo</code> <code>kimi-k2.6</code> <code>deepseek-v4-flash</code> <code>north-mini-code</code>
       </td>
    </tr>
    <tr>
@@ -337,12 +337,12 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Default Model:</b> <code>openai/gpt-5.6-sol (high)</code>
+      <b>Default Model:</b> <code>gpt-5.6-sol (high)</code>
     </td>
   </tr>
   <tr>
     <td colspan="2">
-      <b>Recommended Models:</b> <code>openai/gpt-5.6-sol (xhigh)</code> <code>anthropic/claude-fable-5</code> <code>anthropic/claude-opus-4-8 (xhigh)</code> <code>opencode-go/deepseek-v4-pro</code> <code>opencode-go/qwen3.7-max</code> <code>opencode-go/mimo-v2.5-pro</code> <code>opencode-go/glm-5.2</code> <code>opencode/big-pickle</code>
+      <b>Recommended Models:</b> <code>gpt-5.6-sol (xhigh)</code> <code>claude-fable-5</code> <code>claude-opus-4-8 (xhigh)</code> <code>deepseek-v4-pro</code> <code>qwen3.7-max</code> <code>mimo-v2.5-pro</code> <code>glm-5.2</code> <code>big-pickle</code>
     </td>
   </tr>
   <tr>
@@ -427,12 +427,12 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Default Model:</b> <code>openai/gpt-5.6-luna</code>
+      <b>Default Model:</b> <code>gpt-5.6-luna</code>
     </td>
   </tr>
   <tr>
     <td colspan="2">
-      <b>Recommended Models:</b> <code>openai/gpt-5.3-codex</code> <code>cerebras/zai-glm-4.7</code> <code>fireworks-ai/accounts/fireworks/routers/kimi-k2p6-turbo</code> <code>opencode-go/kimi-k2.6</code> <code>opencode-go/deepseek-v4-flash</code> <code>opencode-go/mimo-v2.5</code> <code>opencode/north-mini-code</code> <code>opencode/minimax-m2.7</code>
+      <b>Recommended Models:</b> <code>gpt-5.3-codex</code> <code>zai-glm-4.7</code> <code>kimi-k2p6-turbo</code> <code>kimi-k2.6</code> <code>deepseek-v4-flash</code> <code>mimo-v2.5</code> <code>north-mini-code</code> <code>minimax-m2.7</code>
       </td>
    </tr>
    <tr>
@@ -468,12 +468,12 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Default Model:</b> <code>openai/gpt-5.6-luna</code>
+      <b>Default Model:</b> <code>gpt-5.6-luna</code>
     </td>
   </tr>
   <tr>
     <td colspan="2">
-      <b>Recommended Models:</b> <code>google/gemini-3.5-flash</code> <code>moonshotai/kimi-k2.7-code</code> <code>opencode-go/kimi-k2.7-code</code> <code>opencode-go/minimax-m3</code>
+      <b>Recommended Models:</b> <code>gemini-3.5-flash</code> <code>kimi-k2.7-code</code> <code>kimi-k2.7-code</code> <code>minimax-m3</code>
     </td>
   </tr>
   <tr>
@@ -509,12 +509,12 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Default Model:</b> <code>openai/gpt-5.6-luna (medium)</code>
+      <b>Default Model:</b> <code>gpt-5.6-luna (medium)</code>
     </td>
   </tr>
   <tr>
     <td colspan="2">
-      <b>Recommended Models:</b> <code>openai/gpt-5.6-luna (medium)</code> <code>anthropic/claude-sonnet-4-6</code> <code>opencode-go/kimi-k2.7-code</code> <code>opencode-go/deepseek-v4-flash</code> <code>opencode/north-mini-code</code>
+      <b>Recommended Models:</b> <code>gpt-5.6-luna (medium)</code> <code>claude-sonnet-4-6</code> <code>kimi-k2.7-code</code> <code>deepseek-v4-flash</code> <code>north-mini-code</code>
     </td>
   </tr>
   <tr>
@@ -556,12 +556,12 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Default Model:</b> <code>openai/gpt-5.6-luna</code> - <i>configure a vision-capable model to enable</i>
+      <b>Default Model:</b> <code>gpt-5.6-luna</code> - <i>configure a vision-capable model to enable</i>
       </td>
    </tr>
    <tr>
       <td colspan="2">
-         <b>Recommended Models:</b> <code>opencode-go/mimo-v2.5</code> <code>opencode-go/mimo-v2.5-pro</code> <code>opencode/qwen3.5-plus</code>
+         <b>Recommended Models:</b> <code>mimo-v2.5</code> <code>mimo-v2.5-pro</code> <code>qwen3.5-plus</code>
       </td>
    </tr>
    <tr>

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Recommended Models:</b> <code>claude-fable-5</code> <code>claude-opus-4-8</code> <code>glm-5.2</code> <code>gpt-5.6-terra</code> <code>mimo-v2.5</code> <code>minimax-m3</code> <code>qwen3.7-plus</code>
+      <b>Recommended Models:</b> <code>openai/gpt-5.6-terra (medium)</code> <code>claude-fable-5</code> <code>claude-opus-4-8</code> <code>glm-5.2</code> <code>mimo-v2.5</code> <code>minimax-m3</code> <code>qwen3.7-plus</code>
     </td>
   </tr>
   <tr>
@@ -301,7 +301,7 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Recommended Models:</b> <code>deepseek-v4-flash</code> <code>gpt-5.3-codex</code>
+      <b>Recommended Models:</b> <code>deepseek-v4-flash</code> <code>openai/gpt-5.3-codex</code>
       </td>
    </tr>
    <tr>
@@ -342,7 +342,7 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Recommended Models:</b> <code>claude-fable-5</code> <code>claude-opus-4-8</code> <code>deepseek-v4-pro</code> <code>glm-5.2</code> <code>gpt-5.6-sol</code> <code>qwen3.7-max</code>
+      <b>Recommended Models:</b> <code>claude-fable-5</code> <code>claude-opus-4-8</code> <code>deepseek-v4-pro</code> <code>glm-5.2</code> <code>openai/gpt-5.6-sol (xhigh)</code> <code>qwen3.7-max</code>
     </td>
   </tr>
   <tr>
@@ -432,7 +432,7 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Recommended Models:</b> <code>deepseek-v4-flash</code> <code>gpt-5.3-codex</code> <code>mimo-v2.5</code> <code>minimax-m2.7</code>
+      <b>Recommended Models:</b> <code>deepseek-v4-flash</code> <code>openai/gpt-5.3-codex</code> <code>mimo-v2.5</code> <code>minimax-m2.7</code>
       </td>
    </tr>
    <tr>
@@ -473,7 +473,7 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Recommended Models:</b> <code>gemini-3.5-flash</code> <code>kimi-k2.7-code</code> <code>minimax-m3</code>
+      <b>Recommended Models:</b> <code>google/gemini-3.5-flash</code> <code>kimi-k2.7-code</code> <code>minimax-m3</code>
     </td>
   </tr>
   <tr>
@@ -514,7 +514,7 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Recommended Models:</b> <code>claude-sonnet-4-6</code> <code>deepseek-v4-flash</code> <code>gpt-5.6-luna</code> <code>kimi-k2.7-code</code>
+      <b>Recommended Models:</b> <code>claude-sonnet-4-6</code> <code>deepseek-v4-flash</code> <code>openai/gpt-5.6-luna (medium)</code> <code>kimi-k2.7-code</code>
     </td>
   </tr>
   <tr>
@@ -561,7 +561,7 @@ If any agent fails to respond, check your provider authentication and config fil
    </tr>
    <tr>
       <td colspan="2">
-         <b>Recommended Models:</b> <code>mimo-v2.5</code> <code>qwen3.5-plus</code>
+         <b>Recommended Models:</b> <code>mimo-v2.5</code> <code>openai/gpt-5.6-luna</code> <code>qwen3.5-plus</code>
       </td>
    </tr>
    <tr>

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Default Model:</b> <code>gpt-5.6-terra</code>
+      <b>Default Model:</b> <code>openai/gpt-5.6-terra (medium)</code>
     </td>
   </tr>
   <tr>
@@ -296,7 +296,7 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Default Model:</b> <code>gpt-5.6-luna</code>
+      <b>Default Model:</b> <code>openai/gpt-5.6-luna</code>
     </td>
   </tr>
   <tr>
@@ -337,7 +337,7 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Default Model:</b> <code>gpt-5.6-sol</code>
+      <b>Default Model:</b> <code>openai/gpt-5.6-sol (high)</code>
     </td>
   </tr>
   <tr>
@@ -427,7 +427,7 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Default Model:</b> <code>gpt-5.6-luna</code>
+      <b>Default Model:</b> <code>openai/gpt-5.6-luna</code>
     </td>
   </tr>
   <tr>
@@ -468,7 +468,7 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Default Model:</b> <code>gpt-5.6-luna</code>
+      <b>Default Model:</b> <code>openai/gpt-5.6-luna</code>
     </td>
   </tr>
   <tr>
@@ -509,7 +509,7 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Default Model:</b> <code>gpt-5.6-luna</code>
+      <b>Default Model:</b> <code>openai/gpt-5.6-luna</code>
     </td>
   </tr>
   <tr>
@@ -556,7 +556,7 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Default Model:</b> <code>gpt-5.6-luna</code> - <i>configure a vision-capable model to enable</i>
+      <b>Default Model:</b> <code>openai/gpt-5.6-luna</code> - <i>configure a vision-capable model to enable</i>
       </td>
    </tr>
    <tr>

--- a/README.md
+++ b/README.md
@@ -307,8 +307,8 @@ If any agent fails to respond, check your provider authentication and config fil
    <tr>
       <td colspan="2">
          <b>Model Guidance:</b> Choose a fast, low-cost model. Explorer handles broad scouting work, so speed and efficiency usually matter more than using your strongest reasoning model.
-    </td>
-  </tr>
+      </td>
+   </tr>
 </table>
 
 ---
@@ -438,8 +438,8 @@ If any agent fails to respond, check your provider authentication and config fil
    <tr>
       <td colspan="2">
          <b>Model Guidance:</b> Choose a fast, low-cost model. Librarian handles research and documentation lookups, so speed and efficiency usually matter more than using your strongest reasoning model.
-    </td>
-  </tr>
+      </td>
+   </tr>
 </table>
 
 ---
@@ -567,7 +567,7 @@ If any agent fails to respond, check your provider authentication and config fil
    <tr>
       <td colspan="2">
          <b>Model Guidance:</b> Choose a vision-capable model if you want the agent to read screenshots, images, PDFs, and other visual files.
-    </td>
+      </td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Recommended Models:</b> <code>openai/gpt-5.6-terra (medium)</code> <code>anthropic/claude-fable-5</code> <code>anthropic/claude-opus-4-8</code>
+      <b>Recommended Models:</b> <code>openai/gpt-5.6-terra (medium)</code> <code>anthropic/claude-fable-5</code> <code>anthropic/claude-opus-4-8</code> <code>opencode-go/glm-5.2</code> <code>opencode-go/minimax-m3</code> <code>opencode-go/qwen3.7-plus</code>
     </td>
   </tr>
   <tr>
@@ -301,12 +301,12 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Recommended Models:</b> <code>openai/gpt-5.3-codex</code> <code>cerebras/zai-glm-4.7</code> <code>fireworks-ai/accounts/fireworks/routers/kimi-k2p6-turbo</code>
-    </td>
-  </tr>
-  <tr>
-    <td colspan="2">
-      <b>Model Guidance:</b> Choose a fast, low-cost model. Explorer handles broad scouting work, so speed and efficiency usually matter more than using your strongest reasoning model.
+      <b>Recommended Models:</b> <code>openai/gpt-5.3-codex</code> <code>cerebras/zai-glm-4.7</code> <code>fireworks-ai/accounts/fireworks/routers/kimi-k2p6-turbo</code> <code>opencode-go/kimi-k2.6</code> <code>opencode-go/deepseek-v4-flash</code>
+      </td>
+   </tr>
+   <tr>
+      <td colspan="2">
+         <b>Model Guidance:</b> Choose a fast, low-cost model. Explorer handles broad scouting work, so speed and efficiency usually matter more than using your strongest reasoning model.
     </td>
   </tr>
 </table>
@@ -342,7 +342,7 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Recommended Models:</b> <code>openai/gpt-5.6-sol (xhigh)</code> <code>anthropic/claude-fable-5</code> <code>anthropic/claude-opus-4-8 (xhigh)</code>
+      <b>Recommended Models:</b> <code>openai/gpt-5.6-sol (xhigh)</code> <code>anthropic/claude-fable-5</code> <code>anthropic/claude-opus-4-8 (xhigh)</code> <code>opencode-go/deepseek-v4-pro</code> <code>opencode-go/qwen3.7-max</code> <code>opencode-go/mimo-v2.5-pro</code> <code>opencode-go/glm-5.2</code>
     </td>
   </tr>
   <tr>
@@ -432,12 +432,12 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Recommended Models:</b> <code>openai/gpt-5.3-codex</code> <code>cerebras/zai-glm-4.7</code> <code>fireworks-ai/accounts/fireworks/routers/kimi-k2p6-turbo</code>
-    </td>
-  </tr>
-  <tr>
-    <td colspan="2">
-      <b>Model Guidance:</b> Choose a fast, low-cost model. Librarian handles research and documentation lookups, so speed and efficiency usually matter more than using your strongest reasoning model.
+      <b>Recommended Models:</b> <code>openai/gpt-5.3-codex</code> <code>cerebras/zai-glm-4.7</code> <code>fireworks-ai/accounts/fireworks/routers/kimi-k2p6-turbo</code> <code>opencode-go/kimi-k2.6</code> <code>opencode-go/deepseek-v4-flash</code> <code>opencode-go/mimo-v2.5</code>
+      </td>
+   </tr>
+   <tr>
+      <td colspan="2">
+         <b>Model Guidance:</b> Choose a fast, low-cost model. Librarian handles research and documentation lookups, so speed and efficiency usually matter more than using your strongest reasoning model.
     </td>
   </tr>
 </table>
@@ -473,7 +473,7 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Recommended Models:</b> <code>google/gemini-3.5-flash</code> <code>moonshotai/kimi-k2.7-code</code>
+      <b>Recommended Models:</b> <code>google/gemini-3.5-flash</code> <code>moonshotai/kimi-k2.7-code</code> <code>opencode-go/kimi-k2.7-code</code> <code>opencode-go/minimax-m3</code>
     </td>
   </tr>
   <tr>
@@ -514,7 +514,7 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Recommended Models:</b> <code>openai/gpt-5.6-luna (medium)</code> <code>anthropic/claude-sonnet-4-6</code>
+      <b>Recommended Models:</b> <code>openai/gpt-5.6-luna (medium)</code> <code>anthropic/claude-sonnet-4-6</code> <code>opencode-go/kimi-k2.7-code</code> <code>opencode-go/deepseek-v4-flash</code>
     </td>
   </tr>
   <tr>
@@ -557,11 +557,16 @@ If any agent fails to respond, check your provider authentication and config fil
   <tr>
     <td colspan="2">
       <b>Default Model:</b> <code>openai/gpt-5.6-luna</code> - <i>configure a vision-capable model to enable</i>
-    </td>
-  </tr>
-  <tr>
-    <td colspan="2">
-      <b>Model Guidance:</b> Choose a vision-capable model if you want the agent to read screenshots, images, PDFs, and other visual files.
+      </td>
+   </tr>
+   <tr>
+      <td colspan="2">
+         <b>Recommended Models:</b> <code>opencode-go/mimo-v2.5</code> <code>opencode-go/mimo-v2.5-pro</code>
+      </td>
+   </tr>
+   <tr>
+      <td colspan="2">
+         <b>Model Guidance:</b> Choose a vision-capable model if you want the agent to read screenshots, images, PDFs, and other visual files.
     </td>
   </tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -255,12 +255,12 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Default Model:</b> <code>gpt-5.6-terra (medium)</code>
+      <b>Default Model:</b> <code>gpt-5.6-terra</code>
     </td>
   </tr>
   <tr>
     <td colspan="2">
-      <b>Recommended Models:</b> <code>gpt-5.6-terra (medium)</code> <code>claude-fable-5</code> <code>claude-opus-4-8</code> <code>glm-5.2</code> <code>minimax-m3</code> <code>qwen3.7-plus</code> <code>mimo-v2.5</code>
+      <b>Recommended Models:</b> <code>gpt-5.6-terra</code> <code>claude-fable-5</code> <code>claude-opus-4-8</code> <code>glm-5.2</code> <code>minimax-m3</code> <code>qwen3.7-plus</code> <code>mimo-v2.5</code>
     </td>
   </tr>
   <tr>
@@ -337,12 +337,12 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Default Model:</b> <code>gpt-5.6-sol (high)</code>
+      <b>Default Model:</b> <code>gpt-5.6-sol</code>
     </td>
   </tr>
   <tr>
     <td colspan="2">
-      <b>Recommended Models:</b> <code>gpt-5.6-sol (xhigh)</code> <code>claude-fable-5</code> <code>claude-opus-4-8 (xhigh)</code> <code>deepseek-v4-pro</code> <code>qwen3.7-max</code> <code>mimo-v2.5-pro</code> <code>glm-5.2</code> <code>big-pickle</code>
+      <b>Recommended Models:</b> <code>gpt-5.6-sol</code> <code>claude-fable-5</code> <code>claude-opus-4-8</code> <code>deepseek-v4-pro</code> <code>qwen3.7-max</code> <code>mimo-v2.5-pro</code> <code>glm-5.2</code> <code>big-pickle</code>
     </td>
   </tr>
   <tr>
@@ -509,12 +509,12 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Default Model:</b> <code>gpt-5.6-luna (medium)</code>
+      <b>Default Model:</b> <code>gpt-5.6-luna</code>
     </td>
   </tr>
   <tr>
     <td colspan="2">
-      <b>Recommended Models:</b> <code>gpt-5.6-luna (medium)</code> <code>claude-sonnet-4-6</code> <code>kimi-k2.7-code</code> <code>deepseek-v4-flash</code> <code>north-mini-code</code>
+      <b>Recommended Models:</b> <code>gpt-5.6-luna</code> <code>claude-sonnet-4-6</code> <code>kimi-k2.7-code</code> <code>deepseek-v4-flash</code> <code>north-mini-code</code>
     </td>
   </tr>
   <tr>

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ If any agent fails to respond, check your provider authentication and config fil
   </tr>
   <tr>
     <td colspan="2">
-      <b>Recommended Models:</b> <code>openai/gpt-5.6-terra (medium)</code> <code>anthropic/claude-fable-5</code> <code>anthropic/claude-opus-4-8</code> <code>opencode-go/glm-5.2</code> <code>opencode-go/minimax-m3</code> <code>opencode-go/qwen3.7-plus</code> <code>opencode/mimo-v2.5</code> <code>opencode/nemotron-3-ultra</code>
+      <b>Recommended Models:</b> <code>openai/gpt-5.6-terra (medium)</code> <code>anthropic/claude-fable-5</code> <code>anthropic/claude-opus-4-8</code> <code>opencode-go/glm-5.2</code> <code>opencode-go/minimax-m3</code> <code>opencode-go/qwen3.7-plus</code> <code>opencode/mimo-v2.5</code>
     </td>
   </tr>
   <tr>

--- a/src/utils/env.test.ts
+++ b/src/utils/env.test.ts
@@ -10,12 +10,17 @@ describe('isTruthyEnvValue', () => {
     expect(isTruthyEnvValue(value)).toBe(true);
   });
 
-  test.each([undefined, '', '0', 'false', 'no', 'off', 'anything'])(
-    '%p is not truthy',
-    (value) => {
-      expect(isTruthyEnvValue(value)).toBe(false);
-    },
-  );
+  test.each([
+    undefined,
+    '',
+    '0',
+    'false',
+    'no',
+    'off',
+    'anything',
+  ])('%p is not truthy', (value) => {
+    expect(isTruthyEnvValue(value)).toBe(false);
+  });
 });
 
 describe('isPluginDisabledByEnv', () => {

--- a/src/utils/env.test.ts
+++ b/src/utils/env.test.ts
@@ -10,17 +10,12 @@ describe('isTruthyEnvValue', () => {
     expect(isTruthyEnvValue(value)).toBe(true);
   });
 
-  test.each([
-    undefined,
-    '',
-    '0',
-    'false',
-    'no',
-    'off',
-    'anything',
-  ])('%p is not truthy', (value) => {
-    expect(isTruthyEnvValue(value)).toBe(false);
-  });
+  test.each([undefined, '', '0', 'false', 'no', 'off', 'anything'])(
+    '%p is not truthy',
+    (value) => {
+      expect(isTruthyEnvValue(value)).toBe(false);
+    },
+  );
 });
 
 describe('isPluginDisabledByEnv', () => {


### PR DESCRIPTION
Fixes #823

## What problem are you solving?
Issue #823 asked to surface a set of current models (GLM 5.2, Kimi K2.7/K2.6, DeepSeek V4 Pro/Flash, MiniMax M3, MiMo V2.5/Pro, Qwen3.7 Max/Plus) in the README's per-agent "Recommended Models" ranges so users know which models fit each agent role. The README ranges only listed OpenAI/Anthropic/Google/Moonshot models and omitted these.

## What does this change?
Adds the issue #823 models to each agent's "Recommended Models" line where the model fits the role, plus folds in the user's balanced-preset model families. All provider prefixes and variant suffixes are stripped, duplicates removed, and each agent's list alphabetized. Also normalizes table indentation in three agent sections and includes a pre-existing Biome auto-fix to src/utils/env.test.ts so check:ci passes on the branch.

## Why this approach?
Models are listed without provider/variant prefixes so the ranges read as model families rather than provider-locked IDs, and alphabetized per agent for scanability. No alternative presentation was considered beyond the existing per-agent table format, which we kept.

## Related work
- [x] Checked open AND closed PRs/issues for duplicates — none found for #823.
- Related: none found.

## AI assistance
- Model / harness: OpenCode (hy3-free) orchestrator; @oracle subagent for code review ran on opencode/big-pickle (fallback opencode-go/glm-5.2) per the active balanced preset; @skeptic not invoked.
- Human reviewed the full diff? Yes — user approved before submit.

## Checklist
- [x] `bun run check:ci`, `bun run typecheck`, and `bun test` pass
- [x] Docs (README.md) updated
- [x] One logical change per PR
- [x] PR targets the `master` branch