### PR TITLE
fix(tui): hide council and dynamic councillors from sidebar

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -759,7 +759,12 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
       const tuiAgentModels: Record<string, string> = {};
       const tuiAgentVariants: Record<string, string> = {};
       for (const agentDef of agentDefs) {
-        if (agentDef.name === 'councillor') continue;
+        if (
+          agentDef.name === 'council' ||
+          agentDef.name === 'councillor' ||
+          agentDef.name.startsWith('councillor-')
+        )
+          continue;
 
         const entry = configAgent[agentDef.name] as
           | Record<string, unknown>


### PR DESCRIPTION
Fixes #824

## What changed, and why was it needed?

The TUI side panel was listing council members that should be hidden: `council`, `councillor-alpha`, `councillor-beta`, etc. The TUI model-recording loop in `src/index.ts` only skipped the exact name `'councillor'`, so the `council` agent and the dynamic councillor seats (named `councillor-alpha`, `councillor-beta`, …) were written into `tui-state.json` and rendered as sidebar rows. The SDK `hidden: true` flag only affects `@`-autocomplete, not the sidebar data path.

## What does this change?

Extends the skip condition to exclude all council-related agents (`council`, `councillor`, and any `councillor-*`), mirroring the existing classification in `agents/index.ts` `getAgentConfigs`.

## Why this approach?

The classification already exists in `getAgentConfigs` (`name === 'council'` → `mode: 'all'`; `name === 'councillor' || name.startsWith('councillor-')` → `mode: 'subagent', hidden: true`). Reusing that exact same name set keeps the two code paths consistent instead of introducing a divergent filter. No new abstraction or dependency.

## Related work

Checked open/closed issues — none found for this specific bug. Issue #824 filed alongside this PR.

## AI assistance

- Harness: OpenCode
- Orchestrator model: opencode/hy3-free
- `@oracle` (used for code review): model not resolvable from a local `oh-my-opencode-slim.jsonc` preset in this environment — report as "preset config not available locally".
- `@skeptic` / `/receiving-code-review`: not used for this PR.
- Human reviewed the full diff: yes (user approved the diff at the sign-off gate).

## Verification

- `bun run typecheck`: clean
- `bun test`: 1618 pass, 0 fail
- `bun run check:ci`: 1 pre-existing failure in `src/utils/env.test.ts` (unrelated formatting, present on `master`, not touched by this change)
- Oracle code review: clean, consistent with `getAgentConfigs` classification, no races, minimal correct fix.

## Docs

No user-facing behavior, commands, or configuration changed. No doc update needed.
