### PR TITLE
fix(foreground-fallback): retry same-model on streaming 5xx errors for agents without chains

### DIFF
--- a/src/hooks/foreground-fallback/index.test.ts
+++ b/src/hooks/foreground-fallback/index.test.ts
@@ -1452,8 +1452,14 @@ describe('ForegroundFallbackManager resolveChain cross-agent isolation', () => {
       },
     });
 
-    // oracle has no chain → should not fall back at all
-    expect(mocks.promptAsync).not.toHaveBeenCalled();
+    // oracle has no chain → retries with its own model, never
+    // cross-bleeds into orchestrator's chain.
+    expect(mocks.promptAsync).toHaveBeenCalledTimes(1);
+    const call = mocks.promptAsync.mock.calls[0] as [
+      { model: { providerID: string; modelID: string } },
+    ];
+    expect(call[0].model.providerID).toBe('anthropic');
+    expect(call[0].model.modelID).toBe('claude-opus-4-5');
   });
 
   test('uses cross-agent last-resort only when agent name is unknown', async () => {
@@ -1508,8 +1514,14 @@ describe('ForegroundFallbackManager resolveChain cross-agent isolation', () => {
       },
     });
 
-    // build has no configured chain and must not inherit orchestrator's
-    expect(mocks.promptAsync).not.toHaveBeenCalled();
+    // build has no configured chain → retries with its own model, never
+    // inherits orchestrator's chain.
+    expect(mocks.promptAsync).toHaveBeenCalledTimes(1);
+    const call = mocks.promptAsync.mock.calls[0] as [
+      { model: { providerID: string; modelID: string } },
+    ];
+    expect(call[0].model.providerID).toBe('openai');
+    expect(call[0].model.modelID).toBe('gpt-5.6');
   });
 });
 
@@ -1549,8 +1561,9 @@ describe('ForegroundFallbackManager no-chain sessions', () => {
       },
     });
 
-    expect(mocks.abort).not.toHaveBeenCalled();
-    expect(mocks.promptAsync).not.toHaveBeenCalled();
+    // Councillor has no chain → same-model retry with current model.
+    expect(mocks.abort).toHaveBeenCalled();
+    expect(mocks.promptAsync).toHaveBeenCalledTimes(1);
   });
 
   test('councillor session.error: no abort and no re-prompt', async () => {
@@ -1577,8 +1590,9 @@ describe('ForegroundFallbackManager no-chain sessions', () => {
       },
     });
 
+    // Councillor has no chain → same-model retry with current model.
     expect(mocks.abort).not.toHaveBeenCalled();
-    expect(mocks.promptAsync).not.toHaveBeenCalled();
+    expect(mocks.promptAsync).toHaveBeenCalledTimes(1);
   });
 
   test('disableChain agent on session.status: no abort (not just no re-prompt)', async () => {

--- a/src/hooks/foreground-fallback/index.test.ts
+++ b/src/hooks/foreground-fallback/index.test.ts
@@ -2260,8 +2260,14 @@ describe('ForegroundFallbackManager resolveChain cross-agent isolation', () => {
       },
     });
 
-    // oracle has no chain → should not fall back at all
-    expect(mocks.promptAsync).not.toHaveBeenCalled();
+    // oracle has no chain → retries with its own model, never
+    // cross-bleeds into orchestrator's chain.
+    expect(mocks.promptAsync).toHaveBeenCalledTimes(1);
+    const call = mocks.promptAsync.mock.calls[0] as [
+      { body: { model: { providerID: string; modelID: string } } },
+    ];
+    expect(call[0].body.model.providerID).toBe('anthropic');
+    expect(call[0].body.model.modelID).toBe('claude-opus-4-5');
   });
 
   test('uses cross-agent last-resort only when agent name is unknown', async () => {
@@ -2316,8 +2322,14 @@ describe('ForegroundFallbackManager resolveChain cross-agent isolation', () => {
       },
     });
 
-    // build has no configured chain and must not inherit orchestrator's
-    expect(mocks.promptAsync).not.toHaveBeenCalled();
+    // build has no configured chain → retries with its own model, never
+    // inherits orchestrator's chain.
+    expect(mocks.promptAsync).toHaveBeenCalledTimes(1);
+    const call = mocks.promptAsync.mock.calls[0] as [
+      { body: { model: { providerID: string; modelID: string } } },
+    ];
+    expect(call[0].body.model.providerID).toBe('openai');
+    expect(call[0].body.model.modelID).toBe('gpt-5.6');
   });
 });
 
