### PR TITLE
fix(foreground-fallback): replay v2 user messages and detect quota-threshold errors

### DIFF
--- a/src/hooks/foreground-fallback/index.test.ts
+++ b/src/hooks/foreground-fallback/index.test.ts
@@ -121,6 +121,20 @@ describe('isFailoverError', () => {
     );
   });
 
+  test('returns true for codex quota-threshold errors', () => {
+    expect(
+      isFailoverError({
+        message:
+          'AI_APICallError: [codex/gpt-5.6-sol-medium] All codex accounts reached configured quota threshold (reset after 20h 41m 59s)',
+      }),
+    ).toBe(true);
+    expect(
+      isFailoverError(
+        'AI_APICallError: [codex/gpt-5.6-sol-medium] All codex accounts reached configured quota threshold (reset after 20h 41m 59s)',
+      ),
+    ).toBe(true);
+  });
+
   test('returns true for "usage exceeded"', () => {
     expect(isRetryableError({ message: 'usage exceeded' })).toBe(true);
   });
@@ -502,6 +516,93 @@ describe('ForegroundFallbackManager session.error', () => {
       { parts: Array<{ text?: string }> },
     ];
     expect(call[0].parts[0]?.text).toBe('real prompt');
+  });
+
+  test('replays the last user message from v2-shaped session.messages data', async () => {
+    // OpenCode 1.18+ session.messages() returns v2 SessionMessage objects
+    // ({ type, text }) instead of the v1 { info, parts } shape. The fallback
+    // must locate and re-submit the v2 user text even when an assistant
+    // message appears after it.
+    ({ mocks } = createMockClient({
+      messagesData: [
+        { id: 'm1', type: 'user', text: 'v2 prompt' },
+        {
+          id: 'm2',
+          type: 'assistant',
+          parts: [{ type: 'text', text: 'reply' }],
+        },
+      ],
+    }));
+    mgr = new ForegroundFallbackManager(makeChains(), true, {
+      directory: '/test',
+    } as any);
+
+    await mgr.handleEvent({
+      type: 'message.updated',
+      properties: {
+        info: {
+          sessionID: 'sess-1',
+          providerID: 'anthropic',
+          modelID: 'claude-opus-4-5',
+          role: 'assistant',
+        },
+      },
+    });
+
+    await mgr.handleEvent({
+      type: 'session.error',
+      properties: {
+        sessionID: 'sess-1',
+        error: { message: 'Rate limit exceeded' },
+      },
+    });
+
+    expect(mocks.promptAsync).toHaveBeenCalledTimes(1);
+    const call = mocks.promptAsync.mock.calls[0] as [
+      { parts: Array<{ text?: string }> },
+    ];
+    expect(call[0].parts[0]?.text).toBe('v2 prompt');
+  });
+
+  test('prefers the latest user message across mixed v1/v2 shapes', async () => {
+    ({ mocks } = createMockClient({
+      messagesData: [
+        {
+          info: { role: 'user' },
+          parts: [{ type: 'text', text: 'legacy prompt' }],
+        },
+        { id: 'm2', type: 'user', text: 'v2 prompt' },
+      ],
+    }));
+    mgr = new ForegroundFallbackManager(makeChains(), true, {
+      directory: '/test',
+    } as any);
+
+    await mgr.handleEvent({
+      type: 'message.updated',
+      properties: {
+        info: {
+          sessionID: 'sess-1',
+          providerID: 'anthropic',
+          modelID: 'claude-opus-4-5',
+          role: 'assistant',
+        },
+      },
+    });
+
+    await mgr.handleEvent({
+      type: 'session.error',
+      properties: {
+        sessionID: 'sess-1',
+        error: { message: 'Rate limit exceeded' },
+      },
+    });
+
+    expect(mocks.promptAsync).toHaveBeenCalledTimes(1);
+    const call = mocks.promptAsync.mock.calls[0] as [
+      { parts: Array<{ text?: string }> },
+    ];
+    expect(call[0].parts[0]?.text).toBe('v2 prompt');
   });
 
   test('does nothing when error is not a rate limit', async () => {

--- a/src/hooks/foreground-fallback/index.ts
+++ b/src/hooks/foreground-fallback/index.ts
@@ -26,7 +26,7 @@ import {
   parseModelReference,
 } from '../../utils/session';
 import type { SessionLifecycle } from '../session-lifecycle';
-import { isUserMessageWithParts } from '../types';
+import { isReplayableUserMessage, partsFromReplayMessage } from '../types';
 
 // ---------------------------------------------------------------------------
 // Retryable error detection
@@ -37,6 +37,7 @@ const RETRYABLE_ERROR_PATTERNS = [
   /rate.?limit/i,
   /too many requests/i,
   /quota.?exceeded/i,
+  /quota.?threshold/i,
   /usage.?exceeded/i,
   /ExceededBudget/i,
   /over.?budget/i,
@@ -624,12 +625,17 @@ export class ForegroundFallbackManager {
         sessionID,
       });
       // result.data may contain partial/streaming messages whose `info` is
-      // undefined at runtime (OpenCode violates its own declared type), so
-      // guard each entry instead of dereferencing `info` directly.
+      // undefined at runtime (OpenCode violates its own declared type), and
+      // v2 messages carry `type`/`text` instead of `info`/`parts`, so guard
+      // each entry instead of dereferencing a fixed shape.
       const messages = (result.data ?? []) as unknown[];
-      const lastUser = [...messages].reverse().find(isUserMessageWithParts);
+      const lastUser = [...messages].reverse().find(isReplayableUserMessage);
       if (!lastUser) {
-        log('[foreground-fallback] no user message found', { sessionID });
+        log('[foreground-fallback] no user message found', {
+          sessionID,
+          messageCount: messages.length,
+          requestError: result.error ?? undefined,
+        });
         return;
       }
 
@@ -641,12 +647,18 @@ export class ForegroundFallbackManager {
         return;
       }
 
+      const replayParts = partsFromReplayMessage(lastUser) as Array<{
+        type: 'text';
+        text: string;
+      }>;
+
       const promptBody = {
-        // ponytail: lastUser.parts are MessagePart[] from API, but v2
-        // promptAsync expects TextPartInput[] — runtime-compatible, TS
-        // doesn't know the `type` field is already 'text'.
+        // ponytail: replayed parts are MessagePart[] from the transform API
+        // or a synthesized v2 text part, but promptAsync expects
+        // TextPartInput[] — runtime-compatible, TS doesn't know the `type`
+        // field is already 'text'.
         parts: [
-          ...(lastUser.parts as Array<{ type: 'text'; text: string }>),
+          ...replayParts,
           createInternalAgentTextPart('Foreground fallback replay.'),
         ],
         model: ref,

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -58,3 +58,43 @@ export function findLatestUserMessage(
   }
   return undefined;
 }
+
+/**
+ * A user message that can be replayed into a fallback prompt.
+ *
+ * Accepts both the v1 transform shape (`{ info: { role: 'user' }, parts }`)
+ * and the v2 `session.messages()` shape (`{ type: 'user', text }`) returned
+ * by the plugin SDK's HTTP API since OpenCode 1.18.
+ */
+export type ReplayableUserMessage =
+  | MessageWithParts
+  | {
+      type: 'user';
+      text?: string;
+    };
+
+export function isReplayableUserMessage(
+  message: unknown,
+): message is ReplayableUserMessage {
+  if (isUserMessageWithParts(message)) {
+    return true;
+  }
+  if (!message || typeof message !== 'object') {
+    return false;
+  }
+  const candidate = message as { type?: unknown };
+  return candidate.type === 'user';
+}
+
+export function partsFromReplayMessage(
+  message: ReplayableUserMessage,
+): MessagePart[] {
+  const parts = (message as Partial<MessageWithParts>).parts;
+  if (Array.isArray(parts)) {
+    return parts;
+  }
+  const text = (message as { text?: string }).text;
+  return typeof text === 'string' && text.length > 0
+    ? [{ type: 'text', text }]
+    : [];
+}


### PR DESCRIPTION
## What changed, and why was it needed?

Fixes the plugin-side root cause of #954: foreground fallback never switches models because replay of the last user message always fails.

### Bug 1 — `no user message found` on every fallback (closes #954)

`execFallback` located the last user message with `isUserMessageWithParts`, which requires the v1 shape `{ info: { role: 'user' }, parts }`. Since OpenCode 1.18 the plugin SDK's `session.messages()` returns v2 `SessionMessage` objects (`{ type: 'user', text, time, id }` — verified in `@opencode-ai/sdk@1.18.13` `SessionMessageUser`), so the finder never matched and replay aborted with `no user message found` every time. This is why the reporter saw 20+ identical failures over ~25 minutes against a long-persisted message — the fetch succeeded, but the shape never matched.

- Add `isReplayableUserMessage` / `partsFromReplayMessage` in `src/hooks/types.ts` accepting both the v1 transform shape and the v2 `session.messages()` shape.
- Use them in `execFallback`; v2 user text is replayed as a `text` part alongside the existing internal-initiator marker.
- When no replayable message exists, log `messageCount` and `requestError` (from `result.error`) so a failed request is no longer conflated with an empty session (per the request in #954).

### Bug 2 — codex quota-threshold errors never trigger fallback

The codex provider reports quota exhaustion as `All codex accounts reached configured quota threshold (reset after 20h ...)`. That matched no `RETRYABLE_ERROR_PATTERNS` entry, so the chain was never consulted and the same dead model was retried. Add `/quota.?threshold/i` to the pattern list.

Note on #966: the quota-exhaustion *infinite re-fallback loop* reported there is a separate defect in the chain-exhaustion path (sticky re-prompt without a limit), not in error classification. Falling back to the next model when one model's quota is exhausted is the desired behavior; #966's fix belongs in the reset/re-prompt branch.

## Verification

- `bun run typecheck` — passes
- `bun run check:ci` — passes (only a pre-existing biome-config-migration info)
- `bun test src/hooks/foreground-fallback/index.test.ts` — 73/73 pass, including 3 new tests:
  - `returns true for codex quota-threshold errors`
  - `replays the last user message from v2-shaped session.messages data`
  - `prefers the latest user message across mixed v1/v2 shapes`
- Full suite: 1598 pass / 78 fail — identical failure set to the pristine base commit (pre-existing Windows/platform-specific failures in multiplexer/snapshot tests, verified via `git stash` comparison), so this change adds 3 passing tests and zero new failures.
