### PR TITLE
fix(prompt): remove misleading 'do not poll' instructions

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -48,7 +48,7 @@ export const POLL_INTERVAL_BACKGROUND_MS = 2000;
 export const MAX_POLL_TIME_MS = 5 * 60 * 1000; // 5 minutes
 
 // Workflow reminders
-export const PHASE_REMINDER_TEXT = `!IMPORTANT! Scheduler workflow: First choose the lightest workflow that fits the work. If direct execution is justified, complete it and verify proportionately. Otherwise: plan lanes/dependencies → dispatch background specialists → track task IDs → wait for hook-driven completion → reconcile terminal results → verify. Do not poll running jobs, consume running-job output, or advance dependent work. !END!`;
+export const PHASE_REMINDER_TEXT = `!IMPORTANT! Scheduler workflow: First choose the lightest workflow that fits the work. If direct execution is justified, complete it and verify proportionately. Otherwise: plan lanes/dependencies → dispatch background specialists → track task IDs → wait for hook-driven completion → reconcile terminal results → verify. !END!`;
 
 export function formatSystemReminder(text: string): string {
   return `<system-reminder>\n${text}\n</system-reminder>`;

--- a/src/hooks/__snapshots__/cache-payload.snapshot.test.ts.snap
+++ b/src/hooks/__snapshots__/cache-payload.snapshot.test.ts.snap
@@ -467,7 +467,6 @@ exports[`cache-impact snapshots (update deliberately — see file header) transf
 "<system-reminder>
 ### Background Job Board
 SENTINEL: background-job-board-v2
-Do not poll running jobs. Wait for hook-driven completion, or use cancel_task only for explicit cancellation. Reconcile terminal jobs before final response.
 Completed or reconciled sessions are reusable by alias for the same specialist/context.
 Timed-out running sessions are recoverable by alias for safe resume after a live busy signal.
 Cancelled or errored sessions are not reusable.

--- a/src/hooks/__snapshots__/cache-payload.snapshot.test.ts.snap
+++ b/src/hooks/__snapshots__/cache-payload.snapshot.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`cache-impact snapshots (update deliberately — see file header) phase reminder text 1`] = `
 "<system-reminder>
-!IMPORTANT! Scheduler workflow: First choose the lightest workflow that fits the work. If direct execution is justified, complete it and verify proportionately. Otherwise: plan lanes/dependencies → dispatch background specialists → track task IDs → wait for hook-driven completion → reconcile terminal results → verify. Do not poll running jobs, consume running-job output, or advance dependent work. !END!
+!IMPORTANT! Scheduler workflow: First choose the lightest workflow that fits the work. If direct execution is justified, complete it and verify proportionately. Otherwise: plan lanes/dependencies → dispatch background specialists → track task IDs → wait for hook-driven completion → reconcile terminal results → verify. !END!
 </system-reminder>"
 `;
 
@@ -244,7 +244,7 @@ exports[`cache-impact snapshots (update deliberately — see file header) transf
         "synthetic": true,
         "text": 
 "<system-reminder>
-!IMPORTANT! Scheduler workflow: First choose the lightest workflow that fits the work. If direct execution is justified, complete it and verify proportionately. Otherwise: plan lanes/dependencies → dispatch background specialists → track task IDs → wait for hook-driven completion → reconcile terminal results → verify. Do not poll running jobs, consume running-job output, or advance dependent work. !END!
+!IMPORTANT! Scheduler workflow: First choose the lightest workflow that fits the work. If direct execution is justified, complete it and verify proportionately. Otherwise: plan lanes/dependencies → dispatch background specialists → track task IDs → wait for hook-driven completion → reconcile terminal results → verify. !END!
 </system-reminder>"
 ,
         "type": "text",
@@ -296,7 +296,7 @@ exports[`cache-impact snapshots (update deliberately — see file header) transf
         "synthetic": true,
         "text": 
 "<system-reminder>
-!IMPORTANT! Scheduler workflow: First choose the lightest workflow that fits the work. If direct execution is justified, complete it and verify proportionately. Otherwise: plan lanes/dependencies → dispatch background specialists → track task IDs → wait for hook-driven completion → reconcile terminal results → verify. Do not poll running jobs, consume running-job output, or advance dependent work. !END!
+!IMPORTANT! Scheduler workflow: First choose the lightest workflow that fits the work. If direct execution is justified, complete it and verify proportionately. Otherwise: plan lanes/dependencies → dispatch background specialists → track task IDs → wait for hook-driven completion → reconcile terminal results → verify. !END!
 </system-reminder>"
 ,
         "type": "text",
@@ -391,7 +391,7 @@ exports[`cache-impact snapshots (update deliberately — see file header) transf
         "synthetic": true,
         "text": 
 "<system-reminder>
-!IMPORTANT! Scheduler workflow: First choose the lightest workflow that fits the work. If direct execution is justified, complete it and verify proportionately. Otherwise: plan lanes/dependencies → dispatch background specialists → track task IDs → wait for hook-driven completion → reconcile terminal results → verify. Do not poll running jobs, consume running-job output, or advance dependent work. !END!
+!IMPORTANT! Scheduler workflow: First choose the lightest workflow that fits the work. If direct execution is justified, complete it and verify proportionately. Otherwise: plan lanes/dependencies → dispatch background specialists → track task IDs → wait for hook-driven completion → reconcile terminal results → verify. !END!
 </system-reminder>"
 ,
         "type": "text",
@@ -443,7 +443,7 @@ exports[`cache-impact snapshots (update deliberately — see file header) transf
         "synthetic": true,
         "text": 
 "<system-reminder>
-!IMPORTANT! Scheduler workflow: First choose the lightest workflow that fits the work. If direct execution is justified, complete it and verify proportionately. Otherwise: plan lanes/dependencies → dispatch background specialists → track task IDs → wait for hook-driven completion → reconcile terminal results → verify. Do not poll running jobs, consume running-job output, or advance dependent work. !END!
+!IMPORTANT! Scheduler workflow: First choose the lightest workflow that fits the work. If direct execution is justified, complete it and verify proportionately. Otherwise: plan lanes/dependencies → dispatch background specialists → track task IDs → wait for hook-driven completion → reconcile terminal results → verify. !END!
 </system-reminder>"
 ,
         "type": "text",

--- a/src/utils/background-job-board.ts
+++ b/src/utils/background-job-board.ts
@@ -495,7 +495,6 @@ export class BackgroundJobBoard implements BackgroundJobStore {
       [
         '### Background Job Board',
         'SENTINEL: background-job-board-v2',
-        'Do not poll running jobs. Wait for hook-driven completion, or use cancel_task only for explicit cancellation. Reconcile terminal jobs before final response.',
         'Completed or reconciled sessions are reusable by alias for the same specialist/context.',
         'Timed-out running sessions are recoverable by alias for safe resume after a live busy signal.',
         'Cancelled or errored sessions are not reusable.',


### PR DESCRIPTION
1. What changed, and why was it needed?

The Background Job Board prompt (`src/utils/background-job-board.ts`) and the scheduler `PHASE_REMINDER_TEXT` (`src/config/constants.ts`) both instructed the orchestrator to "not poll running jobs." This instruction was inaccurate: the agent has no poll/status tool — background-job completion is hook-driven. The misleading clause was removed from both prompt surfaces, and the golden snapshot (`src/hooks/__snapshots__/cache-payload.snapshot.test.ts.snap`) was updated deliberately to reflect the trimmed text.

Two commits:
- `37a3d78` — remove the line from the job board prompt + snapshot
- `7b3684a` — remove the same clause from `PHASE_REMINDER_TEXT` + snapshot (5 snapshot sites)

Verification: `bun test src/hooks/cache-payload.snapshot.test.ts` passes (3 pass, 0 fail); snapshot is in sync with the trimmed source. A repo-wide search confirms no remaining "do not poll" / "consume running-job" / "advance dependent" instructions in any prompt surface.