### PR TITLE
feat(agents): add task rejection contract

### DIFF
--- a/docs/background-orchestration.md
+++ b/docs/background-orchestration.md
@@ -266,6 +266,21 @@ Include:
 - validation to run or report,
 - what not to do.
 
+### Task-fit rejections
+
+A specialist may reject a task outside its role, permissions, or available
+context instead of attempting partial work. It returns:
+
+```text
+<task_rejection>
+<reason>brief explanation for the orchestrator</reason>
+<recommended_agent>@agent-name when clear</recommended_agent>
+</task_rejection>
+```
+
+`recommended_agent` is optional. The orchestrator uses the reason to reroute
+or clarify the task and must not retry the unchanged task with the same agent.
+
 Good background task prompt:
 
 ```text

--- a/docs/background-orchestration.md
+++ b/docs/background-orchestration.md
@@ -268,17 +268,10 @@ Include:
 
 ### Task-fit rejections
 
-Specialists receive this instruction:
-
-```text
-If an assignment is outside your role, permissions, or available context, reject it rather than partially attempting it. Respond exactly:
-<task_rejection>
-<reason>brief explanation for the orchestrator</reason>
-</task_rejection>
-```
-
-The orchestrator inspects only the reason to reroute or clarify the task and
-must not retry the unchanged task with the same agent.
+If a task is outside a specialist's role, permissions, or available context, it
+must not attempt partial work. It returns a brief reason to the orchestrator.
+The orchestrator treats that reason as routing input to reroute or clarify the
+task and must not retry the unchanged task with the same specialist.
 
 Good background task prompt:
 

--- a/docs/background-orchestration.md
+++ b/docs/background-orchestration.md
@@ -268,18 +268,17 @@ Include:
 
 ### Task-fit rejections
 
-A specialist may reject a task outside its role, permissions, or available
-context instead of attempting partial work. It returns:
+Specialists receive this instruction:
 
 ```text
+If an assignment is outside your role, permissions, or available context, reject it rather than partially attempting it. Respond exactly:
 <task_rejection>
 <reason>brief explanation for the orchestrator</reason>
-<recommended_agent>@agent-name when clear</recommended_agent>
 </task_rejection>
 ```
 
-`recommended_agent` is optional. The orchestrator uses the reason to reroute
-or clarify the task and must not retry the unchanged task with the same agent.
+The orchestrator inspects only the reason to reroute or clarify the task and
+must not retry the unchanged task with the same agent.
 
 Good background task prompt:
 

--- a/docs/background-orchestration.md
+++ b/docs/background-orchestration.md
@@ -268,8 +268,8 @@ Include:
 
 ### Task-fit rejections
 
-If a task is outside a specialist's role, permissions, or available context, it
-must not attempt partial work. It returns a brief reason to the orchestrator.
+If a task is outside a specialist's role, it must not attempt partial work. It
+returns a brief reason to the orchestrator.
 The orchestrator treats that reason as routing input to reroute or clarify the
 task and must not retry the unchanged task with the same specialist.
 

--- a/src/agents/custom.test.ts
+++ b/src/agents/custom.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, spyOn, test } from 'bun:test';
 import { DEFAULT_MODELS, type PluginConfig } from '../config';
 import { createAgents, getAgentConfigs } from './index';
+import { TASK_REJECTION_INSTRUCTION } from './task-rejection';
 
 describe('custom-agent creation', () => {
   test('infers custom agents from unknown keys', () => {
@@ -23,7 +24,7 @@ describe('custom-agent creation', () => {
     expect(customAgent).toBeDefined();
     expect(customAgent?.config.model).toBe('openai/gpt-5.6');
     expect(customAgent?.config.prompt).toBe(
-      'You are the custom reviewer agent.',
+      `You are the custom reviewer agent.\n\n${TASK_REJECTION_INSTRUCTION}`,
     );
   });
 
@@ -44,7 +45,7 @@ describe('custom-agent creation', () => {
 
     expect(customAgent).toBeDefined();
     expect(customAgent?.config.prompt).toBe(
-      'You are a custom subagent for auditing.',
+      `You are a custom subagent for auditing.\n\n${TASK_REJECTION_INSTRUCTION}`,
     );
 
     const orchestrator = agents.find((agent) => agent.name === 'orchestrator');

--- a/src/agents/custom.test.ts
+++ b/src/agents/custom.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, spyOn, test } from 'bun:test';
 import { DEFAULT_MODELS, type PluginConfig } from '../config';
 import { createAgents, getAgentConfigs } from './index';
-import { TASK_REJECTION_INSTRUCTION } from './task-rejection';
 
 describe('custom-agent creation', () => {
   test('infers custom agents from unknown keys', () => {
@@ -24,7 +23,7 @@ describe('custom-agent creation', () => {
     expect(customAgent).toBeDefined();
     expect(customAgent?.config.model).toBe('openai/gpt-5.6');
     expect(customAgent?.config.prompt).toBe(
-      `You are the custom reviewer agent.\n\n${TASK_REJECTION_INSTRUCTION}`,
+      'You are the custom reviewer agent.',
     );
   });
 
@@ -45,7 +44,7 @@ describe('custom-agent creation', () => {
 
     expect(customAgent).toBeDefined();
     expect(customAgent?.config.prompt).toBe(
-      `You are a custom subagent for auditing.\n\n${TASK_REJECTION_INSTRUCTION}`,
+      'You are a custom subagent for auditing.',
     );
 
     const orchestrator = agents.find((agent) => agent.name === 'orchestrator');

--- a/src/agents/fixer.ts
+++ b/src/agents/fixer.ts
@@ -7,11 +7,6 @@ const FIXER_PROMPT = `You are Fixer - a fast, focused implementation specialist.
 
 **Behavior**:
 - Execute the task specification provided by the Orchestrator
