### PR TITLE
fix: send ACP client version during initialization

### DIFF
--- a/src/tools/acp-run.test.ts
+++ b/src/tools/acp-run.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'bun:test';
+import packageJson from '../../package.json' with { type: 'json' };
+import { createAcpInitializeParams } from './acp-run';
+
+describe('ACP initialize payload', () => {
+  test('sends protocol-compliant client implementation information', () => {
+    const params = createAcpInitializeParams();
+
+    expect(params).toEqual({
+      protocolVersion: 1,
+      clientCapabilities: {},
+      clientInfo: {
+        name: 'oh-my-opencode-slim',
+        version: packageJson.version,
+      },
+    });
+    expect(params.clientInfo).not.toHaveProperty('title');
+  });
+});

--- a/src/tools/acp-run.ts
+++ b/src/tools/acp-run.ts
@@ -1,6 +1,7 @@
 import { type ChildProcessWithoutNullStreams, spawn } from 'node:child_process';
 import { createInterface } from 'node:readline';
 import { type ToolDefinition, tool } from '@opencode-ai/plugin';
+import packageJson from '../../package.json' with { type: 'json' };
 import {
   type AcpAgentConfig,
   type AcpAgentsConfig,
@@ -32,6 +33,17 @@ type Pending = {
   resolve: (value: Json | undefined) => void;
   reject: (error: Error) => void;
 };
+
+export function createAcpInitializeParams() {
+  return {
+    protocolVersion: 1,
+    clientCapabilities: {},
+    clientInfo: {
+      name: 'oh-my-opencode-slim',
+      version: packageJson.version,
+    },
+  };
+}
 
 class AcpClient {
   private child: ChildProcessWithoutNullStreams;
@@ -86,14 +98,7 @@ class AcpClient {
   }
 
   async run(prompt: string): Promise<string> {
-    const init = await this.request('initialize', {
-      protocolVersion: 1,
-      clientCapabilities: {},
-      clientInfo: {
-        name: 'oh-my-opencode-slim',
-        title: 'oh-my-opencode-slim ACP bridge',
-      },
-    });
+    const init = await this.request('initialize', createAcpInitializeParams());
     this.authMethods = readAuthMethods(init);
     const created = await this.newSession();
     const sessionId = readSessionId(created);


### PR DESCRIPTION
## Problem

`acp_run` sends `clientInfo` with `name` and `title`. ACP implementation information uses `name` and `version`, so strict agents such as Grok reject the `initialize` request with `-32602 Invalid params: missing field version`.

## Fix

- replace the unsupported `clientInfo.title` field with the current package version;
- source the version from `package.json`, so release bumps cannot leave the ACP metadata stale; and
- add a focused regression test for the complete initialize payload and the absence of `title`.

The protocol version and advertised client capabilities remain unchanged.

## Verification

- `bun run check:ci`
- `bun run typecheck`
- `bun test src/tools/acp-run.test.ts` — 1 passed, 0 failed
- `bun test` — 1722 passed, 0 failed
- `bun run build`

No documentation update is needed because this corrects an internal wire payload without changing configuration, commands, workflows, or user-facing output.

Fixes #866
