### PR TITLE
fix(preset): set OpenAI xhigh variants

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -153,12 +153,12 @@ bun run build
   "preset": "openai",
   "presets": {
     "openai": {
-      "orchestrator": { "model": "openai/gpt-5.6-terra", "variant": "medium", "skills": ["*"], "mcps": ["*", "!context7"] },
-      "oracle": { "model": "openai/gpt-5.6-sol", "variant": "high", "skills": ["simplify"], "mcps": [] },
+      "orchestrator": { "model": "openai/gpt-5.6-terra", "variant": "xhigh", "skills": ["*"], "mcps": ["*", "!context7"] },
+      "oracle": { "model": "openai/gpt-5.6-sol", "variant": "xhigh", "skills": ["simplify"], "mcps": [] },
       "librarian": { "model": "openai/gpt-5.6-luna", "variant": "low", "skills": [], "mcps": ["websearch", "context7", "gh_grep"] },
       "explorer": { "model": "openai/gpt-5.6-luna", "variant": "low", "skills": [], "mcps": [] },
       "designer": { "model": "openai/gpt-5.6-luna", "variant": "medium", "skills": [], "mcps": [] },
-      "fixer": { "model": "openai/gpt-5.6-luna", "variant": "medium", "skills": [], "mcps": [] }
+      "fixer": { "model": "openai/gpt-5.6-luna", "variant": "xhigh", "skills": [], "mcps": [] }
     },
     "opencode-go": {
       "orchestrator": { "model": "opencode-go/minimax-m3", "variant": "max", "skills": [ "*" ], "mcps": [ "*", "!context7" ] },

--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -164,12 +164,12 @@ bun run build
   "preset": "openai",
   "presets": {
     "openai": {
-      "orchestrator": { "model": "openai/gpt-5.6-terra", "variant": "medium", "skills": ["*"], "mcps": ["*", "!context7"] },
-      "oracle": { "model": "openai/gpt-5.6-sol", "variant": "high", "skills": ["simplify"], "mcps": [] },
+      "orchestrator": { "model": "openai/gpt-5.6-terra", "variant": "xhigh", "skills": ["*"], "mcps": ["*", "!context7"] },
+      "oracle": { "model": "openai/gpt-5.6-sol", "variant": "xhigh", "skills": ["simplify"], "mcps": [] },
       "librarian": { "model": "openai/gpt-5.6-luna", "variant": "low", "skills": [], "mcps": ["websearch", "context7", "gh_grep"] },
       "explorer": { "model": "openai/gpt-5.6-luna", "variant": "low", "skills": [], "mcps": [] },
       "designer": { "model": "openai/gpt-5.6-luna", "variant": "medium", "skills": [], "mcps": [] },
-      "fixer": { "model": "openai/gpt-5.6-luna", "variant": "medium", "skills": [], "mcps": [] }
+      "fixer": { "model": "openai/gpt-5.6-luna", "variant": "xhigh", "skills": [], "mcps": [] }
     },
     "opencode-go": {
       "orchestrator": { "model": "opencode-go/minimax-m3", "variant": "max", "skills": [ "*" ], "mcps": [ "*", "!context7" ] },

--- a/README.md
+++ b/README.md
@@ -172,12 +172,12 @@ The default generated configuration includes both `openai` and `opencode-go` pre
   "preset": "openai",
   "presets": {
     "openai": {
-      "orchestrator": { "model": "openai/gpt-5.6-terra", "variant": "medium", "skills": ["*"], "mcps": ["*", "!context7"] },
-      "oracle": { "model": "openai/gpt-5.6-sol", "variant": "high", "skills": ["simplify"], "mcps": [] },
+      "orchestrator": { "model": "openai/gpt-5.6-terra", "variant": "xhigh", "skills": ["*"], "mcps": ["*", "!context7"] },
+      "oracle": { "model": "openai/gpt-5.6-sol", "variant": "xhigh", "skills": ["simplify"], "mcps": [] },
       "librarian": { "model": "openai/gpt-5.6-luna", "variant": "low", "skills": [], "mcps": ["websearch", "context7", "gh_grep"] },
       "explorer": { "model": "openai/gpt-5.6-luna", "variant": "low", "skills": [], "mcps": [] },
       "designer": { "model": "openai/gpt-5.6-luna", "variant": "medium", "skills": [], "mcps": [] },
-      "fixer": { "model": "openai/gpt-5.6-luna", "variant": "medium", "skills": [], "mcps": [] }
+      "fixer": { "model": "openai/gpt-5.6-luna", "variant": "xhigh", "skills": [], "mcps": [] }
     },
     "opencode-go": {
       "orchestrator": { "model": "opencode-go/minimax-m3", "variant": "max", "skills": [ "*" ], "mcps": [ "*", "!context7" ] },

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -146,12 +146,12 @@ bun run build
   "preset": "openai",
   "presets": {
     "openai": {
-      "orchestrator": { "model": "openai/gpt-5.6-terra", "variant": "medium", "skills": ["*"], "mcps": ["*", "!context7"] },
-      "oracle": { "model": "openai/gpt-5.6-sol", "variant": "high", "skills": ["simplify"], "mcps": [] },
+      "orchestrator": { "model": "openai/gpt-5.6-terra", "variant": "xhigh", "skills": ["*"], "mcps": ["*", "!context7"] },
+      "oracle": { "model": "openai/gpt-5.6-sol", "variant": "xhigh", "skills": ["simplify"], "mcps": [] },
       "librarian": { "model": "openai/gpt-5.6-luna", "variant": "low", "skills": [], "mcps": ["websearch", "context7", "gh_grep"] },
       "explorer": { "model": "openai/gpt-5.6-luna", "variant": "low", "skills": [], "mcps": [] },
       "designer": { "model": "openai/gpt-5.6-luna", "variant": "medium", "skills": [], "mcps": [] },
-      "fixer": { "model": "openai/gpt-5.6-luna", "variant": "medium", "skills": [], "mcps": [] }
+      "fixer": { "model": "openai/gpt-5.6-luna", "variant": "xhigh", "skills": [], "mcps": [] }
     },
     "opencode-go": {
       "orchestrator": { "model": "opencode-go/minimax-m3", "variant": "max", "skills": [ "*" ], "mcps": [ "*", "!context7" ] },

--- a/docs/openai-preset.md
+++ b/docs/openai-preset.md
@@ -33,12 +33,12 @@ The generated `openai` preset assigns each specialist an OpenAI model:
 
 | Agent | Model |
 |-------|-------|
-| Orchestrator | `openai/gpt-5.6-terra` (`medium`) |
-| Oracle | `openai/gpt-5.6-sol` (`high`) |
+| Orchestrator | `openai/gpt-5.6-terra` (`xhigh`) |
+| Oracle | `openai/gpt-5.6-sol` (`xhigh`) |
 | Librarian | `openai/gpt-5.6-luna` (`low`) |
 | Explorer | `openai/gpt-5.6-luna` (`low`) |
 | Designer | `openai/gpt-5.6-luna` (`medium`) |
-| Fixer | `openai/gpt-5.6-luna` (`medium`) |
+| Fixer | `openai/gpt-5.6-luna` (`xhigh`) |
 
 ## Generated Config Shape
 
@@ -52,13 +52,13 @@ setting the top-level `preset` field:
     "openai": {
       "orchestrator": {
         "model": "openai/gpt-5.6-terra",
-        "variant": "medium",
+        "variant": "xhigh",
         "skills": ["*"],
         "mcps": ["*", "!context7"]
       },
       "oracle": {
         "model": "openai/gpt-5.6-sol",
-        "variant": "high",
+        "variant": "xhigh",
         "skills": ["simplify"],
         "mcps": []
       },
@@ -82,7 +82,7 @@ setting the top-level `preset` field:
       },
       "fixer": {
         "model": "openai/gpt-5.6-luna",
-        "variant": "medium",
+        "variant": "xhigh",
         "skills": [],
         "mcps": []
       }

--- a/src/cli/providers.test.ts
+++ b/src/cli/providers.test.ts
@@ -35,12 +35,12 @@ describe('providers', () => {
     const agents = (config.presets as any).openai;
     expect(agents).toBeDefined();
     expect(agents.orchestrator.model).toBe('openai/gpt-5.6-terra');
-    expect(agents.orchestrator.variant).toBe('medium');
+    expect(agents.orchestrator.variant).toBe('xhigh');
     expect(agents.fixer.model).toBe('openai/gpt-5.6-luna');
-    expect(agents.fixer.variant).toBe('medium');
+    expect(agents.fixer.variant).toBe('xhigh');
   });
 
-  test('generateLiteConfig uses correct OpenAI models', () => {
+  test('preserves exact OpenAI model and variant mappings', () => {
     const config = generateLiteConfig({
       hasTmux: false,
       installCustomSkills: false,
@@ -49,17 +49,17 @@ describe('providers', () => {
     });
 
     const agents = (config.presets as any).openai;
-    expect(agents.orchestrator.model).toBe(
-      MODEL_MAPPINGS.openai.orchestrator.model,
-    );
-    expect(agents.oracle.model).toBe('openai/gpt-5.6-sol');
-    expect(agents.oracle.variant).toBe('high');
-    expect(agents.librarian.model).toBe('openai/gpt-5.6-luna');
-    expect(agents.librarian.variant).toBe('low');
-    expect(agents.explorer.model).toBe('openai/gpt-5.6-luna');
-    expect(agents.explorer.variant).toBe('low');
-    expect(agents.designer.model).toBe('openai/gpt-5.6-luna');
-    expect(agents.designer.variant).toBe('medium');
+    const expected = {
+      orchestrator: { model: 'openai/gpt-5.6-terra', variant: 'xhigh' },
+      oracle: { model: 'openai/gpt-5.6-sol', variant: 'xhigh' },
+      librarian: { model: 'openai/gpt-5.6-luna', variant: 'low' },
+      explorer: { model: 'openai/gpt-5.6-luna', variant: 'low' },
+      designer: { model: 'openai/gpt-5.6-luna', variant: 'medium' },
+      fixer: { model: 'openai/gpt-5.6-luna', variant: 'xhigh' },
+    } as const;
+
+    expect(MODEL_MAPPINGS.openai).toEqual(expected);
+    expect(agents).toMatchObject(expected);
   });
 
   test('generateLiteConfig can set opencode-go as active preset', () => {

--- a/src/cli/providers.ts
+++ b/src/cli/providers.ts
@@ -10,12 +10,12 @@ export const GENERATED_PRESETS = ['openai', 'opencode-go'] as const;
 // Model mappings by provider/preset.
 export const MODEL_MAPPINGS = {
   openai: {
-    orchestrator: { model: 'openai/gpt-5.6-terra', variant: 'medium' },
-    oracle: { model: 'openai/gpt-5.6-sol', variant: 'high' },
+    orchestrator: { model: 'openai/gpt-5.6-terra', variant: 'xhigh' },
+    oracle: { model: 'openai/gpt-5.6-sol', variant: 'xhigh' },
     librarian: { model: 'openai/gpt-5.6-luna', variant: 'low' },
     explorer: { model: 'openai/gpt-5.6-luna', variant: 'low' },
     designer: { model: 'openai/gpt-5.6-luna', variant: 'medium' },
-    fixer: { model: 'openai/gpt-5.6-luna', variant: 'medium' },
+    fixer: { model: 'openai/gpt-5.6-luna', variant: 'xhigh' },
   },
   kimi: {
     orchestrator: { model: 'kimi-for-coding/k2p5', variant: 'max' },


### PR DESCRIPTION
## Summary
- Only the OpenAI preset orchestrator, oracle, and fixer variants change to \`xhigh\`.
- All model IDs and other agent variants remain unchanged.

## Validation
- \`bun run check:ci\`, \`bun run typecheck\`, and \`bun run build\` pass.
- Full \`bun test\` has the unrelated existing deepwork prompt assertion failure expecting \`simplify/readability\`.