### PR TITLE
fix(task-session): fill false-completed task parts with child session real output (#863)

### DIFF
--- a/src/hooks/task-session-manager/board-injection.ts
+++ b/src/hooks/task-session-manager/board-injection.ts
@@ -7,6 +7,7 @@
  * All injection logic must go through the cache-safe helpers in
  * ../cache-safe-injection.ts to ensure prompt cache safety.
  */
+import type { PluginInput } from '@opencode-ai/plugin';
 import type {
   BackgroundJobRecord,
   BackgroundJobStore,
@@ -16,7 +17,9 @@ import {
   isInternalInitiatorPart,
   parseTaskStatusOutput,
   renderRunningTaskPlaceholder,
+  renderTaskCompletedWithText,
 } from '../../utils';
+import { extractSessionResult } from '../../utils/session';
 import { isRecord } from '../../utils/guards';
 import { log } from '../../utils/logger';
 import {
@@ -159,6 +162,82 @@ export function stabilizeRunningTaskParts(messages: unknown[]): void {
       const placeholder = renderRunningTaskPlaceholder(taskID);
       if (state.output === placeholder) continue;
       state.output = placeholder;
+    }
+  }
+}
+
+/**
+ * Reconcile false-completed foreground task tool parts.
+ *
+ * When a foreground task's primary model halts on a non-retryable error
+ * (e.g. 403 quota exhausted), opencode's `halt` produces an empty assistant
+ * message and `runTask` settles the BackgroundJob as `completed` with an
+ * empty output (`result.parts.findLast(text)?.text ?? ""`). omos's
+ * `tryFallback` then re-prompts with the fallback model on an orphan runLoop
+ * that produces the real result, but the parent task part already says
+ * `completed` with an empty `<task_result>` — the orchestrator reads the
+ * empty output, mis-judges the task as failed/empty, and self-amplifies by
+ * launching redundant replacement tasks (#863).
+ *
+ * This in-place rewrites such false-completed parts with the child session's
+ * real assistant text once the fallback model has produced it. The pass is
+ * idempotent and non-blocking: if the child session has not yet produced
+ * non-empty text, `extractSessionResult` returns empty and the part is left
+ * unchanged — the next transform turn re-evaluates naturally, so no explicit
+ * wait/poll is needed. Because the transform hook only mutates the
+ * in-memory `output.messages` (not the persisted DB), the rewrite is
+ * per-turn but the real output eventually lands in history once the child
+ * session completes and opencode writes it itself.
+ *
+ * Gated: only acts on `status:"completed"` task parts whose parsed
+ * `<task_result>` is empty. True completions with real text are preserved
+ * unchanged.
+ */
+export async function reconcileFalseCompleteFallback(
+  state: InjectionState,
+  messages: unknown[],
+  client: PluginInput['client'],
+  directory?: string,
+): Promise<void> {
+  for (const message of messages) {
+    if (!isMessageWithParts(message)) continue;
+    for (const part of message.parts) {
+      if (part.type !== 'tool' || part.tool !== 'task') continue;
+      const partState = part.state;
+      if (!isRecord(partState)) continue;
+      if (partState.status !== 'completed') continue;
+      if (typeof partState.output !== 'string') continue;
+
+      const status = parseTaskStatusOutput(partState.output);
+      if (!status || status.state !== 'completed') continue;
+      // Only reconcile empty results — real completions are intact.
+      if (status.result && status.result.trim().length > 0) continue;
+
+      const childSessionId = status.taskID;
+      const job = state.backgroundJobBoard.get(childSessionId);
+      if (!job) continue;
+
+      // Read the child session's real assistant text. Non-blocking: returns
+      // empty when the fallback model has not yet produced output, and the
+      // next transform turn re-evaluates naturally (idempotent polling).
+      const extracted = await extractSessionResult(client, childSessionId, {
+        directory,
+        includeReasoning: false,
+      });
+      if (extracted.empty) continue;
+
+      const summary = `Background task completed: ${job.description}`;
+      partState.output = renderTaskCompletedWithText(
+        childSessionId,
+        summary,
+        extracted.text,
+      );
+      log('[task-session-manager] reconciled false-completed task part', {
+        taskID: childSessionId,
+        alias: job.alias,
+        parentSessionID: job.parentSessionID,
+        textLength: extracted.text.length,
+      });
     }
   }
 }

--- a/src/hooks/task-session-manager/board-injection.ts
+++ b/src/hooks/task-session-manager/board-injection.ts
@@ -216,14 +216,32 @@ export async function reconcileFalseCompleteFallback(
       const childSessionId = status.taskID;
       const job = state.backgroundJobBoard.get(childSessionId);
       if (!job) continue;
+      // Wait until the board is no longer actively running so we do not
+      // promote mid-generation fallback text into a "completed" part.
+      // False-complete already settles the board as completed+empty while
+      // the orphan runLoop continues — that terminal board state is enough.
+      if (job.state === 'running') continue;
+      if (job.state === 'cancelled' || job.terminalState === 'cancelled') {
+        continue;
+      }
 
-      // Read the child session's real assistant text. Non-blocking: returns
-      // empty when the fallback model has not yet produced output, and the
-      // next transform turn re-evaluates naturally (idempotent polling).
-      const extracted = await extractSessionResult(client, childSessionId, {
-        directory,
-        includeReasoning: false,
-      });
+      // Fail-open: a transient child-session read must never abort the
+      // parent messages transform (Greptile P1). Empty/error → leave part
+      // unchanged; the next transform turn re-evaluates naturally.
+      let extracted: { text: string; empty: boolean };
+      try {
+        extracted = await extractSessionResult(client, childSessionId, {
+          directory,
+          includeReasoning: false,
+        });
+      } catch (error) {
+        log('[task-session-manager] false-complete extract failed', {
+          taskID: childSessionId,
+          alias: job.alias,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        continue;
+      }
       if (extracted.empty) continue;
 
       const summary = `Background task completed: ${job.description}`;

--- a/src/hooks/task-session-manager/false-complete-fallback.test.ts
+++ b/src/hooks/task-session-manager/false-complete-fallback.test.ts
@@ -74,12 +74,27 @@ function setupCompletedBoard(board: BackgroundJobBoard, description = 'test task
     agent: 'fixer',
     description,
   });
+  // False-complete settles the board as completed+empty while the orphan
+  // fallback runLoop may still produce text later.
+  board.updateStatus({
+    taskID: CHILD,
+    state: 'completed',
+    resultSummary: '',
+  });
 }
 
-function mockClient(childMessages: Array<{ info?: { role: string }; parts?: Array<{ type: string; text?: string }> }>) {
+function mockClient(
+  childMessages:
+    | Array<{ info?: { role: string }; parts?: Array<{ type: string; text?: string }> }>
+    | (() => Promise<unknown>),
+) {
+  const messages =
+    typeof childMessages === 'function'
+      ? mock(childMessages)
+      : mock(async () => ({ data: childMessages }));
   return {
     session: {
-      messages: mock(async () => ({ data: childMessages })),
+      messages,
       status: mock(async () => ({ data: {} })),
     },
   };
@@ -256,5 +271,106 @@ describe('reconcileFalseCompleteFallback', () => {
 
     // read tool parts are not reconciled.
     expect(part.state.output).toContain('<task_result></task_result>');
+  });
+
+  test('does NOT rewrite when board job is still running', async () => {
+    const board = new BackgroundJobBoard();
+    board.registerLaunch({
+      taskID: CHILD,
+      parentSessionID: PARENT,
+      agent: 'fixer',
+      description: 'still running',
+    });
+    const childMessages = [
+      { info: { role: 'assistant' }, parts: [{ type: 'text', text: 'partial draft' }] },
+    ];
+    const hook = createTaskSessionManagerHook(
+      { client: mockClient(childMessages), directory: '/tmp' } as never,
+      {
+        maxSessionsPerAgent: 2,
+        maxRetainedSnapshots: 2,
+        backgroundJobBoard: board,
+        shouldManageSession: () => true,
+      },
+    );
+
+    const history = [
+      userMessage('u1', 'run task'),
+      taskCompletedPart('call-1', CHILD, ''),
+    ];
+
+    const result = await transform(hook, history);
+    const part = findTaskPart(result, 'call-1') as any;
+    const tagMatch = /<task_result>\s*([\s\S]*?)\s*<\/task_result>/m.exec(
+      part.state.output,
+    );
+    expect(tagMatch?.[1]?.trim()).toBe('');
+    expect(part.state.output).not.toContain('partial draft');
+  });
+
+  test('does NOT abort transform when child session extract throws', async () => {
+    const board = new BackgroundJobBoard();
+    setupCompletedBoard(board, 'test task');
+    const hook = createTaskSessionManagerHook(
+      {
+        client: mockClient(async () => {
+          throw new Error('session unavailable');
+        }),
+        directory: '/tmp',
+      } as never,
+      {
+        maxSessionsPerAgent: 2,
+        maxRetainedSnapshots: 2,
+        backgroundJobBoard: board,
+        shouldManageSession: () => true,
+      },
+    );
+
+    const history = [
+      userMessage('u1', 'run task'),
+      taskCompletedPart('call-1', CHILD, ''),
+    ];
+
+    const result = await transform(hook, history);
+    const part = findTaskPart(result, 'call-1') as any;
+    expect(part.state.status).toBe('completed');
+    const tagMatch = /<task_result>\s*([\s\S]*?)\s*<\/task_result>/m.exec(
+      part.state.output,
+    );
+    expect(tagMatch?.[1]?.trim()).toBe('');
+  });
+
+  test('preserves recovered text that embeds a literal </task_result>', async () => {
+    const board = new BackgroundJobBoard();
+    setupCompletedBoard(board, 'test task');
+    const body =
+      'Example close tag in report:\n</task_result>\nthen more findings.';
+    const childMessages = [
+      { info: { role: 'assistant' }, parts: [{ type: 'text', text: body }] },
+    ];
+    const hook = createTaskSessionManagerHook(
+      { client: mockClient(childMessages), directory: '/tmp' } as never,
+      {
+        maxSessionsPerAgent: 2,
+        maxRetainedSnapshots: 2,
+        backgroundJobBoard: board,
+        shouldManageSession: () => true,
+      },
+    );
+
+    const history = [
+      userMessage('u1', 'run task'),
+      taskCompletedPart('call-1', CHILD, ''),
+    ];
+
+    const result = await transform(hook, history);
+    const part = findTaskPart(result, 'call-1') as any;
+    expect(part.state.output).toContain('Example close tag in report:');
+    expect(part.state.output).toContain('then more findings.');
+    // Non-greedy parse must recover the full body after sanitize.
+    const { parseTaskResultFromOutput } = await import('../../utils/task');
+    const parsed = parseTaskResultFromOutput(part.state.output);
+    expect(parsed).toContain('then more findings.');
+    expect(parsed).toContain('Example close tag in report:');
   });
 });

--- a/src/hooks/task-session-manager/false-complete-fallback.test.ts
+++ b/src/hooks/task-session-manager/false-complete-fallback.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, test, mock } from 'bun:test';
+import { BackgroundJobBoard } from '../../utils';
+import { createTaskSessionManagerHook } from './index';
+
+const PARENT = 'parent-1';
+const CHILD = 'child-1';
+
+function taskCompletedPart(
+  callID: string,
+  childSessionId: string,
+  resultText = '',
+) {
+  const tag = 'task_result';
+  return {
+    info: {
+      role: 'assistant',
+      agent: 'orchestrator',
+      sessionID: PARENT,
+      id: callID,
+    },
+    parts: [
+      { type: 'text', text: ' ' },
+      {
+        type: 'tool',
+        tool: 'task',
+        callID,
+        state: {
+          status: 'completed',
+          output: [
+            `<task id="${childSessionId}" state="completed">`,
+            `<${tag}>`,
+            resultText,
+            `</${tag}>`,
+            '</task>',
+          ].join('\n'),
+          metadata: { sessionId: childSessionId },
+        },
+      },
+    ],
+  };
+}
+
+function userMessage(id: string, text: string) {
+  return {
+    info: { role: 'user', agent: 'orchestrator', sessionID: PARENT, id },
+    parts: [{ type: 'text', text }],
+  };
+}
+
+function findTaskPart(messages: unknown[], callID: string) {
+  for (const message of messages as { parts?: any[] }[]) {
+    for (const part of message?.parts ?? []) {
+      if (part?.type === 'tool' && part?.tool === 'task' && part?.callID === callID) {
+        return part;
+      }
+    }
+  }
+  return undefined;
+}
+
+async function transform(
+  hook: ReturnType<typeof createTaskSessionManagerHook>,
+  history: unknown[],
+) {
+  const request = { messages: structuredClone(history) };
+  await hook['experimental.chat.messages.transform']({}, request as never);
+  return request.messages;
+}
+
+function setupCompletedBoard(board: BackgroundJobBoard, description = 'test task') {
+  board.registerLaunch({
+    taskID: CHILD,
+    parentSessionID: PARENT,
+    agent: 'fixer',
+    description,
+  });
+}
+
+function mockClient(childMessages: Array<{ info?: { role: string }; parts?: Array<{ type: string; text?: string }> }>) {
+  return {
+    session: {
+      messages: mock(async () => ({ data: childMessages })),
+      status: mock(async () => ({ data: {} })),
+    },
+  };
+}
+
+describe('reconcileFalseCompleteFallback', () => {
+  test('fills empty completed output with child session real assistant text', async () => {
+    const board = new BackgroundJobBoard();
+    setupCompletedBoard(board, 'audit DATA.md');
+    // Child session has produced a real 9346-char report
+    const childMessages = [
+      { info: { role: 'user' }, parts: [{ type: 'text', text: 'audit' }] },
+      {
+        info: { role: 'assistant' },
+        parts: [{ type: 'text', text: '# Audit Report\nAll claims verified.' }],
+      },
+    ];
+    const hook = createTaskSessionManagerHook(
+      { client: mockClient(childMessages), directory: '/tmp' } as never,
+      {
+        maxSessionsPerAgent: 2,
+        maxRetainedSnapshots: 2,
+        backgroundJobBoard: board,
+        shouldManageSession: () => true,
+      },
+    );
+
+    const history = [
+      userMessage('u1', 'run audit'),
+      taskCompletedPart('call-1', CHILD, ''), // empty result = false-complete
+    ];
+
+    const result = await transform(hook, history);
+    const part = findTaskPart(result, 'call-1') as any;
+
+    expect(part.state.status).toBe('completed');
+    expect(part.state.output).toContain('state="completed"');
+    expect(part.state.output).toContain('Background task completed: audit DATA.md');
+    expect(part.state.output).toContain('# Audit Report');
+    expect(part.state.output).toContain('All claims verified.');
+  });
+
+  test('does NOT rewrite when completed output already has real text', async () => {
+    const board = new BackgroundJobBoard();
+    setupCompletedBoard(board, 'test task');
+    const childMessages = [
+      { info: { role: 'assistant' }, parts: [{ type: 'text', text: 'real output' }] },
+    ];
+    const hook = createTaskSessionManagerHook(
+      { client: mockClient(childMessages), directory: '/tmp' } as never,
+      {
+        maxSessionsPerAgent: 2,
+        maxRetainedSnapshots: 2,
+        backgroundJobBoard: board,
+        shouldManageSession: () => true,
+      },
+    );
+
+    const realText = 'Already have real result here';
+    const history = [
+      userMessage('u1', 'run task'),
+      taskCompletedPart('call-1', CHILD, realText),
+    ];
+
+    const result = await transform(hook, history);
+    const part = findTaskPart(result, 'call-1') as any;
+
+    // Real completion is preserved unchanged.
+    expect(part.state.output).toContain(realText);
+    expect(part.state.output).not.toContain('Background task completed:');
+  });
+
+  test('does NOT rewrite when child session has no assistant text yet (still running)', async () => {
+    const board = new BackgroundJobBoard();
+    setupCompletedBoard(board, 'test task');
+    // Child session has no assistant text — fallback model still running
+    const childMessages = [
+      { info: { role: 'user' }, parts: [{ type: 'text', text: 'prompt' }] },
+    ];
+    const hook = createTaskSessionManagerHook(
+      { client: mockClient(childMessages), directory: '/tmp' } as never,
+      {
+        maxSessionsPerAgent: 2,
+        maxRetainedSnapshots: 2,
+        backgroundJobBoard: board,
+        shouldManageSession: () => true,
+      },
+    );
+
+    const history = [
+      userMessage('u1', 'run task'),
+      taskCompletedPart('call-1', CHILD, ''),
+    ];
+
+    const result = await transform(hook, history);
+    const part = findTaskPart(result, 'call-1') as any;
+
+    // No real text available yet — part stays empty (next turn re-evaluates).
+    expect(part.state.status).toBe('completed');
+    const tagMatch = /<task_result>\s*([\s\S]*?)\s*<\/task_result>/m.exec(
+      part.state.output,
+    );
+    expect(tagMatch?.[1]?.trim()).toBe('');
+  });
+
+  test('is idempotent across consecutive transforms', async () => {
+    const board = new BackgroundJobBoard();
+    setupCompletedBoard(board, 'test task');
+    const childMessages = [
+      { info: { role: 'assistant' }, parts: [{ type: 'text', text: 'real output' }] },
+    ];
+    const hook = createTaskSessionManagerHook(
+      { client: mockClient(childMessages), directory: '/tmp' } as never,
+      {
+        maxSessionsPerAgent: 2,
+        maxRetainedSnapshots: 2,
+        backgroundJobBoard: board,
+        shouldManageSession: () => true,
+      },
+    );
+
+    const history = [
+      userMessage('u1', 'run task'),
+      taskCompletedPart('call-1', CHILD, ''),
+    ];
+
+    const first = await transform(hook, history);
+    const firstOutput = findTaskPart(first, 'call-1').state.output;
+
+    const second = await transform(hook, history);
+    const secondOutput = findTaskPart(second, 'call-1').state.output;
+
+    expect(secondOutput).toBe(firstOutput);
+  });
+
+  test('does not touch non-task tool parts', async () => {
+    const board = new BackgroundJobBoard();
+    setupCompletedBoard(board, 'test task');
+    const childMessages = [
+      { info: { role: 'assistant' }, parts: [{ type: 'text', text: 'real' }] },
+    ];
+    const hook = createTaskSessionManagerHook(
+      { client: mockClient(childMessages), directory: '/tmp' } as never,
+      {
+        maxSessionsPerAgent: 2,
+        maxRetainedSnapshots: 2,
+        backgroundJobBoard: board,
+        shouldManageSession: () => true,
+      },
+    );
+
+    const history = [
+      userMessage('u1', 'run task'),
+      {
+        info: { role: 'assistant', agent: 'orchestrator', sessionID: PARENT, id: 'call-2' },
+        parts: [
+          { type: 'text', text: ' ' },
+          {
+            type: 'tool',
+            tool: 'read',
+            callID: 'call-2',
+            state: {
+              status: 'completed',
+              output: '<task id="child-1" state="completed"><task_result></task_result></task>',
+              metadata: { sessionId: CHILD },
+            },
+          },
+        ],
+      },
+    ];
+
+    const result = await transform(hook, history);
+    const part = result[1].parts[1] as any;
+
+    // read tool parts are not reconciled.
+    expect(part.state.output).toContain('<task_result></task_result>');
+  });
+});

--- a/src/hooks/task-session-manager/index.ts
+++ b/src/hooks/task-session-manager/index.ts
@@ -12,6 +12,7 @@ import {
   type InjectionState,
   injectBackgroundJobBoard,
   MAX_PROCESSED_INJECTED_COMPLETIONS,
+  reconcileFalseCompleteFallback,
   reconcileInjectedTerminalJobs,
   stabilizeRunningTaskParts,
   updateFromInjectedCompletion,
@@ -277,6 +278,20 @@ export function createTaskSessionManagerHook(
       // lane never rewrites mid-history bytes and invalidates the prompt
       // cache. Terminal results are left untouched (they materialize once).
       stabilizeRunningTaskParts(messages);
+
+      // Reconcile false-completed foreground task parts: when the primary
+      // model halts on a non-retryable error, opencode settles the task as
+      // completed with an empty output while the fallback model still
+      // produces the real result on an orphan runLoop (#863). Fill the empty
+      // output with the child session's real assistant text once available.
+      // Idempotent and non-blocking — empty extractions are skipped and
+      // re-evaluated on the next transform turn.
+      await reconcileFalseCompleteFallback(
+        injectionState,
+        messages,
+        _ctx.client,
+        _ctx.directory,
+      );
 
       for (const [messageIndex, message] of messages.entries()) {
         if (!isUserMessageWithParts(message)) continue;

--- a/src/utils/task.test.ts
+++ b/src/utils/task.test.ts
@@ -5,6 +5,8 @@ import {
   parseTaskResultFromOutput,
   parseTaskStatusOutput,
   renderRunningTaskPlaceholder,
+  renderTaskCompletedWithText,
+  sanitizeTaskResultBody,
 } from './task';
 
 describe('renderRunningTaskPlaceholder', () => {
@@ -25,6 +27,21 @@ describe('renderRunningTaskPlaceholder', () => {
     const b = renderRunningTaskPlaceholder('ses_b');
     expect(a).not.toBe(b);
     expect(a.replace('ses_a', 'ses_b')).toBe(b);
+  });
+});
+
+describe('renderTaskCompletedWithText', () => {
+  test('round-trips body that embeds a literal close tag', () => {
+    const body = 'before\n</task_result>\nafter';
+    const rendered = renderTaskCompletedWithText(
+      'ses_1',
+      'Background task completed: t',
+      body,
+    );
+    const parsed = parseTaskResultFromOutput(rendered);
+    expect(parsed).toContain('before');
+    expect(parsed).toContain('after');
+    expect(sanitizeTaskResultBody(body)).toContain('\u200b');
   });
 });
 

--- a/src/utils/task.ts
+++ b/src/utils/task.ts
@@ -54,6 +54,15 @@ export function renderRunningTaskPlaceholder(taskID: string): string {
  * true outcome once the fallback model has produced it. Mirrors the
  * `state:"completed"` branch of opencode `renderOutput` (task.ts:64-76).
  */
+/**
+ * Neutralize embedded task close tags so non-greedy
+ * `parseTaskResultFromOutput` cannot truncate recovered body early.
+ * Zero-width space after `</` keeps the visible text intact.
+ */
+export function sanitizeTaskResultBody(text: string): string {
+  return text.replace(/<\/(task_(?:result|error))>/gi, '</\u200b$1>');
+}
+
 export function renderTaskCompletedWithText(
   taskID: string,
   summary: string,
@@ -63,7 +72,7 @@ export function renderTaskCompletedWithText(
     `<task id="${taskID}" state="completed">`,
     `<summary>${summary}</summary>`,
     '<task_result>',
-    text,
+    sanitizeTaskResultBody(text),
     '</task_result>',
     '</task>',
   ].join('\n');

--- a/src/utils/task.ts
+++ b/src/utils/task.ts
@@ -36,6 +36,39 @@ export function renderRunningTaskPlaceholder(taskID: string): string {
   ].join('\n');
 }
 
+/**
+ * Render a terminal task tool output carrying real assistant text.
+ *
+ * opencode's `runTask` settles a foreground task as `completed` with an empty
+ * `output` when the primary model halts on a non-retryable error (e.g. 403
+ * quota exhausted): the halted assistant message has no text part, so
+ * `result.parts.findLast(text)?.text ?? ""` yields "" and `Exit.succeed("")`
+ * marks the job completed. omos's `tryFallback` then re-prompts with the
+ * fallback model on an orphan runLoop and produces the real result, but the
+ * parent task part already says completed+empty — the orchestrator reads an
+ * empty `<task_result>` and mis-judges the task as failed/empty (#863
+ * self-amplify).
+ *
+ * This renders the opencode `renderOutput` shape (task.ts) with the child
+ * session's real assistant text, so the orchestrator's history reflects the
+ * true outcome once the fallback model has produced it. Mirrors the
+ * `state:"completed"` branch of opencode `renderOutput` (task.ts:64-76).
+ */
+export function renderTaskCompletedWithText(
+  taskID: string,
+  summary: string,
+  text: string,
+): string {
+  return [
+    `<task id="${taskID}" state="completed">`,
+    `<summary>${summary}</summary>`,
+    '<task_result>',
+    text,
+    '</task_result>',
+    '</task>',
+  ].join('\n');
+}
+
 export function parseTaskIdFromTaskOutput(output: string): string | undefined {
   const xmlMatch = /<task\s+[^>]*\bid=["']([^"']+)["'][^>]*>/i.exec(output);
   if (xmlMatch) return xmlMatch[1];


### PR DESCRIPTION
## Problem

When a foreground task's primary model halts on a **non-retryable** error (e.g. 403 quota exhausted), the orchestrator receives a **completed** task tool part with an **empty** `<task_result>`, even though the fallback model continues on an orphan runLoop and produces the real result minutes later. The orchestrator reads the empty output, mis-judges the task as failed/empty, and **self-amplifies by launching redundant replacement tasks** (#863).

### Verified root cause (DB + opencode 1.18.5 source)

Complete chain, anchored in opencode core:
1. Model 1 returns 403 `isRetryable:false` → opencode `halt` (`processor.ts:599`) sets `ctx.assistantMessage.error`, publishes `session.error`, sets status `idle`
2. `process` returns `"stop"` (`processor.ts:680`: `if (ctx.assistantMessage.error) return "stop"`)
3. prompt loop breaks → `ops.prompt` returns the last assistant message, which is **empty** (`finish=undefined`, `parts=[]`) because halt produced no content
4. omos `session.error` handler triggers `tryFallback` (non-abort path) → `promptAsync` re-prompts with model 2
5. opencode `runTask` (`task.ts:213`): `result.parts.findLast(text)?.text ?? ""` → **empty string**
6. settle `Exit.succeed("")` (`background-job.ts:148`) → `status:"completed"`, `output:""`
7. parent task part written as `completed` with empty `<task_result>` — **12s after launch**
8. omos `tryFallback`'s `promptAsync` takes effect only after model 1's runLoop ends → model 2 runs on an orphan runLoop, producing **9346 chars over 855s** — but the parent part already says completed+empty

**Root cause is in opencode `runTask`'s `?? ""` fallback**, which treats a halt-empty assistant message as success. omos cannot patch this as a plugin (no hook to intercept `runTask` settle). This is the **false-complete** counterpart to the false-cancel bug in PR #880.

### DB evidence (reproduced session)

| | Time | State |
|---|---|---|
| B-1 launch | +0s | — |
| parent part `completed` + empty output | +12s | `<task_result></task_result>` |
| B-1 child continues | +12s → +867s | **70 parts, 9346-char audit report** |
| orchestrator mis-judges | +645s | "Councillor B errored/empty — retry once" |
| orchestrator relaunches B-2/B-3 | +692s/+693s | from scratch, missing the 9346 chars |

## Fix

In the `experimental.chat.messages.transform` hook, after `stabilizeRunningTaskParts`, scan task tool parts with `status:"completed"` whose parsed `<task_result>` is **empty**. For each, read the child session's real assistant text via the existing `extractSessionResult` helper and in-place rewrite the part output with `renderTaskCompletedWithText` (mirrors opencode `renderOutput` `task.ts:64-76`).

**Idempotent and non-blocking**: if the child session has not yet produced non-empty text (fallback model still running), `extractSessionResult` returns empty and the part is left unchanged — the next transform turn re-evaluates naturally, so no explicit wait/poll is needed. The transform hook only mutates the in-memory `output.messages` (not the persisted DB), so the rewrite is per-turn but the real output eventually lands in history once the child session completes and opencode writes it itself.

**Gated**: only acts on `completed` task parts whose parsed result is empty. True completions with real text are preserved unchanged. Non-task tool parts are not touched.

## Tests

New `false-complete-fallback.test.ts` (5 cases):
- Fills empty completed output with child session real assistant text
- Does **not** rewrite when completed output already has real text
- Does **not** rewrite when child session has no assistant text yet (still running)
- Idempotent across consecutive transforms
- Does not touch non-task tool parts

Full suite: **1719 pass, 0 fail**. Typecheck: pass.

## Relation to other work

| PR/Issue | Scope | Relation |
|---|---|---|
| **#863** (closed, #870 merged) | self-amplify; #870 added `reconcile_task` tool (operation layer) | **This PR fixes the root cause** (#870 only mitigated the operation layer) |
| **#606** (OPEN, Fixes #595) | **background task**: prevent fallback from aborting background task child sessions (preventive) | **Complementary, not conflicting** — #606 is preventive for background tasks; this PR is corrective for **foreground tasks**. File-level changes don't overlap (#606: foreground-fallback + event/options; this: board-injection + transform/import) |
| **#595** (open) | fallback detached from lifecycle | Same family; #606 targets the background-task sub-case, this targets the foreground-task false-complete sub-case |
| **#880** (my OPEN PR) | false-cancel: `error`+`cancelled` parts rewritten from board record | **Mirror counterpart** — #880 handles false-cancel, this handles false-complete. Shared render template shape |

## AI assistance

Co-developed-with:
- **oracle** (GLM-5.2) — read full omos + opencode source, confirmed precise root cause chain (runTask `?? ""` on halt-empty assistant), recommended this approach over idle-reconcile竞态 alternatives

> Note: the analysis council (councillor-reviewer-a/b/c) could not access the omos source tree from their workspace, so their input was based on the root-cause summary rather than direct source verification. The oracle's analysis is the source-verified basis for this fix.