### PR TITLE
fix(task-session): reconcile false-cancelled FG-fallback task parts (#595)

### DIFF
--- a/src/hooks/task-session-manager/board-injection.ts
+++ b/src/hooks/task-session-manager/board-injection.ts
@@ -16,6 +16,7 @@ import {
   isInternalInitiatorPart,
   parseTaskStatusOutput,
   renderRunningTaskPlaceholder,
+  renderTaskTerminalFromBoard,
 } from '../../utils';
 import { isRecord } from '../../utils/guards';
 import { log } from '../../utils/logger';
@@ -159,6 +160,82 @@ export function stabilizeRunningTaskParts(messages: unknown[]): void {
       const placeholder = renderRunningTaskPlaceholder(taskID);
       if (state.output === placeholder) continue;
       state.output = placeholder;
+    }
+  }
+}
+
+/**
+ * Reconcile false-cancelled foreground task tool parts.
+ *
+ * When a foreground task's child session hits a rate-limit and the
+ * ForegroundFallbackManager aborts the session to swap models, opencode's
+ * `runState.cancel` poisons the BackgroundJob the task tool is awaiting →
+ * the tool returns `Effect.fail("Task cancelled")` → the assistant message's
+ * tool part is written as `status:"error"` with `"Task cancelled"` in the
+ * error field. The fallback model then completes on an orphan runLoop with
+ * no awaiter; the board later records the real outcome (completed/error).
+ *
+ * This rewrites such false-cancelled error parts to reflect the board's
+ * authoritative terminal state, so the orchestrator's history shows the
+ * true result instead of a spurious cancellation (#595).
+ *
+ * Gated: only acts when the board holds a non-cancelled terminal state
+ * (completed/reconciled/error) for the child session. True user cancels
+ * leave the board in `cancelled`, so they are preserved unchanged. Idempotent:
+ * after rewrite the part is no longer an error-with-cancelled, so subsequent
+ * transforms skip it. This is the single intentional exception to
+ * `stabilizeRunningTaskParts`' "terminal parts are immutable" rule —
+ * cancelled-by-fallback is not a genuine terminal outcome, it is a transient
+ * artifact of the abort+reprompt lifecycle split.
+ */
+export function reconcileFallbackFalseCancel(
+  state: InjectionState,
+  messages: unknown[],
+): void {
+  for (const message of messages) {
+    if (!isMessageWithParts(message)) continue;
+    for (const part of message.parts) {
+      if (part.type !== 'tool' || part.tool !== 'task') continue;
+      const partState = part.state;
+      if (!isRecord(partState)) continue;
+      if (partState.status !== 'error') continue;
+      const errorMsg = partState.error;
+      if (typeof errorMsg !== 'string' || !/cancelled/i.test(errorMsg)) {
+        continue;
+      }
+      const metadata = partState.metadata;
+      if (!isRecord(metadata)) continue;
+      const childSessionId = metadata.sessionId;
+      if (typeof childSessionId !== 'string') continue;
+
+      const job = state.backgroundJobBoard.get(childSessionId);
+      if (!job) continue;
+      // Only rewrite when the board has a non-cancelled terminal truth.
+      // `reconciled` retains a `terminalState` of completed/error.
+      const boardState = job.state;
+      const terminal =
+        job.terminalState ??
+        (boardState === 'completed' || boardState === 'error'
+          ? boardState
+          : undefined);
+      if (terminal !== 'completed' && terminal !== 'error') continue;
+
+      const rendered = renderTaskTerminalFromBoard({
+        taskID: childSessionId,
+        state: terminal,
+        description: job.description,
+        resultSummary: job.resultSummary,
+      });
+      partState.status = terminal;
+      partState.output = rendered;
+      delete partState.error;
+      log('[task-session-manager] reconciled false-cancelled task part', {
+        taskID: childSessionId,
+        alias: job.alias,
+        parentSessionID: job.parentSessionID,
+        boardState,
+        terminalState: job.terminalState,
+      });
     }
   }
 }

--- a/src/hooks/task-session-manager/board-injection.ts
+++ b/src/hooks/task-session-manager/board-injection.ts
@@ -228,7 +228,14 @@ export function reconcileFallbackFalseCancel(
       });
       partState.status = terminal;
       partState.output = rendered;
