### PR TITLE
refactor(utils): dedup identical helper implementations

### DIFF
--- a/src/agents/codemap.md
+++ b/src/agents/codemap.md
@@ -104,7 +104,7 @@ export function getAgentConfigs(config?: PluginConfig): Record<string, SDKAgentC
     
     // Handle display names: create both displayName and hidden alias
     if (a.displayName) {
-      entries.push([normalizeDisplayName(a.displayName), sdkConfig]);
+      entries.push([normalizeAgentName(a.displayName), sdkConfig]);
       entries.push([a.name, { ...sdkConfig, hidden: true }]);
     } else {
       entries.push([a.name, sdkConfig]);

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -15,6 +15,7 @@ import {
   SUBAGENT_NAMES,
 } from '../config';
 import { getAgentMcpList } from '../config/agent-mcps';
+import { escapeRegExp, normalizeAgentName } from '../utils/agent-variant';
 
 import { createCouncilAgent } from './council';
 import { buildCouncillorAgents, getCouncillorSeatName } from './council-agents';
@@ -42,11 +43,6 @@ type AgentFactory = (
 
 const CANCEL_TASK_ALLOWED_AGENTS = new Set(['orchestrator']);
 const SAFE_AGENT_ALIAS_RE = /^[a-z][a-z0-9_-]*$/i;
-
-function normalizeDisplayName(displayName: string): string {
-  const trimmed = displayName.trim();
-  return trimmed.startsWith('@') ? trimmed.slice(1) : trimmed;
-}
 
 function getPrimaryModelFromOverride(
   override: AgentOverrideConfig | undefined,
@@ -140,10 +136,6 @@ function buildAcpAgentDefinition(
 
 function isSafeDisplayName(displayName: string): boolean {
   return SAFE_AGENT_ALIAS_RE.test(displayName);
-}
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 // Agent Configuration Helpers
@@ -269,7 +261,7 @@ function injectDisplayNames(
   for (const [internalName, displayName] of nameMap) {
     prompt = prompt.replace(
       new RegExp(`@${escapeRegExp(internalName)}\\b`, 'g'),
-      `@${normalizeDisplayName(displayName)}`,
+      `@${normalizeAgentName(displayName)}`,
     );
   }
 
@@ -614,7 +606,7 @@ export function createAgents(
   // Validate display names
   const usedDisplayNames = new Set<string>();
   for (const [, displayName] of displayNameMap) {
-    const normalizedDisplayName = normalizeDisplayName(displayName);
+    const normalizedDisplayName = normalizeAgentName(displayName);
     if (!isSafeDisplayName(normalizedDisplayName)) {
       throw new Error(
         `displayName '${normalizedDisplayName}' must match /^[a-z][a-z0-9_-]*$/i`,
@@ -647,7 +639,7 @@ export function createAgents(
     for (const [internalName, displayName] of displayNameMap) {
       text = text.replace(
         new RegExp(`@${escapeRegExp(internalName)}\\b`, 'g'),
-        `@${normalizeDisplayName(displayName)}`,
+        `@${normalizeAgentName(displayName)}`,
       );
     }
     return text;
@@ -747,7 +739,7 @@ export function getAgentConfigs(
     applyClassification(a.name, sdkConfig);
 
     const normalizedDisplayName = a.displayName
-      ? normalizeDisplayName(a.displayName)
+      ? normalizeAgentName(a.displayName)
       : undefined;
 
     if (normalizedDisplayName && !isInternalOnly(a.name)) {

--- a/src/companion/updater.ts
+++ b/src/companion/updater.ts
@@ -15,6 +15,7 @@ import { homedir, platform, tmpdir } from 'node:os';
 import * as path from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
 import type { CompanionConfig } from '../config/schema';
+import { getErrorMessage } from '../hooks/apply-patch/errors';
 import { crossSpawn } from '../utils/compat';
 import { log } from '../utils/logger';
 
@@ -260,7 +261,7 @@ async function installCompanionArchive(
     return {
       status: 'failed',
       binaryPath: finalBinaryPath,
-      error: `Failed to fetch companion archive: ${formatError(err)}`,
+      error: `Failed to fetch companion archive: ${getErrorMessage(err)}`,
     };
   } finally {
     clearTimeout(timeout);
@@ -344,7 +345,7 @@ async function installCompanionArchive(
     return {
       status: 'failed',
       binaryPath: finalBinaryPath,
-      error: `Failed to install companion: ${formatError(err)}`,
+      error: `Failed to install companion: ${getErrorMessage(err)}`,
     };
   } finally {
     if (tempDir) {
@@ -455,8 +456,4 @@ function parseSemver(version: string): [number, number, number] | null {
   const match = version.match(/^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/);
   if (!match) return null;
   return [Number(match[1]), Number(match[2]), Number(match[3])];
-}
-
-function formatError(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
 }

--- a/src/hooks/cache-safety.property.test.ts
+++ b/src/hooks/cache-safety.property.test.ts
@@ -87,62 +87,63 @@ describe('cache-safety: board strategy coverage drift guard', () => {
   });
 });
 
-describe.each(
-  BOARD_STRATEGIES,
-)('cache-safety: turn-over-turn prefix stability (%s)', (strategy) => {
-  test('re-rendering a growing conversation reproduces byte-identical history', async () => {
-    const pipeline = createPipeline({ strategy });
-    const history = buildHistory();
-    const turns = turnEndIndices(history);
-    const fingerprintsFor = STRATEGY_STABLE_FINGERPRINTS[strategy];
+describe.each(BOARD_STRATEGIES)(
+  'cache-safety: turn-over-turn prefix stability (%s)',
+  (strategy) => {
+    test('re-rendering a growing conversation reproduces byte-identical history', async () => {
+      const pipeline = createPipeline({ strategy });
+      const history = buildHistory();
+      const turns = turnEndIndices(history);
+      const fingerprintsFor = STRATEGY_STABLE_FINGERPRINTS[strategy];
 
-    let previous: string[] | undefined;
-    for (const [turnNumber, endIndex] of turns.entries()) {
-      // Exercise cross-turn hook state: a file-tool nudge fires and a
-      // background job launches before the second turn (a real user turn,
-      // so checkpoint mode creates a snapshot), the job is dropped before
-      // the internal-initiator turn renders with an empty board, and a
-      // second job launches before the fourth turn. Snapshot creation,
-      // replay across internal-initiator and empty-board turns, and
-      // unchanged-board dedupe all must leave stable bytes untouched —
-      // the v2.2.5 checkpoint regression rewrote them on exactly these
-      // transitions.
-      if (turnNumber === 1) {
-        pipeline.markFileToolPending();
-        pipeline.board.registerLaunch({
-          taskID: 'task-alpha',
-          parentSessionID: SESSION_ID,
-          agent: 'explorer',
-          description: 'churn fixture',
-          now: FIXTURE_NOW,
-        });
-      }
-      if (turnNumber === 2) pipeline.board.drop('task-alpha');
-      if (turnNumber === 3) {
-        pipeline.board.registerLaunch({
-          taskID: 'task-beta',
-          parentSessionID: SESSION_ID,
-          agent: 'fixer',
-          description: 'second churn fixture',
-          now: FIXTURE_NOW,
-        });
-      }
-
-      const output = await renderTurn(pipeline, history, endIndex);
-      const fingerprints = fingerprintsFor(output.messages);
-
-      if (previous) {
-        if (fingerprints.length < previous.length) {
-          throw new Error(
-            'A transform removed stable messages between turns — this rewrites the cached prefix. Route the content through src/hooks/cache-safe-injection.ts instead.',
-          );
+      let previous: string[] | undefined;
+      for (const [turnNumber, endIndex] of turns.entries()) {
+        // Exercise cross-turn hook state: a file-tool nudge fires and a
+        // background job launches before the second turn (a real user turn,
+        // so checkpoint mode creates a snapshot), the job is dropped before
+        // the internal-initiator turn renders with an empty board, and a
+        // second job launches before the fourth turn. Snapshot creation,
+        // replay across internal-initiator and empty-board turns, and
+        // unchanged-board dedupe all must leave stable bytes untouched —
+        // the v2.2.5 checkpoint regression rewrote them on exactly these
+        // transitions.
+        if (turnNumber === 1) {
+          pipeline.markFileToolPending();
+          pipeline.board.registerLaunch({
+            taskID: 'task-alpha',
+            parentSessionID: SESSION_ID,
+            agent: 'explorer',
+            description: 'churn fixture',
+            now: FIXTURE_NOW,
+          });
         }
-        expect(fingerprints.slice(0, previous.length)).toEqual(previous);
+        if (turnNumber === 2) pipeline.board.drop('task-alpha');
+        if (turnNumber === 3) {
+          pipeline.board.registerLaunch({
+            taskID: 'task-beta',
+            parentSessionID: SESSION_ID,
+            agent: 'fixer',
+            description: 'second churn fixture',
+            now: FIXTURE_NOW,
+          });
+        }
+
+        const output = await renderTurn(pipeline, history, endIndex);
+        const fingerprints = fingerprintsFor(output.messages);
+
+        if (previous) {
+          if (fingerprints.length < previous.length) {
+            throw new Error(
+              'A transform removed stable messages between turns — this rewrites the cached prefix. Route the content through src/hooks/cache-safe-injection.ts instead.',
+            );
+          }
+          expect(fingerprints.slice(0, previous.length)).toEqual(previous);
+        }
+        previous = fingerprints;
       }
-      previous = fingerprints;
-    }
-  });
-});
+    });
+  },
+);
 
 describe('cache-safety: turn-over-turn prefix stability', () => {
   test('a consumed file-tool nudge is reproduced by the phase reminder on the next turn', async () => {
@@ -165,43 +166,44 @@ describe('cache-safety: turn-over-turn prefix stability', () => {
   });
 });
 
-describe.each(
-  BOARD_STRATEGIES,
-)('cache-safety: specialist sessions (%s)', (strategy) => {
-  test('non-orchestrator payloads pass through byte-identical', async () => {
-    const pipeline = createPipeline({ strategy });
-    const specialistSession = 'ses_specialist_fixture';
-    const history = [
-      {
-        info: {
-          role: 'user',
-          agent: 'explorer',
-          sessionID: specialistSession,
-          id: 's01',
+describe.each(BOARD_STRATEGIES)(
+  'cache-safety: specialist sessions (%s)',
+  (strategy) => {
+    test('non-orchestrator payloads pass through byte-identical', async () => {
+      const pipeline = createPipeline({ strategy });
+      const specialistSession = 'ses_specialist_fixture';
+      const history = [
+        {
+          info: {
+            role: 'user',
+            agent: 'explorer',
+            sessionID: specialistSession,
+            id: 's01',
+          },
+          parts: [{ type: 'text', text: 'find the config loader' }],
         },
-        parts: [{ type: 'text', text: 'find the config loader' }],
-      },
-      assistantTurn('s02', 'Searching now.'),
-      {
-        info: {
-          role: 'user',
-          agent: 'explorer',
-          sessionID: specialistSession,
-          id: 's03',
+        assistantTurn('s02', 'Searching now.'),
+        {
+          info: {
+            role: 'user',
+            agent: 'explorer',
+            sessionID: specialistSession,
+            id: 's03',
+          },
+          parts: [{ type: 'text', text: 'summarize what you found' }],
         },
-        parts: [{ type: 'text', text: 'summarize what you found' }],
-      },
-    ];
-    const before = history.map((message) => JSON.stringify(message));
+      ];
+      const before = history.map((message) => JSON.stringify(message));
 
-    const output: TransformOutput = { messages: structuredClone(history) };
-    await pipeline.run(output);
+      const output: TransformOutput = { messages: structuredClone(history) };
+      await pipeline.run(output);
 
-    expect(output.messages.map((message) => JSON.stringify(message))).toEqual(
-      before,
-    );
-  });
-});
+      expect(output.messages.map((message) => JSON.stringify(message))).toEqual(
+        before,
+      );
+    });
+  },
+);
 
 describe('cache-safety: volatile content isolation', () => {
   test('background-job state only ever changes the tagged trailing message', async () => {
@@ -292,40 +294,44 @@ describe('cache-safety: volatile content isolation', () => {
   });
 });
 
-describe.each(
-  BOARD_STRATEGIES,
-)('cache-safety: determinism under ambient inputs (%s)', (strategy) => {
-  test('wall clock and randomness never leak into the payload', async () => {
-    const history = buildHistory();
-    const lastTurn = history.length - 1;
-    const originalRandom = Math.random;
+describe.each(BOARD_STRATEGIES)(
+  'cache-safety: determinism under ambient inputs (%s)',
+  (strategy) => {
+    test('wall clock and randomness never leak into the payload', async () => {
+      const history = buildHistory();
+      const lastTurn = history.length - 1;
+      const originalRandom = Math.random;
 
-    const render = async (time: number, random: number): Promise<string[]> => {
-      setSystemTime(new Date(time));
-      Math.random = () => random;
-      try {
-        const pipeline = createPipeline({ strategy });
-        pipeline.board.registerLaunch({
-          taskID: 'task-gamma',
-          parentSessionID: SESSION_ID,
-          agent: 'oracle',
-          description: 'determinism fixture',
-          now: FIXTURE_NOW,
-        });
-        const output = await renderTurn(pipeline, history, lastTurn);
-        return output.messages.map((message) => JSON.stringify(message));
-      } finally {
-        Math.random = originalRandom;
-        setSystemTime();
-      }
-    };
+      const render = async (
+        time: number,
+        random: number,
+      ): Promise<string[]> => {
+        setSystemTime(new Date(time));
+        Math.random = () => random;
+        try {
+          const pipeline = createPipeline({ strategy });
+          pipeline.board.registerLaunch({
+            taskID: 'task-gamma',
+            parentSessionID: SESSION_ID,
+            agent: 'oracle',
+            description: 'determinism fixture',
+            now: FIXTURE_NOW,
+          });
+          const output = await renderTurn(pipeline, history, lastTurn);
+          return output.messages.map((message) => JSON.stringify(message));
+        } finally {
+          Math.random = originalRandom;
+          setSystemTime();
+        }
+      };
 
-    const first = await render(FIXTURE_NOW, 0.1234);
-    const second = await render(FIXTURE_NOW + 987_654_321, 0.9876);
+      const first = await render(FIXTURE_NOW, 0.1234);
+      const second = await render(FIXTURE_NOW + 987_654_321, 0.9876);
 
-    expect(second).toEqual(first);
-  });
-});
+      expect(second).toEqual(first);
+    });
+  },
+);
 
 describe('cache-safety: pipeline drift guard', () => {
   const srcRoot = path.resolve(import.meta.dir, '..');

--- a/src/hooks/task-session-manager/board-injection.ts
+++ b/src/hooks/task-session-manager/board-injection.ts
@@ -266,7 +266,10 @@ export function updateFromInjectedCompletion(
     // Only flag text shaped like task-status output that failed to parse.
     // Native delegation prompts (e.g. OpenCode's "@agent" expansion) are
     // synthetic but never task-status shaped — skip silently.
-    if (parseTaskIdFromTaskOutput(part.text) || parseTaskStateFromOutput(part.text)) {
+    if (
+      parseTaskIdFromTaskOutput(part.text) ||
+      parseTaskStateFromOutput(part.text)
+    ) {
       log('[task-session-manager] synthetic part missing task status', {
         textPreview: part.text.slice(0, 120),
       });

--- a/src/hooks/task-session-manager/index.test.ts
+++ b/src/hooks/task-session-manager/index.test.ts
@@ -4622,77 +4622,80 @@ describe('task-session-manager hook', () => {
   test.each([
     ['foreground-created-first', ['foreground-child', 'background-child']],
     ['background-created-first', ['background-child', 'foreground-child']],
-  ])('ambiguous early created events never supervise the foreground child (%s)', async (_, createdOrder) => {
-    const board = new BackgroundJobBoard();
-    const clock = createSupervisorClock();
-    const abort = mock(async () => undefined);
-    const supervisor = new BackgroundJobSupervisor({
-      backgroundJobStore: board,
-      wallClockTimeoutMs: 100,
-      abortGraceMs: 10,
-      abort,
-      now: clock.now,
-      setTimeout: clock.setTimeout,
-      clearTimeout: clock.clearTimeout,
-    });
-    const { hook } = createHook({
-      backgroundJobBoard: board,
-      backgroundJobSupervisor: supervisor,
-    });
-
-    await hook['tool.execute.before'](
-      { tool: 'task', sessionID: 'parent-1', callID: 'background-call' },
-      {
-        args: {
-          subagent_type: 'explorer',
-          background: true,
-          description: 'background child',
-        },
-      },
-    );
-    await hook['tool.execute.before'](
-      { tool: 'task', sessionID: 'parent-1', callID: 'foreground-call' },
-      {
-        args: {
-          subagent_type: 'explorer',
-          background: false,
-          description: 'foreground child',
-        },
-      },
-    );
-
-    for (const taskID of createdOrder) {
-      await hook.event({
-        event: {
-          type: 'session.created',
-          properties: { info: { id: taskID, parentID: 'parent-1' } },
-        },
+  ])(
+    'ambiguous early created events never supervise the foreground child (%s)',
+    async (_, createdOrder) => {
+      const board = new BackgroundJobBoard();
+      const clock = createSupervisorClock();
+      const abort = mock(async () => undefined);
+      const supervisor = new BackgroundJobSupervisor({
+        backgroundJobStore: board,
+        wallClockTimeoutMs: 100,
+        abortGraceMs: 10,
+        abort,
+        now: clock.now,
+        setTimeout: clock.setTimeout,
+        clearTimeout: clock.clearTimeout,
       });
-    }
+      const { hook } = createHook({
+        backgroundJobBoard: board,
+        backgroundJobSupervisor: supervisor,
+      });
 
-    expect(board.get('background-child')?.background).toBe(false);
-    expect(board.get('foreground-child')?.background).toBe(false);
-    expect(abort).not.toHaveBeenCalled();
+      await hook['tool.execute.before'](
+        { tool: 'task', sessionID: 'parent-1', callID: 'background-call' },
+        {
+          args: {
+            subagent_type: 'explorer',
+            background: true,
+            description: 'background child',
+          },
+        },
+      );
+      await hook['tool.execute.before'](
+        { tool: 'task', sessionID: 'parent-1', callID: 'foreground-call' },
+        {
+          args: {
+            subagent_type: 'explorer',
+            background: false,
+            description: 'foreground child',
+          },
+        },
+      );
 
-    await hook['tool.execute.after'](
-      { tool: 'task', sessionID: 'parent-1', callID: 'foreground-call' },
-      { output: taskLaunchOutput('foreground-child') },
-    );
-    await hook['tool.execute.after'](
-      { tool: 'task', sessionID: 'parent-1', callID: 'background-call' },
-      { output: taskLaunchOutput('background-child') },
-    );
+      for (const taskID of createdOrder) {
+        await hook.event({
+          event: {
+            type: 'session.created',
+            properties: { info: { id: taskID, parentID: 'parent-1' } },
+          },
+        });
+      }
 
-    expect(board.get('foreground-child')?.background).toBe(false);
-    expect(board.get('background-child')?.background).toBe(true);
-    const backgroundJob = board.get('background-child');
-    expect(backgroundJob).toBeDefined();
-    const deadline = (backgroundJob?.runStartedAt ?? 0) + 100;
-    await clock.advanceTo(deadline);
+      expect(board.get('background-child')?.background).toBe(false);
+      expect(board.get('foreground-child')?.background).toBe(false);
+      expect(abort).not.toHaveBeenCalled();
 
-    expect(abort).toHaveBeenCalledTimes(1);
-    expect(abort).toHaveBeenCalledWith('background-child');
-  });
+      await hook['tool.execute.after'](
+        { tool: 'task', sessionID: 'parent-1', callID: 'foreground-call' },
+        { output: taskLaunchOutput('foreground-child') },
+      );
+      await hook['tool.execute.after'](
+        { tool: 'task', sessionID: 'parent-1', callID: 'background-call' },
+        { output: taskLaunchOutput('background-child') },
+      );
+
+      expect(board.get('foreground-child')?.background).toBe(false);
+      expect(board.get('background-child')?.background).toBe(true);
+      const backgroundJob = board.get('background-child');
+      expect(backgroundJob).toBeDefined();
+      const deadline = (backgroundJob?.runStartedAt ?? 0) + 100;
+      await clock.advanceTo(deadline);
+
+      expect(abort).toHaveBeenCalledTimes(1);
+      expect(abort).toHaveBeenCalledWith('background-child');
+    },
+  );
 
   test('missing after-hook callID fails closed while an exact background call remains', async () => {
     const board = new BackgroundJobBoard();

--- a/src/hooks/task-session-manager/tool-execute-hooks.ts
+++ b/src/hooks/task-session-manager/tool-execute-hooks.ts
@@ -18,12 +18,11 @@ import {
 } from '../../utils';
 import { isRecord as isObjectRecord } from '../../utils/guards';
 import { log } from '../../utils/logger';
+import { SESSION_ID_PATTERN } from '../../utils/session';
 import { isMissingRememberedSessionError } from './board-injection';
 import type { PendingTaskCall } from './pending-call-tracker';
 import { normalizeLateCancelledTaskOutput } from './status-utils';
 import { extractReadFiles } from './task-context-tracker';
-
-const RAW_SESSION_ID_PATTERN = /^ses_[A-Za-z0-9_-]+$/;
 
 interface TaskArgs {
   description?: unknown;
@@ -122,7 +121,7 @@ export async function handleToolExecuteBefore(
 
       if (knownManagedTask) {
         delete args.task_id;
-      } else if (RAW_SESSION_ID_PATTERN.test(requested)) {
+      } else if (SESSION_ID_PATTERN.test(requested)) {
         pendingCall.resumedTaskId = requested;
       } else {
         delete args.task_id;

--- a/src/tools/cancel-task.ts
+++ b/src/tools/cancel-task.ts
@@ -7,7 +7,12 @@ import type { BackgroundJobStore } from '../utils/background-job-store';
 import { isRecord as isObjectRecord } from '../utils/guards';
 import { log } from '../utils/logger';
 import { getClient } from '../utils/opencode-client';
-import { abortSessionWithTimeout, withTimeout } from '../utils/session';
+import { delay } from '../utils/polling';
+import {
+  abortSessionWithTimeout,
+  SESSION_ID_PATTERN,
+  withTimeout,
+} from '../utils/session';
 
 const z = tool.schema;
 
@@ -74,7 +79,7 @@ Use only for obsolete, wrong, conflicting, or user-requested cancellation. Accep
         cancellationRequested: job?.cancellationRequested,
       });
       if (!job) {
-        if (isSessionID(requested)) {
+        if (SESSION_ID_PATTERN.test(requested)) {
           if (requested === parentSessionID) {
             log('[cancel-task] rejected parent session cancellation', {
               parentSessionID,
@@ -359,14 +364,6 @@ async function getSessionStatus(
     });
     return { status: undefined, source: 'lookup-error', keys: [] };
   }
-}
-
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function isSessionID(value: string): boolean {
-  return /^ses_[\w-]+$/.test(value);
 }
 
 function normalizeCancelReason(reason?: string): string {

--- a/src/utils/agent-variant.ts
+++ b/src/utils/agent-variant.ts
@@ -63,7 +63,7 @@ export function resolveRuntimeAgentName(
   return normalized;
 }
 
-function escapeRegExp(value: string): string {
+export function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 

--- a/src/utils/background-job-supervisor.test.ts
+++ b/src/utils/background-job-supervisor.test.ts
@@ -134,29 +134,32 @@ describe('BackgroundJobSupervisor', () => {
     ['resolve', async () => undefined],
     ['reject', async () => Promise.reject(new Error('abort failed'))],
     ['hang', () => new Promise<never>(() => {})],
-  ])('abort %s is requested once and grace remains independent', async (_, abortCall) => {
-    const { board, supervisor, timers, abort } = createSupervisor({
-      abort: abortCall,
-    });
-    const job = launch(board, true);
-    supervisor.onLaunch(job);
-    await timers.advanceTo(100);
-    await timers.advanceTo(119);
+  ])(
+    'abort %s is requested once and grace remains independent',
+    async (_, abortCall) => {
+      const { board, supervisor, timers, abort } = createSupervisor({
+        abort: abortCall,
+      });
+      const job = launch(board, true);
+      supervisor.onLaunch(job);
+      await timers.advanceTo(100);
+      await timers.advanceTo(119);
 
-    expect(abort).toHaveBeenCalledTimes(1);
-    expect(board.get(job.taskID)?.state).toBe('running');
-    await timers.advanceTo(120);
+      expect(abort).toHaveBeenCalledTimes(1);
+      expect(board.get(job.taskID)?.state).toBe('running');
+      await timers.advanceTo(120);
 
-    expect(board.get(job.taskID)).toMatchObject({
-      state: 'error',
-      timedOut: true,
-      statusUncertain: true,
-      cancellationRequested: true,
-    });
-    expect(board.getResultSummary(job.taskID)).toContain(
-      'abort was not confirmed',
-    );
-  });
+      expect(board.get(job.taskID)).toMatchObject({
+        state: 'error',
+        timedOut: true,
+        statusUncertain: true,
+        cancellationRequested: true,
+      });
+      expect(board.getResultSummary(job.taskID)).toContain(
+        'abort was not confirmed',
+      );
+    },
+  );
 
   test('completion after the deadline claim cannot replace the timeout', async () => {
     const { board, coordinator, supervisor, timers, abort } =

--- a/src/utils/env.test.ts
+++ b/src/utils/env.test.ts
@@ -10,17 +10,12 @@ describe('isTruthyEnvValue', () => {
     expect(isTruthyEnvValue(value)).toBe(true);
   });
 
-  test.each([
-    undefined,
-    '',
-    '0',
-    'false',
-    'no',
-    'off',
-    'anything',
-  ])('%p is not truthy', (value) => {
-    expect(isTruthyEnvValue(value)).toBe(false);
-  });
+  test.each([undefined, '', '0', 'false', 'no', 'off', 'anything'])(
+    '%p is not truthy',
+    (value) => {
+      expect(isTruthyEnvValue(value)).toBe(false);
+    },
+  );
 });
 
 describe('isPluginDisabledByEnv', () => {

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -7,6 +7,8 @@ import { log } from './logger';
 
 export const SESSION_ABORT_TIMEOUT_MS = 1_000;
 
+export const SESSION_ID_PATTERN = /^ses_[A-Za-z0-9_-]+$/;
+
 export class OperationTimeoutError extends Error {
   constructor(message: string) {
     super(message);


### PR DESCRIPTION
## Summary

Deduplicate byte-identical helper implementations. Zero behavior change. `bun run lint`, `bun run check:ci`, `bun run typecheck`, `bun test` (1852 pass), and `bun run build` all pass.

## What was deduplicated (7 files)

1. **`delay`** — `src/tools/cancel-task.ts` previously defined its own `new Promise((r) => setTimeout(r, ms))`; now imports the exported `delay` from `src/utils/polling.ts` (cancel-task already imports from `../utils`).
2. **`escapeRegExp`** — `src/agents/index.ts` had a byte-identical copy of `src/utils/agent-variant.ts:66`; now imports the shared export, local copy deleted.
3. **`getErrorMessage`** — `src/companion/updater.ts` local `formatError` (identical `err instanceof Error ? err.message : String(err)`) replaced by the exported `getErrorMessage` from `src/hooks/apply-patch/errors.ts`.
4. **`normalizeAgentName`** — `src/agents/index.ts` local `normalizeDisplayName` (identical trim + strip leading `@`) replaced by the exported `normalizeAgentName` from `src/utils/agent-variant.ts`; ~5 call sites renamed, codemap synced.
5. **Session-ID regex** — `src/tools/cancel-task.ts` `isSessionID` (`/^ses_[\w-]+$/`) and `src/hooks/task-session-manager/tool-execute-hooks.ts` `RAW_SESSION_ID_PATTERN` (`/^ses_[A-Za-z0-9_-]+$/`) were equivalent (`\w == [A-Za-z0-9_]`); consolidated into one exported `SESSION_ID_PATTERN` const in `src/utils/session.ts`.

Net: 34 lines deleted, 21 added across 7 files.

## Note on the second commit

`style: fix pre-existing biome format drift in test files` — 5 files (`cache-safety.property.test.ts`, `task-session-manager/index.test.ts`, `background-job-supervisor.test.ts`, `env.test.ts`, and `board-injection.ts`). These files already fail `bun run check:ci` on clean upstream `master` (`593547c`); upstream CI does not run the format check (it runs `bun run lint`), so this drift predates this PR. I applied the formatting so `check:ci` is green locally, matching the existing `6eb3cff style: fix pre-existing biome format drift in two test files` precedent. No test behavior changed (1852 pass).

## Deliberate exclusions

- `isRecord`: needs a strict shared variant, deferred.
- `slugify`: deferred until the loop-session fate is decided.