### PR TITLE
docs: add Docker/sandbox tip to installation guide

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,6 +27,8 @@ Or use non-interactive mode:
 bunx oh-my-opencode-slim@latest install --no-tui --skills=yes --background-subagents=yes
 ```
 
+> **Running in Docker or a sandbox?** Install inside the container with the same command, and mount `~/.config/opencode` for persistence. Pass `--companion=no` to skip the desktop companion (it requires a display server). Auto-updates write to `~/.cache/opencode/packages/`, which is separate from config — mount that too if you want updates to survive container restarts.
+
 ### Configuration Options
 
 The installer supports the following options:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,7 +27,7 @@ Or use non-interactive mode:
 bunx oh-my-opencode-slim@latest install --no-tui --skills=yes --background-subagents=yes
 ```
 
-> **Running in Docker or a sandbox?** Install inside the container with the same command, and mount `~/.config/opencode` for persistence. Pass `--companion=no` to skip the desktop companion (it requires a display server). Auto-updates write to `~/.cache/opencode/packages/`, which is separate from config — mount that too if you want updates to survive container restarts.
+> **Running in Docker or a sandbox?** Install inside the container with `--no-tui` (headless environments can't run the interactive TUI), and mount `~/.config/opencode` for persistence. Pass `--companion=no` to skip the desktop companion (it requires a display server). Auto-updates write to `~/.cache/opencode/packages/`, which is separate from config — mount that too if you want updates to survive container restarts.
 
 ### Configuration Options
 


### PR DESCRIPTION
Adds a brief tip under Quick Install in  covering plugin-specific container details: install command, config mount, companion skip, and auto-update cache caveat.

Closes #599