### PR TITLE
feat: add Atlas Cloud preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,13 +134,13 @@ bun run build
 
 ### Getting Started
 
-The installer generates both OpenAI and OpenCode Go presets, with OpenAI active by default.
+The installer generates OpenAI, OpenCode Go, and Atlas Cloud presets, with OpenAI active by default.
 
 > [!TIP]
 > Tune the models and agents for your own workflow. The defaults are only a
 > starting point; the plugin is designed for deep flexibility and customization.
 
-To make OpenCode Go active during install, run `bunx oh-my-opencode-slim@latest install --preset=opencode-go` or change the default preset name in `~/.config/opencode/oh-my-opencode-slim.json` after installation.
+To make OpenCode Go active during install, run `bunx oh-my-opencode-slim@latest install --preset=opencode-go`. For Atlas Cloud, set `ATLASCLOUD_API_KEY` and use `--preset=atlas-cloud`. You can also change the default preset name in `~/.config/opencode/oh-my-opencode-slim.json` after installation.
 
 Then:
 
@@ -164,7 +164,7 @@ Then:
 > [!TIP]
 > Because background agents are now the default workflow, it is **highly recommended** to enable and configure **[Multiplexer Integration](docs/multiplexer-integration.md)**. It automatically opens each agent in a dedicated Tmux, Zellij, Herdr, cmux, or kitty pane, so you can watch specialists work live while the Orchestrator continues coordinating the session.
 
-The default generated configuration includes both `openai` and `opencode-go` presets.
+The default generated configuration includes `openai`, `opencode-go`, and `atlas-cloud` presets.
 
 ```jsonc
 {
@@ -187,6 +187,14 @@ The default generated configuration includes both `openai` and `opencode-go` pre
       "designer": { "model": "opencode-go/kimi-k2.7-code" },
       "fixer": { "model": "opencode-go/deepseek-v4-flash", "variant": "high" },
       "observer": { "model": "opencode-go/mimo-v2.5" }
+    },
+    "atlas-cloud": {
+      "orchestrator": { "model": "atlas-cloud/deepseek-ai/deepseek-v4-pro" },
+      "oracle": { "model": "atlas-cloud/deepseek-ai/deepseek-v4-pro" },
+      "librarian": { "model": "atlas-cloud/deepseek-ai/deepseek-v4-pro" },
+      "explorer": { "model": "atlas-cloud/deepseek-ai/deepseek-v4-pro" },
+      "designer": { "model": "atlas-cloud/deepseek-ai/deepseek-v4-pro" },
+      "fixer": { "model": "atlas-cloud/deepseek-ai/deepseek-v4-pro" }
     }
   }
 }

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -37,7 +37,7 @@ The installer supports the following options:
 |--------|-------------|
 | `--skills=yes|no` | Install bundled skills (default: yes) |
 | `--companion=ask\|yes\|no` | Install and enable the desktop Companion (`ask` by default; prompt defaults to no) |
-| `--preset=<name>` | Active generated config preset: `openai` or `opencode-go` (default: `openai`) |
+| `--preset=<name>` | Active generated config preset: `openai`, `opencode-go`, or `atlas-cloud` (default: `openai`) |
 | `--background-subagents=ask\|yes\|no` | Configure the required background-subagents environment export (`ask` by default; prompt defaults to yes) |
 | `--background-subagents-target=<path>` | Write the background-subagents export to a specific shell/profile file |
 | `--no-tui` | Non-interactive mode |
@@ -99,7 +99,21 @@ bunx oh-my-opencode-slim@latest install --reset
 
 ### After Installation
 
-The installer generates both OpenAI and OpenCode Go presets, with OpenAI active by default (using variant-aware GPT-5.6 models, including `gpt-5.6-terra (medium)` for Orchestrator, `gpt-5.6-sol (high)` for Oracle, `gpt-5.6-luna (medium)` for Fixer, and `gpt-5.6-luna` variants for other specialists). To make OpenCode Go active during install, run `bunx oh-my-opencode-slim@latest install --preset=opencode-go`. That preset uses Minimax-M3 for Orchestrator, so the installer also enables Observer with `opencode-go/mimo-v2.5` for visual analysis. To switch providers later or build a mixed setup, use **[Configuration Reference](configuration.md)** for the full option reference and the preset docs for copyable examples.
+The installer generates OpenAI, OpenCode Go, and Atlas Cloud presets, with OpenAI active by default (using variant-aware GPT-5.6 models, including `gpt-5.6-terra (medium)` for Orchestrator, `gpt-5.6-sol (high)` for Oracle, `gpt-5.6-luna (medium)` for Fixer, and `gpt-5.6-luna` variants for other specialists). To make OpenCode Go active during install, run `bunx oh-my-opencode-slim@latest install --preset=opencode-go`. That preset uses Minimax-M3 for Orchestrator, so the installer also enables Observer with `opencode-go/mimo-v2.5` for visual analysis. To switch providers later or build a mixed setup, use **[Configuration Reference](configuration.md)** for the full option reference and the preset docs for copyable examples.
+
+### Atlas Cloud Preset
+
+Set `ATLASCLOUD_API_KEY` and select `atlas-cloud` during installation:
+
+```bash
+ATLASCLOUD_API_KEY=... bunx oh-my-opencode-slim@latest install --preset=atlas-cloud
+```
+
+The installer adds an OpenAI-compatible `atlas-cloud` provider to the OpenCode
+config without storing the key, so the generated preset is also ready for
+later `/preset atlas-cloud` switching. It defaults to
+`https://api.atlascloud.ai/v1` and `deepseek-ai/deepseek-v4-pro`, while
+preserving any existing Atlas endpoint, model, or environment overrides.
 
 The plugin safely reconciles bundled skills on startup and after successful
 auto-updates. Missing bundled skills are installed, and previously managed skills

