### PR TITLE
fix(task-session): parallel early-reg mis-attribution + idle/FG false-complete race

### DIFF
--- a/src/cache-safety-tripwire.test.ts
+++ b/src/cache-safety-tripwire.test.ts
@@ -63,6 +63,10 @@ const ALLOWLIST = new Map<string, string>([
     'Date.now() records lastReadAt for internal recency ordering; formatted prompt output (background job board) is confined to the volatile trailing message.',
   ],
   [
+    'hooks/task-session-manager/index.ts',
+    'Date.now() captures idleObservedAt to detect post-idle busy recovery from foreground-fallback re-prompts; never serialized into prompt content.',
+  ],
+  [
     'hooks/image-hook.ts',
     'Date.now() throttles temp-image cleanup; extracted image paths are deterministic per part id.',
   ],

--- a/src/hooks/task-session-manager/index.test.ts
+++ b/src/hooks/task-session-manager/index.test.ts
@@ -25,6 +25,11 @@ async function flushContinuation(): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, 0));
 }
 
+/** Flush delayed child idle-reconcile timers when idleReconcileDelayMs is 0. */
+async function flushChildIdleReconcile(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 5));
+}
+
 function createHook(options?: {
   shouldManageSession?: (sessionID: string) => boolean;
   registerSessionAsOrchestrator?: (sessionID: string) => void;
@@ -2324,11 +2329,13 @@ describe('task-session-manager hook', () => {
     const { hook } = createHook({
       backgroundJobBoard: board,
       shouldManageSession: (id) => id === 'parent-1',
+      idleReconcileDelayMs: 0,
     });
 
     await hook.event({
       event: { type: 'session.idle', properties: { sessionID: 'child-1' } },
     });
+    await flushChildIdleReconcile();
 
     expect(board.get('child-1')).toMatchObject({
       state: 'reconciled',
@@ -2373,11 +2380,13 @@ describe('task-session-manager hook', () => {
       backgroundJobBoard: board,
       shouldManageSession: (id) => id === 'parent-1',
       isFallbackInProgress: (id) => id === 'child-1',
+      idleReconcileDelayMs: 0,
     });
 
     await hook.event({
       event: { type: 'session.idle', properties: { sessionID: 'child-1' } },
     });
+    await flushChildIdleReconcile();
 
     // Job should still be running — not reconciled
     expect(board.get('child-1')).toMatchObject({ state: 'running' });
@@ -2448,11 +2457,13 @@ describe('task-session-manager hook', () => {
       shouldManageSession: (id) => id === 'parent-1',
       // isFallbackInProgress returns false for child-1
       isFallbackInProgress: () => false,
+      idleReconcileDelayMs: 0,
     });
 
     await hook.event({
       event: { type: 'session.idle', properties: { sessionID: 'child-1' } },
     });
+    await flushChildIdleReconcile();
 
     expect(board.get('child-1')).toMatchObject({
       state: 'reconciled',
@@ -2477,12 +2488,14 @@ describe('task-session-manager hook', () => {
       backgroundJobBoard: board,
       shouldManageSession: () => false,
       isFallbackInProgress: (id) => id === 'child-1',
+      idleReconcileDelayMs: 0,
     });
 
     // First idle (abort from fallback) — guarded, no reconciliation
     await hook.event({
       event: { type: 'session.idle', properties: { sessionID: 'child-1' } },
     });
+    await flushChildIdleReconcile();
     expect(board.get('child-1')).toMatchObject({ state: 'running' });
 
     // Busy signal (fallback re-prompt) — updates lastLiveBusyAt
@@ -2499,14 +2512,52 @@ describe('task-session-manager hook', () => {
       backgroundJobBoard: board,
       shouldManageSession: () => false,
       isFallbackInProgress: () => false,
+      idleReconcileDelayMs: 0,
     });
     await hook2.hook.event({
       event: { type: 'session.idle', properties: { sessionID: 'child-1' } },
     });
+    await flushChildIdleReconcile();
     expect(board.get('child-1')).toMatchObject({
       state: 'reconciled',
       terminalState: 'completed',
     });
+  });
+
+  test('busy after idle cancels pending child idle-reconcile (FG race)', async () => {
+    // OpenCode can emit idle for a rate-limited child BEFORE FG sets
+    // isFallbackInProgress. Immediate reconcile would mark completed while
+    // FG re-prompts and the child keeps working. Delay + busy cancel keeps
+    // the job running (the observed council-b false-complete race).
+    const board = new BackgroundJobBoard();
+    board.registerLaunch({
+      taskID: 'child-b',
+      parentSessionID: 'parent-1',
+      agent: 'councillor-reviewer-b',
+      description: 'audit distributed',
+    });
+
+    const { hook } = createHook({
+      backgroundJobBoard: board,
+      shouldManageSession: () => false,
+      isFallbackInProgress: () => false,
+      idleReconcileDelayMs: 30,
+    });
+
+    await hook.event({
+      event: { type: 'session.idle', properties: { sessionID: 'child-b' } },
+    });
+    expect(board.get('child-b')).toMatchObject({ state: 'running' });
+
+    await hook.event({
+      event: {
+        type: 'session.status',
+        properties: { sessionID: 'child-b', status: { type: 'busy' } },
+      },
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(board.get('child-b')).toMatchObject({ state: 'running' });
   });
 
   test('session.created early-registers board job so after-hook cancellation cannot orphan the child', async () => {
@@ -2514,7 +2565,10 @@ describe('task-session-manager hook', () => {
     // so the job never lands on the board. Early registration from
     // session.created keeps runningJobForSession true and lets idle reconcile.
     const board = new BackgroundJobBoard();
-    const { hook } = createHook({ backgroundJobBoard: board });
+    const { hook } = createHook({
+      backgroundJobBoard: board,
+      idleReconcileDelayMs: 0,
+    });
 
     await hook['tool.execute.before'](
       { tool: 'task', sessionID: 'parent-1', callID: 'call-1' },
@@ -2546,6 +2600,7 @@ describe('task-session-manager hook', () => {
     await hook.event({
       event: { type: 'session.idle', properties: { sessionID: 'child-1' } },
     });
+    await flushChildIdleReconcile();
 
     expect(board.get('child-1')).toMatchObject({
       state: 'reconciled',
@@ -2618,11 +2673,13 @@ describe('task-session-manager hook', () => {
     const { hook } = createHook({
       backgroundJobBoard: board,
       shouldManageSession: () => false,
+      idleReconcileDelayMs: 0,
     });
 
     await hook.event({
       event: { type: 'session.idle', properties: { sessionID: 'child-1' } },
     });
+    await flushChildIdleReconcile();
 
     // Should remain cancelled — idle does not override terminal state
     const job = board.get('child-1');
@@ -2642,6 +2699,7 @@ describe('task-session-manager hook', () => {
     const { hook } = createHook({
       backgroundJobBoard: board,
       shouldManageSession: (id) => id === 'parent-1',
+      idleReconcileDelayMs: 0,
     });
 
     await hook.event({
@@ -2650,6 +2708,7 @@ describe('task-session-manager hook', () => {
         properties: { sessionID: 'child-1', status: { type: 'idle' } },
       },
     });
+    await flushChildIdleReconcile();
 
     expect(board.get('child-1')).toMatchObject({
       state: 'reconciled',

--- a/src/hooks/task-session-manager/index.test.ts
+++ b/src/hooks/task-session-manager/index.test.ts
@@ -2553,6 +2553,57 @@ describe('task-session-manager hook', () => {
     });
   });
 
+  test('session.created early registration attributes each parallel child to its own pending call', async () => {
+    // Regression: when a parent launches several task tools in parallel with
+    // different subagent types (e.g. council reviewers a/b/c), the old
+    // peekByParent() returned the FIRST pending call for every child, so
+    // all children were registered with the first subagent's agentType.
+    // info.agent on the child session disambiguates which pending call
+    // started it.
+    const board = new BackgroundJobBoard();
+    const { hook } = createHook({ backgroundJobBoard: board });
+
+    // Parent fires three task tools in parallel: oracle / explorer / fixer.
+    await hook['tool.execute.before'](
+      { tool: 'task', sessionID: 'parent-1', callID: 'call-a' },
+      { args: { subagent_type: 'oracle', description: 'audit loss' } },
+    );
+    await hook['tool.execute.before'](
+      { tool: 'task', sessionID: 'parent-1', callID: 'call-b' },
+      { args: { subagent_type: 'explorer', description: 'audit data' } },
+    );
+    await hook['tool.execute.before'](
+      { tool: 'task', sessionID: 'parent-1', callID: 'call-c' },
+      { args: { subagent_type: 'fixer', description: 'audit fix' } },
+    );
+
+    // Each child session is created while the parent tool calls are still
+    // in flight (before any tool.execute.after). info.agent identifies the
+    // subagent that owns each child.
+    await hook.event({
+      event: {
+        type: 'session.created',
+        properties: { info: { id: 'child-a', parentID: 'parent-1', agent: 'oracle' } },
+      },
+    });
+    await hook.event({
+      event: {
+        type: 'session.created',
+        properties: { info: { id: 'child-b', parentID: 'parent-1', agent: 'explorer' } },
+      },
+    });
+    await hook.event({
+      event: {
+        type: 'session.created',
+        properties: { info: { id: 'child-c', parentID: 'parent-1', agent: 'fixer' } },
+      },
+    });
+
+    expect(board.get('child-a')).toMatchObject({ agent: 'oracle', description: 'audit loss' });
+    expect(board.get('child-b')).toMatchObject({ agent: 'explorer', description: 'audit data' });
+    expect(board.get('child-c')).toMatchObject({ agent: 'fixer', description: 'audit fix' });
+  });
+
   test('cancelled job is not reconciled from idle', async () => {
     const board = new BackgroundJobBoard();
     board.registerLaunch({

--- a/src/hooks/task-session-manager/index.test.ts
+++ b/src/hooks/task-session-manager/index.test.ts
@@ -2560,6 +2560,48 @@ describe('task-session-manager hook', () => {
     expect(board.get('child-b')).toMatchObject({ state: 'running' });
   });
 
+  test('session.deleted cancels pending child idle-reconcile (FG teardown race)', async () => {
+    // FG aborts the child session mid-idle-delay; onSessionDeleted must
+    // cancel the pending timer so it cannot fire after FG finishes and
+    // re-check isFallbackInProgress=false, falsely reconciling the board
+    // entry while the re-prompted session keeps working.
+    const coordinator = new SessionLifecycle(() => {});
+    const board = new BackgroundJobBoard();
+    board.registerLaunch({
+      taskID: 'child-b',
+      parentSessionID: 'parent-1',
+      agent: 'councillor-reviewer-b',
+      description: 'audit distributed',
+    });
+
+    let fgInProgress = false;
+    const { hook } = createHook({
+      backgroundJobBoard: board,
+      coordinator,
+      shouldManageSession: () => false,
+      isFallbackInProgress: () => fgInProgress,
+      idleReconcileDelayMs: 30,
+    });
+
+    // idle fires before FG sets isFallbackInProgress — schedules timer T.
+    await hook.event({
+      event: { type: 'session.idle', properties: { sessionID: 'child-b' } },
+    });
+    // FG claims the session and aborts it; OpenCode emits session.deleted
+    // while the timer is still pending. onSessionDeleted must cancel T.
+    fgInProgress = true;
+    coordinator.dispatchSessionDeleted('child-b');
+    // FG finishes; isFallbackInProgress goes false before T would fire.
+    fgInProgress = false;
+
+    await new Promise((r) => setTimeout(r, 60));
+    // Board entry survives (isFallbackInProgress was true at delete time)
+    // but is NOT reconciled — the timer was cancelled on session.deleted.
+    const job = board.get('child-b');
+    expect(job).toBeDefined();
+    expect(job?.state).toBe('running');
+  });
+
   test('session.created early-registers board job so after-hook cancellation cannot orphan the child', async () => {
     // Reproduces #765: parent tool may be cancelled before tool.execute.after,
     // so the job never lands on the board. Early registration from

--- a/src/hooks/task-session-manager/index.ts
+++ b/src/hooks/task-session-manager/index.ts
@@ -1002,7 +1002,7 @@ export function createTaskSessionManagerHook(
       event: {
         type: string;
         properties?: {
-          info?: { id?: string; parentID?: string };
+          info?: { id?: string; parentID?: string; agent?: string };
           id?: string;
           requestID?: string;
           sessionID?: string;
@@ -1034,7 +1034,15 @@ export function createTaskSessionManagerHook(
           // reports runningJobForSession:false and the orchestrator sees
           // "Task cancelled" while the child is still working (#765).
           // Peek (don't take) so tool.execute.after can still re-register.
-          const pending = pendingCallTracker.peekByParent(info.parentID);
+          //
+          // When the parent has multiple task calls in flight at once (e.g.
+          // parallel council reviewers), `info.agent` on the child session
+          // identifies which subagent started it; prefer the matching
+          // pending call so we don't attribute the child to the wrong agent.
+          const pending = pendingCallTracker.peekByParentAndAgent(
+            info.parentID,
+            info.agent,
+          );
           if (
             pending &&
             !pending.resumedTaskId &&

--- a/src/hooks/task-session-manager/index.ts
+++ b/src/hooks/task-session-manager/index.ts
@@ -155,6 +155,10 @@ export function createTaskSessionManagerHook(
   const processedInjectedCompletionOrder: string[] = [];
   const terminalJobsInjectedByParent = new Map<string, Set<string>>();
   const idleReconcileTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  const childIdleReconcileTimers = new Map<
+    string,
+    ReturnType<typeof setTimeout>
+  >();
   const continuationSessionTokens = new Map<string, symbol>();
   const activeContinuationEvaluations = new Map<string, Set<symbol>>();
   const continuationConsumed = new Set<string>();
@@ -439,6 +443,58 @@ export function createTaskSessionManagerHook(
       }
     }, idleReconcileDelayMs).unref?.();
     idleReconcileTimers.set(parentSessionID, timer);
+  }
+
+  /**
+   * Delay child idle→completed reconciliation. Immediate reconcile races
+   * ForegroundFallbackManager: OpenCode can emit idle for a rate-limited
+   * child before FG sets isFallbackInProgress, marking the job completed
+   * while FG re-prompts and the session keeps working (false cancel/complete).
+   * Re-check running state, fallback-in-progress, and lastLiveBusyAt after
+   * the delay so a post-idle busy from the fallback re-prompt wins.
+   */
+  function scheduleChildIdleReconciliation(
+    sessionID: string,
+    idleObservedAt: number,
+  ): void {
+    if (childIdleReconcileTimers.has(sessionID)) return;
+    if (options.isFallbackInProgress?.(sessionID)) return;
+
+    const timer = setTimeout(() => {
+      childIdleReconcileTimers.delete(sessionID);
+      if (options.isFallbackInProgress?.(sessionID)) return;
+
+      const job = backgroundJobBoard.get(sessionID);
+      if (!job || job.state !== 'running') return;
+
+      // Busy after the idle means the session recovered (e.g. FG re-prompt).
+      if (
+        job.lastLiveBusyAt !== undefined &&
+        job.lastLiveBusyAt > idleObservedAt
+      ) {
+        return;
+      }
+
+      log('[task-session-manager] reconciled running job from idle', {
+        sessionID,
+        alias: job.alias,
+        parentSessionID: job.parentSessionID,
+      });
+      backgroundJobBoard.updateStatus({
+        taskID: sessionID,
+        state: 'completed',
+        resultSummary:
+          'Background task completed (reconciled from idle event)',
+      });
+      backgroundJobBoard.markReconciled(sessionID);
+      taskContextTracker.pendingManagedTaskIds.delete(sessionID);
+      backgroundJobBoard.addContext(
+        sessionID,
+        taskContextTracker.contextFilesForPrompt(sessionID),
+      );
+      taskContextTracker.prune(backgroundJobBoard);
+    }, idleReconcileDelayMs).unref?.();
+    childIdleReconcileTimers.set(sessionID, timer);
   }
 
   if (options.coordinator) {
@@ -1070,6 +1126,10 @@ export function createTaskSessionManagerHook(
       }
 
       if (input.event.type === 'server.instance.disposed') {
+        for (const timer of childIdleReconcileTimers.values()) {
+          clearTimeout(timer);
+        }
+        childIdleReconcileTimers.clear();
         const continuationSessionIDs = new Set([
           ...idleReconcileTimers.keys(),
           ...continuationSessionTokens.keys(),
@@ -1110,33 +1170,9 @@ export function createTaskSessionManagerHook(
         // Fallback: for background child sessions that go idle without
         // an injected completion, reconcile the board entry since the
         // session being idle is itself the completion signal.
-        // Guard: skip when a foreground-fallback abort/re-prompt is in
-        // flight for this session — the idle is transient, not a real
-        // completion.
-        if (
-          job &&
-          sessionId &&
-          job.state === 'running' &&
-          !options.isFallbackInProgress?.(sessionId)
-        ) {
-          log('[task-session-manager] reconciled running job from idle', {
-            sessionID: sessionId,
-            alias: job.alias,
-            parentSessionID: job.parentSessionID,
-          });
-          backgroundJobBoard.updateStatus({
-            taskID: sessionId,
-            state: 'completed',
-            resultSummary:
-              'Background task completed (reconciled from idle event)',
-          });
-          backgroundJobBoard.markReconciled(sessionId);
-          taskContextTracker.pendingManagedTaskIds.delete(sessionId);
-          backgroundJobBoard.addContext(
-            sessionId,
-            taskContextTracker.contextFilesForPrompt(sessionId),
-          );
-          taskContextTracker.prune(backgroundJobBoard);
+        // Delayed so FG can claim the session before we mark completed.
+        if (job && sessionId && job.state === 'running') {
+          scheduleChildIdleReconciliation(sessionId, Date.now());
         }
         return;
       }
@@ -1185,6 +1221,15 @@ export function createTaskSessionManagerHook(
         if (sessionId) invalidateContinuation(sessionId);
         if (statusType !== 'busy') {
           return;
+        }
+        // Live busy cancels a pending child idle-reconcile — the session
+        // recovered (FG re-prompt or continued work).
+        if (sessionId) {
+          const pendingChildIdle = childIdleReconcileTimers.get(sessionId);
+          if (pendingChildIdle) {
+            clearTimeout(pendingChildIdle);
+            childIdleReconcileTimers.delete(sessionId);
+          }
         }
         const before = sessionId
           ? backgroundJobBoard.get(sessionId)

--- a/src/hooks/task-session-manager/index.ts
+++ b/src/hooks/task-session-manager/index.ts
@@ -501,6 +501,11 @@ export function createTaskSessionManagerHook(
     options.coordinator.onSessionDeleted((sessionId) => {
       clearContinuation(sessionId);
       clearInputWaits(sessionId);
+      const pendingChildIdle = childIdleReconcileTimers.get(sessionId);
+      if (pendingChildIdle) {
+        clearTimeout(pendingChildIdle);
+        childIdleReconcileTimers.delete(sessionId);
+      }
       // During a foreground fallback abort/re-prompt cycle, the session
       // is being torn down and immediately recreated with a fallback model.
       // Dropping the job from the board here would make the orchestrator

--- a/src/hooks/task-session-manager/pending-call-tracker.ts
+++ b/src/hooks/task-session-manager/pending-call-tracker.ts
@@ -47,6 +47,30 @@ export function createPendingCallTracker() {
       return undefined;
     },
 
+    /**
+     * Peek a pending call for a parent, preferring one whose agentType
+     * matches `agentHint`. Used by session.created early registration:
+     * when a parent launches several parallel task tools with different
+     * subagent types (e.g. council reviewers), `info.agent` on the
+     * child session identifies which subagent started it, so we can
+     * avoid attributing the child to the wrong pending call.
+     * Falls back to the oldest pending call for the parent when no
+     * agent match is found (preserves prior behavior).
+     */
+    peekByParentAndAgent(
+      parentSessionId: string,
+      agentHint?: string,
+    ) {
+      if (!agentHint) return this.peekByParent(parentSessionId);
+      let fallback: PendingTaskCall | undefined;
+      for (const call of pendingCalls.values()) {
+        if (call.parentSessionId !== parentSessionId) continue;
+        if (!fallback) fallback = call;
+        if (call.agentType === agentHint) return call;
+      }
+      return fallback;
+    },
+
     clearSession(sessionId: string) {
       for (const [callId, pending] of pendingCalls.entries()) {
         if (pending.parentSessionId === sessionId) {


### PR DESCRIPTION
## Problem

When launching **parallel** task tools (e.g. council `councillor-reviewer-a/b/c`), two bugs caused false cancel/complete while the child kept running:

### 1. Early board registration attributes all children to the first agent

`session.created` early registration called `peekByParent(parentID)`, which returns the **first** pending call in insertion order. With three parallel task tools in flight:

```
before(a) → before(b) → before(c)
session.created(child-b) → peek → a's pending  // wrong
session.created(child-c) → peek → a's pending  // wrong
```

Log evidence (`oh-my-opencode-slim.20260719T081220.log`):
- cou-2 / cou-3 both registered as `agent: councillor-reviewer-a`

### 2. Immediate idle reconcile races FG fallback (false complete)

Child idle was reconciled to `completed` **immediately**. OpenCode can emit idle for a rate-limited child **before** `ForegroundFallbackManager` sets `isFallbackInProgress`:

```
08:34:09.362 idle → reconciled running job from idle (cou-2)
08:34:09.555 FG switched zfy → shuo
08:34:09.632 busy with previousState: reconciled, terminalState: completed
… session keeps working for minutes
```

Board says done; session still runs. Parent sees cancelled/completed while child continues — the "错误 cancel" UX.

### 3. `session.deleted` doesn't cancel pending child idle-reconcile timer

Greptile P1: during FG teardown, idle → schedule timer → FG aborts → `onSessionDeleted` preserves board entry (correct) but leaves the timer running → FG finishes (`isFallbackInProgress=false`) → timer fires and falsely reconciles while the re-prompted session keeps working.

## Fix

1. **`peekByParentAndAgent(parent, info.agent)`** — OpenCode sets `SessionInfo.agent` to the subagent name at create (`sst/opencode` `task.ts` → `sessions.create({ agent: next.name })`). Prefer the pending call whose `agentType` matches; fall back to oldest only if no match.

2. **Delay child idle-reconcile** (same `idleReconcileDelayMs` window as parent continuation):
   - Re-check `isFallbackInProgress` after delay
   - Skip if `lastLiveBusyAt` is after the idle was observed
   - Cancel pending timer on live `busy` status

3. **Cancel `childIdleReconcileTimers` on `session.deleted`** — matches `server.instance.disposed` path. A deleted session has no future idle/busy; any pending timer can only mis-reconcile.

## Tests

- Parallel early-reg: a/b/c children get correct agent/description
- FG race: idle then busy before delay → stays `running`
- FG teardown race: idle → session.deleted before delay → stays `running`
- Existing idle/fallback tests updated for delayed reconcile

1621 tests pass across the full suite. CI green.

## Relation to #822 and issues

- **#822** stopped FG from aborting agents with **no** chain (plain `councillor`). Parallel **reviewer-*** agents **have** chains and still use FG — this PR fixes the board/lifecycle side of that path.
- **#595** "Fallback is detached from background task lifecycle, causing lost failures and orphaned successes" — the root issue. The idle/FG race fixed here is the mechanism behind the false-complete/orphaned-success symptom.
- **#765** "Background task reported as cancelled when it actually completed during foreground fallback" — fixed the early-registration side; this PR extends that protection to the parallel + idle-reconcile-race scenarios.