### PR TITLE
fix: skip shell wrapper for .exe files in canExecute on Windows

### DIFF
--- a/src/cli/system.ts
+++ b/src/cli/system.ts
@@ -61,7 +61,7 @@ function canExecute(
       env: environment,
       // Required on Windows to execute .cmd/.bat shims produced by npm/pnpm/yarn
       // (Node's CVE-2024-27980 patch blocks them without a shell).
-      shell: isWindows,
+      shell: isWindows && !/\.exe$/i.test(command),
     });
     return result.status === 0;
   } catch {


### PR DESCRIPTION
## Problem

`bun dist/cli/index.js install` (and `bunx oh-my-opencode-slim@latest install`) 
report "OpenCode is not installed on this system" on Windows even when OpenCode 
is installed and functional. 

This affects any installation path containing spaces — particularly the common 
winget-installed location `C:\Program Files\WinGet\Links\opencode.exe`. 
Reported upstream as #803.

## Root Cause

`canExecute()` in `src/cli/system.ts` unconditionally uses `shell: true` on Windows
when spawning the opencode binary to verify its existence:

```typescript
shell: isWindows,  // always true
With shell: true, cmd.exe receives the command path without quotes. If the 
path contains spaces (e.g. C:\Program Files\WinGet\Links\opencode.exe), cmd 
interprets only the portion before the first space (C:\Program) as the command 
name and fails:
'C:\Program' is not recognized as an internal or external command
Node's spawnSync can execute .exe files directly (they are native 
executables). The shell: true workaround is only needed for .cmd/.bat/.ps1 
shims (Node.js CVE-2024-27980).
Fix
Skip shell: true for .exe files in canExecute():
- shell: isWindows,
+ shell: isWindows && !/\.exe$/i.test(command),
Verification
Tested on Windows with OpenCode 1.18.4 installed via winget at 
C:\Program Files\WinGet\Links\opencode.exe:
- Before: [x] OpenCode is not installed on this system.
- After: [ok] OpenCode 1.18.4 detected (C:\Program Files\WinGet\Links\opencode.exe)
All 9 install steps complete successfully.

Closes #803

Note: The code is generated by an agent with human review. 