### PR TITLE
[codex] Guard malformed disabled tool lists

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -10,6 +10,11 @@ describe('plugin health thresholds', () => {
     );
     expect(minimumExpectedToolCount(['unknown_tool'])).toBe(5);
   });
+
+  test('treats malformed disabled tool lists as empty', () => {
+    expect(minimumExpectedToolCount(null)).toBe(5);
+    expect(minimumExpectedToolCount({ wait_for_user: true })).toBe(5);
+  });
 });
 
 describe('plugin env disable', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -119,8 +119,9 @@ const BASELINE_TOOL_NAMES = new Set([
 export function minimumExpectedToolCount(
   disabledTools: unknown = [],
 ): number {
+  const disabledToolList = Array.isArray(disabledTools) ? disabledTools : [];
   const disabledBaselineTools = new Set(
-    (Array.isArray(disabledTools) ? disabledTools : []).filter((toolName) => BASELINE_TOOL_NAMES.has(toolName)),
+    disabledToolList.filter((toolName) => BASELINE_TOOL_NAMES.has(toolName)),
   );
   return HEALTH_CHECK.minTools - disabledBaselineTools.size;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,10 +117,10 @@ const BASELINE_TOOL_NAMES = new Set([
 
 /** @internal Exposed for deterministic health-threshold tests. */
 export function minimumExpectedToolCount(
-  disabledTools: readonly string[] = [],
+  disabledTools: unknown = [],
 ): number {
   const disabledBaselineTools = new Set(
-    disabledTools.filter((toolName) => BASELINE_TOOL_NAMES.has(toolName)),
+    (Array.isArray(disabledTools) ? disabledTools : []).filter((toolName) => BASELINE_TOOL_NAMES.has(toolName)),
   );
   return HEALTH_CHECK.minTools - disabledBaselineTools.size;
 }


### PR DESCRIPTION
## Summary

Guard the health-check threshold calculation against malformed `disabled_tools` values.

## Root Cause

`minimumExpectedToolCount(config.disabled_tools)` runs after plugin initialization. When a non-array value reaches that function, calling `.filter()` throws and makes the whole plugin fail to load.

## Changes

- Treat a non-array `disabled_tools` value as an empty list in the health check.
- Add regression coverage for `null` and object values.

Normal array values keep their existing behavior.

## Validation

- Verified a fresh OpenCode agent load no longer reports `disabledTools.filter is not a function`.
- Verified Council, councillor, and configured councillor subagents register successfully.

Fixes #894
