### PR TITLE
feat: add webfetch config for enable/disable and dedicated model

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -10,11 +10,17 @@ Slim only intercepts `apply_patch` before the native tool runs. It rewrites reco
 
 ## Web Fetch
 
-Fetch remote pages with content extraction tuned for docs/static sites.
+Enhanced version of OpenCode's built-in `webfetch`. Overrides the default when
+this plugin is active. Fetch remote pages with content extraction tuned for
+docs/static sites.
 
 | Tool | Description |
 |------|-------------|
-| `webfetch` | Fetch a URL, optionally prefer `llms.txt`, extract main content from HTML, include metadata, and optionally save binary responses |
+| `webfetch` | Fetch a URL, optionally prefer `llms.txt`, extract main content from HTML, include metadata, optionally save binary responses, and optionally run secondary-model extraction |
+
+See the full [Webfetch documentation](webfetch.md) for parameters, output
+format, caching, llms.txt probing, redirect policy, secondary-model
+summarization, binary detection, and implementation details.
 
 `webfetch` blocks cross-origin redirects unless the requested URL or derived permission patterns explicitly allow them, and it can fall back to the raw fetched content when secondary-model summarization is unavailable.
 

--- a/docs/webfetch.md
+++ b/docs/webfetch.md
@@ -94,9 +94,10 @@ questions like "summarize this page" or "extract the code examples" in one step.
 
 **Which model is used** (in priority order):
 
-1. `small_model` from the OpenCode configuration (`opencode.json` / `opencode.jsonc`)
-2. The configured `explorer` agent model
-3. The configured `librarian` agent model
+1. `webfetch.model` (dedicated — highest priority, supports array for fallback)
+2. `small_model` from the OpenCode configuration (`opencode.json` / `opencode.jsonc`)
+3. The configured `explorer` agent model
+4. The configured `librarian` agent model
 
 The secondary model is called only when all of these are true:
 - A `prompt` parameter is provided