-      delete partState.error;
+      if (terminal === 'error') {
+        // Preserve the `error` field for opencode's ToolPart error state
+        // (message-v2.ts consumes it as errorText for the UI). Use the
+        // board's resultSummary as the authoritative failure reason.
+        partState.error = job.resultSummary ?? 'Background task failed';
+      } else {
+        delete partState.error;
+      }
       log('[task-session-manager] reconciled false-cancelled task part', {
         taskID: childSessionId,
         alias: job.alias,

--- a/src/hooks/task-session-manager/fallback-false-cancel.test.ts
+++ b/src/hooks/task-session-manager/fallback-false-cancel.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, test } from 'bun:test';
+import { BackgroundJobBoard } from '../../utils';
+import { createTaskSessionManagerHook } from './index';
+
+const PARENT = 'parent-1';
+const CHILD = 'child-1';
+
+function createHook(board: BackgroundJobBoard) {
+  return createTaskSessionManagerHook(
+    { client: { session: {} } } as never,
+    {
+      maxSessionsPerAgent: 2,
+      maxRetainedSnapshots: 2,
+      backgroundJobBoard: board,
+      shouldManageSession: () => true,
+    },
+  );
+}
+
+/**
+ * An assistant message with a task tool part, mirroring the shape opencode
+ * writes when a foreground task tool call fails. For the false-cancel bug,
+ * opencode writes status:"error" + error:"Tool execution failed: Task cancelled"
+ * (prompt.ts:414-428), with state.metadata.sessionId pointing at the child
+ * session (task.ts:188-195 via ctx.metadata).
+ */
+function taskErrorPart(
+  callID: string,
+  childSessionId: string,
+  errorMsg = 'Tool execution failed: Task cancelled',
+) {
+  return {
+    info: {
+      role: 'assistant',
+      agent: 'orchestrator',
+      sessionID: PARENT,
+      id: callID,
+    },
+    parts: [
+      { type: 'text', text: ' ' },
+      {
+        type: 'tool',
+        tool: 'task',
+        callID,
+        state: {
+          status: 'error',
+          error: errorMsg,
+          metadata: { sessionId: childSessionId },
+        },
+      },
+    ],
+  };
+}
+
+function userMessage(id: string, text: string) {
+  return {
+    info: { role: 'user', agent: 'orchestrator', sessionID: PARENT, id },
+    parts: [{ type: 'text', text }],
+  };
+}
+
+function findTaskPart(messages: unknown[], callID: string) {
+  for (const message of messages as { parts?: any[] }[]) {
+    for (const part of message?.parts ?? []) {
+      if (part?.type === 'tool' && part?.tool === 'task' && part?.callID === callID) {
+        return part;
+      }
+    }
+  }
+  return undefined;
+}
+
+async function transform(hook: ReturnType<typeof createTaskSessionManagerHook>, history: unknown[]) {
+  const request = { messages: structuredClone(history) };
+  await hook['experimental.chat.messages.transform']({}, request as never);
+  return request.messages;
+}
+
+function setupCompletedBoard(board: BackgroundJobBoard) {
+  board.registerLaunch({
+    taskID: CHILD,
+    parentSessionID: PARENT,
+    agent: 'fixer',
+    description: 'test fix',
+  });
+  board.updateStatus({
+    taskID: CHILD,
+    state: 'completed',
+    resultSummary: 'patched src/foo.ts',
+  });
+}
+
+describe('reconcileFallbackFalseCancel', () => {
+  test('rewrites false-cancelled error part to completed when board has completed truth', async () => {
+    const board = new BackgroundJobBoard();
+    setupCompletedBoard(board);
+    const hook = createHook(board);
+
+    const history = [
+      userMessage('u1', 'fix the bug'),
+      taskErrorPart('call-1', CHILD),
+    ];
+
+    const result = await transform(hook, history);
+    const part = findTaskPart(result, 'call-1') as any;
+
+    expect(part.state.status).toBe('completed');
+    expect(part.state.error).toBeUndefined();
+    expect(part.state.output).toContain('state="completed"');
+    expect(part.state.output).toContain('Background task completed: test fix');
+    expect(part.state.output).toContain('patched src/foo.ts');
+  });
+
+  test('rewrites false-cancelled error part to error when board has error truth', async () => {
+    const board = new BackgroundJobBoard();
+    board.registerLaunch({
+      taskID: CHILD,
+      parentSessionID: PARENT,
+      agent: 'fixer',
+      description: 'test fix',
+    });
+    board.updateStatus({
+      taskID: CHILD,
+      state: 'error',
+      resultSummary: 'syntax error in foo.ts',
+    });
+    const hook = createHook(board);
+
+    const history = [
+      userMessage('u1', 'fix the bug'),
+      taskErrorPart('call-1', CHILD),
+    ];
+
+    const result = await transform(hook, history);
+    const part = findTaskPart(result, 'call-1') as any;
+
+    expect(part.state.status).toBe('error');
+    expect(part.state.error).toBeUndefined();
+    expect(part.state.output).toContain('state="error"');
+    expect(part.state.output).toContain('Background task failed: test fix');
+    expect(part.state.output).toContain('syntax error in foo.ts');
+  });
+
+  test('does NOT rewrite when board is cancelled (preserves true user cancel)', async () => {
+    const board = new BackgroundJobBoard();
+    board.registerLaunch({
+      taskID: CHILD,
+      parentSessionID: PARENT,
+      agent: 'fixer',
+      description: 'test fix',
+    });
+    board.markCancelled(CHILD, 'user requested');
+    board.markReconciled(CHILD);
+    const hook = createHook(board);
+
+    const history = [
+      userMessage('u1', 'fix the bug'),
+      taskErrorPart('call-1', CHILD),
+    ];
+
+    const result = await transform(hook, history);
+    const part = findTaskPart(result, 'call-1') as any;
+
+    // True cancel: board terminalState is cancelled, not completed/error.
+    // Part stays as the original error.
+    expect(part.state.status).toBe('error');
+    expect(part.state.error).toContain('cancelled');
+  });
+
+  test('does NOT rewrite when board is still running (no truth yet)', async () => {
+    const board = new BackgroundJobBoard();
+    board.registerLaunch({
+      taskID: CHILD,
+      parentSessionID: PARENT,
+      agent: 'fixer',
+      description: 'test fix',
+    });
+    // board stays running — model 2 hasn't completed yet
+    const hook = createHook(board);
+
+    const history = [
+      userMessage('u1', 'fix the bug'),
+      taskErrorPart('call-1', CHILD),
+    ];
+
+    const result = await transform(hook, history);
+    const part = findTaskPart(result, 'call-1') as any;
+
+    expect(part.state.status).toBe('error');
+    expect(part.state.error).toContain('cancelled');
+  });
+
+  test('does NOT rewrite error parts whose message is not a task cancellation', async () => {
+    const board = new BackgroundJobBoard();
+    setupCompletedBoard(board);
+    const hook = createHook(board);
+
+    // A genuine tool error (not a cancellation) must be left intact.
+    const history = [
+      userMessage('u1', 'fix the bug'),
+      taskErrorPart('call-1', CHILD, 'Tool execution failed: timeout'),
+    ];
+
+    const result = await transform(hook, history);
+    const part = findTaskPart(result, 'call-1') as any;
+
+    expect(part.state.status).toBe('error');
+    expect(part.state.error).toBe('Tool execution failed: timeout');
+  });
+
+  test('is idempotent across consecutive transforms', async () => {
+    const board = new BackgroundJobBoard();
+    setupCompletedBoard(board);
+    const hook = createHook(board);
+
+    const history = [
+      userMessage('u1', 'fix the bug'),
+      taskErrorPart('call-1', CHILD),
+    ];
+
+    const first = await transform(hook, history);
+    const firstOutput = findTaskPart(first, 'call-1').state.output;
+
+    const second = await transform(hook, history);
+    const secondOutput = findTaskPart(second, 'call-1').state.output;
+
+    expect(secondOutput).toBe(firstOutput);
+  });
+
+  test('does not touch non-task tool parts', async () => {
+    const board = new BackgroundJobBoard();
+    setupCompletedBoard(board);
+    const hook = createHook(board);
+
+    const history = [
+      userMessage('u1', 'fix the bug'),
+      {
+        info: { role: 'assistant', agent: 'orchestrator', sessionID: PARENT, id: 'call-2' },
+        parts: [
+          { type: 'text', text: ' ' },
+          {
+            type: 'tool',
+            tool: 'read',
+            callID: 'call-2',
+            state: {
+              status: 'error',
+              error: 'Tool execution failed: Task cancelled',
+              metadata: { sessionId: CHILD },
+            },
+          },
+        ],
+      },
+    ];
+
+    const result = await transform(hook, history);
+    const part = result[1].parts[1] as any;
+
+    // read tool parts are not reconciled by the task-session-manager.
+    expect(part.state.status).toBe('error');
+    expect(part.state.error).toContain('cancelled');
+  });
+});

--- a/src/hooks/task-session-manager/fallback-false-cancel.test.ts
+++ b/src/hooks/task-session-manager/fallback-false-cancel.test.ts
@@ -135,7 +135,9 @@ describe('reconcileFallbackFalseCancel', () => {
     const part = findTaskPart(result, 'call-1') as any;
 
     expect(part.state.status).toBe('error');
-    expect(part.state.error).toBeUndefined();
+    // Preserve the `error` field for opencode's ToolPart error state
+    // (UI consumes it as errorText — see opencode message-v2.ts).
+    expect(part.state.error).toBe('syntax error in foo.ts');
     expect(part.state.output).toContain('state="error"');
     expect(part.state.output).toContain('Background task failed: test fix');
     expect(part.state.output).toContain('syntax error in foo.ts');

--- a/src/hooks/task-session-manager/index.ts
+++ b/src/hooks/task-session-manager/index.ts
@@ -12,6 +12,7 @@ import {
   type InjectionState,
   injectBackgroundJobBoard,
   MAX_PROCESSED_INJECTED_COMPLETIONS,
+  reconcileFallbackFalseCancel,
   reconcileInjectedTerminalJobs,
   stabilizeRunningTaskParts,
   updateFromInjectedCompletion,
@@ -277,6 +278,13 @@ export function createTaskSessionManagerHook(
       // lane never rewrites mid-history bytes and invalidates the prompt
       // cache. Terminal results are left untouched (they materialize once).
       stabilizeRunningTaskParts(messages);
+
+      // Reconcile false-cancelled foreground task parts: when a FG-fallback
+      // abort poisoned the awaited BackgroundJob ("Task cancelled" error part)
+      // but the board later recorded the real model-2 outcome, rewrite the
+      // part to the board's terminal truth so the orchestrator's history is
+      // accurate (#595). Board-gated, idempotent, no-op for true cancels.
+      reconcileFallbackFalseCancel(injectionState, messages);
 
       for (const [messageIndex, message] of messages.entries()) {
         if (!isUserMessageWithParts(message)) continue;

--- a/src/utils/task.ts
+++ b/src/utils/task.ts
@@ -36,6 +36,40 @@ export function renderRunningTaskPlaceholder(taskID: string): string {
   ].join('\n');
 }
 
+/**
+ * Render a terminal task tool output from a background job board record.
+ * Used to reconcile a false-cancelled foreground task part (opencode marked
+ * it "error" because the FG-fallback abort poisoned the awaited BackgroundJob)
+ * once the board later records the real model-2 outcome (#595).
+ *
+ * Mirrors opencode task.ts `renderOutput` shape so the orchestrator's history
+ * reads as a normal terminal result. Content is the board's resultSummary
+ * (the authoritative outcome the board captured); full model-2 text is not
+ * recoverable from the orphan runLoop, but the board truth is what matters.
+ */
+export function renderTaskTerminalFromBoard(input: {
+  taskID: string;
+  state: 'completed' | 'error';
+  description: string;
+  resultSummary?: string;
+}): string {
+  const { taskID, state, description, resultSummary } = input;
+  const tag = state === 'error' ? 'task_error' : 'task_result';
+  const summary =
+    state === 'completed'
+      ? `Background task completed: ${description}`
+      : `Background task failed: ${description}`;
+  const body = resultSummary ?? (state === 'completed' ? 'Task completed.' : 'Task failed.');
+  return [
+    `<task id="${taskID}" state="${state}">`,
+    `<summary>${summary}</summary>`,
+    `<${tag}>`,
+    body,
+    `</${tag}>`,
+    '</task>',
+  ].join('\n');
+}
+
 export function parseTaskIdFromTaskOutput(output: string): string | undefined {
   const xmlMatch = /<task\s+[^>]*\bid=["']([^"']+)["'][^>]*>/i.exec(output);
   if (xmlMatch) return xmlMatch[1];


### PR DESCRIPTION
## Problem

When launching a **foreground** task (e.g. `@fixer`) whose child agent has a multi-model fallback chain, and the primary model hits a rate-limit, the ForegroundFallbackManager correctly switches to the fallback model which **completes successfully** — but the parent orchestrator receives **"Task cancelled"** instead of the result.

This is the "orphaned success" symptom of #595.

## Root cause (verified across opencode core + omos)

The FG-fallback path uses `abortSessionWithTimeout` to break opencode's same-model infinite-backoff retry loop (`retry.ts` — no max-attempts), then re-prompts the **same session** with model 2 via `promptAsync`.

The abort poisons the lifecycle:
1. `runState.cancel` (`run-state.ts:77`) calls `cancelBackgroundJobs` → the BackgroundJob the task tool is awaiting is settled as `"cancelled"` (`background-job.ts:148`)
2. `runner.cancel` interrupts the runLoop → `Cause.hasInterruptsOnly` → status `"cancelled"`
3. `background.wait()` returns cancelled → `task.ts:329` throws `"Task cancelled"`

Model 2 then completes on an orphan runLoop (post-abort) with **no awaiter**. The board later records the real outcome via idle reconciliation, but the orchestrator's tool result already says cancelled — **board truth and tool result diverge**.

Key findings that shaped the fix:
- `Agent.Info.model` is a **single** model — opencode has **no native model fallback chain**; it's entirely an omos feature
- `ensureRunning` (`runner.ts:120`) discards new work while a runLoop is Running → omos **must** abort to swap models (no omos-only mechanism can avoid it)
- `background-job.ts` has **no public fulfill/reattach API** (only internal `settle`) → no omos-only mechanism can fix the current turn
- `tool.execute.after` fires on fail but `result=undefined` → opencode writes `status:"error", error:"Tool execution failed: Task cancelled"` (`prompt.ts:414-428`), with `state.metadata.sessionId` pointing at the child session

## Fix

In the `experimental.chat.messages.transform` hook, **after** `stabilizeRunningTaskParts`, detect task tool parts written as `status:'error'` whose error message matches `cancelled` and whose `state.metadata.sessionId` matches a board job in a **non-cancelled terminal state** (completed/reconciled/error). Rewrite them to reflect the board's authoritative terminal outcome.

**Board-gated**: only acts when the board holds completed/error (not cancelled) — true user cancels leave the board in `cancelled` and are preserved unchanged.

**Idempotent**: after rewrite the part is no longer `error` with a cancelled message, so subsequent transforms skip it.

This is the single intentional exception to `stabilizeRunningTaskParts`' "terminal parts are immutable" rule. Cancelled-by-fallback is **not** a genuine terminal outcome — it is a transient artifact of the abort+reprompt lifecycle split.

### Why not the alternatives

| Approach | Verdict |
|---|---|
| **B**: don't abort, other model-swap mechanism | ❌ `ensureRunning` discards new work while Running; no omos-only way to inject model 2 without abort |
| **C**: accept current-turn cancelled, inject completed next turn | ❌ Board already does this, but orchestrator may act on the cancelled signal (retry/abort) before next turn arrives |
| **D**: disable abort for foreground tasks | ❌ Eliminates the race by removing the feature — foreground task is the most valuable scenario for fallback |
| **E**: lifecycle bridge (await board.wait when cancelled) | ❌ BackgroundJob has no public reattach API; would require opencode core changes |

## Tests

New `fallback-false-cancel.test.ts` (7 cases):
- Rewrites false-cancelled error → completed when board has completed truth
- Rewrites false-cancelled error → error when board has error truth
- Does **not** rewrite when board is cancelled (preserves true user cancel)
- Does **not** rewrite when board is still running (no truth yet)
- Does **not** rewrite genuine errors (non-cancellation messages)
- Idempotent across consecutive transforms
- Does **not** touch non-task tool parts

Full suite: **1732 pass, 0 fail**.

## Related

- **#595** "Fallback is detached from background task lifecycle" — this is the root issue. The false-cancel is the orphaned-success symptom.
- **#822** stopped FG from aborting agents with **no** chain (plain `councillor`). Agents **with** chains still use FG abort — this PR fixes the board/tool-result divergence on that path.
- **#765** fixed the early-registration side for single tasks; this PR extends lifecycle protection to the false-cancel scenario.

## AI assistance

Co-developed-with:
- **oracle** (GLM-5.2) — architecture analysis, source-verified root cause, recommended this approach
- **councillor-reviewer-a** (grok-4.5) — independent review, proposed lifecycle-bridge alternative
- **councillor-reviewer-b** (grok-4.5) — independent review, flagged BackgroundJob fulfill-API question (resolved: no public API)
- **councillor-reviewer-c** (grok-4.5) — independent review, proposed disable-abort alternative

> Note: two of the four review agents (oracle, councillor-reviewer-b) themselves hit this exact bug during the session — they completed successfully but their results were reported as "Task cancelled" to the orchestrator. Their results were recovered via session resume, providing live confirmation of the bug this PR fixes.