-- Use the research context (file paths, documentation, patterns) provided
-- Read files before using edit/write tools and gather exact content before making changes
-- Be fast and direct - no research, no delegation, No multi-step research/planning; minimal execution sequence ok
-- Write or update tests when requested, especially for bounded tasks involving test files, fixtures, mocks, or test helpers
-- Run relevant validation when requested or clearly applicable (otherwise note as skipped with reason)
 - Report completion with summary of changes
 
 ${WRITABLE_FILE_OPERATIONS_RULES}
@@ -37,15 +32,7 @@ Brief summary of what was implemented
 - Tests passed: [yes/no/skip reason]
 - Validation: [passed/failed/skip reason]
 </verification>
-
-Use the following when no code changes were made:
-<summary>
-No changes required
-</summary>
-<verification>
-- Tests passed: [not run - reason]
-- Validation: [not run - reason]
-</verification>`;
+`;
 
 export function createFixerAgent(
   model: string,

--- a/src/agents/index.test.ts
+++ b/src/agents/index.test.ts
@@ -468,7 +468,7 @@ describe('agent classification', () => {
 });
 
 describe('createAgents', () => {
-  test('adds task-rejection instructions to every subagent after prompt resolution', () => {
+  test('keeps task-rejection instructions in default subagent prompts without modifying replacements', () => {
     const agents = createAgents({
       disabled_agents: [],
       council: councilConfig(),
@@ -496,9 +496,7 @@ describe('createAgents', () => {
     const orchestrator = agents.find((agent) => agent.name === 'orchestrator');
     const explorer = agents.find((agent) => agent.name === 'explorer');
 
-    expect(explorer?.config.prompt).toBe(
-      `Replacement explorer prompt.\n\n${TASK_REJECTION_INSTRUCTION}`,
-    );
+    expect(explorer?.config.prompt).toBe('Replacement explorer prompt.');
     expect(orchestrator?.config.prompt).not.toContain(
       TASK_REJECTION_INSTRUCTION,
     );
@@ -513,8 +511,14 @@ describe('createAgents', () => {
       ]),
     );
 
-    for (const agent of agents.filter(
-      (agent) => agent.name !== 'orchestrator',
+    for (const agent of agents.filter((agent) =>
+      [
+        'observer',
+        'council',
+        'councillor',
+        'councillor-alpha',
+        'bridge',
+      ].includes(agent.name),
     )) {
       expect(agent.config.prompt).toContain(TASK_REJECTION_INSTRUCTION);
     }

--- a/src/agents/index.test.ts
+++ b/src/agents/index.test.ts
@@ -14,6 +14,7 @@ import {
   getDisabledAgents,
   isSubagent,
 } from './index';
+import { TASK_REJECTION_INSTRUCTION } from './task-rejection';
 
 function councilConfig() {
   const parsed = CouncilConfigSchema.parse({
@@ -467,6 +468,58 @@ describe('agent classification', () => {
 });
 
 describe('createAgents', () => {
+  test('adds task-rejection instructions to every subagent after prompt resolution', () => {
+    const agents = createAgents({
+      disabled_agents: [],
+      council: councilConfig(),
+      agents: {
+        explorer: {
+          model: 'test/explorer',
+          prompt: 'Replacement explorer prompt.',
+        },
+        reviewer: {
+          model: 'test/reviewer',
+          prompt: 'Custom reviewer prompt.',
+        },
+      },
+      acpAgents: {
+        bridge: {
+          command: 'bridge-acp',
+          args: [],
+          env: {},
+          timeoutMs: 0,
+          permissionMode: 'ask',
+        },
+      },
+    });
+
+    const orchestrator = agents.find((agent) => agent.name === 'orchestrator');
+    const explorer = agents.find((agent) => agent.name === 'explorer');
+
+    expect(explorer?.config.prompt).toBe(
+      `Replacement explorer prompt.\n\n${TASK_REJECTION_INSTRUCTION}`,
+    );
+    expect(orchestrator?.config.prompt).not.toContain(
+      TASK_REJECTION_INSTRUCTION,
+    );
+    expect(agents.map((agent) => agent.name)).toEqual(
+      expect.arrayContaining([
+        'observer',
+        'council',
+        'councillor',
+        'councillor-alpha',
+        'reviewer',
+        'bridge',
+      ]),
+    );
+
+    for (const agent of agents.filter(
+      (agent) => agent.name !== 'orchestrator',
+    )) {
+      expect(agent.config.prompt).toContain(TASK_REJECTION_INSTRUCTION);
+    }
+  });
+
   test('creates all agents without config', () => {
     const agents = createAgents();
     const names = agents.map((a) => a.name);

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -232,7 +232,10 @@ function buildCustomAgentDefinition(
   filePrompt?: string,
   fileAppendPrompt?: string,
 ): AgentDefinition {
-  const basePrompt = override.prompt ?? `You are the ${name} specialist.`;
+  const defaultPrompt = appendTaskRejectionInstruction(
+    `You are the ${name} specialist.`,
+  );
+  const basePrompt = override.prompt ?? defaultPrompt;
   const primaryModel = getPrimaryModelFromOverride(override);
 
   return {
@@ -389,7 +392,9 @@ export function createAgents(
 
       const override = getAgentOverride(config, name);
       const inlinePrompt = override?.prompt;
-      const defaultPrompt = agent.config.prompt ?? '';
+      const defaultPrompt = appendTaskRejectionInstruction(
+        agent.config.prompt ?? '',
+      );
 
       const basePrompt =
         inlinePrompt !== undefined ? inlinePrompt : defaultPrompt;
@@ -509,7 +514,7 @@ export function createAgents(
     ...councillorAgents,
   ];
 
-  for (const agent of allSubAgents) {
+  for (const agent of [...acpSubAgents, ...councillorAgents]) {
     agent.config.prompt = appendTaskRejectionInstruction(
       agent.config.prompt ?? '',
     );

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -30,6 +30,7 @@ import {
   createOrchestratorAgent,
   resolvePrompt,
 } from './orchestrator';
+import { appendTaskRejectionInstruction } from './task-rejection';
 
 export type { AgentDefinition } from './orchestrator';
 
@@ -507,6 +508,12 @@ export function createAgents(
     ...acpSubAgents,
     ...councillorAgents,
   ];
+
+  for (const agent of allSubAgents) {
+    agent.config.prompt = appendTaskRejectionInstruction(
+      agent.config.prompt ?? '',
+    );
+  }
 
   // 3. Create Orchestrator (with its own overrides and custom prompts)
   // DEFAULT_MODELS.orchestrator is undefined; model is resolved via override or

--- a/src/agents/orchestrator.test.ts
+++ b/src/agents/orchestrator.test.ts
@@ -11,4 +11,15 @@ describe('orchestrator prompt', () => {
     expect(prompt).toContain('small bounded set of options');
     expect(prompt).toContain('ordinary dialogue that does not block work');
   });
+
+  test('treats task rejections as routing signals', () => {
+    const prompt = buildOrchestratorPrompt();
+
+    expect(prompt).toContain('Treat `<task_rejection>` as a routing signal');
+    expect(prompt).toContain('inspect its `<reason>`');
+    expect(prompt).toContain('optional `<recommended_agent>`');
+    expect(prompt).toContain(
+      'Never reissue an unchanged task to the same agent',
+    );
+  });
 });

--- a/src/agents/orchestrator.test.ts
+++ b/src/agents/orchestrator.test.ts
@@ -12,14 +12,18 @@ describe('orchestrator prompt', () => {
     expect(prompt).toContain('ordinary dialogue that does not block work');
   });
 
-  test('treats task rejections as routing signals', () => {
+  test('treats specialist rejection reasons as routing input', () => {
     const prompt = buildOrchestratorPrompt();
 
-    expect(prompt).toContain('Treat `<task_rejection>` as a routing signal');
-    expect(prompt).toContain('inspect only its `<reason>`');
-    expect(prompt).not.toContain('recommended_agent');
     expect(prompt).toContain(
-      'Never reissue an unchanged task to the same agent',
+      "Treat a specialist's rejection reason as routing input",
+    );
+    expect(prompt).toContain('reroute or clarify');
+    expect(prompt).not.toContain('task_rejection');
+    expect(prompt).not.toContain('<reason>');
+    expect(prompt).not.toMatch(/recommended[_ -]?agent/i);
+    expect(prompt).toContain(
+      'Never reissue an unchanged task to the same specialist',
     );
   });
 });

--- a/src/agents/orchestrator.test.ts
+++ b/src/agents/orchestrator.test.ts
@@ -12,18 +12,4 @@ describe('orchestrator prompt', () => {
     expect(prompt).toContain('ordinary dialogue that does not block work');
   });
 
-  test('treats specialist rejection reasons as routing input', () => {
-    const prompt = buildOrchestratorPrompt();
-
-    expect(prompt).toContain(
-      "Treat a specialist's rejection reason as routing input",
-    );
-    expect(prompt).toContain('reroute or clarify');
-    expect(prompt).not.toContain('task_rejection');
-    expect(prompt).not.toContain('<reason>');
-    expect(prompt).not.toMatch(/recommended[_ -]?agent/i);
-    expect(prompt).toContain(
-      'Never reissue an unchanged task to the same specialist',
-    );
-  });
 });

--- a/src/agents/orchestrator.test.ts
+++ b/src/agents/orchestrator.test.ts
@@ -16,8 +16,8 @@ describe('orchestrator prompt', () => {
     const prompt = buildOrchestratorPrompt();
 
     expect(prompt).toContain('Treat `<task_rejection>` as a routing signal');
-    expect(prompt).toContain('inspect its `<reason>`');
-    expect(prompt).toContain('optional `<recommended_agent>`');
+    expect(prompt).toContain('inspect only its `<reason>`');
+    expect(prompt).not.toContain('recommended_agent');
     expect(prompt).toContain(
       'Never reissue an unchanged task to the same agent',
     );

--- a/src/agents/orchestrator.ts
+++ b/src/agents/orchestrator.ts
@@ -201,8 +201,8 @@ Balance: respect dependencies, avoid parallelizing what must be sequential, and 
 - Prefer \`task(..., background: true)\` for delegated work that can run independently.
 - For work already chosen for delegation, launch independent specialist lanes in the background so the orchestrator stays unblocked and can reconcile results when they return.
 - Track each task's specialist, objective, task/session ID, and file/topic ownership.
-- Treat \`<task_rejection>\` as a routing signal: inspect only its \`<reason>\`, then reroute or clarify.
-- Never reissue an unchanged task to the same agent after a rejection; adjust its scope or context before retrying.
+- Treat a specialist's rejection reason as routing input: reroute or clarify.
+- Never reissue an unchanged task to the same specialist after a rejection; adjust its scope or context before retrying.
 - Continue orchestration only on non-overlapping work; otherwise briefly report what was launched and stop.
 - Before local edits or another writer task, compare against running task scopes.
 - Parallel background tasks are allowed only when their write scopes do not conflict.

--- a/src/agents/orchestrator.ts
+++ b/src/agents/orchestrator.ts
@@ -201,6 +201,8 @@ Balance: respect dependencies, avoid parallelizing what must be sequential, and 
 - Prefer \`task(..., background: true)\` for delegated work that can run independently.
 - For work already chosen for delegation, launch independent specialist lanes in the background so the orchestrator stays unblocked and can reconcile results when they return.
 - Track each task's specialist, objective, task/session ID, and file/topic ownership.
+- Treat \`<task_rejection>\` as a routing signal: inspect its \`<reason>\` and optional \`<recommended_agent>\`, then reroute or clarify.
+- Never reissue an unchanged task to the same agent after a rejection; adjust its scope or context before retrying.
 - Continue orchestration only on non-overlapping work; otherwise briefly report what was launched and stop.
 - Before local edits or another writer task, compare against running task scopes.
 - Parallel background tasks are allowed only when their write scopes do not conflict.

--- a/src/agents/orchestrator.ts
+++ b/src/agents/orchestrator.ts
@@ -201,7 +201,7 @@ Balance: respect dependencies, avoid parallelizing what must be sequential, and 
 - Prefer \`task(..., background: true)\` for delegated work that can run independently.
 - For work already chosen for delegation, launch independent specialist lanes in the background so the orchestrator stays unblocked and can reconcile results when they return.
 - Track each task's specialist, objective, task/session ID, and file/topic ownership.
-- Treat \`<task_rejection>\` as a routing signal: inspect its \`<reason>\` and optional \`<recommended_agent>\`, then reroute or clarify.
+- Treat \`<task_rejection>\` as a routing signal: inspect only its \`<reason>\`, then reroute or clarify.
 - Never reissue an unchanged task to the same agent after a rejection; adjust its scope or context before retrying.
 - Continue orchestration only on non-overlapping work; otherwise briefly report what was launched and stop.
 - Before local edits or another writer task, compare against running task scopes.

--- a/src/agents/orchestrator.ts
+++ b/src/agents/orchestrator.ts
@@ -200,8 +200,6 @@ Balance: respect dependencies, avoid parallelizing what must be sequential, and 
 ### Background Task Discipline
 - Prefer \`task(..., background: true)\` for delegated work that can run independently.
 - For work already chosen for delegation, launch independent specialist lanes in the background so the orchestrator stays unblocked and can reconcile results when they return.
-- Track each task's specialist, objective, task/session ID, and file/topic ownership.
-- Treat a specialist's rejection reason as routing input: reroute or clarify.
 - Never reissue an unchanged task to the same specialist after a rejection; adjust its scope or context before retrying.
 - Continue orchestration only on non-overlapping work; otherwise briefly report what was launched and stop.
 - Before local edits or another writer task, compare against running task scopes.

--- a/src/agents/task-rejection.test.ts
+++ b/src/agents/task-rejection.test.ts
@@ -2,13 +2,12 @@ import { describe, expect, test } from 'bun:test';
 import { TASK_REJECTION_INSTRUCTION } from './task-rejection';
 
 describe('task rejection instruction', () => {
-  test('requires only a reason in the rejection response', () => {
-    expect(
-      TASK_REJECTION_INSTRUCTION,
-    ).toBe(`If an assignment is outside your role, permissions, or available context, reject it rather than partially attempting it. Respond exactly:
-<task_rejection>
-<reason>brief explanation for the orchestrator</reason>
-</task_rejection>`);
-    expect(TASK_REJECTION_INSTRUCTION).not.toContain('recommended_agent');
+  test('requires a plain reason-only response', () => {
+    expect(TASK_REJECTION_INSTRUCTION).toBe(
+      'If a task is outside your role, permissions, or available context, do not attempt partial work. Return a brief reason to the orchestrator.',
+    );
+    expect(TASK_REJECTION_INSTRUCTION).not.toMatch(
+      /<|>|task_rejection|recommended[_ -]?agent/i,
+    );
   });
 });

--- a/src/agents/task-rejection.test.ts
+++ b/src/agents/task-rejection.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from 'bun:test';
+import { TASK_REJECTION_INSTRUCTION } from './task-rejection';
+
+describe('task rejection instruction', () => {
+  test('requires only a reason in the rejection response', () => {
+    expect(
+      TASK_REJECTION_INSTRUCTION,
+    ).toBe(`If an assignment is outside your role, permissions, or available context, reject it rather than partially attempting it. Respond exactly:
+<task_rejection>
+<reason>brief explanation for the orchestrator</reason>
+</task_rejection>`);
+    expect(TASK_REJECTION_INSTRUCTION).not.toContain('recommended_agent');
+  });
+});

--- a/src/agents/task-rejection.test.ts
+++ b/src/agents/task-rejection.test.ts
@@ -4,10 +4,12 @@ import { TASK_REJECTION_INSTRUCTION } from './task-rejection';
 describe('task rejection instruction', () => {
   test('requires a plain reason-only response', () => {
     expect(TASK_REJECTION_INSTRUCTION).toBe(
-      'If a task is outside your role, permissions, or available context, do not attempt partial work. Return a brief reason to the orchestrator.',
+      'If a task is outside your role, do not attempt partial work. Return a brief reason to the orchestrator.',
     );
     expect(TASK_REJECTION_INSTRUCTION).not.toMatch(
       /<|>|task_rejection|recommended[_ -]?agent/i,
     );
+    expect(TASK_REJECTION_INSTRUCTION).not.toContain('permissions');
+    expect(TASK_REJECTION_INSTRUCTION).not.toContain('available context');
   });
 });

--- a/src/agents/task-rejection.ts
+++ b/src/agents/task-rejection.ts
@@ -1,7 +1,5 @@
-export const TASK_REJECTION_INSTRUCTION = `If an assignment is outside your role, permissions, or available context, reject it rather than partially attempting it. Respond exactly:
-<task_rejection>
-<reason>brief explanation for the orchestrator</reason>
-</task_rejection>`;
+export const TASK_REJECTION_INSTRUCTION =
+  'If a task is outside your role, permissions, or available context, do not attempt partial work. Return a brief reason to the orchestrator.';
 
 export function appendTaskRejectionInstruction(prompt: string): string {
   return `${prompt}\n\n${TASK_REJECTION_INSTRUCTION}`;

--- a/src/agents/task-rejection.ts
+++ b/src/agents/task-rejection.ts
@@ -1,0 +1,11 @@
+export const TASK_REJECTION_INSTRUCTION = `<TaskRejection>
+If the assignment is outside your role, permissions, or available context, reject it instead of attempting partial work. Respond exactly:
+<task_rejection>
+<reason>brief explanation for the orchestrator</reason>
+<recommended_agent>@agent-name when clear, otherwise omit this tag</recommended_agent>
+</task_rejection>
+</TaskRejection>`;
+
+export function appendTaskRejectionInstruction(prompt: string): string {
+  return `${prompt}\n\n${TASK_REJECTION_INSTRUCTION}`;
+}

--- a/src/agents/task-rejection.ts
+++ b/src/agents/task-rejection.ts
@@ -1,10 +1,7 @@
-export const TASK_REJECTION_INSTRUCTION = `<TaskRejection>
-If the assignment is outside your role, permissions, or available context, reject it instead of attempting partial work. Respond exactly:
+export const TASK_REJECTION_INSTRUCTION = `If an assignment is outside your role, permissions, or available context, reject it rather than partially attempting it. Respond exactly:
 <task_rejection>
 <reason>brief explanation for the orchestrator</reason>
-<recommended_agent>@agent-name when clear, otherwise omit this tag</recommended_agent>
-</task_rejection>
-</TaskRejection>`;
+</task_rejection>`;
 
 export function appendTaskRejectionInstruction(prompt: string): string {
   return `${prompt}\n\n${TASK_REJECTION_INSTRUCTION}`;

--- a/src/agents/task-rejection.ts
+++ b/src/agents/task-rejection.ts
@@ -1,5 +1,5 @@
 export const TASK_REJECTION_INSTRUCTION =
-  'If a task is outside your role, permissions, or available context, do not attempt partial work. Return a brief reason to the orchestrator.';
+  'If a task is outside your role, do not attempt partial work. Return a brief reason to the orchestrator.';
 
 export function appendTaskRejectionInstruction(prompt: string): string {
   return `${prompt}\n\n${TASK_REJECTION_INSTRUCTION}`;

--- a/src/hooks/__snapshots__/cache-payload.snapshot.test.ts.snap
+++ b/src/hooks/__snapshots__/cache-payload.snapshot.test.ts.snap
@@ -151,7 +151,7 @@ Balance: respect dependencies, avoid parallelizing what must be sequential, and 
 ### Background Task Discipline
 - Prefer \`task(..., background: true)\` for delegated work that can run independently.
 - For work already chosen for delegation, launch independent specialist lanes in the background so the orchestrator stays unblocked and can reconcile results when they return.
-- Track each task's specialist, objective, task/session ID, and file/topic ownership.
+- Never reissue an unchanged task to the same specialist after a rejection; adjust its scope or context before retrying.
 - Continue orchestration only on non-overlapping work; otherwise briefly report what was launched and stop.
 - Before local edits or another writer task, compare against running task scopes.
 - Parallel background tasks are allowed only when their write scopes do not conflict.


### PR DESCRIPTION
## Summary
- give every delegable agent a shared structured task-rejection contract
- teach the orchestrator to reroute rejected work instead of retrying unchanged
- document and test the task-fit rejection flow

## Validation
- bun test src/agents/index.test.ts src/agents/orchestrator.test.ts src/agents/custom.test.ts
- bun run typecheck
- bunx biome check src/agents/custom.test.ts src/agents/index.test.ts src/agents/index.ts src/agents/orchestrator.test.ts src/agents/orchestrator.ts src/agents/task-rejection.ts