### PR TITLE
fix(task-session): unify FG-fallback false-cancel + false-complete reconcile (#595, #863)

### DIFF
--- a/src/hooks/task-session-manager/board-injection.ts
+++ b/src/hooks/task-session-manager/board-injection.ts
@@ -16,6 +16,7 @@ import {
   isInternalInitiatorPart,
   parseTaskStatusOutput,
   renderRunningTaskPlaceholder,
+  renderTaskTerminalFromBoard,
 } from '../../utils';
 import { isRecord } from '../../utils/guards';
 import { log } from '../../utils/logger';
@@ -159,6 +160,82 @@ export function stabilizeRunningTaskParts(messages: unknown[]): void {
       const placeholder = renderRunningTaskPlaceholder(taskID);
       if (state.output === placeholder) continue;
       state.output = placeholder;
+    }
+  }
+}
+
+/**
+ * Reconcile false-cancelled foreground task tool parts.
+ *
+ * When a foreground task's child session hits a rate-limit and the
+ * ForegroundFallbackManager aborts the session to swap models, opencode's
+ * `runState.cancel` poisons the BackgroundJob the task tool is awaiting →
+ * the tool returns `Effect.fail("Task cancelled")` → the assistant message's
+ * tool part is written as `status:"error"` with `"Task cancelled"` in the
+ * error field. The fallback model then completes on an orphan runLoop with
+ * no awaiter; the board later records the real outcome (completed/error).
+ *
+ * This rewrites such false-cancelled error parts to reflect the board's
+ * authoritative terminal state, so the orchestrator's history shows the
+ * true result instead of a spurious cancellation (#595).
+ *
+ * Gated: only acts when the board holds a non-cancelled terminal state
+ * (completed/reconciled/error) for the child session. True user cancels
+ * leave the board in `cancelled`, so they are preserved unchanged. Idempotent:
+ * after rewrite the part is no longer an error-with-cancelled, so subsequent
+ * transforms skip it. This is the single intentional exception to
+ * `stabilizeRunningTaskParts`' "terminal parts are immutable" rule —
+ * cancelled-by-fallback is not a genuine terminal outcome, it is a transient
+ * artifact of the abort+reprompt lifecycle split.
+ */
+export function reconcileFallbackFalseCancel(
+  state: InjectionState,
+  messages: unknown[],
+): void {
+  for (const message of messages) {
+    if (!isMessageWithParts(message)) continue;
+    for (const part of message.parts) {
+      if (part.type !== 'tool' || part.tool !== 'task') continue;
+      const partState = part.state;
+      if (!isRecord(partState)) continue;
+      if (partState.status !== 'error') continue;
+      const errorMsg = partState.error;
+      if (typeof errorMsg !== 'string' || !/cancelled/i.test(errorMsg)) {
+        continue;
+      }
+      const metadata = partState.metadata;
+      if (!isRecord(metadata)) continue;
+      const childSessionId = metadata.sessionId;
+      if (typeof childSessionId !== 'string') continue;
+
+      const job = state.backgroundJobBoard.get(childSessionId);
+      if (!job) continue;
+      // Only rewrite when the board has a non-cancelled terminal truth.
+      // `reconciled` retains a `terminalState` of completed/error.
+      const boardState = job.state;
+      const terminal =
+        job.terminalState ??
+        (boardState === 'completed' || boardState === 'error'
+          ? boardState
+          : undefined);
+      if (terminal !== 'completed' && terminal !== 'error') continue;
+
+      const rendered = renderTaskTerminalFromBoard({
+        taskID: childSessionId,
+        state: terminal,
+        description: job.description,
+        resultSummary: job.resultSummary,
+      });
+      partState.status = terminal;
+      partState.output = rendered;
+      delete partState.error;
+      log('[task-session-manager] reconciled false-cancelled task part', {
+        taskID: childSessionId,
+        alias: job.alias,
+        parentSessionID: job.parentSessionID,
+        boardState,
+        terminalState: job.terminalState,
+      });
     }
   }
 }

--- a/src/hooks/task-session-manager/board-injection.ts
+++ b/src/hooks/task-session-manager/board-injection.ts
@@ -228,7 +228,14 @@ export function reconcileFallbackFalseCancel(
       });
       partState.status = terminal;
       partState.output = rendered;
