### PR TITLE
docs(zen-free): update preset models — hy3 removed, fixer variant dropped

### DIFF
--- a/docs/opencode-zen-free-preset.md
+++ b/docs/opencode-zen-free-preset.md
@@ -14,7 +14,7 @@ You need an API key for the `opencode` provider. Sign up at [OpenCode Zen](https
   "presets": {
     "opencode-zen-free": {
       "orchestrator": {
-        "model": "opencode/hy3-free",
+        "model": "opencode/longcat-2.0-free",
         "temperature": 0.4,
         "skills": ["*"],
         "mcps": ["*", "!context7"]
@@ -46,9 +46,8 @@ You need an API key for the `opencode` provider. Sign up at [OpenCode Zen](https
         "mcps": []
       },
       "fixer": {
-        "model": "opencode/deepseek-v4-flash-free",
+        "model": "opencode/laguna-s-2.1-free",
         "temperature": 0.2,
-        "variant": "high",
         "skills": [],
         "mcps": []
       },


### PR DESCRIPTION
Fixes #959

## What problem are you solving?

hy3 was removed from Zen free tier, so the `opencode-zen-free` preset's orchestrator model (`hy3-free`) is no longer valid. The preset doc needed updating to reflect currently available free models.

## What does this change?

- Orchestrator: `opencode/hy3-free` → `opencode/longcat-2.0-free`
- Fixer: `opencode/deepseek-v4-flash-free` → `opencode/laguna-s-2.1-free`, removed `variant: "high"` (no effort level for this model)

## Why this approach?

Direct model swap to match Zen's current free catalog. No alternatives considered — these are the designated replacements.

## Related work

- [x] I checked open AND closed PRs/issues for duplicates
- Related: #959

## AI assistance

- Model / harness: OpenCode (longcat-2.0-free)
- Human reviewed the full diff? [x]

## Checklist

- [x] Docs updated (preset config)
- [x] One logical change per PR
- [x] PR targets the `master` branch