### PR TITLE
fix(task-session-manager): record background subagent session.error on board (issue #836)

### DIFF
--- a/src/hooks/task-session-manager/index.test.ts
+++ b/src/hooks/task-session-manager/index.test.ts
@@ -1717,6 +1717,79 @@ describe('task-session-manager hook', () => {
     expect(job?.resultSummary).toBe('connection refused');
   });
 
+  test('child session.error (non-orchestrator) records failure on board', async () => {
+    const board = new BackgroundJobBoard();
+    // Child subagent sessions are not orchestrators, so shouldManageSession
+    // returns false for them. The error must still land on the board,
+    // otherwise idle reconciliation marks the job completed (false success).
+    const { hook } = createHook({
+      backgroundJobBoard: board,
+      shouldManageSession: () => false,
+    });
+
+    board.registerLaunch({
+      taskID: 'child-1',
+      parentSessionID: 'parent-1',
+      agent: 'designer',
+      description: 'design ui',
+    });
+    board.updateStatus({ taskID: 'child-1', state: 'running' });
+
+    await hook.event({
+      event: {
+        type: 'session.error',
+        properties: {
+          sessionID: 'child-1',
+          error: {
+            name: 'AI_APICallError',
+            message: 'Internal server error',
+          },
+        },
+      },
+    });
+
+    const job = board.get('child-1');
+    expect(job?.state).toBe('error');
+    expect(job?.resultSummary).toBe('Internal server error');
+  });
+
+  test('child session.error during fallback is not recorded on board', async () => {
+    const board = new BackgroundJobBoard();
+    // isFallbackInProgress is currently always-false for real children
+    // (they have no fallback chain), so this guard path is unreachable in
+    // production today. The test pins the defensive behavior for the day
+    // children gain a fallback chain.
+    const { hook } = createHook({
+      backgroundJobBoard: board,
+      shouldManageSession: () => false,
+      isFallbackInProgress: () => true,
+    });
+
+    board.registerLaunch({
+      taskID: 'child-1',
+      parentSessionID: 'parent-1',
+      agent: 'designer',
+      description: 'design ui',
+    });
+    board.updateStatus({ taskID: 'child-1', state: 'running' });
+
+    await hook.event({
+      event: {
+        type: 'session.error',
+        properties: {
+          sessionID: 'child-1',
+          error: {
+            name: 'AI_APICallError',
+            message: 'Internal server error',
+          },
+        },
+      },
+    });
+
+    const job = board.get('child-1');
+    expect(job?.state).toBe('running');
+  });
+
   test('completed reconciled job appears reusable and resumes via task', async () => {
     const board = new BackgroundJobBoard();
     const { hook } = createHook({ backgroundJobBoard: board });

--- a/src/hooks/task-session-manager/index.ts
+++ b/src/hooks/task-session-manager/index.ts
@@ -1166,6 +1166,27 @@ export function createTaskSessionManagerHook(
               });
             }
           }
+        } else if (sessionId) {
+          // Child subagent sessions are not orchestrators, so the block
+          // above never runs for them. Without this, a failed background
+          // subagent leaves its job in `running` and the idle-reconciliation
+          // path (which has no shouldManageSession guard) marks it
+          // `completed` — a false success. A child with no fallback chain has
+          // nothing to retry into, so surface the failure on the board.
+          const props = input.event.properties as
+            | { error?: unknown }
+            | undefined;
+          if (options.isFallbackInProgress?.(sessionId)) return;
+          const job = backgroundJobBoard.get(sessionId);
+          if (job && job.state === 'running') {
+            backgroundJobBoard.updateStatus({
+              taskID: sessionId,
+              state: 'error',
+              resultSummary:
+                (props?.error as { message?: string } | undefined)?.message ??
+                'Session error',
+            });
+          }
         }
 
         return;

--- a/src/utils/env.test.ts
+++ b/src/utils/env.test.ts
@@ -10,12 +10,17 @@ describe('isTruthyEnvValue', () => {
     expect(isTruthyEnvValue(value)).toBe(true);
   });
 
-  test.each([undefined, '', '0', 'false', 'no', 'off', 'anything'])(
-    '%p is not truthy',
-    (value) => {
-      expect(isTruthyEnvValue(value)).toBe(false);
-    },
-  );
+  test.each([
+    undefined,
+    '',
+    '0',
+    'false',
+    'no',
+    'off',
+    'anything',
+  ])('%p is not truthy', (value) => {
+    expect(isTruthyEnvValue(value)).toBe(false);
+  });
 });
 
 describe('isPluginDisabledByEnv', () => {


### PR DESCRIPTION
Fixes #836

## What problem are you solving?

In v2.2.4, when a background subagent (child session, not an orchestrator) fails with `AI_APICallError: Internal server error`, the failure is silently swallowed. The `session.error` handler only writes the error to the job board when `shouldManageSession(sessionId)` is true, which is `sessionAgentMap.get(id) === 'orchestrator'` — false for child sessions. The job stays `running`, and the idle-reconciliation path (which has no `shouldManageSession` guard) then marks it `completed`. The orchestrator is told the background work finished when it actually failed (false success). This is the cascade behind issue #836's "Designer repeatedly failed / rollback to v2.2.2 restores it" — v2.2.2 recorded every `session.error`, so the orchestrator saw the real failure.

## What does this change?

Adds an `else if (sessionId)` branch in the `session.error` handler that records the error on the board for non-orchestrator sessions with a running board entry, unless a fallback is in progress. Two regression tests cover the child-error path and the fallback-in-progress guard.

## Why this approach?

The error-recording block is duplicated between the orchestrator and child branches, but the guards differ (`isFailoverError` vs `isFallbackInProgress`) and the orchestrator branch has extra side effects (`terminalJobsInjectedByParent.delete`). Extraction would parameterize both guards and the side effect for no readability gain, so the small duplication is kept. Alternatives considered: tracking recent errors per session ID to block idle reconciliation — rejected as more state for the same outcome.

## Related work

- [x] I checked open AND closed PRs/issues for duplicates
- Related: #830 (background tasks reported cancelled during fallback — complementary, different root cause), #801 (prior fix recording non-retryable session errors for orchestrators), #595 (fallback detached from background task lifecycle)

## AI assistance

- Model / harness: OpenCode (`opencode/hy3-free` orchestrator) with subagents on the `balanced` preset: @oracle (`opencode/big-pickle`), @skeptic (`opencode/big-pickle`), @explorer (`opencode/deepseek-v4-flash-free`), @fixer (`opencode/deepseek-v4-flash-free`), @librarian (`opencode/mimo-v2.5-free`), @observer (`opencode/mimo-v2.5-free`), @designer (`opencode-go/kimi-k2.7-code`)
- Human reviewed the full diff? [ ] No — awaiting maintainer review

## Checklist

- [x] `bun run check:ci` passes
- [x] `bun run typecheck` passes
- [x] `bun test` passes (1620 tests, 0 fail)
- [x] Docs (README.md, docs/) — no user-facing behavior changed, no doc update needed
- [x] One logical change per PR
- [x] PR targets the `master` branch