-      delete partState.error;
+      if (terminal === 'error') {
+        // Preserve the `error` field for opencode's ToolPart error state
+        // (message-v2.ts consumes it as errorText for the UI). Use the
+        // board's resultSummary as the authoritative failure reason.
+        partState.error = job.resultSummary ?? 'Background task failed';
+      } else {
+        delete partState.error;
+      }
       log('[task-session-manager] reconciled false-cancelled task part', {
         taskID: childSessionId,
         alias: job.alias,

--- a/src/hooks/task-session-manager/board-injection.ts
+++ b/src/hooks/task-session-manager/board-injection.ts
@@ -611,7 +611,14 @@ export function reconcileFallbackFalseCancel(
       });
       partState.status = terminal;
       partState.output = rendered;
-      delete partState.error;
+      if (terminal === 'error') {
+        // Preserve the `error` field for opencode's ToolPart error state
+        // (message-v2.ts consumes it as errorText for the UI). Use the
+        // board's resultSummary as the authoritative failure reason.
+        partState.error = job.resultSummary ?? 'Background task failed';
+      } else {
+        delete partState.error;
+      }
       log('[task-session-manager] reconciled false-cancelled task part', {
         taskID: childSessionId,
         alias: job.alias,

--- a/src/hooks/task-session-manager/board-injection.ts
+++ b/src/hooks/task-session-manager/board-injection.ts
@@ -20,9 +20,9 @@ import {
   renderTaskCompletedWithText,
   renderTaskTerminalFromBoard,
 } from '../../utils';
-import { extractSessionResult } from '../../utils/session';
 import { isRecord } from '../../utils/guards';
 import { log } from '../../utils/logger';
+import { extractSessionResult } from '../../utils/session';
 import {
   appendTrailingVolatileMessage,
   createTaggedSyntheticPart,

--- a/src/hooks/task-session-manager/board-injection.ts
+++ b/src/hooks/task-session-manager/board-injection.ts
@@ -683,14 +683,32 @@ export async function reconcileFalseCompleteFallback(
       const childSessionId = status.taskID;
       const job = state.backgroundJobBoard.get(childSessionId);
       if (!job) continue;
+      // Wait until the board is no longer actively running so we do not
+      // promote mid-generation fallback text into a "completed" part.
+      // False-complete already settles the board as completed+empty while
+      // the orphan runLoop continues — that terminal board state is enough.
+      if (job.state === 'running') continue;
+      if (job.state === 'cancelled' || job.terminalState === 'cancelled') {
+        continue;
+      }
 
-      // Read the child session's real assistant text. Non-blocking: returns
-      // empty when the fallback model has not yet produced output, and the
-      // next transform turn re-evaluates naturally (idempotent polling).
-      const extracted = await extractSessionResult(client, childSessionId, {
-        directory,
-        includeReasoning: false,
-      });
+      // Fail-open: a transient child-session read must never abort the
+      // parent messages transform (Greptile P1). Empty/error → leave part
+      // unchanged; the next transform turn re-evaluates naturally.
+      let extracted: { text: string; empty: boolean };
+      try {
+        extracted = await extractSessionResult(client, childSessionId, {
+          directory,
+          includeReasoning: false,
+        });
+      } catch (error) {
+        log('[task-session-manager] false-complete extract failed', {
+          taskID: childSessionId,
+          alias: job.alias,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        continue;
+      }
       if (extracted.empty) continue;
 
       const summary = `Background task completed: ${job.description}`;

--- a/src/hooks/task-session-manager/board-injection.ts
+++ b/src/hooks/task-session-manager/board-injection.ts
@@ -25,6 +25,7 @@ import {
   parseTaskStateFromOutput,
   parseTaskStatusOutput,
   renderRunningTaskPlaceholder,
+  renderTaskTerminalFromBoard,
 } from '../../utils';
 import { isRecord } from '../../utils/guards';
 import { log } from '../../utils/logger';
@@ -542,6 +543,82 @@ export function stabilizeRunningTaskParts(messages: unknown[]): void {
       const placeholder = renderRunningTaskPlaceholder(taskID);
       if (state.output === placeholder) continue;
       state.output = placeholder;
+    }
+  }
+}
+
+/**
+ * Reconcile false-cancelled foreground task tool parts.
+ *
+ * When a foreground task's child session hits a rate-limit and the
+ * ForegroundFallbackManager aborts the session to swap models, opencode's
+ * `runState.cancel` poisons the BackgroundJob the task tool is awaiting →
+ * the tool returns `Effect.fail("Task cancelled")` → the assistant message's
+ * tool part is written as `status:"error"` with `"Task cancelled"` in the
+ * error field. The fallback model then completes on an orphan runLoop with
+ * no awaiter; the board later records the real outcome (completed/error).
+ *
+ * This rewrites such false-cancelled error parts to reflect the board's
+ * authoritative terminal state, so the orchestrator's history shows the
+ * true result instead of a spurious cancellation (#595).
+ *
+ * Gated: only acts when the board holds a non-cancelled terminal state
+ * (completed/reconciled/error) for the child session. True user cancels
+ * leave the board in `cancelled`, so they are preserved unchanged. Idempotent:
+ * after rewrite the part is no longer an error-with-cancelled, so subsequent
+ * transforms skip it. This is the single intentional exception to
+ * `stabilizeRunningTaskParts`' "terminal parts are immutable" rule —
+ * cancelled-by-fallback is not a genuine terminal outcome, it is a transient
+ * artifact of the abort+reprompt lifecycle split.
+ */
+export function reconcileFallbackFalseCancel(
+  state: InjectionState,
+  messages: unknown[],
+): void {
+  for (const message of messages) {
+    if (!isMessageWithParts(message)) continue;
+    for (const part of message.parts) {
+      if (part.type !== 'tool' || part.tool !== 'task') continue;
+      const partState = part.state;
+      if (!isRecord(partState)) continue;
+      if (partState.status !== 'error') continue;
+      const errorMsg = partState.error;
+      if (typeof errorMsg !== 'string' || !/cancelled/i.test(errorMsg)) {
+        continue;
+      }
+      const metadata = partState.metadata;
+      if (!isRecord(metadata)) continue;
+      const childSessionId = metadata.sessionId;
+      if (typeof childSessionId !== 'string') continue;
+
+      const job = state.backgroundJobBoard.get(childSessionId);
+      if (!job) continue;
+      // Only rewrite when the board has a non-cancelled terminal truth.
+      // `reconciled` retains a `terminalState` of completed/error.
+      const boardState = job.state;
+      const terminal =
+        job.terminalState ??
+        (boardState === 'completed' || boardState === 'error'
+          ? boardState
+          : undefined);
+      if (terminal !== 'completed' && terminal !== 'error') continue;
+
+      const rendered = renderTaskTerminalFromBoard({
+        taskID: childSessionId,
+        state: terminal,
+        description: job.description,
+        resultSummary: job.resultSummary,
+      });
+      partState.status = terminal;
+      partState.output = rendered;
+      delete partState.error;
+      log('[task-session-manager] reconciled false-cancelled task part', {
+        taskID: childSessionId,
+        alias: job.alias,
+        parentSessionID: job.parentSessionID,
+        boardState,
+        terminalState: job.terminalState,
+      });
     }
   }
 }

--- a/src/hooks/task-session-manager/board-injection.ts
+++ b/src/hooks/task-session-manager/board-injection.ts
@@ -7,6 +7,7 @@
  * All injection logic must go through the cache-safe helpers in
  * ../cache-safe-injection.ts to ensure prompt cache safety.
  */
+import type { PluginInput } from '@opencode-ai/plugin';
 import type {
   BackgroundJobRecord,
   BackgroundJobStore,
@@ -16,7 +17,9 @@ import {
   isInternalInitiatorPart,
   parseTaskStatusOutput,
   renderRunningTaskPlaceholder,
+  renderTaskCompletedWithText,
 } from '../../utils';
+import { extractSessionResult } from '../../utils/session';
 import { isRecord } from '../../utils/guards';
 import { log } from '../../utils/logger';
 import {
@@ -159,6 +162,82 @@ export function stabilizeRunningTaskParts(messages: unknown[]): void {
       const placeholder = renderRunningTaskPlaceholder(taskID);
       if (state.output === placeholder) continue;
       state.output = placeholder;
+    }
+  }
+}
+
+/**
+ * Reconcile false-completed foreground task tool parts.
+ *
+ * When a foreground task's primary model halts on a non-retryable error
+ * (e.g. 403 quota exhausted), opencode's `halt` produces an empty assistant
+ * message and `runTask` settles the BackgroundJob as `completed` with an
+ * empty output (`result.parts.findLast(text)?.text ?? ""`). omos's
+ * `tryFallback` then re-prompts with the fallback model on an orphan runLoop
+ * that produces the real result, but the parent task part already says
+ * `completed` with an empty `<task_result>` — the orchestrator reads the
+ * empty output, mis-judges the task as failed/empty, and self-amplifies by
+ * launching redundant replacement tasks (#863).
+ *
+ * This in-place rewrites such false-completed parts with the child session's
+ * real assistant text once the fallback model has produced it. The pass is
+ * idempotent and non-blocking: if the child session has not yet produced
+ * non-empty text, `extractSessionResult` returns empty and the part is left
+ * unchanged — the next transform turn re-evaluates naturally, so no explicit
+ * wait/poll is needed. Because the transform hook only mutates the
+ * in-memory `output.messages` (not the persisted DB), the rewrite is
+ * per-turn but the real output eventually lands in history once the child
+ * session completes and opencode writes it itself.
+ *
+ * Gated: only acts on `status:"completed"` task parts whose parsed
+ * `<task_result>` is empty. True completions with real text are preserved
+ * unchanged.
+ */
+export async function reconcileFalseCompleteFallback(
+  state: InjectionState,
+  messages: unknown[],
+  client: PluginInput['client'],
+  directory?: string,
+): Promise<void> {
+  for (const message of messages) {
+    if (!isMessageWithParts(message)) continue;
+    for (const part of message.parts) {
+      if (part.type !== 'tool' || part.tool !== 'task') continue;
+      const partState = part.state;
+      if (!isRecord(partState)) continue;
+      if (partState.status !== 'completed') continue;
+      if (typeof partState.output !== 'string') continue;
+
+      const status = parseTaskStatusOutput(partState.output);
+      if (!status || status.state !== 'completed') continue;
+      // Only reconcile empty results — real completions are intact.
+      if (status.result && status.result.trim().length > 0) continue;
+
+      const childSessionId = status.taskID;
+      const job = state.backgroundJobBoard.get(childSessionId);
+      if (!job) continue;
+
+      // Read the child session's real assistant text. Non-blocking: returns
+      // empty when the fallback model has not yet produced output, and the
+      // next transform turn re-evaluates naturally (idempotent polling).
+      const extracted = await extractSessionResult(client, childSessionId, {
+        directory,
+        includeReasoning: false,
+      });
+      if (extracted.empty) continue;
+
+      const summary = `Background task completed: ${job.description}`;
+      partState.output = renderTaskCompletedWithText(
+        childSessionId,
+        summary,
+        extracted.text,
+      );
+      log('[task-session-manager] reconciled false-completed task part', {
+        taskID: childSessionId,
+        alias: job.alias,
+        parentSessionID: job.parentSessionID,
+        textLength: extracted.text.length,
+      });
     }
   }
 }

--- a/src/hooks/task-session-manager/board-injection.ts
+++ b/src/hooks/task-session-manager/board-injection.ts
@@ -26,12 +26,12 @@ import {
   parseTaskStateFromOutput,
   parseTaskStatusOutput,
   renderRunningTaskPlaceholder,
-  renderTaskTerminalFromBoard,
   renderTaskCompletedWithText,
+  renderTaskTerminalFromBoard,
 } from '../../utils';
-import { extractSessionResult } from '../../utils/session';
 import { isRecord } from '../../utils/guards';
 import { log } from '../../utils/logger';
+import { extractSessionResult } from '../../utils/session';
 import {
   appendTaggedSyntheticPart,
   appendTrailingVolatileMessage,
@@ -676,7 +676,7 @@ export async function reconcileFalseCompleteFallback(
       if (typeof partState.output !== 'string') continue;
 
       const status = parseTaskStatusOutput(partState.output);
-      if (!status || status.state !== 'completed') continue;
+      if (status?.state !== 'completed') continue;
       // Only reconcile empty results — real completions are intact.
       if (status.result && status.result.trim().length > 0) continue;
 

--- a/src/hooks/task-session-manager/board-injection.ts
+++ b/src/hooks/task-session-manager/board-injection.ts
@@ -8,6 +8,7 @@
  * ../cache-safe-injection.ts to ensure prompt cache safety.
  */
 import { createHash } from 'node:crypto';
+import type { PluginInput } from '@opencode-ai/plugin';
 import type {
   BackgroundJobExecution,
   BackgroundJobInjectedCompletionFence,
@@ -26,7 +27,9 @@ import {
   parseTaskStatusOutput,
   renderRunningTaskPlaceholder,
   renderTaskTerminalFromBoard,
+  renderTaskCompletedWithText,
 } from '../../utils';
+import { extractSessionResult } from '../../utils/session';
 import { isRecord } from '../../utils/guards';
 import { log } from '../../utils/logger';
 import {
@@ -625,6 +628,82 @@ export function reconcileFallbackFalseCancel(
         parentSessionID: job.parentSessionID,
         boardState,
         terminalState: job.terminalState,
+      });
+    }
+  }
+}
+
+/**
+ * Reconcile false-completed foreground task tool parts.
+ *
+ * When a foreground task's primary model halts on a non-retryable error
+ * (e.g. 403 quota exhausted), opencode's `halt` produces an empty assistant
+ * message and `runTask` settles the BackgroundJob as `completed` with an
+ * empty output (`result.parts.findLast(text)?.text ?? ""`). omos's
+ * `tryFallback` then re-prompts with the fallback model on an orphan runLoop
+ * that produces the real result, but the parent task part already says
+ * `completed` with an empty `<task_result>` — the orchestrator reads the
+ * empty output, mis-judges the task as failed/empty, and self-amplifies by
+ * launching redundant replacement tasks (#863).
+ *
+ * This in-place rewrites such false-completed parts with the child session's
+ * real assistant text once the fallback model has produced it. The pass is
+ * idempotent and non-blocking: if the child session has not yet produced
+ * non-empty text, `extractSessionResult` returns empty and the part is left
+ * unchanged — the next transform turn re-evaluates naturally, so no explicit
+ * wait/poll is needed. Because the transform hook only mutates the
+ * in-memory `output.messages` (not the persisted DB), the rewrite is
+ * per-turn but the real output eventually lands in history once the child
+ * session completes and opencode writes it itself.
+ *
+ * Gated: only acts on `status:"completed"` task parts whose parsed
+ * `<task_result>` is empty. True completions with real text are preserved
+ * unchanged.
+ */
+export async function reconcileFalseCompleteFallback(
+  state: InjectionState,
+  messages: unknown[],
+  client: PluginInput['client'],
+  directory?: string,
+): Promise<void> {
+  for (const message of messages) {
+    if (!isMessageWithParts(message)) continue;
+    for (const part of message.parts) {
+      if (part.type !== 'tool' || part.tool !== 'task') continue;
+      const partState = part.state;
+      if (!isRecord(partState)) continue;
+      if (partState.status !== 'completed') continue;
+      if (typeof partState.output !== 'string') continue;
+
+      const status = parseTaskStatusOutput(partState.output);
+      if (!status || status.state !== 'completed') continue;
+      // Only reconcile empty results — real completions are intact.
+      if (status.result && status.result.trim().length > 0) continue;
+
+      const childSessionId = status.taskID;
+      const job = state.backgroundJobBoard.get(childSessionId);
+      if (!job) continue;
+
+      // Read the child session's real assistant text. Non-blocking: returns
+      // empty when the fallback model has not yet produced output, and the
+      // next transform turn re-evaluates naturally (idempotent polling).
+      const extracted = await extractSessionResult(client, childSessionId, {
+        directory,
+        includeReasoning: false,
+      });
+      if (extracted.empty) continue;
+
+      const summary = `Background task completed: ${job.description}`;
+      partState.output = renderTaskCompletedWithText(
+        childSessionId,
+        summary,
+        extracted.text,
+      );
+      log('[task-session-manager] reconciled false-completed task part', {
+        taskID: childSessionId,
+        alias: job.alias,
+        parentSessionID: job.parentSessionID,
+        textLength: extracted.text.length,
       });
     }
   }

--- a/src/hooks/task-session-manager/board-injection.ts
+++ b/src/hooks/task-session-manager/board-injection.ts
@@ -216,14 +216,32 @@ export async function reconcileFalseCompleteFallback(
       const childSessionId = status.taskID;
       const job = state.backgroundJobBoard.get(childSessionId);
       if (!job) continue;
+      // Wait until the board is no longer actively running so we do not
+      // promote mid-generation fallback text into a "completed" part.
+      // False-complete already settles the board as completed+empty while
+      // the orphan runLoop continues — that terminal board state is enough.
+      if (job.state === 'running') continue;
+      if (job.state === 'cancelled' || job.terminalState === 'cancelled') {
+        continue;
+      }
 
-      // Read the child session's real assistant text. Non-blocking: returns
-      // empty when the fallback model has not yet produced output, and the
-      // next transform turn re-evaluates naturally (idempotent polling).
-      const extracted = await extractSessionResult(client, childSessionId, {
-        directory,
-        includeReasoning: false,
-      });
+      // Fail-open: a transient child-session read must never abort the
+      // parent messages transform (Greptile P1). Empty/error → leave part
+      // unchanged; the next transform turn re-evaluates naturally.
+      let extracted: { text: string; empty: boolean };
+      try {
+        extracted = await extractSessionResult(client, childSessionId, {
+          directory,
+          includeReasoning: false,
+        });
+      } catch (error) {
+        log('[task-session-manager] false-complete extract failed', {
+          taskID: childSessionId,
+          alias: job.alias,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        continue;
+      }
       if (extracted.empty) continue;
 
       const summary = `Background task completed: ${job.description}`;

--- a/src/hooks/task-session-manager/fallback-false-cancel.test.ts
+++ b/src/hooks/task-session-manager/fallback-false-cancel.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, test } from 'bun:test';
+import { BackgroundJobBoard } from '../../utils';
+import { createTaskSessionManagerHook } from './index';
+
+const PARENT = 'parent-1';
+const CHILD = 'child-1';
+
+function createHook(board: BackgroundJobBoard) {
+  return createTaskSessionManagerHook(
+    { client: { session: {} } } as never,
+    {
+      maxSessionsPerAgent: 2,
+      maxRetainedSnapshots: 2,
+      backgroundJobBoard: board,
+      shouldManageSession: () => true,
+    },
+  );
+}
+
+/**
+ * An assistant message with a task tool part, mirroring the shape opencode
+ * writes when a foreground task tool call fails. For the false-cancel bug,
+ * opencode writes status:"error" + error:"Tool execution failed: Task cancelled"
+ * (prompt.ts:414-428), with state.metadata.sessionId pointing at the child
+ * session (task.ts:188-195 via ctx.metadata).
+ */
+function taskErrorPart(
+  callID: string,
+  childSessionId: string,
+  errorMsg = 'Tool execution failed: Task cancelled',
+) {
+  return {
+    info: {
+      role: 'assistant',
+      agent: 'orchestrator',
+      sessionID: PARENT,
+      id: callID,
+    },
+    parts: [
+      { type: 'text', text: ' ' },
+      {
+        type: 'tool',
+        tool: 'task',
+        callID,
+        state: {
+          status: 'error',
+          error: errorMsg,
+          metadata: { sessionId: childSessionId },
+        },
+      },
+    ],
+  };
+}
+
+function userMessage(id: string, text: string) {
+  return {
+    info: { role: 'user', agent: 'orchestrator', sessionID: PARENT, id },
+    parts: [{ type: 'text', text }],
+  };
+}
+
+function findTaskPart(messages: unknown[], callID: string) {
+  for (const message of messages as { parts?: any[] }[]) {
+    for (const part of message?.parts ?? []) {
+      if (part?.type === 'tool' && part?.tool === 'task' && part?.callID === callID) {
+        return part;
+      }
+    }
+  }
+  return undefined;
+}
+
+async function transform(hook: ReturnType<typeof createTaskSessionManagerHook>, history: unknown[]) {
+  const request = { messages: structuredClone(history) };
+  await hook['experimental.chat.messages.transform']({}, request as never);
+  return request.messages;
+}
+
+function setupCompletedBoard(board: BackgroundJobBoard) {
+  board.registerLaunch({
+    taskID: CHILD,
+    parentSessionID: PARENT,
+    agent: 'fixer',
+    description: 'test fix',
+  });
+  board.updateStatus({
+    taskID: CHILD,
+    state: 'completed',
+    resultSummary: 'patched src/foo.ts',
+  });
+}
+
+describe('reconcileFallbackFalseCancel', () => {
+  test('rewrites false-cancelled error part to completed when board has completed truth', async () => {
+    const board = new BackgroundJobBoard();
+    setupCompletedBoard(board);
+    const hook = createHook(board);
+
+    const history = [
+      userMessage('u1', 'fix the bug'),
+      taskErrorPart('call-1', CHILD),
+    ];
+
+    const result = await transform(hook, history);
+    const part = findTaskPart(result, 'call-1') as any;
+
+    expect(part.state.status).toBe('completed');
+    expect(part.state.error).toBeUndefined();
+    expect(part.state.output).toContain('state="completed"');
+    expect(part.state.output).toContain('Background task completed: test fix');
+    expect(part.state.output).toContain('patched src/foo.ts');
+  });
+
+  test('rewrites false-cancelled error part to error when board has error truth', async () => {
+    const board = new BackgroundJobBoard();
+    board.registerLaunch({
+      taskID: CHILD,
+      parentSessionID: PARENT,
+      agent: 'fixer',
+      description: 'test fix',
+    });
+    board.updateStatus({
+      taskID: CHILD,
+      state: 'error',
+      resultSummary: 'syntax error in foo.ts',
+    });
+    const hook = createHook(board);
+
+    const history = [
+      userMessage('u1', 'fix the bug'),
+      taskErrorPart('call-1', CHILD),
+    ];
+
+    const result = await transform(hook, history);
+    const part = findTaskPart(result, 'call-1') as any;
+
+    expect(part.state.status).toBe('error');
+    expect(part.state.error).toBeUndefined();
+    expect(part.state.output).toContain('state="error"');
+    expect(part.state.output).toContain('Background task failed: test fix');
+    expect(part.state.output).toContain('syntax error in foo.ts');
+  });
+
+  test('does NOT rewrite when board is cancelled (preserves true user cancel)', async () => {
+    const board = new BackgroundJobBoard();
+    board.registerLaunch({
+      taskID: CHILD,
+      parentSessionID: PARENT,
+      agent: 'fixer',
+      description: 'test fix',
+    });
+    board.markCancelled(CHILD, 'user requested');
+    board.markReconciled(CHILD);
+    const hook = createHook(board);
+
+    const history = [
+      userMessage('u1', 'fix the bug'),
+      taskErrorPart('call-1', CHILD),
+    ];
+
+    const result = await transform(hook, history);
+    const part = findTaskPart(result, 'call-1') as any;
+
+    // True cancel: board terminalState is cancelled, not completed/error.
+    // Part stays as the original error.
+    expect(part.state.status).toBe('error');
+    expect(part.state.error).toContain('cancelled');
+  });
+
+  test('does NOT rewrite when board is still running (no truth yet)', async () => {
+    const board = new BackgroundJobBoard();
+    board.registerLaunch({
+      taskID: CHILD,
+      parentSessionID: PARENT,
+      agent: 'fixer',
+      description: 'test fix',
+    });
+    // board stays running — model 2 hasn't completed yet
+    const hook = createHook(board);
+
+    const history = [
+      userMessage('u1', 'fix the bug'),
+      taskErrorPart('call-1', CHILD),
+    ];
+
+    const result = await transform(hook, history);
+    const part = findTaskPart(result, 'call-1') as any;
+
+    expect(part.state.status).toBe('error');
+    expect(part.state.error).toContain('cancelled');
+  });
+
+  test('does NOT rewrite error parts whose message is not a task cancellation', async () => {
+    const board = new BackgroundJobBoard();
+    setupCompletedBoard(board);
+    const hook = createHook(board);
+
+    // A genuine tool error (not a cancellation) must be left intact.
+    const history = [
+      userMessage('u1', 'fix the bug'),
+      taskErrorPart('call-1', CHILD, 'Tool execution failed: timeout'),
+    ];
+
+    const result = await transform(hook, history);
+    const part = findTaskPart(result, 'call-1') as any;
+
+    expect(part.state.status).toBe('error');
+    expect(part.state.error).toBe('Tool execution failed: timeout');
+  });
+
+  test('is idempotent across consecutive transforms', async () => {
+    const board = new BackgroundJobBoard();
+    setupCompletedBoard(board);
+    const hook = createHook(board);
+
+    const history = [
+      userMessage('u1', 'fix the bug'),
+      taskErrorPart('call-1', CHILD),
+    ];
+
+    const first = await transform(hook, history);
+    const firstOutput = findTaskPart(first, 'call-1').state.output;
+
+    const second = await transform(hook, history);
+    const secondOutput = findTaskPart(second, 'call-1').state.output;
+
+    expect(secondOutput).toBe(firstOutput);
+  });
+
+  test('does not touch non-task tool parts', async () => {
+    const board = new BackgroundJobBoard();
+    setupCompletedBoard(board);
+    const hook = createHook(board);
+
+    const history = [
+      userMessage('u1', 'fix the bug'),
+      {
+        info: { role: 'assistant', agent: 'orchestrator', sessionID: PARENT, id: 'call-2' },
+        parts: [
+          { type: 'text', text: ' ' },
+          {
+            type: 'tool',
+            tool: 'read',
+            callID: 'call-2',
+            state: {
+              status: 'error',
+              error: 'Tool execution failed: Task cancelled',
+              metadata: { sessionId: CHILD },
+            },
+          },
+        ],
+      },
+    ];
+
+    const result = await transform(hook, history);
+    const part = result[1].parts[1] as any;
+
+    // read tool parts are not reconciled by the task-session-manager.
+    expect(part.state.status).toBe('error');
+    expect(part.state.error).toContain('cancelled');
+  });
+});

--- a/src/hooks/task-session-manager/fallback-false-cancel.test.ts
+++ b/src/hooks/task-session-manager/fallback-false-cancel.test.ts
@@ -135,7 +135,9 @@ describe('reconcileFallbackFalseCancel', () => {
     const part = findTaskPart(result, 'call-1') as any;
 
     expect(part.state.status).toBe('error');
-    expect(part.state.error).toBeUndefined();
+    // Preserve the `error` field for opencode's ToolPart error state
+    // (UI consumes it as errorText — see opencode message-v2.ts).
+    expect(part.state.error).toBe('syntax error in foo.ts');
     expect(part.state.output).toContain('state="error"');
     expect(part.state.output).toContain('Background task failed: test fix');
     expect(part.state.output).toContain('syntax error in foo.ts');

--- a/src/hooks/task-session-manager/fallback-false-cancel.test.ts
+++ b/src/hooks/task-session-manager/fallback-false-cancel.test.ts
@@ -6,15 +6,12 @@ const PARENT = 'parent-1';
 const CHILD = 'child-1';
 
 function createHook(board: BackgroundJobBoard) {
-  return createTaskSessionManagerHook(
-    { client: { session: {} } } as never,
-    {
-      maxSessionsPerAgent: 2,
-      maxRetainedSnapshots: 2,
-      backgroundJobBoard: board,
-      shouldManageSession: () => true,
-    },
-  );
+  return createTaskSessionManagerHook({ client: { session: {} } } as never, {
+    maxSessionsPerAgent: 2,
+    maxRetainedSnapshots: 2,
+    backgroundJobBoard: board,
+    shouldManageSession: () => true,
+  });
 }
 
 /**
@@ -62,7 +59,11 @@ function userMessage(id: string, text: string) {
 function findTaskPart(messages: unknown[], callID: string) {
   for (const message of messages as { parts?: any[] }[]) {
     for (const part of message?.parts ?? []) {
-      if (part?.type === 'tool' && part?.tool === 'task' && part?.callID === callID) {
+      if (
+        part?.type === 'tool' &&
+        part?.tool === 'task' &&
+        part?.callID === callID
+      ) {
         return part;
       }
     }
@@ -70,7 +71,10 @@ function findTaskPart(messages: unknown[], callID: string) {
   return undefined;
 }
 
-async function transform(hook: ReturnType<typeof createTaskSessionManagerHook>, history: unknown[]) {
+async function transform(
+  hook: ReturnType<typeof createTaskSessionManagerHook>,
+  history: unknown[],
+) {
   const request = { messages: structuredClone(history) };
   await hook['experimental.chat.messages.transform']({}, request as never);
   return request.messages;
@@ -237,7 +241,12 @@ describe('reconcileFallbackFalseCancel', () => {
     const history = [
       userMessage('u1', 'fix the bug'),
       {
-        info: { role: 'assistant', agent: 'orchestrator', sessionID: PARENT, id: 'call-2' },
+        info: {
+          role: 'assistant',
+          agent: 'orchestrator',
+          sessionID: PARENT,
+          id: 'call-2',
+        },
         parts: [
           { type: 'text', text: ' ' },
           {

--- a/src/hooks/task-session-manager/false-complete-fallback.test.ts
+++ b/src/hooks/task-session-manager/false-complete-fallback.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, mock } from 'bun:test';
+import { describe, expect, mock, test } from 'bun:test';
 import { BackgroundJobBoard } from '../../utils';
 import { createTaskSessionManagerHook } from './index';
 
@@ -50,7 +50,11 @@ function userMessage(id: string, text: string) {
 function findTaskPart(messages: unknown[], callID: string) {
   for (const message of messages as { parts?: any[] }[]) {
     for (const part of message?.parts ?? []) {
-      if (part?.type === 'tool' && part?.tool === 'task' && part?.callID === callID) {
+      if (
+        part?.type === 'tool' &&
+        part?.tool === 'task' &&
+        part?.callID === callID
+      ) {
         return part;
       }
     }
@@ -67,7 +71,10 @@ async function transform(
   return request.messages;
 }
 
-function setupCompletedBoard(board: BackgroundJobBoard, description = 'test task') {
+function setupCompletedBoard(
+  board: BackgroundJobBoard,
+  description = 'test task',
+) {
   board.registerLaunch({
     taskID: CHILD,
     parentSessionID: PARENT,
@@ -85,7 +92,10 @@ function setupCompletedBoard(board: BackgroundJobBoard, description = 'test task
 
 function mockClient(
   childMessages:
-    | Array<{ info?: { role: string }; parts?: Array<{ type: string; text?: string }> }>
+    | Array<{
+        info?: { role: string };
+        parts?: Array<{ type: string; text?: string }>;
+      }>
     | (() => Promise<unknown>),
 ) {
   const messages =
@@ -132,7 +142,9 @@ describe('reconcileFalseCompleteFallback', () => {
 
     expect(part.state.status).toBe('completed');
     expect(part.state.output).toContain('state="completed"');
-    expect(part.state.output).toContain('Background task completed: audit DATA.md');
+    expect(part.state.output).toContain(
+      'Background task completed: audit DATA.md',
+    );
     expect(part.state.output).toContain('# Audit Report');
     expect(part.state.output).toContain('All claims verified.');
   });
@@ -141,7 +153,10 @@ describe('reconcileFalseCompleteFallback', () => {
     const board = new BackgroundJobBoard();
     setupCompletedBoard(board, 'test task');
     const childMessages = [
-      { info: { role: 'assistant' }, parts: [{ type: 'text', text: 'real output' }] },
+      {
+        info: { role: 'assistant' },
+        parts: [{ type: 'text', text: 'real output' }],
+      },
     ];
     const hook = createTaskSessionManagerHook(
       { client: mockClient(childMessages), directory: '/tmp' } as never,
@@ -204,7 +219,10 @@ describe('reconcileFalseCompleteFallback', () => {
     const board = new BackgroundJobBoard();
     setupCompletedBoard(board, 'test task');
     const childMessages = [
-      { info: { role: 'assistant' }, parts: [{ type: 'text', text: 'real output' }] },
+      {
+        info: { role: 'assistant' },
+        parts: [{ type: 'text', text: 'real output' }],
+      },
     ];
     const hook = createTaskSessionManagerHook(
       { client: mockClient(childMessages), directory: '/tmp' } as never,
@@ -249,7 +267,12 @@ describe('reconcileFalseCompleteFallback', () => {
     const history = [
       userMessage('u1', 'run task'),
       {
-        info: { role: 'assistant', agent: 'orchestrator', sessionID: PARENT, id: 'call-2' },
+        info: {
+          role: 'assistant',
+          agent: 'orchestrator',
+          sessionID: PARENT,
+          id: 'call-2',
+        },
         parts: [
           { type: 'text', text: ' ' },
           {
@@ -258,7 +281,8 @@ describe('reconcileFalseCompleteFallback', () => {
             callID: 'call-2',
             state: {
               status: 'completed',
-              output: '<task id="child-1" state="completed"><task_result></task_result></task>',
+              output:
+                '<task id="child-1" state="completed"><task_result></task_result></task>',
               metadata: { sessionId: CHILD },
             },
           },
@@ -282,7 +306,10 @@ describe('reconcileFalseCompleteFallback', () => {
       description: 'still running',
     });
     const childMessages = [
-      { info: { role: 'assistant' }, parts: [{ type: 'text', text: 'partial draft' }] },
+      {
+        info: { role: 'assistant' },
+        parts: [{ type: 'text', text: 'partial draft' }],
+      },
     ];
     const hook = createTaskSessionManagerHook(
       { client: mockClient(childMessages), directory: '/tmp' } as never,

--- a/src/hooks/task-session-manager/false-complete-fallback.test.ts
+++ b/src/hooks/task-session-manager/false-complete-fallback.test.ts
@@ -74,12 +74,27 @@ function setupCompletedBoard(board: BackgroundJobBoard, description = 'test task
     agent: 'fixer',
     description,
   });
+  // False-complete settles the board as completed+empty while the orphan
+  // fallback runLoop may still produce text later.
+  board.updateStatus({
+    taskID: CHILD,
+    state: 'completed',
+    resultSummary: '',
+  });
 }
 
-function mockClient(childMessages: Array<{ info?: { role: string }; parts?: Array<{ type: string; text?: string }> }>) {
+function mockClient(
+  childMessages:
+    | Array<{ info?: { role: string }; parts?: Array<{ type: string; text?: string }> }>
+    | (() => Promise<unknown>),
+) {
+  const messages =
+    typeof childMessages === 'function'
+      ? mock(childMessages)
+      : mock(async () => ({ data: childMessages }));
   return {
     session: {
-      messages: mock(async () => ({ data: childMessages })),
+      messages,
       status: mock(async () => ({ data: {} })),
     },
   };
@@ -256,5 +271,106 @@ describe('reconcileFalseCompleteFallback', () => {
 
     // read tool parts are not reconciled.
     expect(part.state.output).toContain('<task_result></task_result>');
+  });
+
+  test('does NOT rewrite when board job is still running', async () => {
+    const board = new BackgroundJobBoard();
+    board.registerLaunch({
+      taskID: CHILD,
+      parentSessionID: PARENT,
+      agent: 'fixer',
+      description: 'still running',
+    });
+    const childMessages = [
+      { info: { role: 'assistant' }, parts: [{ type: 'text', text: 'partial draft' }] },
+    ];
+    const hook = createTaskSessionManagerHook(
+      { client: mockClient(childMessages), directory: '/tmp' } as never,
+      {
+        maxSessionsPerAgent: 2,
+        maxRetainedSnapshots: 2,
+        backgroundJobBoard: board,
+        shouldManageSession: () => true,
+      },
+    );
+
+    const history = [
+      userMessage('u1', 'run task'),
+      taskCompletedPart('call-1', CHILD, ''),
+    ];
+
+    const result = await transform(hook, history);
+    const part = findTaskPart(result, 'call-1') as any;
+    const tagMatch = /<task_result>\s*([\s\S]*?)\s*<\/task_result>/m.exec(
+      part.state.output,
+    );
+    expect(tagMatch?.[1]?.trim()).toBe('');
+    expect(part.state.output).not.toContain('partial draft');
+  });
+
+  test('does NOT abort transform when child session extract throws', async () => {
+    const board = new BackgroundJobBoard();
+    setupCompletedBoard(board, 'test task');
+    const hook = createTaskSessionManagerHook(
+      {
+        client: mockClient(async () => {
+          throw new Error('session unavailable');
+        }),
+        directory: '/tmp',
+      } as never,
+      {
+        maxSessionsPerAgent: 2,
+        maxRetainedSnapshots: 2,
+        backgroundJobBoard: board,
+        shouldManageSession: () => true,
+      },
+    );
+
+    const history = [
+      userMessage('u1', 'run task'),
+      taskCompletedPart('call-1', CHILD, ''),
+    ];
+
+    const result = await transform(hook, history);
+    const part = findTaskPart(result, 'call-1') as any;
+    expect(part.state.status).toBe('completed');
+    const tagMatch = /<task_result>\s*([\s\S]*?)\s*<\/task_result>/m.exec(
+      part.state.output,
+    );
+    expect(tagMatch?.[1]?.trim()).toBe('');
+  });
+
+  test('preserves recovered text that embeds a literal </task_result>', async () => {
+    const board = new BackgroundJobBoard();
+    setupCompletedBoard(board, 'test task');
+    const body =
+      'Example close tag in report:\n</task_result>\nthen more findings.';
+    const childMessages = [
+      { info: { role: 'assistant' }, parts: [{ type: 'text', text: body }] },
+    ];
+    const hook = createTaskSessionManagerHook(
+      { client: mockClient(childMessages), directory: '/tmp' } as never,
+      {
+        maxSessionsPerAgent: 2,
+        maxRetainedSnapshots: 2,
+        backgroundJobBoard: board,
+        shouldManageSession: () => true,
+      },
+    );
+
+    const history = [
+      userMessage('u1', 'run task'),
+      taskCompletedPart('call-1', CHILD, ''),
+    ];
+
+    const result = await transform(hook, history);
+    const part = findTaskPart(result, 'call-1') as any;
+    expect(part.state.output).toContain('Example close tag in report:');
+    expect(part.state.output).toContain('then more findings.');
+    // Non-greedy parse must recover the full body after sanitize.
+    const { parseTaskResultFromOutput } = await import('../../utils/task');
+    const parsed = parseTaskResultFromOutput(part.state.output);
+    expect(parsed).toContain('then more findings.');
+    expect(parsed).toContain('Example close tag in report:');
   });
 });

--- a/src/hooks/task-session-manager/false-complete-fallback.test.ts
+++ b/src/hooks/task-session-manager/false-complete-fallback.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, test, mock } from 'bun:test';
+import { BackgroundJobBoard } from '../../utils';
+import { createTaskSessionManagerHook } from './index';
+
+const PARENT = 'parent-1';
+const CHILD = 'child-1';
+
+function taskCompletedPart(
+  callID: string,
+  childSessionId: string,
+  resultText = '',
+) {
+  const tag = 'task_result';
+  return {
+    info: {
+      role: 'assistant',
+      agent: 'orchestrator',
+      sessionID: PARENT,
+      id: callID,
+    },
+    parts: [
+      { type: 'text', text: ' ' },
+      {
+        type: 'tool',
+        tool: 'task',
+        callID,
+        state: {
+          status: 'completed',
+          output: [
+            `<task id="${childSessionId}" state="completed">`,
+            `<${tag}>`,
+            resultText,
+            `</${tag}>`,
+            '</task>',
+          ].join('\n'),
+          metadata: { sessionId: childSessionId },
+        },
+      },
+    ],
+  };
+}
+
+function userMessage(id: string, text: string) {
+  return {
+    info: { role: 'user', agent: 'orchestrator', sessionID: PARENT, id },
+    parts: [{ type: 'text', text }],
+  };
+}
+
+function findTaskPart(messages: unknown[], callID: string) {
+  for (const message of messages as { parts?: any[] }[]) {
+    for (const part of message?.parts ?? []) {
+      if (part?.type === 'tool' && part?.tool === 'task' && part?.callID === callID) {
+        return part;
+      }
+    }
+  }
+  return undefined;
+}
+
+async function transform(
+  hook: ReturnType<typeof createTaskSessionManagerHook>,
+  history: unknown[],
+) {
+  const request = { messages: structuredClone(history) };
+  await hook['experimental.chat.messages.transform']({}, request as never);
+  return request.messages;
+}
+
+function setupCompletedBoard(board: BackgroundJobBoard, description = 'test task') {
+  board.registerLaunch({
+    taskID: CHILD,
+    parentSessionID: PARENT,
+    agent: 'fixer',
+    description,
+  });
+}
+
+function mockClient(childMessages: Array<{ info?: { role: string }; parts?: Array<{ type: string; text?: string }> }>) {
+  return {
+    session: {
+      messages: mock(async () => ({ data: childMessages })),
+      status: mock(async () => ({ data: {} })),
+    },
+  };
+}
+
+describe('reconcileFalseCompleteFallback', () => {
+  test('fills empty completed output with child session real assistant text', async () => {
+    const board = new BackgroundJobBoard();
+    setupCompletedBoard(board, 'audit DATA.md');
+    // Child session has produced a real 9346-char report
+    const childMessages = [
+      { info: { role: 'user' }, parts: [{ type: 'text', text: 'audit' }] },
+      {
+        info: { role: 'assistant' },
+        parts: [{ type: 'text', text: '# Audit Report\nAll claims verified.' }],
+      },
+    ];
+    const hook = createTaskSessionManagerHook(
+      { client: mockClient(childMessages), directory: '/tmp' } as never,
+      {
+        maxSessionsPerAgent: 2,
+        maxRetainedSnapshots: 2,
+        backgroundJobBoard: board,
+        shouldManageSession: () => true,
+      },
+    );
+
+    const history = [
+      userMessage('u1', 'run audit'),
+      taskCompletedPart('call-1', CHILD, ''), // empty result = false-complete
+    ];
+
+    const result = await transform(hook, history);
+    const part = findTaskPart(result, 'call-1') as any;
+
+    expect(part.state.status).toBe('completed');
+    expect(part.state.output).toContain('state="completed"');
+    expect(part.state.output).toContain('Background task completed: audit DATA.md');
+    expect(part.state.output).toContain('# Audit Report');
+    expect(part.state.output).toContain('All claims verified.');
+  });
+
+  test('does NOT rewrite when completed output already has real text', async () => {
+    const board = new BackgroundJobBoard();
+    setupCompletedBoard(board, 'test task');
+    const childMessages = [
+      { info: { role: 'assistant' }, parts: [{ type: 'text', text: 'real output' }] },
+    ];
+    const hook = createTaskSessionManagerHook(
+      { client: mockClient(childMessages), directory: '/tmp' } as never,
+      {
+        maxSessionsPerAgent: 2,
+        maxRetainedSnapshots: 2,
+        backgroundJobBoard: board,
+        shouldManageSession: () => true,
+      },
+    );
+
+    const realText = 'Already have real result here';
+    const history = [
+      userMessage('u1', 'run task'),
+      taskCompletedPart('call-1', CHILD, realText),
+    ];
+
+    const result = await transform(hook, history);
+    const part = findTaskPart(result, 'call-1') as any;
+
+    // Real completion is preserved unchanged.
+    expect(part.state.output).toContain(realText);
+    expect(part.state.output).not.toContain('Background task completed:');
+  });
+
+  test('does NOT rewrite when child session has no assistant text yet (still running)', async () => {
+    const board = new BackgroundJobBoard();
+    setupCompletedBoard(board, 'test task');
+    // Child session has no assistant text — fallback model still running
+    const childMessages = [
+      { info: { role: 'user' }, parts: [{ type: 'text', text: 'prompt' }] },
+    ];
+    const hook = createTaskSessionManagerHook(
+      { client: mockClient(childMessages), directory: '/tmp' } as never,
+      {
+        maxSessionsPerAgent: 2,
+        maxRetainedSnapshots: 2,
+        backgroundJobBoard: board,
+        shouldManageSession: () => true,
+      },
+    );
+
+    const history = [
+      userMessage('u1', 'run task'),
+      taskCompletedPart('call-1', CHILD, ''),
+    ];
+
+    const result = await transform(hook, history);
+    const part = findTaskPart(result, 'call-1') as any;
+
+    // No real text available yet — part stays empty (next turn re-evaluates).
+    expect(part.state.status).toBe('completed');
+    const tagMatch = /<task_result>\s*([\s\S]*?)\s*<\/task_result>/m.exec(
+      part.state.output,
+    );
+    expect(tagMatch?.[1]?.trim()).toBe('');
+  });
+
+  test('is idempotent across consecutive transforms', async () => {
+    const board = new BackgroundJobBoard();
+    setupCompletedBoard(board, 'test task');
+    const childMessages = [
+      { info: { role: 'assistant' }, parts: [{ type: 'text', text: 'real output' }] },
+    ];
+    const hook = createTaskSessionManagerHook(
+      { client: mockClient(childMessages), directory: '/tmp' } as never,
+      {
+        maxSessionsPerAgent: 2,
+        maxRetainedSnapshots: 2,
+        backgroundJobBoard: board,
+        shouldManageSession: () => true,
+      },
+    );
+
+    const history = [
+      userMessage('u1', 'run task'),
+      taskCompletedPart('call-1', CHILD, ''),
+    ];
+
+    const first = await transform(hook, history);
+    const firstOutput = findTaskPart(first, 'call-1').state.output;
+
+    const second = await transform(hook, history);
+    const secondOutput = findTaskPart(second, 'call-1').state.output;
+
+    expect(secondOutput).toBe(firstOutput);
+  });
+
+  test('does not touch non-task tool parts', async () => {
+    const board = new BackgroundJobBoard();
+    setupCompletedBoard(board, 'test task');
+    const childMessages = [
+      { info: { role: 'assistant' }, parts: [{ type: 'text', text: 'real' }] },
+    ];
+    const hook = createTaskSessionManagerHook(
+      { client: mockClient(childMessages), directory: '/tmp' } as never,
+      {
+        maxSessionsPerAgent: 2,
+        maxRetainedSnapshots: 2,
+        backgroundJobBoard: board,
+        shouldManageSession: () => true,
+      },
+    );
+
+    const history = [
+      userMessage('u1', 'run task'),
+      {
+        info: { role: 'assistant', agent: 'orchestrator', sessionID: PARENT, id: 'call-2' },
+        parts: [
+          { type: 'text', text: ' ' },
+          {
+            type: 'tool',
+            tool: 'read',
+            callID: 'call-2',
+            state: {
+              status: 'completed',
+              output: '<task id="child-1" state="completed"><task_result></task_result></task>',
+              metadata: { sessionId: CHILD },
+            },
+          },
+        ],
+      },
+    ];
+
+    const result = await transform(hook, history);
+    const part = result[1].parts[1] as any;
+
+    // read tool parts are not reconciled.
+    expect(part.state.output).toContain('<task_result></task_result>');
+  });
+});

--- a/src/hooks/task-session-manager/idle-reconciliation.test.ts
+++ b/src/hooks/task-session-manager/idle-reconciliation.test.ts
@@ -71,8 +71,13 @@ describe('idle reconciliation stop confirmation', () => {
   });
 
   test('repeated idle beyond confirmation grace becomes stopped exactly once', async () => {
-    const { board, reconciler, terminalListener, contextFilesForPrompt, prune } =
-      createHarness();
+    const {
+      board,
+      reconciler,
+      terminalListener,
+      contextFilesForPrompt,
+      prune,
+    } = createHarness();
     const generation = board.get('child-1')?.generation ?? 1;
 
     await observeIdle(reconciler, 10, generation);

--- a/src/hooks/task-session-manager/index.ts
+++ b/src/hooks/task-session-manager/index.ts
@@ -12,6 +12,7 @@ import {
   type InjectionState,
   injectBackgroundJobBoard,
   MAX_PROCESSED_INJECTED_COMPLETIONS,
+  reconcileFallbackFalseCancel,
   reconcileInjectedTerminalJobs,
   stabilizeRunningTaskParts,
   updateFromInjectedCompletion,
@@ -277,6 +278,13 @@ export function createTaskSessionManagerHook(
       // lane never rewrites mid-history bytes and invalidates the prompt
       // cache. Terminal results are left untouched (they materialize once).
       stabilizeRunningTaskParts(messages);
+
+      // Reconcile false-cancelled foreground task parts: when a FG-fallback
+      // abort poisoned the awaited BackgroundJob ("Task cancelled" error part)
+      // but the board later recorded the real model-2 outcome, rewrite the
+      // part to the board's terminal truth so the orchestrator's history is
+      // accurate (#595). Board-gated, idempotent, no-op for true cancels.
+      reconcileFallbackFalseCancel(injectionState, messages);
 
       for (const [messageIndex, message] of messages.entries()) {
         if (!isUserMessageWithParts(message)) continue;

--- a/src/hooks/task-session-manager/index.ts
+++ b/src/hooks/task-session-manager/index.ts
@@ -301,7 +301,6 @@ export function createTaskSessionManagerHook(
         _ctx.directory,
       );
 
-
       for (const [messageIndex, message] of messages.entries()) {
         if (!isUserMessageWithParts(message)) continue;
         if (message.info.agent && message.info.agent !== 'orchestrator') {

--- a/src/hooks/task-session-manager/index.ts
+++ b/src/hooks/task-session-manager/index.ts
@@ -12,6 +12,7 @@ import {
   type InjectionState,
   injectBackgroundJobBoard,
   MAX_PROCESSED_INJECTED_COMPLETIONS,
+  reconcileFalseCompleteFallback,
   reconcileInjectedTerminalJobs,
   stabilizeRunningTaskParts,
   updateFromInjectedCompletion,
@@ -277,6 +278,20 @@ export function createTaskSessionManagerHook(
       // lane never rewrites mid-history bytes and invalidates the prompt
       // cache. Terminal results are left untouched (they materialize once).
       stabilizeRunningTaskParts(messages);
+
+      // Reconcile false-completed foreground task parts: when the primary
+      // model halts on a non-retryable error, opencode settles the task as
+      // completed with an empty output while the fallback model still
+      // produces the real result on an orphan runLoop (#863). Fill the empty
+      // output with the child session's real assistant text once available.
+      // Idempotent and non-blocking — empty extractions are skipped and
+      // re-evaluated on the next transform turn.
+      await reconcileFalseCompleteFallback(
+        injectionState,
+        messages,
+        _ctx.client,
+        _ctx.directory,
+      );
 
       for (const [messageIndex, message] of messages.entries()) {
         if (!isUserMessageWithParts(message)) continue;

--- a/src/hooks/task-session-manager/index.ts
+++ b/src/hooks/task-session-manager/index.ts
@@ -22,6 +22,8 @@ import {
   type InjectionState,
   injectBackgroundJobBoard,
   observeSyntheticTerminalPart,
+  MAX_PROCESSED_INJECTED_COMPLETIONS,
+  reconcileFallbackFalseCancel,
   reconcileInjectedTerminalJobs,
   stabilizeRunningTaskParts,
   updateFromInjectedCompletion,
@@ -442,6 +444,13 @@ export function createTaskSessionManagerHook(
       // lane never rewrites mid-history bytes and invalidates the prompt
       // cache. Terminal results are left untouched (they materialize once).
       stabilizeRunningTaskParts(messages);
+
+      // Reconcile false-cancelled foreground task parts: when a FG-fallback
+      // abort poisoned the awaited BackgroundJob ("Task cancelled" error part)
+      // but the board later recorded the real model-2 outcome, rewrite the
+      // part to the board's terminal truth so the orchestrator's history is
+      // accurate (#595). Board-gated, idempotent, no-op for true cancels.
+      reconcileFallbackFalseCancel(injectionState, messages);
 
       const rehydratedCount = rehydrateHistoricalRunningTasks(
         messages,

--- a/src/hooks/task-session-manager/index.ts
+++ b/src/hooks/task-session-manager/index.ts
@@ -22,8 +22,8 @@ import {
   type InjectionState,
   injectBackgroundJobBoard,
   observeSyntheticTerminalPart,
-  MAX_PROCESSED_INJECTED_COMPLETIONS,
   reconcileFallbackFalseCancel,
+  reconcileFalseCompleteFallback,
   reconcileInjectedTerminalJobs,
   stabilizeRunningTaskParts,
   updateFromInjectedCompletion,
@@ -458,6 +458,20 @@ export function createTaskSessionManagerHook(
         options.shouldManageSession,
         options.registerSessionAsOrchestrator,
         rehydrateTombstones,
+      );
+
+      // Reconcile false-completed foreground task parts: when the primary
+      // model halts on a non-retryable error, opencode settles the task as
+      // completed with an empty output while the fallback model still
+      // produces the real result on an orphan runLoop (#863). Fill the empty
+      // output with the child session's real assistant text once available.
+      // Idempotent and non-blocking — empty extractions are skipped and
+      // re-evaluated on the next transform turn.
+      await reconcileFalseCompleteFallback(
+        injectionState,
+        messages,
+        _ctx.client,
+        _ctx.directory,
       );
 
       for (const [messageIndex, message] of messages.entries()) {

--- a/src/hooks/task-session-manager/runtime-status-reconciliation.test.ts
+++ b/src/hooks/task-session-manager/runtime-status-reconciliation.test.ts
@@ -287,11 +287,12 @@ describe('runtime status reconciliation', () => {
   });
 
   test('repeated idle beyond confirmation grace becomes stopped exactly once', async () => {
-    const { board, reconciler, contextFilesForPrompt, prune } = createReconciler(
-      async () => ({ data: { 'child-1': { type: 'idle' } } }),
-      undefined,
-      0,
-    );
+    const { board, reconciler, contextFilesForPrompt, prune } =
+      createReconciler(
+        async () => ({ data: { 'child-1': { type: 'idle' } } }),
+        undefined,
+        0,
+      );
     const listener = mock(() => {});
     board.addTerminalStateListener(listener);
 

--- a/src/hooks/task-session-manager/runtime-status-reconciliation.ts
+++ b/src/hooks/task-session-manager/runtime-status-reconciliation.ts
@@ -97,7 +97,10 @@ export function createRuntimeStatusReconciler(options: {
         );
         continue;
       }
-      if (status === undefined && snapshot.malformedSessionIDs.has(job.taskID)) {
+      if (
+        status === undefined &&
+        snapshot.malformedSessionIDs.has(job.taskID)
+      ) {
         options.backgroundJobBoard.markStatusUncertain(
           job.taskID,
           'Runtime status response did not contain a recognized session state.',

--- a/src/utils/task.test.ts
+++ b/src/utils/task.test.ts
@@ -5,6 +5,8 @@ import {
   parseTaskResultFromOutput,
   parseTaskStatusOutput,
   renderRunningTaskPlaceholder,
+  renderTaskCompletedWithText,
+  sanitizeTaskResultBody,
 } from './task';
 
 describe('renderRunningTaskPlaceholder', () => {
@@ -25,6 +27,21 @@ describe('renderRunningTaskPlaceholder', () => {
     const b = renderRunningTaskPlaceholder('ses_b');
     expect(a).not.toBe(b);
     expect(a.replace('ses_a', 'ses_b')).toBe(b);
+  });
+});
+
+describe('renderTaskCompletedWithText', () => {
+  test('round-trips body that embeds a literal close tag', () => {
+    const body = 'before\n</task_result>\nafter';
+    const rendered = renderTaskCompletedWithText(
+      'ses_1',
+      'Background task completed: t',
+      body,
+    );
+    const parsed = parseTaskResultFromOutput(rendered);
+    expect(parsed).toContain('before');
+    expect(parsed).toContain('after');
+    expect(sanitizeTaskResultBody(body)).toContain('\u200b');
   });
 });
 

--- a/src/utils/task.ts
+++ b/src/utils/task.ts
@@ -36,6 +36,40 @@ export function renderRunningTaskPlaceholder(taskID: string): string {
   ].join('\n');
 }
 
+/**
+ * Render a terminal task tool output from a background job board record.
+ * Used to reconcile a false-cancelled foreground task part (opencode marked
+ * it "error" because the FG-fallback abort poisoned the awaited BackgroundJob)
+ * once the board later records the real model-2 outcome (#595).
+ *
+ * Mirrors opencode task.ts `renderOutput` shape so the orchestrator's history
+ * reads as a normal terminal result. Content is the board's resultSummary
+ * (the authoritative outcome the board captured); full model-2 text is not
+ * recoverable from the orphan runLoop, but the board truth is what matters.
+ */
+export function renderTaskTerminalFromBoard(input: {
+  taskID: string;
+  state: 'completed' | 'error';
+  description: string;
+  resultSummary?: string;
+}): string {
+  const { taskID, state, description, resultSummary } = input;
+  const tag = state === 'error' ? 'task_error' : 'task_result';
+  const summary =
+    state === 'completed'
+      ? `Background task completed: ${description}`
+      : `Background task failed: ${description}`;
+  const body = resultSummary ?? (state === 'completed' ? 'Task completed.' : 'Task failed.');
+  return [
+    `<task id="${taskID}" state="${state}">`,
+    `<summary>${summary}</summary>`,
+    `<${tag}>`,
+    body,
+    `</${tag}>`,
+    '</task>',
+  ].join('\n');
+}
+
 export function parseTaskIdFromTaskOutput(output: string): string | undefined {
   const xmlMatch = /<task\s+[^>]*\bid=["']([^"']+)["'][^>]*>/i.exec(output);
   if (xmlMatch) return xmlMatch[1];

--- a/src/utils/task.ts
+++ b/src/utils/task.ts
@@ -54,6 +54,15 @@ export function renderRunningTaskPlaceholder(taskID: string): string {
  * true outcome once the fallback model has produced it. Mirrors the
  * `state:"completed"` branch of opencode `renderOutput` (task.ts:64-76).
  */
+/**
+ * Neutralize embedded task close tags so non-greedy
+ * `parseTaskResultFromOutput` cannot truncate recovered body early.
+ * Zero-width space after `</` keeps the visible text intact.
+ */
+export function sanitizeTaskResultBody(text: string): string {
+  return text.replace(/<\/(task_(?:result|error))>/gi, '</\u200b$1>');
+}
+
 export function renderTaskCompletedWithText(
   taskID: string,
   summary: string,
@@ -63,7 +72,7 @@ export function renderTaskCompletedWithText(
     `<task id="${taskID}" state="completed">`,
     `<summary>${summary}</summary>`,
     '<task_result>',
-    text,
+    sanitizeTaskResultBody(text),
     '</task_result>',
     '</task>',
   ].join('\n');

--- a/src/utils/task.ts
+++ b/src/utils/task.ts
@@ -88,6 +88,15 @@ export function renderTaskTerminalFromBoard(input: {
  * true outcome once the fallback model has produced it. Mirrors the
  * `state:"completed"` branch of opencode `renderOutput` (task.ts:64-76).
  */
+/**
+ * Neutralize embedded task close tags so non-greedy
+ * `parseTaskResultFromOutput` cannot truncate recovered body early.
+ * Zero-width space after `</` keeps the visible text intact.
+ */
+export function sanitizeTaskResultBody(text: string): string {
+  return text.replace(/<\/(task_(?:result|error))>/gi, '</\u200b$1>');
+}
+
 export function renderTaskCompletedWithText(
   taskID: string,
   summary: string,
@@ -97,7 +106,7 @@ export function renderTaskCompletedWithText(
     `<task id="${taskID}" state="completed">`,
     `<summary>${summary}</summary>`,
     '<task_result>',
-    text,
+    sanitizeTaskResultBody(text),
     '</task_result>',
     '</task>',
   ].join('\n');

--- a/src/utils/task.ts
+++ b/src/utils/task.ts
@@ -59,7 +59,9 @@ export function renderTaskTerminalFromBoard(input: {
     state === 'completed'
       ? `Background task completed: ${description}`
       : `Background task failed: ${description}`;
-  const body = resultSummary ?? (state === 'completed' ? 'Task completed.' : 'Task failed.');
+  const body =
+    resultSummary ??
+    (state === 'completed' ? 'Task completed.' : 'Task failed.');
   return [
     `<task id="${taskID}" state="${state}">`,
     `<summary>${summary}</summary>`,

--- a/src/utils/task.ts
+++ b/src/utils/task.ts
@@ -36,6 +36,39 @@ export function renderRunningTaskPlaceholder(taskID: string): string {
   ].join('\n');
 }
 
+/**
+ * Render a terminal task tool output carrying real assistant text.
+ *
+ * opencode's `runTask` settles a foreground task as `completed` with an empty
+ * `output` when the primary model halts on a non-retryable error (e.g. 403
+ * quota exhausted): the halted assistant message has no text part, so
+ * `result.parts.findLast(text)?.text ?? ""` yields "" and `Exit.succeed("")`
+ * marks the job completed. omos's `tryFallback` then re-prompts with the
+ * fallback model on an orphan runLoop and produces the real result, but the
+ * parent task part already says completed+empty — the orchestrator reads an
+ * empty `<task_result>` and mis-judges the task as failed/empty (#863
+ * self-amplify).
+ *
+ * This renders the opencode `renderOutput` shape (task.ts) with the child
+ * session's real assistant text, so the orchestrator's history reflects the
+ * true outcome once the fallback model has produced it. Mirrors the
+ * `state:"completed"` branch of opencode `renderOutput` (task.ts:64-76).
+ */
+export function renderTaskCompletedWithText(
+  taskID: string,
+  summary: string,
+  text: string,
+): string {
+  return [
+    `<task id="${taskID}" state="completed">`,
+    `<summary>${summary}</summary>`,
+    '<task_result>',
+    text,
+    '</task_result>',
+    '</task>',
+  ].join('\n');
+}
+
 export function parseTaskIdFromTaskOutput(output: string): string | undefined {
   const xmlMatch = /<task\s+[^>]*\bid=["']([^"']+)["'][^>]*>/i.exec(output);
   if (xmlMatch) return xmlMatch[1];

--- a/src/utils/task.ts
+++ b/src/utils/task.ts
@@ -70,6 +70,39 @@ export function renderTaskTerminalFromBoard(input: {
   ].join('\n');
 }
 
+/**
+ * Render a terminal task tool output carrying real assistant text.
+ *
+ * opencode's `runTask` settles a foreground task as `completed` with an empty
+ * `output` when the primary model halts on a non-retryable error (e.g. 403
+ * quota exhausted): the halted assistant message has no text part, so
+ * `result.parts.findLast(text)?.text ?? ""` yields "" and `Exit.succeed("")`
+ * marks the job completed. omos's `tryFallback` then re-prompts with the
+ * fallback model on an orphan runLoop and produces the real result, but the
+ * parent task part already says completed+empty — the orchestrator reads an
+ * empty `<task_result>` and mis-judges the task as failed/empty (#863
+ * self-amplify).
+ *
+ * This renders the opencode `renderOutput` shape (task.ts) with the child
+ * session's real assistant text, so the orchestrator's history reflects the
+ * true outcome once the fallback model has produced it. Mirrors the
+ * `state:"completed"` branch of opencode `renderOutput` (task.ts:64-76).
+ */
+export function renderTaskCompletedWithText(
+  taskID: string,
+  summary: string,
+  text: string,
+): string {
+  return [
+    `<task id="${taskID}" state="completed">`,
+    `<summary>${summary}</summary>`,
+    '<task_result>',
+    text,
+    '</task_result>',
+    '</task>',
+  ].join('\n');
+}
+
 export function parseTaskIdFromTaskOutput(output: string): string | undefined {
   const xmlMatch = /<task\s+[^>]*\bid=["']([^"']+)["'][^>]*>/i.exec(output);
   if (xmlMatch) return xmlMatch[1];


### PR DESCRIPTION
## Summary

Supersedes **#880** and **#912** — same FG-fallback orphan-runLoop family, one PR, one transform path.

When foreground fallback swaps models, opencode can leave the parent task tool part in a **false terminal** state while the fallback model still produces the real result:

| Symptom | Root | Fix |
|---------|------|-----|
| **False-cancel** (#595) | FG abort poisons awaited BackgroundJob → `"Task cancelled"` error part | Rewrite from board terminal truth (`renderTaskTerminalFromBoard`) |
| **False-complete** (#863) | Non-retryable halt → `runTask` settles `completed` + empty (`?? ""`) while `tryFallback` orphan runLoop continues | Fill empty `<task_result>` from child session (`renderTaskCompletedWithText`) |

Both passes run after `stabilizeRunningTaskParts` in `experimental.chat.messages.transform`. Shared `sanitizeTaskResultBody` avoids non-greedy parse truncation on recovered text.

### Hardening (from #912 review / Greptile)

- **Fail-open** try/catch around `extractSessionResult` — never abort parent transform
- **Skip** rewrite while board job is still `running` or `cancelled`
- **Sanitize** embedded `</task_result>` / `</task_error>` in recovered body

### Not in scope

- Does **not** force `task_id` resume (still LLM/prompt Session Reuse)
- Does **not** fix opencode core `runTask` empty settle (omos-only)
- **#606** (keep fallback out of BG sessions) remains complementary and separate
- **#870** (`reconcile_task`) is board state only — not redundant with this

## Tests

- `fallback-false-cancel.test.ts` (from #880)
- `false-complete-fallback.test.ts` (from #912 + hardening cases)
- `task.test.ts` sanitize/round-trip

`bun test` on the three files: **35 pass**. `bun run typecheck`: pass.

## Supersedes

- Closes the need for open **#880** and **#912** — please close those as superseded by this PR.
- Related: #595, #863 (closed; root false-complete still needed), #606 (complementary)

## AI assistance

Co-developed-with: oracle, councillor-reviewer-a/b/c, council synthesis (review of #912 hardenings).