@@ -2362,8 +2374,9 @@ describe('ForegroundFallbackManager no-chain sessions', () => {
       },
     });
 
-    expect(mocks.abort).not.toHaveBeenCalled();
-    expect(mocks.promptAsync).not.toHaveBeenCalled();
+    // Councillor has no chain → same-model retry with current model.
+    expect(mocks.abort).toHaveBeenCalled();
+    expect(mocks.promptAsync).toHaveBeenCalledTimes(1);
   });
 
   test('councillor session.error: no abort and no re-prompt', async () => {
@@ -2392,8 +2405,9 @@ describe('ForegroundFallbackManager no-chain sessions', () => {
       },
     });
 
+    // Councillor has no chain → same-model retry with current model.
     expect(mocks.abort).not.toHaveBeenCalled();
-    expect(mocks.promptAsync).not.toHaveBeenCalled();
+    expect(mocks.promptAsync).toHaveBeenCalledTimes(1);
   });
 
   test('disableChain agent on session.status: no abort (not just no re-prompt)', async () => {

--- a/src/hooks/foreground-fallback/index.ts
+++ b/src/hooks/foreground-fallback/index.ts
@@ -56,7 +56,7 @@ const RETRYABLE_ERROR_PATTERNS = [
   /blocked by gateway/i,
 ];
 
-const OUTAGE_STATUS_CODES = new Set([500, 502, 503, 504]);
+const OUTAGE_STATUS_CODES = new Set([500, 502, 503, 504, 524]);
 // (ponytail) validated against real OpenCode error shapes
 const TRANSPORT_CODES = new Set([
   'ECONNREFUSED',
@@ -86,6 +86,10 @@ const PROVIDER_OUTAGE_PATTERNS = [
   /\bmodel is not available\b/i,
   /\bunsupported model\b/i,
   /\bunknown model\b/i,
+  /\bupstream error\b/i,
+  /\bstreaming response failed\b/i,
+  /\brequest queue is full\b/i,
+  /\bworker local total request limit reached\b/i,
 ];
 
 function extractStatusCode(error: {
@@ -480,24 +484,115 @@ export class ForegroundFallbackManager {
   }
 
   // ---------------------------------------------------------------------------
+  // Re-prompt helper (shared by fallback and same-model retry paths)
+  // ---------------------------------------------------------------------------
+
+  private async rePromptWithModel(
+    sessionID: string,
+    model: { providerID: string; modelID: string },
+    agentName?: string,
+    label?: string,
+  ): Promise<void> {
+    const result = await getClient(this.input!).session.messages({
+      sessionID,
+    });
+    const messages = (result.data ?? []) as unknown[];
+    const lastUser = [...messages].reverse().find(isUserMessageWithParts);
+    if (!lastUser) {
+      log('[foreground-fallback] no user message found', { sessionID });
+      return;
+    }
+
+    const sessionClient = getClient(this.input!).session;
+    if (typeof sessionClient.promptAsync !== 'function') {
+      log('[foreground-fallback] promptAsync unavailable', { sessionID });
+      return;
+    }
+
+    const promptBody = {
+      parts: [
+        ...(lastUser.parts as Array<{ type: 'text'; text: string }>),
+        createInternalAgentTextPart(
+          label ?? 'Foreground fallback replay.',
+        ),
+      ],
+      model,
+      ...(agentName ? { agent: agentName } : {}),
+    };
+
+    try {
+      await sessionClient.promptAsync({ sessionID, ...promptBody });
+    } catch (_promptErr) {
+      log('[foreground-fallback] promptAsync on busy session, aborting', {
+        sessionID,
+      });
+      await abortSessionWithTimeout(getClient(this.input!), sessionID);
+      await new Promise((r) => setTimeout(r, REPROMPT_DELAY_MS));
+      await sessionClient.promptAsync({ sessionID, ...promptBody });
+    }
+  }
+
+  // ---------------------------------------------------------------------------
   // Core fallback logic
   // ---------------------------------------------------------------------------
 
   private async tryFallback(sessionID: string): Promise<void> {
     if (!sessionID) return;
     if (this.inProgress.has(sessionID)) return;
-    // No chain → no fallback. Skip before dedup so we don't stamp lastTrigger
-    // for sessions we will never re-prompt (e.g. councillor via CouncilManager).
-    if (!this.hasFallbackChain(sessionID)) return;
 
-    // Deduplicate: multiple events can fire for a single rate-limit event.
-    // Bypass dedup when the model changed since the last trigger - the new
-    // model's failure is a separate incident and the cascade should continue.
+    // Has a fallback chain: switch models as before.
+    if (this.hasFallbackChain(sessionID)) {
+      if (this.isDeduped(sessionID)) return;
+
+      this.inProgress.add(sessionID);
+      try {
+        await this.execFallback(sessionID);
+      } finally {
+        this.inProgress.delete(sessionID);
+      }
+      return;
+    }
+
+    // No chain — retry with the current model (transient upstream errors
+    // like 502/503/504 ResourceExhausted / queue full are often resolved
+    // by a simple retry hitting a different worker).
+    const currentModel = this.sessionModel.get(sessionID);
+    if (!currentModel) return;
+
+    // Agent chain explicitly disabled — skip same-model retry.
+    const agentName = this.sessionAgent.get(sessionID);
+    if (agentName && Array.isArray(this.chains[agentName]) && this.chains[agentName].length === 0) return;
+
+    const tried = this.sessionRetries.get(sessionID) ?? 0;
+    if (tried >= this.maxRetries) {
+      log(
+        '[foreground-fallback] same-model retries exhausted, giving up',
+        { sessionID, currentModel, tried },
+      );
+      this.sessionRetries.delete(sessionID);
+      return;
+    }
+
     if (this.isDeduped(sessionID)) return;
+
+    this.sessionRetries.set(sessionID, tried + 1);
 
     this.inProgress.add(sessionID);
     try {
-      await this.execFallback(sessionID);
+      const ref = parseModelReference(currentModel);
+      if (!ref) return;
+      log('[foreground-fallback] retrying with current model', {
+        sessionID,
+        model: currentModel,
+        attempt: tried + 1,
+        maxRetries: this.maxRetries,
+      });
+      await this.rePromptWithModel(
+        sessionID,
+        ref,
+        agentName,
+        'Same-model retry after transient error.',
+      );
     } finally {
       this.inProgress.delete(sessionID);
     }
@@ -510,20 +605,66 @@ export class ForegroundFallbackManager {
    * task-session-manager sees isFallbackInProgress()=true during the
    * abort idle window and does not cancel the pending task call.
    *
-   * When no chain is available, do nothing (no abort, no log). Aborting
-   * without a replacement model only races owners that manage their own
-   * lifecycle (e.g. CouncilManager for councillor) and produces noise.
+   * When no chain is available, retries the current model (up to maxRetries)
+   * — transient upstream errors like 502/503/504 often resolve with a retry
+   * to a different worker.
    */
   private async tryFallbackWithAbort(sessionID: string): Promise<void> {
     if (!sessionID) return;
     if (this.inProgress.has(sessionID)) return;
-    if (!this.hasFallbackChain(sessionID)) return;
+
+    if (this.hasFallbackChain(sessionID)) {
+      if (this.isDeduped(sessionID)) return;
+
+      this.inProgress.add(sessionID);
+      try {
+        await abortSessionWithTimeout(getClient(this.input!), sessionID);
+        await this.execFallback(sessionID);
+      } finally {
+        this.inProgress.delete(sessionID);
+      }
+      return;
+    }
+
+    // No chain — retry with current model after abort.
+    const currentModel = this.sessionModel.get(sessionID);
+    if (!currentModel) return;
+
+    // Agent chain explicitly disabled — skip same-model retry.
+    const agentName = this.sessionAgent.get(sessionID);
+    if (agentName && Array.isArray(this.chains[agentName]) && this.chains[agentName].length === 0) return;
+
+    const tried = this.sessionRetries.get(sessionID) ?? 0;
+    if (tried >= this.maxRetries) {
+      log(
+        '[foreground-fallback] same-model retries exhausted, giving up',
+        { sessionID, currentModel, tried },
+      );
+      this.sessionRetries.delete(sessionID);
+      return;
+    }
+
     if (this.isDeduped(sessionID)) return;
+
+    this.sessionRetries.set(sessionID, tried + 1);
 
     this.inProgress.add(sessionID);
     try {
+      const ref = parseModelReference(currentModel);
+      if (!ref) return;
       await abortSessionWithTimeout(getClient(this.input!), sessionID);
-      await this.execFallback(sessionID);
+      log('[foreground-fallback] retrying with current model after abort', {
+        sessionID,
+        model: currentModel,
+        attempt: tried + 1,
+        maxRetries: this.maxRetries,
+      });
+      await this.rePromptWithModel(
+        sessionID,
+        ref,
+        agentName,
+        'Same-model retry after transient error.',
+      );
     } finally {
       this.inProgress.delete(sessionID);
     }
@@ -614,54 +755,8 @@ export class ForegroundFallbackManager {
         return;
       }
 
-      // Retrieve the last user message to re-submit with the fallback model.
-      const result = await getClient(this.input!).session.messages({
-        sessionID,
-      });
-      // result.data may contain partial/streaming messages whose `info` is
-      // undefined at runtime (OpenCode violates its own declared type), so
-      // guard each entry instead of dereferencing `info` directly.
-      const messages = (result.data ?? []) as unknown[];
-      const lastUser = [...messages].reverse().find(isUserMessageWithParts);
-      if (!lastUser) {
-        log('[foreground-fallback] no user message found', { sessionID });
-        return;
-      }
-
-      // promptAsync queues the prompt and returns immediately - this avoids
-      // blocking the event handler while waiting for a full LLM response.
-      const sessionClient = getClient(this.input!).session;
-      if (typeof sessionClient.promptAsync !== 'function') {
-        log('[foreground-fallback] promptAsync unavailable', { sessionID });
-        return;
-      }
-
-      const promptBody = {
-        // ponytail: lastUser.parts are MessagePart[] from API, but v2
-        // promptAsync expects TextPartInput[] — runtime-compatible, TS
-        // doesn't know the `type` field is already 'text'.
-        parts: [
-          ...(lastUser.parts as Array<{ type: 'text'; text: string }>),
-          createInternalAgentTextPart('Foreground fallback replay.'),
-        ],
-        model: ref,
-        ...(agentName ? { agent: agentName } : {}),
-      };
-
-      // Try queuing the fallback prompt without aborting first. If OpenCode
-      // accepts it (204), the fallback model replaces the retry loop
-      // transparently — no dialog, no session error shown to the user.
-      // If promptAsync throws (e.g. session busy), fall back to abort+retry.
-      try {
-        await sessionClient.promptAsync({ sessionID, ...promptBody });
-      } catch (_promptErr) {
-        log('[foreground-fallback] promptAsync on busy session, aborting', {
-          sessionID,
-        });
-        await abortSessionWithTimeout(getClient(this.input!), sessionID);
-        await new Promise((r) => setTimeout(r, REPROMPT_DELAY_MS));
-        await sessionClient.promptAsync({ sessionID, ...promptBody });
-      }
+      // Re-prompt with the fallback model.
+      await this.rePromptWithModel(sessionID, ref, agentName);
 
       this.sessionModel.set(sessionID, nextModel);
       log('[foreground-fallback] switched to fallback model', {

--- a/src/hooks/foreground-fallback/index.ts
+++ b/src/hooks/foreground-fallback/index.ts
@@ -26,7 +26,11 @@ import {
   parseModelReference,
 } from '../../utils/session';
 import type { SessionLifecycle } from '../session-lifecycle';
-import { isReplayableUserMessage, partsFromReplayMessage } from '../types';
+import {
+  isReplayableUserMessage,
+  partsFromReplayMessage,
+  type ReplayableUserMessage,
+} from '../types';
 
 // ---------------------------------------------------------------------------
 // Retryable error detection
@@ -69,7 +73,7 @@ const RETRYABLE_ERROR_PATTERNS = [
   /\b401\b/,
 ];
 
-const OUTAGE_STATUS_CODES = new Set([500, 502, 503, 504]);
+const OUTAGE_STATUS_CODES = new Set([500, 502, 503, 504, 524]);
 // (ponytail) validated against real OpenCode error shapes
 const TRANSPORT_CODES = new Set([
   'ECONNREFUSED',
@@ -117,6 +121,10 @@ const PROVIDER_OUTAGE_PATTERNS = [
   /(?:^|\s)Gone(?:$|\s)/i,
   /\bHTTP 410\b/i,
   /\bstatus.?410\b/i,
+  /\bupstream error\b/i,
+  /\bstreaming response failed\b/i,
+  /\brequest queue is full\b/i,
+  /\bworker local total request limit reached\b/i,
 ];
 
 function extractStatusCode(error: {
@@ -577,24 +585,136 @@ export class ForegroundFallbackManager {
   }
 
   // ---------------------------------------------------------------------------
+  // Re-prompt helper (shared by fallback and same-model retry paths)
+  // ---------------------------------------------------------------------------
+
+  private async rePromptWithModel(
+    sessionID: string,
+    model: { providerID: string; modelID: string },
+    agentName?: string,
+    label?: string,
+  ): Promise<void> {
+    let lastUser: ReplayableUserMessage | undefined;
+    // ponytail: retry up to 3 times, 500ms apart — the message may still
+    // be in-flight when the stream error fires; a short wait usually lands it.
+    for (let attempt = 0; attempt < 3; attempt++) {
+      const result = await getClient(this.input).session.messages({
+        path: { id: sessionID },
+      });
+      const messages = (result.data ?? []) as unknown[];
+      lastUser = [...messages].reverse().find(isReplayableUserMessage);
+      if (lastUser) break;
+      if (attempt < 2) {
+        await new Promise((r) => setTimeout(r, REPROMPT_DELAY_MS));
+      }
+    }
+    if (!lastUser) {
+      log('[foreground-fallback] no user message found', { sessionID });
+      return;
+    }
+
+    const sessionClient = getClient(this.input).session;
+    if (typeof sessionClient.promptAsync !== 'function') {
+      log('[foreground-fallback] promptAsync unavailable', { sessionID });
+      return;
+    }
+
+    const replayParts = partsFromReplayMessage(lastUser) as Array<{
+      type: 'text';
+      text: string;
+    }>;
+
+    const promptBody = {
+      path: { id: sessionID },
+      body: {
+        parts: [
+          ...replayParts,
+          createInternalAgentTextPart(label ?? 'Foreground fallback replay.'),
+        ],
+        model,
+        ...(agentName ? { agent: agentName } : {}),
+      },
+    };
+
+    try {
+      await sessionClient.promptAsync(promptBody);
+    } catch (_promptErr) {
+      log('[foreground-fallback] promptAsync on busy session, aborting', {
+        sessionID,
+      });
+      await abortSessionWithTimeout(getClient(this.input), sessionID);
+      await new Promise((r) => setTimeout(r, REPROMPT_DELAY_MS));
+      await sessionClient.promptAsync(promptBody);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
   // Core fallback logic
   // ---------------------------------------------------------------------------
 
   private async tryFallback(sessionID: string, error?: unknown): Promise<void> {
     if (!sessionID) return;
     if (this.inProgress.has(sessionID)) return;
-    // No chain → no fallback. Skip before dedup so we don't stamp lastTrigger
-    // for sessions we will never re-prompt (e.g. councillor via CouncilManager).
-    if (!this.hasFallbackChain(sessionID)) return;
 
-    // Deduplicate: multiple events can fire for a single rate-limit event.
-    // Bypass dedup when the model changed since the last trigger - the new
-    // model's failure is a separate incident and the cascade should continue.
+    // Has a fallback chain: switch models as before.
+    if (this.hasFallbackChain(sessionID)) {
+      if (this.isDeduped(sessionID)) return;
+
+      this.inProgress.add(sessionID);
+      try {
+        await this.execFallback(sessionID, error);
+      } finally {
+        this.inProgress.delete(sessionID);
+      }
+      return;
+    }
+
+    // No chain — retry with the current model (transient upstream errors
+    // like 502/503/504 ResourceExhausted / queue full are often resolved
+    // by a simple retry hitting a different worker).
+    const currentModel = this.sessionModel.get(sessionID);
+    if (!currentModel) return;
+
+    // Agent chain explicitly disabled — skip same-model retry.
+    const agentName = this.sessionAgent.get(sessionID);
+    if (
+      agentName &&
+      Array.isArray(this.chains[agentName]) &&
+      this.chains[agentName].length === 0
+    )
+      return;
+
+    const tried = this.sessionRetries.get(sessionID) ?? 0;
+    if (tried >= this.maxRetries) {
+      log('[foreground-fallback] same-model retries exhausted, giving up', {
+        sessionID,
+        currentModel,
+        tried,
+      });
+      this.sessionRetries.delete(sessionID);
+      return;
+    }
+
     if (this.isDeduped(sessionID)) return;
+
+    this.sessionRetries.set(sessionID, tried + 1);
 
     this.inProgress.add(sessionID);
     try {
-      await this.execFallback(sessionID, error);
+      const ref = parseModelReference(currentModel);
+      if (!ref) return;
+      log('[foreground-fallback] retrying with current model', {
+        sessionID,
+        model: currentModel,
+        attempt: tried + 1,
+        maxRetries: this.maxRetries,
+      });
+      await this.rePromptWithModel(
+        sessionID,
+        ref,
+        agentName,
+        'Same-model retry after transient error.',
+      );
     } finally {
       this.inProgress.delete(sessionID);
     }
@@ -607,9 +727,9 @@ export class ForegroundFallbackManager {
    * task-session-manager sees isFallbackInProgress()=true during the
    * abort idle window and does not cancel the pending task call.
    *
-   * When no chain is available, do nothing (no abort, no log). Aborting
-   * without a replacement model only races owners that manage their own
-   * lifecycle (e.g. CouncilManager for councillor) and produces noise.
+   * When no chain is available, retries the current model (up to maxRetries)
+   * — transient upstream errors like 502/503/504 often resolve with a retry
+   * to a different worker.
    */
   private async tryFallbackWithAbort(
     sessionID: string,
@@ -617,13 +737,65 @@ export class ForegroundFallbackManager {
   ): Promise<void> {
     if (!sessionID) return;
     if (this.inProgress.has(sessionID)) return;
-    if (!this.hasFallbackChain(sessionID)) return;
+
+    if (this.hasFallbackChain(sessionID)) {
+      if (this.isDeduped(sessionID)) return;
+
+      this.inProgress.add(sessionID);
+      try {
+        await abortSessionWithTimeout(getClient(this.input), sessionID);
+        await this.execFallback(sessionID, error);
+      } finally {
+        this.inProgress.delete(sessionID);
+      }
+      return;
+    }
+
+    // No chain — retry with current model after abort.
+    const currentModel = this.sessionModel.get(sessionID);
+    if (!currentModel) return;
+
+    // Agent chain explicitly disabled — skip same-model retry.
+    const agentName = this.sessionAgent.get(sessionID);
+    if (
+      agentName &&
+      Array.isArray(this.chains[agentName]) &&
+      this.chains[agentName].length === 0
+    )
+      return;
+
+    const tried = this.sessionRetries.get(sessionID) ?? 0;
+    if (tried >= this.maxRetries) {
+      log('[foreground-fallback] same-model retries exhausted, giving up', {
+        sessionID,
+        currentModel,
+        tried,
+      });
+      this.sessionRetries.delete(sessionID);
+      return;
+    }
+
     if (this.isDeduped(sessionID)) return;
+
+    this.sessionRetries.set(sessionID, tried + 1);
 
     this.inProgress.add(sessionID);
     try {
+      const ref = parseModelReference(currentModel);
+      if (!ref) return;
       await abortSessionWithTimeout(getClient(this.input), sessionID);
-      await this.execFallback(sessionID, error);
+      log('[foreground-fallback] retrying with current model after abort', {
+        sessionID,
+        model: currentModel,
+        attempt: tried + 1,
+        maxRetries: this.maxRetries,
+      });
+      await this.rePromptWithModel(
+        sessionID,
+        ref,
+        agentName,
+        'Same-model retry after transient error.',
+      );
     } finally {
       this.inProgress.delete(sessionID);
     }
@@ -651,7 +823,6 @@ export class ForegroundFallbackManager {
     sessionID: string,
     error?: unknown,
   ): Promise<void> {
-    const session = getClient(this.input).session;
     try {
       // After the chain has been exhausted twice (reset retry failed and we
       // aborted), do not intervene again for this session: re-entering would
@@ -741,60 +912,8 @@ export class ForegroundFallbackManager {
         return;
       }
 
-      // Retrieve the last user message to re-submit with the fallback model.
-      const result = await session.messages({
-        path: { id: sessionID },
-      });
-      // result.data may contain partial/streaming messages whose `info` is
-      // undefined at runtime (OpenCode violates its own declared type), and
-      // v2 messages carry `type`/`text` instead of `info`/`parts`, so guard
-      // each entry instead of dereferencing a fixed shape.
-      const messages = (result.data ?? []) as unknown[];
-      const lastUser = [...messages].reverse().find(isReplayableUserMessage);
-      if (!lastUser) {
-        log('[foreground-fallback] no user message found', {
-          sessionID,
-          messageCount: messages.length,
-          requestError: result.error ?? undefined,
-        });
-        return;
-      }
-
-      // promptAsync queues the prompt and returns immediately - this avoids
-      // blocking the event handler while waiting for a full LLM response.
-      const sessionClient = session;
-      if (typeof sessionClient.promptAsync !== 'function') {
-        log('[foreground-fallback] promptAsync unavailable', { sessionID });
-        return;
-      }
-
-      const replayParts = partsFromReplayMessage(lastUser) as Array<{
-        type: 'text';
-        text: string;
-      }>;
-
-      const promptBody = {
-        path: { id: sessionID },
-        body: {
-          parts: [
-            ...replayParts,
-            createInternalAgentTextPart('Foreground fallback replay.'),
-          ],
-          model: ref,
-          ...(agentName ? { agent: agentName } : {}),
-        },
-      };
-
-      try {
-        await sessionClient.promptAsync(promptBody);
-      } catch (_promptErr) {
-        log('[foreground-fallback] promptAsync on busy session, aborting', {
-          sessionID,
-        });
-        await abortSessionWithTimeout(getClient(this.input), sessionID);
-        await new Promise((r) => setTimeout(r, REPROMPT_DELAY_MS));
-        await sessionClient.promptAsync(promptBody);
-      }
+      // Re-prompt with the fallback model.
+      await this.rePromptWithModel(sessionID, ref, agentName);
 
       this.sessionModel.set(sessionID, nextModel);
       log('[foreground-fallback] switched to fallback model', {

--- a/src/hooks/foreground-fallback/index.ts
+++ b/src/hooks/foreground-fallback/index.ts
@@ -493,11 +493,20 @@ export class ForegroundFallbackManager {
     agentName?: string,
     label?: string,
   ): Promise<void> {
-    const result = await getClient(this.input!).session.messages({
-      sessionID,
-    });
-    const messages = (result.data ?? []) as unknown[];
-    const lastUser = [...messages].reverse().find(isUserMessageWithParts);
+    let lastUser: any;
+    // ponytail: retry up to 3 times, 500ms apart — the message may still
+    // be in-flight when the stream error fires; a short wait usually lands it.
+    for (let attempt = 0; attempt < 3; attempt++) {
+      const result = await getClient(this.input!).session.messages({
+        sessionID,
+      });
+      const messages = (result.data ?? []) as unknown[];
+      lastUser = [...messages].reverse().find(isUserMessageWithParts);
+      if (lastUser) break;
+      if (attempt < 2) {
+        await new Promise((r) => setTimeout(r, REPROMPT_DELAY_MS));
+      }
+    }
     if (!lastUser) {
       log('[foreground-fallback] no user message found', { sessionID });
       return;
@@ -511,7 +520,7 @@ export class ForegroundFallbackManager {
 
     const promptBody = {
       parts: [
-        ...(lastUser.parts as Array<{ type: 'text'; text: string }>),
+        ...(lastUser.parts as any[]),
         createInternalAgentTextPart(
           label ?? 'Foreground fallback replay.',
         ),


### PR DESCRIPTION
Fixes #947

## What problem are you solving?

Streaming response errors from upstream Nvidia NIM (502 ResourceExhausted, 503 queue full, 504 error code 524) fail silently with no retry for agents without a fallback chain (councillors, explorer, etc.). The orchestrator also gets no retry when the session goes from stream error straight to idle without a retry loop. These are transient worker-overload errors — a retry hitting a different worker usually succeeds.

Log evidence:
```
stream error agent=councillor-beta mode=subagent error="Streaming response failed: [502] Upstream error from Nvidia: ResourceExhausted..."
stream error agent=orchestrator mode=primary error="Streaming response failed: [504] error code: 524"
```
No foreground-fallback retry occurred — isFailoverError caught the error but tryFallback bailed because councillor has no chain.

## What does this change?

When a retryable streaming error hits a session with no fallback chain, the foreground-fallback manager now retries the current model up to maxRetries (default 3) with a 5-second dedup window. Respects disableChain — explicitly disabled agents skip same-model retry. Extracted rePromptWithModel() helper from the existing chain-fallback code.

## Why this approach?

Two alternatives considered: (a) add fallback chains to every agent — but councillors would inherit orchestrator chains, switching to the wrong agent. (b) retry at the OpenCode SDK level — but we can not control that, and isRetryable is false for 502/503/504. Same-model retry is the minimal intervention — transient NIM worker overloads resolve quickly by hitting a different worker.

## Related work

- [x] I checked open AND closed PRs/issues for duplicates
- Related: #947

## AI assistance

- Model / harness: Pi (Claude Opus 4.5) with OpenCode (gpt-5.2)
- Human reviewed the full diff? [x]

## Checklist

- [x] bun run check:ci, bun run typecheck, and bun test pass (pre-existing biome lint only, 1852 tests)
- [x] No behavior/command docs changed
- [x] One logical change per PR
- [x] PR targets the master branch
