### PR TITLE
fix: add status code 400 to error handling logic

### DIFF
--- a/src/hooks/foreground-fallback/index.ts
+++ b/src/hooks/foreground-fallback/index.ts
@@ -125,6 +125,7 @@ export function isFailoverError(error: unknown): boolean {
   if (
     statusCode === 429 ||
     statusCode === 403 ||
+    statusCode === 400 ||
     (statusCode !== undefined && OUTAGE_STATUS_CODES.has(statusCode))
   ) {
     return true;


### PR DESCRIPTION
### What changed
- Added `400` to the failover status codes in `isFailoverError()`.

### Why
- To make the fallback logic handle HTTP `400` responses consistently with the other failover codes.

### Notes
- No additional logic was changed.