### PR TITLE
fix(foreground-fallback): detect cannot-connect transport errors

### DIFF
--- a/src/hooks/foreground-fallback/index.test.ts
+++ b/src/hooks/foreground-fallback/index.test.ts
@@ -229,6 +229,18 @@ describe('isFailoverError', () => {
     ).toBe(true);
   });
 
+  test('returns true for "cannot connect to API" transport errors', () => {
+    expect(isRetryableError('Cannot connect to API')).toBe(true);
+    expect(isRetryableError('stream error: Cannot connect to API')).toBe(true);
+    expect(
+      isRetryableError({ message: 'stream error: Cannot connect to API' }),
+    ).toBe(true);
+  });
+
+  test('returns false for non-API connection errors', () => {
+    expect(isRetryableError('Cannot connect to database')).toBe(false);
+  });
+
   test('returns false for permanent channel-not-found errors', () => {
     expect(
       isRetryableError({
@@ -370,6 +382,41 @@ describe('ForegroundFallbackManager session.error', () => {
         error: {
           message:
             'auth_unavailable: no auth available (providers=cli-proxy-api, model=gemini-3.6-flash)',
+        },
+      },
+    });
+
+    expect(mocks.abort).not.toHaveBeenCalled();
+    expect(mocks.promptAsync).toHaveBeenCalledTimes(1);
+
+    const call = mocks.promptAsync.mock.calls[0] as [
+      {
+        model: { providerID: string; modelID: string };
+      },
+    ];
+    expect(call[0].model.providerID).toBe('openai');
+    expect(call[0].model.modelID).toBe('gpt-4o');
+  });
+
+  test('triggers fallback on cannot-connect session.error', async () => {
+    await mgr.handleEvent({
+      type: 'message.updated',
+      properties: {
+        info: {
+          sessionID: 'sess-1',
+          providerID: 'anthropic',
+          modelID: 'claude-opus-4-5',
+          role: 'assistant',
+        },
+      },
+    });
+
+    await mgr.handleEvent({
+      type: 'session.error',
+      properties: {
+        sessionID: 'sess-1',
+        error: {
+          message: 'stream error: Cannot connect to API',
         },
       },
     });

--- a/src/hooks/foreground-fallback/index.ts
+++ b/src/hooks/foreground-fallback/index.ts
@@ -78,6 +78,10 @@ const TRANSPORT_MESSAGE_PATTERNS = [
   /^request timeout$/i,
   /^connect ECONNREFUSED\b/i,
   /^getaddrinfo ENOTFOUND\b/i,
+  // Provider SDKs also report connection failures with natural-language
+  // messages (e.g. "stream error: Cannot connect to API") that carry no
+  // transport code. Match the narrow phrase only.
+  /cannot connect to api/i,
 ];
 const PROVIDER_OUTAGE_PATTERNS = [
   /\binternal server error\b/i,


### PR DESCRIPTION
## What problem are you solving?

Provider SDKs report connection failures with natural-language messages such as `stream error: Cannot connect to API` that carry no transport code. The `TRANSPORT_MESSAGE_PATTERNS` classifier only matches anchored transport phrases (`connect ECONNREFUSED`, `fetch failed`, ...), so these errors are not recognized as failover-worthy and the session retries the dead provider instead of advancing to the next model in the fallback chain.

## What does this change?

- Add a narrow `cannot connect to api` pattern to `TRANSPORT_MESSAGE_PATTERNS`.
- Cover the plain string and `{ message }` error shapes with the `stream error:` prefix.
- Preserve non-API connection errors (`Cannot connect to database`) as non-retryable.
- Add a manager-level regression test showing `session.error` advances to the next configured fallback model.

## Why this approach?

The pattern is deliberately limited to the API connection phrase so unrelated connection errors (database, etc.) are not treated as fallback candidates. The existing anchored transport patterns and the rest of the classifier remain unchanged.

## Verification

- [x] `bun test src/hooks/foreground-fallback/index.test.ts` — 70 pass, 0 fail
- [x] `bun x biome check src/hooks/foreground-fallback/index.ts src/hooks/foreground-fallback/index.test.ts`
- [x] `bun run typecheck`

> Related: issue #956 reports background subagent sessions never advancing on the same error family (`stream error: Cannot connect to API`). This PR fixes the shared error-classification gap; whether it fully resolves #956 depends on the separate background event-delivery path.