### PR TITLE
fix(foreground-fallback): trigger fallback for unavailable relay channels (#943)

### DIFF
--- a/src/hooks/foreground-fallback/index.test.ts
+++ b/src/hooks/foreground-fallback/index.test.ts
@@ -171,6 +171,27 @@ describe('isFailoverError', () => {
   test('returns true for "forbidden" (lowercase) in message', () => {
     expect(isRetryableError({ message: 'forbidden' })).toBe(true);
   });
+
+  test('returns true for NewAPI "no available channel" error shapes', () => {
+    const message =
+      'No available channel for model gpt-5.6-luna under group Codex专用 (distributor) (request id: abc123)';
+
+    expect(isRetryableError(message)).toBe(true);
+    expect(isRetryableError({ message })).toBe(true);
+    expect(
+      isRetryableError({
+        data: { statusCode: 400, responseBody: message },
+      }),
+    ).toBe(true);
+  });
+
+  test('returns false for permanent channel-not-found errors', () => {
+    expect(
+      isRetryableError({
+        message: 'channel not found for model gpt-5.6-luna',
+      }),
+    ).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -242,6 +263,42 @@ describe('ForegroundFallbackManager session.error', () => {
     ];
     expect(call[0].path.id).toBe('sess-1');
     // Should have picked the next model after anthropic/claude-opus-4-5
+    expect(call[0].body.model.providerID).toBe('openai');
+    expect(call[0].body.model.modelID).toBe('gpt-4o');
+  });
+
+  test('triggers fallback on unavailable provider channel session.error', async () => {
+    await mgr.handleEvent({
+      type: 'message.updated',
+      properties: {
+        info: {
+          sessionID: 'sess-1',
+          providerID: 'anthropic',
+          modelID: 'claude-opus-4-5',
+          role: 'assistant',
+        },
+      },
+    });
+
+    await mgr.handleEvent({
+      type: 'session.error',
+      properties: {
+        sessionID: 'sess-1',
+        error: {
+          message:
+            'No available channel for model gpt-5.6-luna under group Codex专用 (distributor)',
+        },
+      },
+    });
+
+    expect(mocks.abort).not.toHaveBeenCalled();
+    expect(mocks.promptAsync).toHaveBeenCalledTimes(1);
+
+    const call = mocks.promptAsync.mock.calls[0] as [
+      {
+        body: { model: { providerID: string; modelID: string } };
+      },
+    ];
     expect(call[0].body.model.providerID).toBe('openai');
     expect(call[0].body.model.modelID).toBe('gpt-4o');
   });

--- a/src/hooks/foreground-fallback/index.ts
+++ b/src/hooks/foreground-fallback/index.ts
@@ -82,6 +82,7 @@ const PROVIDER_OUTAGE_PATTERNS = [
   /\bupstream outage\b/i,
   /\bprovider outage\b/i,
   /\bprovider unavailable\b/i,
+  /\bno available channel/i,
   /\bmodel\b.*\bnot available\b/i,
   /\bmodel is not available\b/i,
   /\bunsupported model\b/i,


### PR DESCRIPTION
Fixes #943

## What problem are you solving?

When a one-api/new-api relay returns `No available channel for model ...`, `isFailoverError()` does not classify the error as a provider outage.

The error is commonly carried as text or inside an HTTP 400 response body, so it does not reach the existing 5xx status-code path. It also matches none of the current retryable, transport, or provider-outage patterns. As a result, the foreground fallback gate returns false and a configured fallback chain never advances beyond the unavailable primary model.

## What does this change?

- Add a narrow `no available channel` provider-outage pattern.
- Add regression coverage for the reported one-api/new-api error string as a plain string, `message`, and HTTP 400 `responseBody`.
- Preserve `channel not found` as a non-retryable configuration error.
- Add a manager-level regression test showing that `session.error` advances to the next configured fallback model for the reported error family.

## Why this approach?

`No available channel` describes transient relay capacity or routing availability, so it belongs with existing provider-outage detection rather than permanent model or configuration errors.

The pattern is deliberately limited to the full phrase rather than a broad `channel` match. It covers singular and plural relay wording without treating `channel not found`, invalid channel identifiers, or unrelated model errors as fallback candidates. The existing fallback gate, retry budget, and chain selection logic remain unchanged.

## Verification

- [x] `bun test src/hooks/foreground-fallback/index.test.ts` — 65 pass, 0 fail
- [x] `bun x biome check src/hooks/foreground-fallback/index.ts src/hooks/foreground-fallback/index.test.ts`
- [x] `bun run typecheck`