### PR TITLE
fix(board-injection): gate synthetic part log on task-status shape

### DIFF
--- a/src/hooks/task-session-manager/board-injection.ts
+++ b/src/hooks/task-session-manager/board-injection.ts
@@ -16,6 +16,8 @@ import type {
 } from '../../utils';
 import {
   isInternalInitiatorPart,
+  parseTaskIdFromTaskOutput,
+  parseTaskStateFromOutput,
   parseTaskStatusOutput,
   renderRunningTaskPlaceholder,
 } from '../../utils';
@@ -261,9 +263,14 @@ export function updateFromInjectedCompletion(
 
   const status = parseTaskStatusOutput(part.text);
   if (!status) {
-    log('[task-session-manager] synthetic part missing task status', {
-      textPreview: part.text.slice(0, 120),
-    });
+    // Only flag text shaped like task-status output that failed to parse.
+    // Native delegation prompts (e.g. OpenCode's "@agent" expansion) are
+    // synthetic but never task-status shaped — skip silently.
+    if (parseTaskIdFromTaskOutput(part.text) || parseTaskStateFromOutput(part.text)) {
+      log('[task-session-manager] synthetic part missing task status', {
+        textPreview: part.text.slice(0, 120),
+      });
+    }
     return undefined;
   }
   if (status.state !== 'completed' && status.state !== 'error') {


### PR DESCRIPTION
Fixes #948

## What problem are you solving?

Every synthetic text part that is not task-status shaped triggers a log line `[task-session-manager] synthetic part missing task status`. This fires on `@agent` delegation prompts and board parts on every request, producing ~234 lines/session of noise that obscures real parse failures.

## What does this change?

Gates the log call behind `parseTaskIdFromTaskOutput` and `parseTaskStateFromOutput` so it only fires when the text actually looks like task-status output that failed to parse. Native delegation prompts and board parts are now silent.

## Why this approach?

Reuses the existing parser primitives instead of a hand-rolled regex, staying in sync with the parser vocabulary automatically. The alternative (inline regex) duplicated the parser patterns and risked drift.

## Related work

- [x] Checked open AND closed PRs/issues for duplicates
- Related: none found

## AI assistance

- Model / harness: OpenCode (mimo-v2.5-free) with @oracle (mimo-v2.5-free) subagents for correctness, over-engineering, excellence, and comprehensive review
- Human reviewed the full diff? [x]

## Checklist

- [x] `bun run check:ci`, `bun run typecheck`, and `bun test` pass
- [x] Docs updated if behavior/commands changed — no doc change needed (log-only, no user-facing behavior)
- [x] One logical change per PR
- [x] PR targets the `master` branch