### PR TITLE
fix(smartfetch): resolve secondary models from in-memory config, drop per-call disk reads

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -66,6 +66,7 @@ import {
   createWaitForUserTool,
   createWebfetchTool,
 } from './tools';
+import { pickAgentModelRef } from './tools/smartfetch/secondary-model';
 import { recordTuiAgentModel, recordTuiAgentModels } from './tui-state';
 import {
   BackgroundJobBoard,
@@ -185,6 +186,7 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
   let waitForUserTools: ReturnType<typeof createWaitForUserTool>;
   let acpRunTools: Record<string, ReturnType<typeof createAcpRunTool>>;
   let webfetch: ReturnType<typeof createWebfetchTool>;
+  let hostSmallModel: string | undefined;
   let tools: Record<string, ToolDefinition>;
   let rewriteDisplayNameMentions: ReturnType<
     typeof createDisplayNameMentionRewriter
@@ -288,6 +290,9 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
     webfetch = createWebfetchTool(ctx, {
       binaryDir: undefined,
       webfetchModels,
+      smallModelRef: () => hostSmallModel,
+      explorerModel: pickAgentModelRef(config.agents?.explorer?.model),
+      librarianModel: pickAgentModelRef(config.agents?.librarian?.model),
     });
     backgroundJobBoard = new BackgroundJobBoard({
       maxReusablePerAgent:
@@ -607,6 +612,15 @@ const OhMyOpenCodeLite: Plugin = async (ctx) => {
     mcp: mcps,
 
     config: async (opencodeConfig: Record<string, unknown>) => {
+      // Capture `small_model` from the host's already-loaded merged OpenCode
+      // config. This is the only config-file read for webfetch's secondary
+      // model resolution: the host parsed opencode.json before invoking this
+      // hook, so per-call resolution stays disk-free.
+      const rawSmallModel = (opencodeConfig as { small_model?: unknown })
+        .small_model;
+      hostSmallModel =
+        typeof rawSmallModel === 'string' ? rawSmallModel : undefined;
+
       // Force default_agent to 'orchestrator' when unset, and also when the
       // user pointed it at an omos subagent name (opencode rejects subagent
       // names as default_agent with "default agent must be a primary agent").

--- a/src/tools/smartfetch/config-read-guard.test.ts
+++ b/src/tools/smartfetch/config-read-guard.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+// Guards the invariant: after initial plugin load, config must come only from
+// the in-memory map, never re-read from disk. webfetch's secondary-model
+// resolution is the hot path (every fetch call), so this tripwire pins the
+// smartfetch source files to be config-disk-free. Any future change that
+// re-introduces a config-file read here must be an explicit, reviewed
+// decision — and needs a test that proves it is not on the per-call path.
+const SRC_ROOT = path.join(import.meta.dir, '..', '..', '..');
+
+const GUARDED_FILES = [
+  'src/tools/smartfetch/secondary-model.ts',
+  'src/tools/smartfetch/tool.ts',
+];
+
+// Any match here means the file can read config files (or the plugin-config
+// loader) from disk. Importing the loader itself is banned: secondary-model
+// resolution must consume values already captured in memory at construction.
+const FORBIDDEN_PATTERNS: Array<{ name: string; regex: RegExp }> = [
+  { name: 'node:fs', regex: /from 'node:fs['/]/ },
+  { name: 'node:fs/promises', regex: /from 'node:fs\/promises'/ },
+  { name: 'loadPluginConfig', regex: /loadPluginConfig/ },
+  { name: 'config/loader', regex: /config\/loader/ },
+  { name: 'cli/config-io', regex: /cli\/config-io/ },
+  { name: 'cli/paths', regex: /cli\/paths/ },
+  { name: 'getExistingConfigPath', regex: /getExistingConfigPath/ },
+];
+
+describe('smartfetch config re-read guard', () => {
+  test('secondary-model source stays config-disk-free', () => {
+    for (const file of GUARDED_FILES) {
+      const content = readFileSync(path.join(SRC_ROOT, file), 'utf8');
+      for (const { name, regex } of FORBIDDEN_PATTERNS) {
+        expect(
+          content.match(regex),
+          `${file} must not import ${name} (config would be re-read from disk on every webfetch call)`,
+        ).toBeNull();
+      }
+    }
+  });
+});

--- a/src/tools/smartfetch/secondary-model-resolution.test.ts
+++ b/src/tools/smartfetch/secondary-model-resolution.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from 'bun:test';
+import { pickAgentModelRef, resolveSecondaryModels } from './secondary-model';
+
+describe('smartfetch/resolveSecondaryModels', () => {
+  test('dedicated webfetch models take highest priority, in order', () => {
+    const models = resolveSecondaryModels({
+      webfetchModels: [
+        { id: 'openai/gpt-4o-mini' },
+        { id: 'anthropic/claude-haiku', variant: 'cheap' },
+      ],
+      smallModel: 'openai/gpt-4o-mini',
+      explorerModel: 'openai/gpt-4o-mini',
+    });
+
+    expect(models).toEqual([
+      { providerID: 'openai', modelID: 'gpt-4o-mini' },
+      {
+        providerID: 'anthropic',
+        modelID: 'claude-haiku',
+        variant: 'cheap',
+      },
+    ]);
+  });
+
+  test('falls back to smallModel then agent models in priority order', () => {
+    const models = resolveSecondaryModels({
+      smallModel: 'openai/gpt-4o-mini',
+      explorerModel: 'anthropic/claude-haiku',
+      librarianModel: 'google/gemini-flash',
+    });
+
+    expect(models).toEqual([
+      { providerID: 'openai', modelID: 'gpt-4o-mini' },
+      { providerID: 'anthropic', modelID: 'claude-haiku' },
+      { providerID: 'google', modelID: 'gemini-flash' },
+    ]);
+  });
+
+  test('deduplicates identical provider/model across sources', () => {
+    const models = resolveSecondaryModels({
+      webfetchModels: [{ id: 'openai/gpt-4o-mini' }],
+      smallModel: 'openai/gpt-4o-mini',
+      explorerModel: 'openai/gpt-4o-mini',
+      librarianModel: 'openai/gpt-4o-mini',
+    });
+
+    expect(models).toEqual([{ providerID: 'openai', modelID: 'gpt-4o-mini' }]);
+  });
+
+  test('skips malformed model references', () => {
+    const models = resolveSecondaryModels({
+      webfetchModels: [
+        { id: 'openai/gpt-4o-mini' },
+        { id: 'no-slash' },
+        { id: '/missing-provider' },
+        { id: '' },
+      ],
+      smallModel: 'no-slash',
+      explorerModel: '/missing-provider',
+    });
+
+    expect(models).toEqual([{ providerID: 'openai', modelID: 'gpt-4o-mini' }]);
+  });
+
+  test('returns an empty list when nothing is configured', () => {
+    expect(resolveSecondaryModels({})).toEqual([]);
+    expect(resolveSecondaryModels()).toEqual([]);
+  });
+
+  test('variant distinguishes dedupe keys (parity with prior behavior)', () => {
+    const models = resolveSecondaryModels({
+      webfetchModels: [{ id: 'openai/gpt-4o-mini', variant: 'fast' }],
+      smallModel: 'openai/gpt-4o-mini',
+    });
+
+    // The dedupe key includes the variant, so the variant-tagged dedicated
+    // entry and the plain small_model ref are kept as separate candidates.
+    expect(models).toEqual([
+      {
+        providerID: 'openai',
+        modelID: 'gpt-4o-mini',
+        variant: 'fast',
+      },
+      { providerID: 'openai', modelID: 'gpt-4o-mini' },
+    ]);
+  });
+});
+
+describe('smartfetch/pickAgentModelRef', () => {
+  test('resolves a bare string', () => {
+    expect(pickAgentModelRef('openai/gpt-4o-mini')).toBe('openai/gpt-4o-mini');
+  });
+
+  test('resolves the first usable entry in an array', () => {
+    expect(
+      pickAgentModelRef([
+        { id: 'openai/gpt-4o-mini', variant: 'fast' },
+        'anthropic/claude-haiku',
+      ]),
+    ).toBe('openai/gpt-4o-mini');
+    expect(pickAgentModelRef(['anthropic/claude-haiku'])).toBe(
+      'anthropic/claude-haiku',
+    );
+  });
+
+  test('returns undefined for non-model values', () => {
+    expect(pickAgentModelRef(undefined)).toBeUndefined();
+    expect(pickAgentModelRef(null)).toBeUndefined();
+    expect(pickAgentModelRef(42)).toBeUndefined();
+  });
+});

--- a/src/tools/smartfetch/secondary-model.ts
+++ b/src/tools/smartfetch/secondary-model.ts
@@ -1,13 +1,18 @@
-import { existsSync } from 'node:fs';
-import { readFile } from 'node:fs/promises';
-import path from 'node:path';
 import type { PluginInput } from '@opencode-ai/plugin';
-import { stripJsonComments } from '../../cli/config-io';
-import { getConfigSearchDirs } from '../../cli/paths';
-import { loadPluginConfig } from '../../config/loader';
 import { getClient } from '../../utils/opencode-client';
 import { MAX_MODEL_CONTENT_CHARS } from './constants';
 import type { CachedFetch, SecondaryModel } from './types';
+
+export interface SecondaryModelResolutionInput {
+  /** Dedicated webfetch model(s) from the plugin config (highest priority). */
+  webfetchModels?: Array<{ id: string; variant?: string }>;
+  /** `small_model` from the host's already-loaded merged OpenCode config. */
+  smallModel?: string;
+  /** Explorer agent model id, resolved from in-memory config at construction. */
+  explorerModel?: string;
+  /** Librarian agent model id, resolved from in-memory config at construction. */
+  librarianModel?: string;
+}
 
 function parseModelRef(value: string | undefined) {
   if (!value) return undefined;
@@ -17,7 +22,7 @@ function parseModelRef(value: string | undefined) {
   return { providerID, modelID };
 }
 
-function pickAgentModelRef(value: unknown): string | undefined {
+export function pickAgentModelRef(value: unknown): string | undefined {
   if (typeof value === 'string') return value;
   if (Array.isArray(value)) {
     for (const entry of value) {
@@ -35,95 +40,49 @@ function pickAgentModelRef(value: unknown): string | undefined {
   return undefined;
 }
 
-function findPreferredOpenCodeConfigPath(baseDir: string) {
-  for (const file of ['opencode.jsonc', 'opencode.json']) {
-    const fullPath = path.join(baseDir, file);
-    if (existsSync(fullPath)) return fullPath;
-  }
-  return undefined;
-}
-
-async function readOpenCodeConfigFile(configPath: string | undefined) {
-  if (!configPath) return undefined;
-  try {
-    const content = await readFile(configPath, 'utf8');
-    return JSON.parse(stripJsonComments(content)) as {
-      small_model?: unknown;
-    };
-  } catch {
-    return undefined;
-  }
-}
-
-async function readEffectiveOpenCodeConfig(directory: string) {
-  const projectDir = path.join(directory, '.opencode');
-  const userDirs = getConfigSearchDirs();
-  const projectPath = findPreferredOpenCodeConfigPath(projectDir);
-  const userPath = userDirs
-    .map((configDir) => findPreferredOpenCodeConfigPath(configDir))
-    .find(Boolean);
-
-  const userConfig = await readOpenCodeConfigFile(userPath);
-  const projectConfig = await readOpenCodeConfigFile(projectPath);
-
-  return {
-    small_model: projectConfig?.small_model ?? userConfig?.small_model,
+/**
+ * Resolve the secondary-model chain purely from in-memory inputs.
+ *
+ * No filesystem or config-file access: every value is captured once at
+ * plugin construction (`src/index.ts`) from the already-loaded plugin config
+ * and the host's merged OpenCode config. Keeps the webfetch hot path free of
+ * disk reads (see docs/webfetch.md for the resolution order).
+ */
+export function resolveSecondaryModels(
+  input: SecondaryModelResolutionInput = {},
+): SecondaryModel[] {
+  const models: SecondaryModel[] = [];
+  const seen = new Set<string>();
+  const addModel = (model: SecondaryModel) => {
+    const key = `${model.providerID}/${model.modelID}${model.variant ? `#${model.variant}` : ''}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    models.push(model);
   };
-}
 
-export async function readSecondaryModelFromConfig(
-  directory: string,
-  webfetchModels?: Array<{ id: string; variant?: string }>,
-) {
-  try {
-    const models: SecondaryModel[] = [];
-    const seen = new Set<string>();
-    const addModel = (model: SecondaryModel) => {
-      const key = `${model.providerID}/${model.modelID}${model.variant ? `#${model.variant}` : ''}`;
-      if (seen.has(key)) return;
-      seen.add(key);
-      models.push(model);
-    };
-
-    // Dedicated webfetch model(s) take highest priority, in order
-    if (webfetchModels) {
-      for (const ref of webfetchModels) {
-        const parsedModel = parseModelRef(ref.id);
-        if (!parsedModel) continue;
-        addModel({ ...parsedModel, variant: ref.variant });
-      }
+  // Dedicated webfetch model(s) take highest priority, in order
+  if (input.webfetchModels) {
+    for (const ref of input.webfetchModels) {
+      const parsedModel = parseModelRef(ref.id);
+      if (!parsedModel) continue;
+      addModel({ ...parsedModel, variant: ref.variant });
     }
-
-    const opencodeConfig = await readEffectiveOpenCodeConfig(directory);
-    const parsedSmall = parseModelRef(
-      typeof opencodeConfig.small_model === 'string'
-        ? opencodeConfig.small_model
-        : undefined,
-    );
-    if (parsedSmall) addModel(parsedSmall);
-
-    const pluginConfig = loadPluginConfig(directory);
-    const explorerModel = pickAgentModelRef(
-      pluginConfig.agents?.explorer?.model,
-    );
-    const librarianModel = pickAgentModelRef(
-      pluginConfig.agents?.librarian?.model,
-    );
-
-    const parsedExplorer = explorerModel
-      ? parseModelRef(explorerModel)
-      : undefined;
-    if (parsedExplorer) addModel(parsedExplorer);
-
-    const parsedLibrarian = librarianModel
-      ? parseModelRef(librarianModel)
-      : undefined;
-    if (parsedLibrarian) addModel(parsedLibrarian);
-
-    return models;
-  } catch {
-    return [];
   }
+
+  const parsedSmall = parseModelRef(input.smallModel);
+  if (parsedSmall) addModel(parsedSmall);
+
+  const parsedExplorer = input.explorerModel
+    ? parseModelRef(input.explorerModel)
+    : undefined;
+  if (parsedExplorer) addModel(parsedExplorer);
+
+  const parsedLibrarian = input.librarianModel
+    ? parseModelRef(input.librarianModel)
+    : undefined;
+  if (parsedLibrarian) addModel(parsedLibrarian);
+
+  return models;
 }
 
 function buildPrompt(content: string, prompt: string) {

--- a/src/tools/smartfetch/tool.ts
+++ b/src/tools/smartfetch/tool.ts
@@ -41,7 +41,7 @@ import {
 } from './network';
 import {
   decideSecondaryModelUse,
-  readSecondaryModelFromConfig,
+  resolveSecondaryModels,
   runSecondaryModelWithFallback,
 } from './secondary-model';
 import type { RedirectStep, SmartfetchOptions } from './types';
@@ -100,10 +100,12 @@ export function createWebfetchTool(
         ),
     },
     async execute(args, ctx) {
-      const secondaryModels = await readSecondaryModelFromConfig(
-        ctx.directory || pluginCtx.directory,
-        options.webfetchModels,
-      );
+      const secondaryModels = resolveSecondaryModels({
+        webfetchModels: options.webfetchModels,
+        smallModel: options.smallModelRef?.() ?? undefined,
+        explorerModel: options.explorerModel,
+        librarianModel: options.librarianModel,
+      });
       const normalized = normalizeUrl(args.url);
       const url = new URL(normalized.url);
       const cacheKey = buildCacheKey(

--- a/src/tools/smartfetch/types.ts
+++ b/src/tools/smartfetch/types.ts
@@ -12,6 +12,17 @@ export type SmartfetchOptions = {
    * Each entry is tried in order; the first to return usable text is used.
    */
   webfetchModels?: ModelRef[];
+  /**
+   * Getter for the host's `small_model` from the already-loaded merged
+   * OpenCode config. Read once into memory at plugin construction; the
+   * getter only keeps the value in sync when the host config hook fires
+   * after tool construction. Never touches disk.
+   */
+  smallModelRef?: () => string | undefined;
+  /** Explorer agent model id, resolved from in-memory config at construction. */
+  explorerModel?: string;
+  /** Librarian agent model id, resolved from in-memory config at construction. */
+  librarianModel?: string;
 };
 
 export type SecondaryModel = {


### PR DESCRIPTION
## Problem

`readSecondaryModelFromConfig` in `src/tools/smartfetch/secondary-model.ts` ran at the top of **every webfetch execution** (tool.ts:103) and re-read both config surfaces from disk:

- `~/.config/opencode/opencode.json[.c]` + `.opencode/opencode.json` (host `small_model`) via `readEffectiveOpenCodeConfig`
- `oh-my-opencode-slim.json` (explorer/librarian agent models) via a full `loadPluginConfig` round-trip (JSONC + env parse + Zod validation + preset merge)

This violates the plugin invariant that config files are read only at initial load (see [docs/webfetch.md](docs/webfetch.md) "Secondary model fallback chain"): after the closure `config` is built in `src/index.ts`, runtime code must consume the in-memory map only.

## Fix

Resolution inputs are now captured once, in memory:

- **`secondary-model.ts`** — `readSecondaryModelFromConfig` (disk I/O) is replaced by a pure `resolveSecondaryModels(input)` that takes already-parsed values. `pickAgentModelRef` is exported for construction-time use.
- **`index.ts`** — `small_model` is captured from the host's merged `opencodeConfig` inside the `config` hook (the host already parsed `opencode.json` before invoking it) and passed to the tool via `smallModelRef`; explorer/librarian model ids are resolved from the in-memory `config.agents` at construction.
- **`tool.ts`** — the execute path builds the chain from `SmartfetchOptions`; no fs / config-loader imports remain on the hot path.
- **`types.ts`** — `SmartfetchOptions` extended with `smallModelRef`, `explorerModel`, `librarianModel`.

## Verification

- `bun run check:ci`, `bun run typecheck`, `bun run build` all pass.
- `bun test` — 1690 pass / 0 fail (includes cache-safety tripwire suite).
- New `src/tools/smartfetch/config-read-guard.test.ts` pins `secondary-model.ts` and `tool.ts` to be config-disk-free, so a regression that re-introduces per-call config reads fails CI.
- Behavior is unchanged: resolution priority (dedicated webfetch model(s) → `small_model` → explorer → librarian) and dedupe semantics are preserved, including the variant-scoped dedupe key.