### PR TITLE
fix(reflect): remove hardcoded home dir and session id in sqlite queries

### DIFF
--- a/src/skills/reflect/SKILL.md
+++ b/src/skills/reflect/SKILL.md
@@ -37,7 +37,7 @@ repeated patterns, friction, and improvement opportunities.
 
 1. **Load recent sessions** - Query the SQLite database directly:
    ```bash
-   bun -e "import Database from 'bun:sqlite'; const db = new Database('/home/mhenke/.local/share/opencode/opencode.db'); console.log(db.query('SELECT id, directory, title, agent, model, time_created, cost, tokens_input, tokens_output FROM session ORDER BY time_created DESC LIMIT 50').all())"
+   bun -e "import Database from 'bun:sqlite'; const db = new Database(process.env.HOME + '/.local/share/opencode/opencode.db'); console.log(db.query('SELECT id, directory, title, agent, model, time_created, cost, tokens_input, tokens_output FROM session ORDER BY time_created DESC LIMIT 50').all())"
    ```
    Adjust `LIMIT 50` to `--last N` if specified.
 
@@ -45,7 +45,7 @@ repeated patterns, friction, and improvement opportunities.
 
 2. **Load session messages** - For each session ID, query the message table:
    ```bash
-   bun -e "import Database from 'bun:sqlite'; const db = new Database('/home/mhenke/.local/share/opencode/opencode.db'); console.log(db.query('SELECT data FROM message WHERE session_id = ?').all('ses_14de9c68effegtZtlATm42wnz7'))"
+   bun -e "import Database from 'bun:sqlite'; const db = new Database(process.env.HOME + '/.local/share/opencode/opencode.db'); console.log(db.query('SELECT data FROM message WHERE session_id = ?').all('<session_id>'))"
    ```
 
    **Message table columns:** `id, session_id, time_created, time_updated, data` (data is JSON with role, agent, model, summary, etc.)


### PR DESCRIPTION
## Problem

The `reflect` skill's two `bun` sqlite one-liners hardcode the author's own home directory and a literal session id:

- `src/skills/reflect/SKILL.md:40` — `new Database('/home/mhenke/.local/share/opencode/opencode.db')` (sessions query)
- `src/skills/reflect/SKILL.md:48` — same hardcoded path **plus** a literal `ses_14de9c68effegtZtlATm42wnz7` session id (messages query)

This breaks the skill for every user whose home directory is not `/home/mhenke` — i.e. everyone except the author. The DB path must resolve per-user.

## Fix

- Resolve the DB path from `process.env.HOME` instead of a hardcoded absolute path.
- Replace the literal session id in the messages query with a `<session_id>` placeholder so it reads as a parameter, not a constant.

This matches the existing convention already used elsewhere in the project: `src/utils/logger.ts:16` resolves the same XDG path via `os.homedir()`.

Scope: one file, two lines. The example JSON output block (the illustrative `ses_...` id and `/home/user/Projects/...` further down) is intentionally left untouched — it is example output, not executable.

## Before / After

```diff
-const db = new Database('/home/mhenke/.local/share/opencode/opencode.db'); ... .all())
+const db = new Database(process.env.HOME + '/.local/share/opencode/opencode.db'); ... .all())
```
```diff
-const db = new Database('/home/mhenke/.local/share/opencode/opencode.db'); ... .all('ses_14de9c68effegtZtlATm42wnz7'))
+const db = new Database(process.env.HOME + '/.local/share/opencode/opencode.db'); ... .all('<session_id>'))
```
