### PR TITLE
fix(foreground-fallback): detect CliProxyAPI auth-unavailable errors (#957)

### DIFF
--- a/src/hooks/foreground-fallback/index.test.ts
+++ b/src/hooks/foreground-fallback/index.test.ts
@@ -208,6 +208,27 @@ describe('isFailoverError', () => {
     ).toBe(true);
   });
 
+  test('returns true for CliProxyAPI "auth unavailable" error shapes', () => {
+    const message =
+      'auth_unavailable: no auth available (providers=cli-proxy-api, model=gemini-3.6-flash)';
+
+    expect(isRetryableError(message)).toBe(true);
+    expect(isRetryableError({ message })).toBe(true);
+    expect(
+      isRetryableError({
+        data: { statusCode: 400, responseBody: message },
+      }),
+    ).toBe(true);
+    expect(
+      isRetryableError({
+        data: {
+          responseBody:
+            '{"error":{"message":"auth_unavailable: no auth available","type":"server_error","code":"internal_server_error"}}',
+        },
+      }),
+    ).toBe(true);
+  });
+
   test('returns false for permanent channel-not-found errors', () => {
     expect(
       isRetryableError({
@@ -313,6 +334,42 @@ describe('ForegroundFallbackManager session.error', () => {
         error: {
           message:
             'No available channel for model gpt-5.6-luna under group Codex专用 (distributor)',
+        },
+      },
+    });
+
+    expect(mocks.abort).not.toHaveBeenCalled();
+    expect(mocks.promptAsync).toHaveBeenCalledTimes(1);
+
+    const call = mocks.promptAsync.mock.calls[0] as [
+      {
+        model: { providerID: string; modelID: string };
+      },
+    ];
+    expect(call[0].model.providerID).toBe('openai');
+    expect(call[0].model.modelID).toBe('gpt-4o');
+  });
+
+  test('triggers fallback on CliProxyAPI auth-unavailable session.error', async () => {
+    await mgr.handleEvent({
+      type: 'message.updated',
+      properties: {
+        info: {
+          sessionID: 'sess-1',
+          providerID: 'anthropic',
+          modelID: 'claude-opus-4-5',
+          role: 'assistant',
+        },
+      },
+    });
+
+    await mgr.handleEvent({
+      type: 'session.error',
+      properties: {
+        sessionID: 'sess-1',
+        error: {
+          message:
+            'auth_unavailable: no auth available (providers=cli-proxy-api, model=gemini-3.6-flash)',
         },
       },
     });

--- a/src/hooks/foreground-fallback/index.ts
+++ b/src/hooks/foreground-fallback/index.ts
@@ -54,6 +54,12 @@ const RETRYABLE_ERROR_PATTERNS = [
   /\b403\b/,
   /forbidden/i,
   /blocked by gateway/i,
+  // Auth/credential availability (e.g. CliProxyAPI disables an exhausted
+  // upstream and returns 503 "auth_unavailable: no auth available ...").
+  // The provider is temporarily unavailable, so the next model should be
+  // tried instead of retrying the same dead model.
+  /no auth available/i,
+  /auth_unavailable/i,
 ];
 
 const OUTAGE_STATUS_CODES = new Set([500, 502, 503, 504]);


### PR DESCRIPTION
Fixes #957

## What problem are you solving?

CliProxyAPI disables an exhausted upstream and returns HTTP 503 with `auth_unavailable: no auth available (providers=..., model=...)`. The foreground-fallback classifier does not recognize this error family, so the session retries the same dead model indefinitely and never advances to the next model in the configured fallback chain. This affects both foreground and background subagent sessions.

## What does this change?

- Add `no auth available` and `auth_unavailable` to `RETRYABLE_ERROR_PATTERNS`, alongside the existing auth/forbidden signals.
- Cover the reported error string as a plain string, `message`, HTTP 400 `responseBody`, and the full CliProxyAPI JSON response body.
- Add a manager-level regression test showing that `session.error` with this error family advances to the next configured fallback model.

## Why this approach?

`auth_unavailable` means the provider is temporarily unable to serve the model, so it belongs with the existing retryable/outage detection rather than permanent configuration errors. The patterns are deliberately narrow phrases so unrelated errors (`channel not found`, `invalid API key`, etc.) are not treated as fallback candidates. The existing fallback gate, retry budget, and chain selection logic remain unchanged.

## Verification

- [x] `bun test src/hooks/foreground-fallback/index.test.ts` — 67 pass, 0 fail
- [x] `bun x biome check src/hooks/foreground-fallback/index.ts src/hooks/foreground-fallback/index.test.ts`
- [x] `bun run typecheck`