### PR TITLE
add CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,40 @@
+# Code of Conduct
+
+## Standards
+
+We expect contributors to:
+
+- Use inclusive language
+- Accept constructive criticism gracefully
+- Focus on what is best for the community
+
+The following are prohibited:
+
+- Personal attacks, insults, or derogatory comments
+- Harassment, including sexual language or imagery
+- Publishing private information without consent (doxxing)
+- Trolling or deliberate disruption
+
+## Scope
+
+This Code of Conduct applies to:
+
+- All repository spaces: issues, pull requests, discussions, code reviews
+- Associated channels: Discord, Slack, or other project communication spaces
+- Project events: meetups, conferences, or hackathons
+
+## Reporting
+
+Report violations by reaching out to @alvinunreal directly.
+
+Reports are reviewed confidentially by project maintainers. The person accused of a violation will not be informed of the reporter's identity.
+
+## Enforcement
+
+Violations result in escalating consequences:
+
+1. **Warning** for first-time or minor offenses
+2. **Temporary ban** from project spaces for repeated or serious violations
+3. **Permanent ban** for severe or persistent violations
+
+Maintainers reserve the right to skip warnings for egregious behavior.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,14 +1,18 @@
 # Code of Conduct
 
-## Standards
+## Encouraged Behaviors
 
-We expect contributors to:
+We agree to:
 
 - Use inclusive language
 - Accept constructive criticism gracefully
 - Focus on what is best for the community
 
-The following are prohibited:
+We understand that words may be interpreted differently than intended 
+based on culture, background, or native language. When mistakes happen, 
+we commit to acknowledging them and making amends.
+
+## Unacceptable Behaviors
 
 - Personal attacks, insults, or derogatory comments
 - Harassment, including sexual language or imagery


### PR DESCRIPTION
## Summary

Adds a simplified Code of Conduct inspired by Contributor Covenant 3.0, with 4 sections:

1. **Encouraged Behaviors** - positive framing of expected behaviors, plus cultural nuance
2. **Unacceptable Behaviors** - prohibited actions (harassment, doxxing, personal attacks)
3. **Scope** - where the CoC applies (repo spaces, channels, events)
4. **Reporting** - contact @alvinunreal directly
5. **Enforcement** - escalating consequences (warning → temp ban → perm ban)

44 lines, concise and actionable. Uses CC 3.0's positive "Encouraged Behaviors" framing instead of prescriptive "We expect" language.