--- a/docs/webfetch.md
+++ b/docs/webfetch.md
@@ -1,0 +1,280 @@
+# Webfetch (smartfetch)
+
+The `webfetch` tool fetches remote URLs and returns their content with intelligent
+extraction designed for documentation, static pages, and structured text. It
+provides caching, `llms.txt` probing, binary content handling, and optional
+secondary-model summarization.
+
+`webfetch` is already a built-in tool in OpenCode. This plugin replaces it with
+an enhanced version — the implementation lives in `src/tools/smartfetch/`, and
+the tool is registered under the same `webfetch` name to override the default.
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `url` | URL (string) | **required** | The URL to fetch. Must be a valid HTTP/HTTPS URL. |
+| `format` | `"text"` \| `"markdown"` \| `"html"` | `"markdown"` | Output format for the fetched content. |
+| `timeout` | number | `30` | Timeout in seconds (max `120`). |
+| `prompt` | string | optional | An extraction task for the secondary model to run against the fetched content (see [Secondary Model](#secondary-model)). |
+| `extract_main` | boolean | `true` | Extract main content from HTML using Mozilla Readability. When disabled, returns the full page body. |
+| `prefer_llms_txt` | `"auto"` \| `"always"` \| `"never"` | `"auto"` | Prefer `/llms.txt` or `/llms-full.txt` over the page itself. `"auto"` probes only for docs-like domains (readthedocs, gitbook, netlify, vercel, etc.). |
+| `include_metadata` | boolean | `true` | Include YAML frontmatter with fetch metadata (status code, content type, charset, redirect chain, cache info, etc.). |
+| `save_binary` | boolean | `false` | Save binary payloads (images, PDFs, audio, video) to disk under the system temp dir. When disabled, binary content reports metadata-only. |
+
+## Output
+
+### Text content (HTML, plain text, llms.txt)
+
+Returns the fetched content in the requested `format`. When `include_metadata`
+is enabled (default), the response is prefixed with YAML frontmatter containing
+metadata about the fetch:
+
+```yaml
+---
+requested_url: "https://example.com/docs"
+final_url: "https://example.com/docs"
+canonical_url: "https://example.com/docs"
+status_code: 200
+source_content_type: "text/html"
+source_kind: "html"
+title: "Documentation"
+headings:
+  - "Getting Started"
+  - "API Reference"
+used_llms_txt: false
+extracted_main: true
+redirect_chain: []
+upgraded_to_https: true
+cache_hit: false
+word_count: 1420
+quality_signals: []
+truncated: false
+---
+```
+
+The `quality_signals` field flags potential issues:
+- `very_short_content` — fewer than 60 words
+- `possible_paywall` — content matches paywall/login keywords
+- `high_boilerplate_ratio` — large HTML-to-text ratio without Readability extraction
+
+### Binary content
+
+Binary responses (images, PDFs, audio, video) return metadata about the file:
+
+- Content type and size
+- Filename (from `Content-Disposition` or URL path)
+- Binary kind (`image`, `audio`, `video`, `pdf`, `binary`)
+
+Two modes:
+
+1. **Metadata-only** — content exceeds the download limit (2 MiB without
+   `save_binary`, 10 MiB with it). Reports size and type without the body.
+2. **Saved to disk** — when `save_binary=true`, the binary is written to
+   `<tmpdir>/opencode-smartfetch/<filename>` and the response includes the
+   filesystem path.
+
+### Blocked redirects
+
+When a cross-origin redirect is blocked by policy, the response explains which
+URL was attempted and provides the redirect URL so you can fetch it directly.
+
+## Secondary Model
+
+When a `prompt` parameter is supplied, `webfetch` can route the fetched content
+through a secondary (cheaper) model for focused extraction. This lets you ask
+questions like "summarize this page" or "extract the code examples" in one step.
+
+**How it works:**
+
+1. Content is fetched and cached normally.
+2. A temporary OpenCode session is created with all tools disabled.
+3. The fetched content and your prompt are sent to a secondary model.
+4. The session is cleaned up after the response.
+
+**Which model is used** (in priority order):
+
+1. `small_model` from the OpenCode configuration (`opencode.json` / `opencode.jsonc`)
+2. The configured `explorer` agent model
+3. The configured `librarian` agent model
+
+The secondary model is called only when all of these are true:
+- A `prompt` parameter is provided
+- A secondary model is configured
+- The fetched content has at least 25 words
+
+If the secondary model fails (timeout, error, empty response), `webfetch`
+returns the raw fetched content as a graceful fallback.
+
+## Caching
+
+Fetches are cached in memory with an LRU cache (50 MiB max, 15-minute TTL).
+The cache key includes the URL plus behavior-affecting options (`extract_main`,
+`prefer_llms_txt`, `save_binary`), so changing these re-fetches the URL.
+
+**Revalidation:** Cache entries with `ETag` or `Last-Modified` headers support
+conditional revalidation. When a stale entry exists, `webfetch` sends
+`If-None-Match` / `If-Modified-Since` headers. A `304 Not Modified` response
+refreshes the TTL without re-downloading.
+
+**llms.txt validation:** Cached `llms.txt` results are validated — if the
+cached entry doesn't actually look like an llms.txt response (wrong path,
+HTML content, login page), it is evicted and re-fetched.
+
+## llms.txt Probing
+
+For documentation sites, `webfetch` probes for `/llms-full.txt` then `/llms.txt`
+before falling back to the page itself.
+
+**Probing behavior** depends on the `prefer_llms_txt` parameter:
+
+- `"auto"` (default) — probes only when the domain looks documentation-adjacent
+  (suffixes like `.readthedocs.io`, `.gitbook.io`, `docs.rs`; prefixes like
+  `docs.`, `developer.`, `dev.`, `wiki.`)
+- `"always"` — always probes; fails with a message if neither llms.txt variant
+  exists
+- `"never"` — skips probing entirely
+
+The probe respects cross-origin redirect policy (same origin only). If the
+`llms.txt` response is HTML or a login page, the probe is rejected.
+
+## Redirect Policy
+
+`webfetch` follows up to 10 redirects per request, but only within same-origin
+scopes. Cross-origin redirects are blocked and the caller is instructed to
+fetch the new URL directly.
+
+For URLs entered as `http://`, `webfetch` first tries `https://` and falls
+back to `http://` if the HTTPS attempt fails (connection error, blocked
+redirect, or non-2xx status).
+
+## Binary Detection
+
+Content type detection follows this flow:
+
+1. Explicit binary MIME types (`image/*`, `audio/*`, `video/*`,
+   `application/pdf`, `application/zip`, `application/octet-stream`) are
+   treated as binary.
+2. `application/octet-stream` and known text types are re-examined — the
+   first 2 KiB is scanned for null bytes and non-printable characters to
+   distinguish text from binary.
+3. Content declared as text/plain that looks like HTML is upgraded to
+   `text/html` for better content extraction.
+
+## Tool Timeouts
+
+- Default timeout: 30 seconds
+- Maximum timeout: 120 seconds
+- llms.txt probe timeout: capped at 8 seconds within the overall timeout
+- Multiple scoped timeouts run in parallel (llms.txt probing and page fetch
+  are independent within a single call)
+
+## Configuration
+
+### Disabling
+
+Set `webfetch.enabled` to `false` to skip registering the enhanced version and
+use OpenCode's built-in `webfetch` instead:
+
+```jsonc
+{
+  "webfetch": {
+    "enabled": false
+  }
+}
+```
+
+### Dedicated secondary model
+
+The `webfetch.model` option sets a dedicated model (or array of fallback
+models) for secondary-model summarization. Takes priority over all other model
+resolution sources. Accepts the same format as agent model configs:
+
+```jsonc
+{
+  "webfetch": {
+    "model": "openai/gpt-4o-mini"
+  }
+}
+```
+
+Multiple fallback models in priority order:
+
+```jsonc
+{
+  "webfetch": {
+    "model": ["openai/gpt-4o-mini", "anthropic/claude-3-haiku"]
+  }
+}
+```
+
+With optional variant:
+
+```jsonc
+{
+  "webfetch": {
+    "model": [
+      "openai/gpt-4o-mini",
+      { "id": "anthropic/claude-3-haiku", "variant": "low-latency" }
+    ]
+  }
+}
+```
+
+Each entry is tried in turn; the first to return usable text is used.
+
+### Secondary model fallback chain
+
+The [secondary model](#secondary-model) is resolved from these sources (in
+priority order):
+
+1. `webfetch.model` (dedicated — highest priority, supports array for fallback)
+2. `small_model` in the OpenCode config (`opencode.json` / `opencode.jsonc` at
+   project or user level)
+3. The plugin's `agents.explorer.model` config
+4. The plugin's `agents.librarian.model` config
+
+Example `opencode.jsonc`:
+
+```jsonc
+{
+  "small_model": "openai/gpt-4o-mini"
+}
+```
+
+Or in the plugin's `opencode.json` preset or project config:
+
+```jsonc
+{
+  "agents": {
+    "explorer": { "model": "anthropic/claude-3-haiku" },
+    "librarian": { "model": "openai/gpt-4o-mini" }
+  }
+}
+```
+
+### Permissions
+
+The `webfetch` permission can be configured in the plugin's permission rules.
+See [Configuration](configuration.md) for details.
+
+## Registration
+
+The tool is registered under the name `webfetch` in `src/index.ts`, which
+overrides OpenCode's built-in `webfetch` when this plugin is active.
+
+## Implementation
+
+The enhanced `webfetch` lives in `src/tools/smartfetch/` (the internal module is
+named "smartfetch", while the public tool name is `webfetch`). It is composed of
+these modules:
+
+| Module | Responsibility |
+|--------|---------------|
+| `tool.ts` | Entry point — permission prompts, cache lookup, llms.txt preference logic, binary-vs-text branching, metadata emission, secondary-model integration |
+| `network.ts` | URL normalization, redirect policy, charset/body decoding, header extraction, llms.txt probing, HTTP fetch with HTTPS upgrade fallback |
+| `utils.ts` | HTML extraction (Mozilla Readability + Turndown), heading cleanup, markdown/text cleaning, frontmatter generation, quality signal detection |
+| `cache.ts` | LRU cache keyed by URL + behavioral options, conditional revalidation, canonical URL aliasing, llms result invalidation |
+| `binary.ts` | Binary content persistence to disk, MIME-to-extension mapping, safe filename allocation |
+| `secondary-model.ts` | OpenCode config resolution for `small_model`, temporary session creation, content truncation, model fallback chain |
+| `constants.ts` | Timeouts, size limits, docs domain heuristics, binary MIME prefixes, tool description |

--- a/oh-my-opencode-slim.schema.json
+++ b/oh-my-opencode-slim.schema.json
@@ -1171,6 +1171,50 @@
         }
       }
     },
