### PR TITLE
fix(companion): use intro for unknown agents

### DIFF
--- a/companion/src/gifs.rs
+++ b/companion/src/gifs.rs
@@ -95,7 +95,7 @@ impl Gifs {
         self.sheets
             .get_key_value(agent)
             .map(|(name, _)| *name)
-            .unwrap_or("orchestrator")
+            .unwrap_or("intro")
     }
 }
 
@@ -151,7 +151,32 @@ fn decode_sprite_sheet(bytes: &[u8]) -> Result<ColorImage, image::ImageError> {
 
 #[cfg(test)]
 mod tests {
-    use super::{frame_index, frame_uv, normalized_speed, FRAME_COUNT};
+    use super::{frame_index, frame_uv, normalized_speed, Gifs, FRAME_COUNT};
+
+    #[test]
+    fn unknown_agents_use_the_neutral_intro_animation() {
+        let gifs = Gifs::new();
+
+        for agent in ["plan", "build", "general", "explore", "custom-agent"] {
+            assert_eq!(gifs.resolve_name(agent, "default"), "intro");
+        }
+    }
+
+    #[test]
+    fn known_agents_keep_their_own_animations() {
+        let gifs = Gifs::new();
+
+        for agent in [
+            "orchestrator",
+            "explorer",
+            "librarian",
+            "oracle",
+            "designer",
+            "fixer",
+        ] {
+            assert_eq!(gifs.resolve_name(agent, "default"), agent);
+        }
+    }
 
     #[test]
     fn speed_is_clamped_and_defaults_fast() {


### PR DESCRIPTION
## Summary

- render the neutral intro animation for agent names without a bundled animation
- keep the existing animations for the OMO Slim orchestrator and specialists
- cover OpenCode `plan`, `build`, `general`, `explore`, and arbitrary custom agents

## Problem

The companion currently falls back to the Orchestrator animation for every unknown agent name. Native OpenCode agents such as `plan` and `build` are therefore shown as OMO Slim Orchestrator activity even though the orchestrator is not active.

## Verification

- `cargo fmt --check`
- `cargo test` (44 passed)
- `cargo build --release`
- local companion run with `active_agents: ["build", "fixer"]`; debug output confirmed `build` loaded `intro` while `fixer` loaded `fixer`

The existing unrelated `float_literal_f32_fallback` warning in `companion/src/app.rs` remains unchanged.