### PR TITLE
fix(internal-initiator): treat OpenCode compaction continuation as internal (#922)

### DIFF
--- a/src/utils/internal-initiator.test.ts
+++ b/src/utils/internal-initiator.test.ts
@@ -43,4 +43,48 @@ describe('internal initiator markers', () => {
       }),
     ).toBe(false);
   });
+
+  test('recognizes OpenCode compaction continuation as internal initiator', () => {
+    // OpenCode's compaction sends a synthetic continuation prompt with
+    // metadata.compaction_continue = true but no INTERNAL_INITIATOR_METADATA_KEY.
+    // This should be treated as internal to prevent board injection on
+    // the continuation turn (issue #922).
+    const compactionContinuation = {
+      type: 'text',
+      synthetic: true,
+      text: 'Continue if you have next steps.',
+      metadata: { compaction_continue: true },
+    };
+    expect(isInternalInitiatorPart(compactionContinuation)).toBe(true);
+  });
+
+  test('compaction_continue without synthetic is not internal', () => {
+    expect(
+      isInternalInitiatorPart({
+        type: 'text',
+        text: 'Continue if you have next steps.',
+        metadata: { compaction_continue: true },
+      }),
+    ).toBe(false);
+  });
+
+  test('compaction_continue false or string is not internal', () => {
+    expect(
+      isInternalInitiatorPart({
+        type: 'text',
+        synthetic: true,
+        text: 'Continue if you have next steps.',
+        metadata: { compaction_continue: false },
+      }),
+    ).toBe(false);
+
+    expect(
+      isInternalInitiatorPart({
+        type: 'text',
+        synthetic: true,
+        text: 'Continue if you have next steps.',
+        metadata: { compaction_continue: 'true' },
+      }),
+    ).toBe(false);
+  });
 });

--- a/src/utils/internal-initiator.ts
+++ b/src/utils/internal-initiator.ts
@@ -29,5 +29,13 @@ export function isInternalInitiatorPart(part: unknown): boolean {
     return false;
   }
 
-  return part.metadata[INTERNAL_INITIATOR_METADATA_KEY] === true;
+  return (
+    part.metadata[INTERNAL_INITIATOR_METADATA_KEY] === true ||
+    // OpenCode's compaction continuation emits compaction_continue: true
+    // instead of our internal initiator key; treat it as internal to
+    // prevent board injection on the continuation turn (#922).
+    // Upstream key is not a stable plugin contract — graceful degradation
+    // if renamed: injection resumes, loop returns, no crash.
+    part.metadata['compaction_continue'] === true
+  );
 }


### PR DESCRIPTION
Fixes #922

OpenCode auto-compaction emits a synthetic continuation prompt with `metadata.compaction_continue = true`. Without this check, board injection fires on the continuation turn, pushing the prompt back over the compaction boundary and causing an infinite loop.

- Add `compaction_continue` check in `isInternalInitiatorPart()`
- Add negative test cases for synthetic guard and value strictness
- Replace ponytail comment with why-comment documenting upstream fragility

## What problem are you solving?

Issue #922: after a long orchestrator session accumulates ~30 managed subagent sessions, OpenCode reaches its automatic compaction boundary. The compaction continuation prompt triggers board injection, which pushes the prompt back over the limit, causing an infinite loop of compaction → continuation → injection → compaction.

## What does this change?

Widens `isInternalInitiatorPart()` to recognize OpenCode's `compaction_continue` metadata key as internal, preventing board injection on the continuation turn.

## Why this approach?

One predicate widening in the shared function covers all 7 consumers (board-injection ×2, task-session-manager, phase-reminder, post-file-tool-nudge, chat-headers, interview/service). Per-call-site checks would duplicate logic 7 times. The key is verified against OpenCode's upstream source (anomalyco/opencode compaction.ts).

## Related work

- [x] I checked open AND closed PRs/issues for duplicates
- Related: #922

## AI assistance

- Model / harness: OpenCode (mimo-v2.5-free) with @oracle (mimo-v2.5-free) subagents
- Human reviewed the full diff? [x]

## Checklist

- [x] `bun run check:ci`, `bun run typecheck`, and `bun test` pass
- [x] Docs updated if behavior/commands changed (N/A — internal predicate change, no user-facing behavior)
- [x] One logical change per PR
- [x] PR targets the `master` branch