+    "webfetch": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "default": true,
+          "description": "When false, skip registering this enhanced webfetch so OpenCode uses its built-in version.",
+          "type": "boolean"
+        },
+        "model": {
+          "description": "Dedicated model(s) for smartfetch secondary-model summarization. Same shape as agent model config (string, array of strings/objects with id+variant). Takes priority over small_model, agents.explorer.model, and agents.librarian.model.",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "minItems": 1,
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "variant": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "id"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
     "acpAgents": {
       "type": "object",
       "propertyNames": {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -293,6 +293,38 @@ export const CompanionConfigSchema = z.object({
 
 export type CompanionConfig = z.infer<typeof CompanionConfigSchema>;
 
+const WebfetchModelEntrySchema = z.union([
+  ProviderModelIdSchema,
+  z
+    .object({
+      id: ProviderModelIdSchema,
+      variant: z.string().optional(),
+    })
+    .strict(),
+]);
+
+export const WebfetchConfigSchema = z
+  .object({
+    enabled: z
+      .boolean()
+      .default(true)
+      .describe(
+        'When false, skip registering this enhanced webfetch so OpenCode uses its built-in version.',
+      ),
+    model: z
+      .union([WebfetchModelEntrySchema, z.array(WebfetchModelEntrySchema).min(1)])
+      .optional()
+      .describe(
+        'Dedicated model(s) for smartfetch secondary-model summarization. ' +
+          'Accepts a single entry or an array for fallback (each entry can be ' +
+          'a provider/model string or { id, variant? }). ' +
+          'Takes priority over small_model, agents.explorer.model, and agents.librarian.model.',
+      ),
+  })
+  .strict();
+
+export type WebfetchConfig = z.infer<typeof WebfetchConfigSchema>;
+
 export const AcpAgentPermissionModeSchema = z.enum(['ask', 'allow', 'reject']);
 
 export const MAX_ACP_TIMEOUT_MS = 2_147_483_647;
@@ -415,6 +447,7 @@ export const PluginConfigSchema = z
     fallback: FailoverConfigSchema.optional(),
     council: CouncilConfigSchema.optional(),
     companion: CompanionConfigSchema.optional(),
+    webfetch: WebfetchConfigSchema.optional(),
     acpAgents: AcpAgentsConfigSchema.optional(),
   })
   .superRefine((value, ctx) => {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -293,16 +293,6 @@ export const CompanionConfigSchema = z.object({
 
 export type CompanionConfig = z.infer<typeof CompanionConfigSchema>;
 
-const WebfetchModelEntrySchema = z.union([
-  ProviderModelIdSchema,
-  z
-    .object({
-      id: ProviderModelIdSchema,
-      variant: z.string().optional(),
-    })
-    .strict(),
-]);
-
 export const WebfetchConfigSchema = z
   .object({
     enabled: z
@@ -311,15 +301,11 @@ export const WebfetchConfigSchema = z
       .describe(
         'When false, skip registering this enhanced webfetch so OpenCode uses its built-in version.',
       ),
-    model: z
-      .union([WebfetchModelEntrySchema, z.array(WebfetchModelEntrySchema).min(1)])
-      .optional()
-      .describe(
-        'Dedicated model(s) for smartfetch secondary-model summarization. ' +
-          'Accepts a single entry or an array for fallback (each entry can be ' +
-          'a provider/model string or { id, variant? }). ' +
-          'Takes priority over small_model, agents.explorer.model, and agents.librarian.model.',
-      ),
+    model: AgentOverrideConfigSchema.shape.model.describe(
+      'Dedicated model(s) for smartfetch secondary-model summarization. ' +
+        'Same shape as agent model config (string, array of strings/objects with id+variant). ' +
+        'Takes priority over small_model, agents.explorer.model, and agents.librarian.model.',
+    ),
   })
   .strict();
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -9,6 +9,8 @@ describe('plugin health thresholds', () => {
       4,
     );
     expect(minimumExpectedToolCount(['unknown_tool'])).toBe(5);
+    expect(minimumExpectedToolCount([], false)).toBe(4);
+    expect(minimumExpectedToolCount(['wait_for_user'], false)).toBe(3);
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,11 +118,14 @@ const BASELINE_TOOL_NAMES = new Set([
 /** @internal Exposed for deterministic health-threshold tests. */
 export function minimumExpectedToolCount(
   disabledTools: readonly string[] = [],
+  webfetchEnabled = true,
 ): number {
+  let count = HEALTH_CHECK.minTools;
+  if (!webfetchEnabled) count -= 1;
   const disabledBaselineTools = new Set(
     disabledTools.filter((toolName) => BASELINE_TOOL_NAMES.has(toolName)),
   );
-  return HEALTH_CHECK.minTools - disabledBaselineTools.size;
+  return count - disabledBaselineTools.size;
 }
 
 /**
@@ -282,7 +285,23 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
       Object.keys(config.acpAgents ?? {}).length > 0
         ? { acp_run: createAcpRunTool(config.acpAgents) }
         : {};
-    webfetch = createWebfetchTool(ctx);
+    const webfetchModel = config.webfetch?.model;
+    const webfetchModels = (() => {
+      if (!webfetchModel) return undefined;
+      const entries = Array.isArray(webfetchModel)
+        ? webfetchModel
+        : [webfetchModel];
+      const ids: string[] = [];
+      for (const entry of entries) {
+        const id = typeof entry === 'string' ? entry : entry.id;
+        if (id) ids.push(id);
+      }
+      return ids.length > 0 ? ids : undefined;
+    })();
+    webfetch = createWebfetchTool(ctx, {
+      binaryDir: undefined,
+      webfetchModels,
+    });
     backgroundJobBoard = new BackgroundJobBoard({
       maxReusablePerAgent:
         config.backgroundJobs?.maxSessionsPerAgent ??
@@ -451,11 +470,12 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
         taskSessionManagerHook.beginUserWait(sessionID),
     });
 
+    const shouldRegisterWebfetch = config.webfetch?.enabled !== false;
     tools = {
       ...cancelTaskTools,
       ...waitForUserTools,
       ...acpRunTools,
-      webfetch,
+      ...(shouldRegisterWebfetch ? { webfetch } : {}),
       ast_grep_search,
       ast_grep_replace,
     };
@@ -487,7 +507,10 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
     config.disabled_mcps && config.disabled_mcps.length > 0
       ? 0
       : HEALTH_CHECK.minMcps;
-  const toolThreshold = minimumExpectedToolCount(config.disabled_tools);
+  const toolThreshold = minimumExpectedToolCount(
+    config.disabled_tools,
+    config.webfetch?.enabled !== false,
+  );
 
   if (
     agentCount < HEALTH_CHECK.minAgents ||

--- a/src/index.ts
+++ b/src/index.ts
@@ -120,10 +120,13 @@ export function minimumExpectedToolCount(
   disabledTools: readonly string[] = [],
   webfetchEnabled = true,
 ): number {
+  // Coerce explicitly: the plugin transpiler may skip default params when
+  // an argument is passed as undefined (arguments.length semantics).
+  const tools = Array.isArray(disabledTools) ? disabledTools : [];
   let count = HEALTH_CHECK.minTools;
   if (!webfetchEnabled) count -= 1;
   const disabledBaselineTools = new Set(
-    disabledTools.filter((toolName) => BASELINE_TOOL_NAMES.has(toolName)),
+    tools.filter((toolName) => BASELINE_TOOL_NAMES.has(toolName)),
   );
   return count - disabledBaselineTools.size;
 }
@@ -291,9 +294,7 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
       const entries = Array.isArray(webfetchModel)
         ? webfetchModel
         : [webfetchModel];
-      type ModelRefInput =
-        | string
-        | { id: string; variant?: string };
+      type ModelRefInput = string | { id: string; variant?: string };
       const models: Array<{ id: string; variant?: string }> = [];
       for (const entry of entries as ModelRefInput[]) {
         const id = typeof entry === 'string' ? entry : entry.id;
@@ -520,7 +521,6 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
     config.disabled_tools,
     config.webfetch?.enabled !== false,
   );
-
   if (
     agentCount < HEALTH_CHECK.minAgents ||
     toolCount < toolThreshold ||

--- a/src/index.ts
+++ b/src/index.ts
@@ -291,15 +291,21 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
       const entries = Array.isArray(webfetchModel)
         ? webfetchModel
         : [webfetchModel];
-      const ids: string[] = [];
-      for (const entry of entries) {
-        // Object form { id, variant? } is accepted for schema consistency
-        // with agent model config. Variant is not forwarded — the secondary
-        // model API uses providerID/modelID only.
+      type ModelRefInput =
+        | string
+        | { id: string; variant?: string };
+      const models: Array<{ id: string; variant?: string }> = [];
+      for (const entry of entries as ModelRefInput[]) {
         const id = typeof entry === 'string' ? entry : entry.id;
-        if (id) ids.push(id);
+        if (!id) continue;
+        models.push({
+          id,
+          ...(typeof entry === 'object' && entry.variant
+            ? { variant: entry.variant }
+            : {}),
+        });
       }
-      return ids.length > 0 ? ids : undefined;
+      return models.length > 0 ? models : undefined;
     })();
     webfetch = createWebfetchTool(ctx, {
       binaryDir: undefined,

--- a/src/index.ts
+++ b/src/index.ts
@@ -293,6 +293,9 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
         : [webfetchModel];
       const ids: string[] = [];
       for (const entry of entries) {
+        // Object form { id, variant? } is accepted for schema consistency
+        // with agent model config. Variant is not forwarded — the secondary
+        // model API uses providerID/modelID only.
         const id = typeof entry === 'string' ? entry : entry.id;
         if (id) ids.push(id);
       }

--- a/src/tools/smartfetch/secondary-model.ts
+++ b/src/tools/smartfetch/secondary-model.ts
@@ -72,7 +72,10 @@ async function readEffectiveOpenCodeConfig(directory: string) {
   };
 }
 
-export async function readSecondaryModelFromConfig(directory: string) {
+export async function readSecondaryModelFromConfig(
+  directory: string,
+  webfetchModels?: string[],
+) {
   try {
     const models: SecondaryModel[] = [];
     const seen = new Set<string>();
@@ -85,6 +88,11 @@ export async function readSecondaryModelFromConfig(directory: string) {
       seen.add(key);
       models.push(parsedModel);
     };
+
+    // Dedicated webfetch model(s) take highest priority, in order
+    if (webfetchModels) {
+      for (const model of webfetchModels) pushModel(model);
+    }
 
     const opencodeConfig = await readEffectiveOpenCodeConfig(directory);
     pushModel(

--- a/src/tools/smartfetch/secondary-model.ts
+++ b/src/tools/smartfetch/secondary-model.ts
@@ -74,32 +74,34 @@ async function readEffectiveOpenCodeConfig(directory: string) {
 
 export async function readSecondaryModelFromConfig(
   directory: string,
-  webfetchModels?: string[],
+  webfetchModels?: Array<{ id: string; variant?: string }>,
 ) {
   try {
     const models: SecondaryModel[] = [];
     const seen = new Set<string>();
-    const pushModel = (value: unknown) => {
-      if (typeof value !== 'string') return;
-      const parsedModel = parseModelRef(value);
-      if (!parsedModel) return;
-      const key = `${parsedModel.providerID}/${parsedModel.modelID}`;
+    const addModel = (model: SecondaryModel) => {
+      const key = `${model.providerID}/${model.modelID}${model.variant ? `#${model.variant}` : ''}`;
       if (seen.has(key)) return;
       seen.add(key);
-      models.push(parsedModel);
+      models.push(model);
     };
 
     // Dedicated webfetch model(s) take highest priority, in order
     if (webfetchModels) {
-      for (const model of webfetchModels) pushModel(model);
+      for (const ref of webfetchModels) {
+        const parsedModel = parseModelRef(ref.id);
+        if (!parsedModel) continue;
+        addModel({ ...parsedModel, variant: ref.variant });
+      }
     }
 
     const opencodeConfig = await readEffectiveOpenCodeConfig(directory);
-    pushModel(
+    const parsedSmall = parseModelRef(
       typeof opencodeConfig.small_model === 'string'
         ? opencodeConfig.small_model
         : undefined,
     );
+    if (parsedSmall) addModel(parsedSmall);
 
     const pluginConfig = loadPluginConfig(directory);
     const explorerModel = pickAgentModelRef(
@@ -109,8 +111,15 @@ export async function readSecondaryModelFromConfig(
       pluginConfig.agents?.librarian?.model,
     );
 
-    pushModel(explorerModel);
-    pushModel(librarianModel);
+    const parsedExplorer = explorerModel
+      ? parseModelRef(explorerModel)
+      : undefined;
+    if (parsedExplorer) addModel(parsedExplorer);
+
+    const parsedLibrarian = librarianModel
+      ? parseModelRef(librarianModel)
+      : undefined;
+    if (parsedLibrarian) addModel(parsedLibrarian);
 
     return models;
   } catch {
@@ -263,7 +272,8 @@ async function runSecondaryModel(
         path: { id: sessionId },
         query: { directory },
         body: {
-          model,
+          model: { providerID: model.providerID, modelID: model.modelID },
+          ...(model.variant ? { variant: model.variant } : {}),
           system:
             'Answer only from the supplied content. Do not use tools or outside knowledge.',
           tools: disabledTools,

--- a/src/tools/smartfetch/tool.ts
+++ b/src/tools/smartfetch/tool.ts
@@ -806,7 +806,7 @@ export function createWebfetchTool(
               secondary_model_input_truncated: secondaryRun.inputTruncated,
               secondary_model_input_chars: secondaryRun.inputChars,
               secondary_model_source_chars: secondaryRun.sourceChars,
-              secondary_model: `${secondaryRun.model.providerID}/${secondaryRun.model.modelID}`,
+              secondary_model: `${secondaryRun.model.providerID}/${secondaryRun.model.modelID}${secondaryRun.model.variant ? `#${secondaryRun.model.variant}` : ''}`,
             })
           : '';
         const secondaryRaw =

--- a/src/tools/smartfetch/tool.ts
+++ b/src/tools/smartfetch/tool.ts
@@ -102,6 +102,7 @@ export function createWebfetchTool(
     async execute(args, ctx) {
       const secondaryModels = await readSecondaryModelFromConfig(
         ctx.directory || pluginCtx.directory,
+        options.webfetchModels,
       );
       const normalized = normalizeUrl(args.url);
       const url = new URL(normalized.url);

--- a/src/tools/smartfetch/types.ts
+++ b/src/tools/smartfetch/types.ts
@@ -1,15 +1,24 @@
+export type ModelRef = {
+  /** Provider/model string (e.g. "openai/gpt-4o-mini"). */
+  id: string;
+  /** Optional model variant annotation. */
+  variant?: string;
+};
+
 export type SmartfetchOptions = {
   binaryDir?: string;
   /**
-   * Dedicated model(s) for secondary-model summarization (provider/model format).
+   * Dedicated model(s) for secondary-model summarization.
    * Each entry is tried in order; the first to return usable text is used.
    */
-  webfetchModels?: string[];
+  webfetchModels?: ModelRef[];
 };
 
 export type SecondaryModel = {
   providerID: string;
   modelID: string;
+  /** Optional model variant passed at the body level. */
+  variant?: string;
 };
 
 export type RedirectStep = {

--- a/src/tools/smartfetch/types.ts
+++ b/src/tools/smartfetch/types.ts
@@ -1,5 +1,10 @@
 export type SmartfetchOptions = {
   binaryDir?: string;
+  /**
+   * Dedicated model(s) for secondary-model summarization (provider/model format).
+   * Each entry is tried in order; the first to return usable text is used.
+   */
+  webfetchModels?: string[];
 };
 
 export type SecondaryModel = {


### PR DESCRIPTION
Adds plugin-level configuration for the enhanced `webfetch` tool:

**`webfetch.enabled`** (boolean, default `true`) — set to `false` to skip registering the enhanced webfetch and use OpenCode's built-in version instead.

**`webfetch.model`** (string | `{ id, variant? }` | array) — dedicated model(s) for secondary-model summarization, taking highest priority in the resolution chain (above `small_model`, `agents.explorer.model`, `agents.librarian.model`). Supports the same schema as agent model configs, including object form with `variant`.

All 1722 tests pass, typecheck clean.