--- a/src/cli/config-io.test.ts
+++ b/src/cli/config-io.test.ts
@@ -17,6 +17,7 @@ import {
   detectCurrentConfig,
   disableDefaultAgents,
   enableLspByDefault,
+  mergeGeneratedPresetsIntoLiteConfig,
   parseConfig,
   parseConfigFile,
   stripJsonComments,
@@ -549,6 +550,68 @@ describe('config-io', () => {
       'opencode-go/mimo-v2.5',
     );
     expect(saved.presets['opencode-go'].observer.variant).toBeUndefined();
+  });
+
+  test('mergeGeneratedPresetsIntoLiteConfig adds missing presets without overwriting user config', () => {
+    const litePath = join(tmpDir, 'opencode', 'oh-my-opencode-slim.json');
+    paths.ensureConfigDir();
+    const existing = {
+      preset: 'custom',
+      custom_option: true,
+      presets: {
+        custom: { oracle: { model: 'custom/model' } },
+        openai: { oracle: { model: 'custom/openai' } },
+      },
+    };
+    writeFileSync(litePath, JSON.stringify(existing));
+
+    const result = mergeGeneratedPresetsIntoLiteConfig(
+      {
+        installCustomSkills: false,
+        reset: false,
+      },
+      litePath,
+    );
+    expect(result.success).toBe(true);
+
+    const saved = JSON.parse(readFileSync(litePath, 'utf-8'));
+    expect(saved.preset).toBe('custom');
+    expect(saved.custom_option).toBe(true);
+    expect(saved.presets.custom).toEqual(existing.presets.custom);
+    expect(saved.presets.openai).toEqual(existing.presets.openai);
+    expect(saved.presets['opencode-go']).toBeDefined();
+    expect(saved.presets['atlas-cloud']).toBeDefined();
+  });
+
+  test('mergeGeneratedPresetsIntoLiteConfig honors an explicitly selected Atlas preset', () => {
+    const litePath = join(tmpDir, 'opencode', 'oh-my-opencode-slim.json');
+    paths.ensureConfigDir();
+    writeFileSync(
+      litePath,
+      JSON.stringify({
+        preset: 'openai',
+        presets: {
+          openai: { oracle: { model: 'custom/openai' } },
+        },
+      }),
+    );
+
+    const result = mergeGeneratedPresetsIntoLiteConfig(
+      {
+        installCustomSkills: false,
+        preset: 'atlas-cloud',
+        reset: false,
+      },
+      litePath,
+    );
+    expect(result.success).toBe(true);
+
+    const saved = JSON.parse(readFileSync(litePath, 'utf-8'));
+    expect(saved.preset).toBe('atlas-cloud');
+    expect(saved.presets.openai.oracle.model).toBe('custom/openai');
+    expect(saved.presets['atlas-cloud'].orchestrator.model).toBe(
+      'atlas-cloud/deepseek-ai/deepseek-v4-pro',
+    );
   });
 
   test('disableDefaultAgents disables conflicting OpenCode built-in agents', () => {

--- a/src/cli/config-io.test.ts
+++ b/src/cli/config-io.test.ts
@@ -138,6 +138,46 @@ describe('config-io', () => {
     expect(saved.plugin.length).toBe(2);
   });
 
+  test('addPluginToOpenCodeConfig configures Atlas Cloud without overwriting user settings', async () => {
+    const configPath = join(tmpDir, 'opencode', 'opencode.json');
+    paths.ensureConfigDir();
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        plugin: ['other'],
+        provider: {
+          existing: { name: 'Existing Provider' },
+          'atlas-cloud': {
+            env: ['CUSTOM_ATLAS_KEY'],
+            options: { baseURL: 'https://atlas.example/v1', timeout: 30_000 },
+            models: { 'custom/model': { name: 'Custom Model' } },
+          },
+        },
+      }),
+    );
+    process.argv[1] = '';
+
+    const result = await addPluginToOpenCodeConfig({ preset: 'openai' });
+    expect(result.success).toBe(true);
+
+    const saved = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(saved.provider.existing).toEqual({ name: 'Existing Provider' });
+    expect(saved.provider['atlas-cloud']).toEqual({
+      npm: '@ai-sdk/openai-compatible',
+      name: 'Atlas Cloud',
+      env: ['CUSTOM_ATLAS_KEY', 'ATLASCLOUD_API_KEY'],
+      options: {
+        baseURL: 'https://atlas.example/v1',
+        timeout: 30_000,
+      },
+      models: {
+        'deepseek-ai/deepseek-v4-pro': { name: 'DeepSeek V4 Pro' },
+        'custom/model': { name: 'Custom Model' },
+      },
+    });
+    expect(JSON.stringify(saved)).not.toContain('apiKey');
+  });
+
   test('addPluginToOpenCodeConfig respects OPENCODE_CONFIG_DIR', async () => {
     const customConfigDir = join(tmpDir, 'custom-opencode');
     const defaultConfigDir = join(tmpDir, 'opencode');

--- a/src/cli/config-io.ts
+++ b/src/cli/config-io.ts
@@ -615,6 +615,51 @@ export function writeLiteConfig(
   }
 }
 
+export function mergeGeneratedPresetsIntoLiteConfig(
+  installConfig: InstallConfig,
+  targetPath: string,
+): ConfigMergeResult {
+  try {
+    const { config: parsedConfig, error } = parseConfigFile(targetPath);
+    if (error) {
+      return {
+        success: false,
+        configPath: targetPath,
+        error: `Failed to parse lite config: ${error}`,
+      };
+    }
+
+    const existing = parsedConfig ?? {};
+    const generated = generateLiteConfig(installConfig);
+    const existingPresets = isRecord(existing.presets) ? existing.presets : {};
+    const generatedPresets = isRecord(generated.presets)
+      ? generated.presets
+      : {};
+    const merged: OpenCodeConfig = {
+      ...existing,
+      $schema: existing.$schema ?? generated.$schema,
+      preset: existing.preset ?? generated.preset,
+      presets: {
+        ...generatedPresets,
+        ...existingPresets,
+      },
+    };
+
+    if (installConfig.preset !== undefined) {
+      merged.preset = generated.preset;
+    }
+
+    writeConfig(targetPath, merged);
+    return { success: true, configPath: targetPath };
+  } catch (err) {
+    return {
+      success: false,
+      configPath: targetPath,
+      error: `Failed to merge generated presets: ${err}`,
+    };
+  }
+}
+
 export function disableDefaultAgents(): ConfigMergeResult {
   const configPath = getExistingConfigPath();
 

--- a/src/cli/config-io.ts
+++ b/src/cli/config-io.ts
@@ -23,7 +23,11 @@ import {
   getExistingTuiConfigPath,
   getLiteConfig,
 } from './paths';
-import { generateLiteConfig } from './providers';
+import {
+  ATLAS_CLOUD_PROVIDER_ID,
+  generateLiteConfig,
+  getAtlasCloudProviderConfig,
+} from './providers';
 import type {
   ConfigMergeResult,
   DetectedConfig,
@@ -36,6 +40,35 @@ const DEFAULT_OPENCODE_AGENTS_TO_DISABLE = ['explore', 'general'] as const;
 
 function isString(value: unknown): value is string {
   return typeof value === 'string';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function mergeAtlasCloudProvider(config: OpenCodeConfig): void {
+  const providers = isRecord(config.provider) ? config.provider : {};
+  const defaults = getAtlasCloudProviderConfig();
+  const existing = isRecord(providers[ATLAS_CLOUD_PROVIDER_ID])
+    ? providers[ATLAS_CLOUD_PROVIDER_ID]
+    : {};
+  const defaultEnv = Array.isArray(defaults.env) ? defaults.env : [];
+  const existingEnv = Array.isArray(existing.env) ? existing.env : [];
+
+  providers[ATLAS_CLOUD_PROVIDER_ID] = {
+    ...defaults,
+    ...existing,
+    env: [...new Set([...existingEnv, ...defaultEnv])],
+    options: {
+      ...(isRecord(defaults.options) ? defaults.options : {}),
+      ...(isRecord(existing.options) ? existing.options : {}),
+    },
+    models: {
+      ...(isRecord(defaults.models) ? defaults.models : {}),
+      ...(isRecord(existing.models) ? existing.models : {}),
+    },
+  };
+  config.provider = providers;
 }
 
 function getModelIds(model: unknown): string[] {
@@ -450,7 +483,9 @@ export function writeConfig(configPath: string, config: OpenCodeConfig): void {
   renameSync(tmpPath, configPath);
 }
 
-export async function addPluginToOpenCodeConfig(): Promise<ConfigMergeResult> {
+export async function addPluginToOpenCodeConfig(
+  installConfig?: Pick<InstallConfig, 'preset'>,
+): Promise<ConfigMergeResult> {
   const configPath = getExistingConfigPath();
 
   try {
@@ -485,6 +520,10 @@ export async function addPluginToOpenCodeConfig(): Promise<ConfigMergeResult> {
     // Add fresh entry
     filteredPlugins.push(pluginEntry);
     config.plugin = filteredPlugins;
+
+    if (installConfig) {
+      mergeAtlasCloudProvider(config);
+    }
 
     writeConfig(configPath, config);
     return { success: true, configPath };

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -97,7 +97,7 @@ Doctor options:
 
 Available presets: ${getGeneratedPresetNames().join(', ')}
 
-The installer generates OpenAI and OpenCode Go presets by default.
+The installer generates OpenAI, OpenCode Go, and Atlas Cloud presets by default.
 OpenAI is active unless --preset selects another generated preset.
 For the full config reference, see docs/configuration.md.
 
@@ -106,6 +106,7 @@ Examples:
   bunx oh-my-opencode-slim install --no-tui --skills=yes
   bunx oh-my-opencode-slim install --background-subagents=yes
   bunx oh-my-opencode-slim install --preset=opencode-go
+  ATLASCLOUD_API_KEY=... bunx oh-my-opencode-slim install --preset=atlas-cloud
   bunx oh-my-opencode-slim install --reset
   bunx oh-my-opencode-slim doctor
 `);

--- a/src/cli/install.test.ts
+++ b/src/cli/install.test.ts
@@ -82,10 +82,10 @@ mock.module('./config-manager', () => {
       enableInstallMocks
         ? '/usr/local/bin/opencode'
         : originalGetOpenCodePath(),
-    addPluginToOpenCodeConfig: async () =>
+    addPluginToOpenCodeConfig: async (cfg?: any) =>
       enableInstallMocks
         ? { success: true, configPath: '/path' }
-        : originalAddPluginToOpenCodeConfig(),
+        : originalAddPluginToOpenCodeConfig(cfg),
     addPluginToOpenCodeTuiConfig: async () =>
       enableInstallMocks
         ? { success: true, configPath: '/path' }

--- a/src/cli/install.test.ts
+++ b/src/cli/install.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { shouldInstallCompanion } from './install';
 import type { InstallConfig } from './types';
 
@@ -27,6 +30,8 @@ const originalEnableLspByDefault = actualConfigManager.enableLspByDefault;
 const originalDetectCurrentConfig = actualConfigManager.detectCurrentConfig;
 const originalGenerateLiteConfig = actualConfigManager.generateLiteConfig;
 const originalWriteLiteConfig = actualConfigManager.writeLiteConfig;
+const originalMergeGeneratedPresetsIntoLiteConfig =
+  actualConfigManager.mergeGeneratedPresetsIntoLiteConfig;
 
 const originalIsBackgroundSubagentsEnabled =
   actualBackgroundSubagents.isBackgroundSubagentsEnabled;
@@ -50,6 +55,8 @@ let mockAdoptedResult: string[] = [];
 let mockCustomizedResult: string[] = [];
 let receivedSkillSyncOptions: unknown;
 let enableInstallMocks = false;
+let mockLiteConfigPath = '/path/lite-config.json';
+let receivedPresetMerge: { config: InstallConfig; path: string } | undefined;
 
 mock.module('../hooks/auto-update-checker/skill-sync', () => {
   return {
@@ -112,6 +119,13 @@ mock.module('./config-manager', () => {
       enableInstallMocks
         ? { success: true, configPath: '/path' }
         : originalWriteLiteConfig(cfg, path),
+    mergeGeneratedPresetsIntoLiteConfig: (cfg: any, path: string) => {
+      if (enableInstallMocks) {
+        receivedPresetMerge = { config: cfg, path };
+        return { success: true, configPath: path };
+      }
+      return originalMergeGeneratedPresetsIntoLiteConfig(cfg, path);
+    },
   };
 });
 
@@ -142,9 +156,44 @@ mock.module('./paths', () => {
     ...actualPaths,
     getExistingLiteConfigPath: () =>
       enableInstallMocks
-        ? '/path/lite-config.json'
+        ? mockLiteConfigPath
         : originalGetExistingLiteConfigPath(),
   };
+});
+
+describe('install existing configuration updates', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    enableInstallMocks = true;
+    receivedPresetMerge = undefined;
+    tempDir = mkdtempSync(join(tmpdir(), 'slim-install-test-'));
+    mockLiteConfigPath = join(tempDir, 'oh-my-opencode-slim.json');
+    writeFileSync(mockLiteConfigPath, JSON.stringify({ preset: 'openai' }));
+  });
+
+  afterEach(() => {
+    enableInstallMocks = false;
+    mockLiteConfigPath = '/path/lite-config.json';
+    if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test('merges generated presets when an existing config is kept', async () => {
+    const { install } = await import(`./install?test=${importCounter++}`);
+
+    const result = await install({
+      skills: 'no',
+      tui: false,
+      companion: 'no',
+      preset: 'atlas-cloud',
+      backgroundSubagents: 'no',
+    });
+
+    expect(result).toBe(0);
+    expect(receivedPresetMerge?.path).toBe(mockLiteConfigPath);
+    expect(receivedPresetMerge?.config.preset).toBe('atlas-cloud');
+    expect(receivedPresetMerge?.config.reset).toBe(false);
+  });
 });
 
 function baseConfig(): InstallConfig {

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -21,6 +21,7 @@ import {
   getOpenCodePath,
   getOpenCodeVersion,
   isOpenCodeInstalled,
+  mergeGeneratedPresetsIntoLiteConfig,
   warmOpenCodePluginCache,
   writeLiteConfig,
 } from './config-manager';
@@ -408,10 +409,11 @@ async function runInstall(config: InstallConfig): Promise<number> {
     const configExists = existsSync(configPath);
 
     if (configExists && !config.reset) {
-      printInfo(
-        `Configuration already exists at ${configPath}. ` +
-          'Use --reset to overwrite.',
+      const liteResult = mergeGeneratedPresetsIntoLiteConfig(
+        config,
+        configPath,
       );
+      if (!handleStepResult(liteResult, 'Config presets updated')) return 1;
     } else {
       const liteResult = writeLiteConfig(
         config,

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -342,7 +342,7 @@ async function runInstall(config: InstallConfig): Promise<number> {
   if (config.dryRun) {
     printInfo('Dry run mode - skipping plugin installation');
   } else {
-    const pluginResult = await addPluginToOpenCodeConfig();
+    const pluginResult = await addPluginToOpenCodeConfig(config);
     if (!handleStepResult(pluginResult, 'Plugin added')) return 1;
   }
 

--- a/src/cli/providers.test.ts
+++ b/src/cli/providers.test.ts
@@ -7,12 +7,33 @@ describe('providers', () => {
   test('MODEL_MAPPINGS includes supported providers', () => {
     const keys = Object.keys(MODEL_MAPPINGS);
     expect(keys.sort()).toEqual([
+      'atlas-cloud',
       'copilot',
       'kimi',
       'openai',
       'opencode-go',
       'zai-plan',
     ]);
+  });
+
+  test('generateLiteConfig can set Atlas Cloud as active preset', () => {
+    const config = generateLiteConfig({
+      installCustomSkills: false,
+      preset: 'atlas-cloud',
+      backgroundSubagents: 'no',
+      reset: false,
+    });
+
+    expect(config.preset).toBe('atlas-cloud');
+    const agents = (config.presets as any)['atlas-cloud'];
+    expect(agents).toBeDefined();
+    expect(agents.orchestrator.model).toBe(
+      'atlas-cloud/deepseek-ai/deepseek-v4-pro',
+    );
+    expect(agents.orchestrator.variant).toBeUndefined();
+    expect(agents.orchestrator.skills).toEqual(['*']);
+    expect(agents.librarian.mcps).toEqual(['context7', 'gh_grep']);
+    expect(agents.fixer.model).toBe('atlas-cloud/deepseek-ai/deepseek-v4-pro');
   });
 
   test('generateLiteConfig defaults to openai and includes generated presets', () => {

--- a/src/cli/providers.ts
+++ b/src/cli/providers.ts
@@ -5,7 +5,16 @@ import type { InstallConfig } from './types';
 const SCHEMA_URL =
   'https://unpkg.com/oh-my-opencode-slim@latest/oh-my-opencode-slim.schema.json';
 
-export const GENERATED_PRESETS = ['openai', 'opencode-go'] as const;
+export const ATLAS_CLOUD_PROVIDER_ID = 'atlas-cloud';
+export const ATLAS_CLOUD_API_KEY_ENV = 'ATLASCLOUD_API_KEY';
+export const ATLAS_CLOUD_BASE_URL = 'https://api.atlascloud.ai/v1';
+export const ATLAS_CLOUD_DEFAULT_MODEL = 'deepseek-ai/deepseek-v4-pro';
+
+export const GENERATED_PRESETS = [
+  'openai',
+  'opencode-go',
+  ATLAS_CLOUD_PROVIDER_ID,
+] as const;
 
 // Model mappings by provider/preset.
 export const MODEL_MAPPINGS = {
@@ -53,6 +62,14 @@ export const MODEL_MAPPINGS = {
     fixer: { model: 'opencode-go/deepseek-v4-flash', variant: 'high' },
     observer: { model: 'opencode-go/mimo-v2.5' },
   },
+  'atlas-cloud': {
+    orchestrator: { model: 'atlas-cloud/deepseek-ai/deepseek-v4-pro' },
+    oracle: { model: 'atlas-cloud/deepseek-ai/deepseek-v4-pro' },
+    librarian: { model: 'atlas-cloud/deepseek-ai/deepseek-v4-pro' },
+    explorer: { model: 'atlas-cloud/deepseek-ai/deepseek-v4-pro' },
+    designer: { model: 'atlas-cloud/deepseek-ai/deepseek-v4-pro' },
+    fixer: { model: 'atlas-cloud/deepseek-ai/deepseek-v4-pro' },
+  },
 } as const;
 
 export type PresetName = keyof typeof MODEL_MAPPINGS;
@@ -74,6 +91,22 @@ export function isGeneratedPresetName(
 
 export function getGeneratedPresetNames(): GeneratedPresetName[] {
   return [...GENERATED_PRESETS];
+}
+
+export function getAtlasCloudProviderConfig(): Record<string, unknown> {
+  return {
+    npm: '@ai-sdk/openai-compatible',
+    name: 'Atlas Cloud',
+    env: [ATLAS_CLOUD_API_KEY_ENV],
+    options: {
+      baseURL: ATLAS_CLOUD_BASE_URL,
+    },
+    models: {
+      [ATLAS_CLOUD_DEFAULT_MODEL]: {
+        name: 'DeepSeek V4 Pro',
+      },
+    },
+  };
 }
 
 export function generateLiteConfig(


### PR DESCRIPTION
What changed, and why was it needed?

- Add a generated `atlas-cloud` preset backed by `deepseek-ai/deepseek-v4-pro`.
- Register Atlas Cloud as an OpenAI-compatible provider using `ATLASCLOUD_API_KEY` and `https://api.atlascloud.ai/v1`.
- Merge provider defaults into the user's OpenCode config without persisting credentials or overwriting endpoint, environment, or model overrides.
- Document the installer flag and add coverage for preset generation and config merging.

This makes the generated Atlas preset usable immediately instead of requiring a separate manual provider definition.

Validation:
- `bun test` (1718 passed)
- `bun test src/cli/providers.test.ts src/cli/config-io.test.ts` (50 passed)
- `bun run typecheck`
- `bun run build`
- Biome checks on changed TypeScript files
- isolated CLI install and generated-config verification
- live Atlas Cloud forced tool-call request (HTTP 200)

`bun run check:ci` also reached formatting checks; it reports two existing issues in unchanged `src/hooks/cache-safety.property.test.ts` and `src/utils/env.test.ts`. The changed files pass Biome. The local machine does not have the `opencode` binary, so verification used the repository installer plus a live provider request.