### PR TITLE
fix: replace * glob in --external flags with explicit subpaths for Windows compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
   ],
   "scripts": {
     "clean:dist": "bun -e \"import { rmSync } from 'node:fs'; rmSync('dist', { recursive: true, force: true })\"",
-    "build:plugin": "bun build src/index.ts src/tui.ts --outdir dist --target node --format esm --external @ast-grep/napi --external @opencode-ai/plugin --external @opencode-ai/plugin/* --external @opencode-ai/sdk --external @opencode-ai/sdk/* --external @opentui/core --external @opentui/solid --external jsdom --external zod",
-    "build:cli": "bun build src/cli/index.ts --outdir dist/cli --target node --format esm --external @ast-grep/napi --external @opencode-ai/plugin --external @opencode-ai/plugin/* --external @opencode-ai/sdk --external @opencode-ai/sdk/* --external jsdom --external zod",
+    "build:plugin": "bun build src/index.ts src/tui.ts --outdir dist --target node --format esm --external @ast-grep/napi --external @opencode-ai/plugin --external @opencode-ai/plugin/tui --external @opencode-ai/sdk --external @opencode-ai/sdk/v2 --external @opentui/core --external @opentui/solid --external jsdom --external zod",
+    "build:cli": "bun build src/cli/index.ts --outdir dist/cli --target node --format esm --external @ast-grep/napi --external @opencode-ai/plugin --external @opencode-ai/plugin/tui --external @opencode-ai/sdk --external @opencode-ai/sdk/v2 --external jsdom --external zod",
     "build": "bun run clean:dist && bun run build:plugin && bun run build:cli && tsc --emitDeclarationOnly && bun run generate-schema",
     "prepare": "bun run build",
     "contributors:add": "all-contributors add",


### PR DESCRIPTION
On Windows, `bun build` interprets the `*` in `--external @opencode-ai/plugin/*` as a 
filesystem glob, producing `bun: no matches found`. This prevents `bun install` from 
completing (via the `prepare` lifecycle script).

The actual subpath imports in the codebase are:
  - `@opencode-ai/plugin/tui` (src/tui.ts)
  - `@opencode-ai/sdk/v2` (src/agents/index.ts, src/agents/orchestrator.ts)

This replaces `@opencode-ai/plugin/*` with `@opencode-ai/plugin/tui` and 
`@opencode-ai/sdk/*` with `@opencode-ai/sdk/v2` in both `build:plugin` and `build:cli` scripts.

Fixes `bun install` failure on Windows (Bun 1.3.14).

Note: The code is generated by an agent with my review. 