### PR TITLE
fix(smartfetch): suppress jsdom css-parsing errors leaking into the TUI

### DIFF
--- a/src/tools/smartfetch/utils.test.ts
+++ b/src/tools/smartfetch/utils.test.ts
@@ -4,6 +4,7 @@ import {
   extractHeadingsFromMarkdown,
   joinRenderedContent,
   withCssTreeWarningsSuppressed,
+  withJsdomCssParsingErrorsSuppressed,
 } from './utils';
 
 // 200 段逗号分隔的 box-shadow 链 —— csstree/csstree#294 的复现案例，
@@ -18,6 +19,13 @@ const CSS_TREE_WARNING_HTML = (() => {
 .range-block__range::-webkit-slider-thumb { box-shadow: ${shadows.join(', ')}; }
 </style></head><body><article><h1>Hello</h1><p>World</p></article></body></html>`;
 })();
+
+// Garbage CSS tokens that jsdom's CSS parser cannot make sense of; verified
+// to emit a "css-parsing" jsdomError ("Could not parse CSS stylesheet"),
+// which leaks to console.error when no custom virtualConsole is supplied.
+const CSS_PARSING_ERROR_HTML = `<!DOCTYPE html><html><head>
+<style>}}} ;;;; @@@</style>
+</head><body><article><h1>Hello</h1><p>World</p></article></body></html>`;
 
 describe('smartfetch/utils', () => {
   test('extracts cleaned headings from markdown', () => {
@@ -90,6 +98,101 @@ describe('smartfetch/utils', () => {
       expect(console.warn).toBe(originalWarn);
     } finally {
       console.warn = originalWarn;
+    }
+  });
+
+  test('suppresses jsdom css-parsing errors during html extraction', async () => {
+    const originalError = console.error;
+    const errorCalls: unknown[][] = [];
+    console.error = (...args: unknown[]) => errorCalls.push(args);
+    try {
+      const result = await extractFromHtml(
+        CSS_PARSING_ERROR_HTML,
+        'https://example.com/',
+        false,
+      );
+
+      expect(errorCalls).toEqual([]);
+      expect(result.text).toContain('Hello');
+      expect(result.text).toContain('World');
+    } finally {
+      console.error = originalError;
+    }
+  });
+
+  test('suppresses css-parsing errors on the extractMain path too', async () => {
+    const originalError = console.error;
+    const errorCalls: unknown[][] = [];
+    console.error = (...args: unknown[]) => errorCalls.push(args);
+    try {
+      const result = await extractFromHtml(
+        CSS_PARSING_ERROR_HTML,
+        'https://example.com/',
+        true,
+      );
+
+      expect(errorCalls).toEqual([]);
+      expect(result.text).toContain('Hello');
+    } finally {
+      console.error = originalError;
+    }
+  });
+
+  test('forwards non-css-parsing jsdomErrors to console.error', () => {
+    const originalError = console.error;
+    const errorCalls: unknown[][] = [];
+    console.error = (...args: unknown[]) => errorCalls.push(args);
+    try {
+      withJsdomCssParsingErrorsSuppressed((vc) => {
+        vc.emit('jsdomError', {
+          type: 'resource-loading',
+          message: 'Failed to load resource',
+        });
+      });
+
+      expect(errorCalls).toEqual([['Failed to load resource']]);
+    } finally {
+      console.error = originalError;
+    }
+  });
+
+  test('filters css-parsing errors but forwards other jsdomErrors', () => {
+    const originalError = console.error;
+    const errorCalls: unknown[][] = [];
+    console.error = (...args: unknown[]) => errorCalls.push(args);
+    try {
+      withJsdomCssParsingErrorsSuppressed((vc) => {
+        vc.emit('jsdomError', {
+          type: 'css-parsing',
+          message: 'Could not parse CSS stylesheet',
+        });
+        vc.emit('jsdomError', {
+          type: 'resource-loading',
+          message: 'Failed to load resource',
+        });
+      });
+
+      expect(errorCalls).toEqual([['Failed to load resource']]);
+    } finally {
+      console.error = originalError;
+    }
+  });
+
+  test('clean css produces no console.error noise', async () => {
+    const originalError = console.error;
+    const errorCalls: unknown[][] = [];
+    console.error = (...args: unknown[]) => errorCalls.push(args);
+    try {
+      const result = await extractFromHtml(
+        CSS_TREE_WARNING_HTML,
+        'https://example.com/',
+        false,
+      );
+
+      expect(errorCalls).toEqual([]);
+      expect(result.text).toContain('Hello');
+    } finally {
+      console.error = originalError;
     }
   });
 });

--- a/src/tools/smartfetch/utils.test.ts
+++ b/src/tools/smartfetch/utils.test.ts
@@ -150,7 +150,10 @@ describe('smartfetch/utils', () => {
         });
       });
 
-      expect(errorCalls).toEqual([['Failed to load resource']]);
+      expect(errorCalls).toHaveLength(1);
+      expect((errorCalls[0][0] as Error).message).toBe(
+        'Failed to load resource',
+      );
     } finally {
       console.error = originalError;
     }
@@ -172,7 +175,10 @@ describe('smartfetch/utils', () => {
         });
       });
 
-      expect(errorCalls).toEqual([['Failed to load resource']]);
+      expect(errorCalls).toHaveLength(1);
+      expect((errorCalls[0][0] as Error).message).toBe(
+        'Failed to load resource',
+      );
     } finally {
       console.error = originalError;
     }

--- a/src/tools/smartfetch/utils.ts
+++ b/src/tools/smartfetch/utils.ts
@@ -32,7 +32,8 @@ export function withCssTreeWarningsSuppressed<T>(fn: () => T): T {
  * Suppresses jsdom "css-parsing" errors ("Could not parse CSS stylesheet")
  * that jsdom would otherwise forward to console.error when no custom
  * virtualConsole is supplied, leaking parser noise into the TUI. Other
- * jsdomErrors pass through to console.error untouched.
+ * jsdomErrors pass through to console.error as full error objects,
+ * preserving stack, cause, and URL metadata.
  */
 export function withJsdomCssParsingErrorsSuppressed<T>(
   fn: (vc: VirtualConsole) => T,
@@ -40,7 +41,7 @@ export function withJsdomCssParsingErrorsSuppressed<T>(
   const vc = new VirtualConsole();
   vc.on('jsdomError', (error) => {
     const type = (error as Error & { type?: string }).type;
-    if (type !== 'css-parsing') console.error(error.message);
+    if (type !== 'css-parsing') console.error(error);
   });
   return fn(vc);
 }

--- a/src/tools/smartfetch/utils.ts
+++ b/src/tools/smartfetch/utils.ts
@@ -1,4 +1,5 @@
 import { Readability } from '@mozilla/readability';
+import { JSDOM, VirtualConsole } from 'jsdom';
 import TurndownService from 'turndown';
 import { escapeHtml } from '../../utils/escape-html';
 import { parseFrontmatter } from '../../utils/frontmatter';
@@ -27,12 +28,21 @@ export function withCssTreeWarningsSuppressed<T>(fn: () => T): T {
   }
 }
 
-let jsdomPromise: Promise<typeof import('jsdom')> | undefined;
-
-async function getJSDOM() {
-  jsdomPromise ??= import('jsdom');
-  const { JSDOM } = await jsdomPromise;
-  return JSDOM;
+/**
+ * Suppresses jsdom "css-parsing" errors ("Could not parse CSS stylesheet")
+ * that jsdom would otherwise forward to console.error when no custom
+ * virtualConsole is supplied, leaking parser noise into the TUI. Other
+ * jsdomErrors pass through to console.error untouched.
+ */
+export function withJsdomCssParsingErrorsSuppressed<T>(
+  fn: (vc: VirtualConsole) => T,
+): T {
+  const vc = new VirtualConsole();
+  vc.on('jsdomError', (error) => {
+    const type = (error as Error & { type?: string }).type;
+    if (type !== 'css-parsing') console.error(error.message);
+  });
+  return fn(vc);
 }
 
 export function wordCount(text: string): number {
@@ -304,9 +314,10 @@ export async function extractFromHtml(
   finalUrl: string,
   extractMain: boolean,
 ): Promise<ExtractedContent> {
-  const JSDOM = await getJSDOM();
-  const dom = withCssTreeWarningsSuppressed(
-    () => new JSDOM(html, { url: finalUrl }),
+  const dom = withCssTreeWarningsSuppressed(() =>
+    withJsdomCssParsingErrorsSuppressed(
+      (vc) => new JSDOM(html, { url: finalUrl, virtualConsole: vc }),
+    ),
   );
   const document = dom.window.document;
   const title = document.title || undefined;
@@ -329,8 +340,10 @@ export async function extractFromHtml(
     .slice(0, 12);
 
   if (extractMain) {
-    const readerDom = withCssTreeWarningsSuppressed(
-      () => new JSDOM(html, { url: finalUrl }),
+    const readerDom = withCssTreeWarningsSuppressed(() =>
+      withJsdomCssParsingErrorsSuppressed(
+        (vc) => new JSDOM(html, { url: finalUrl, virtualConsole: vc }),
+      ),
     );
     const article = new Readability(readerDom.window.document).parse();
     if (article?.content?.trim()) {


### PR DESCRIPTION
Related: #934

## What problem are you solving?

PR #934 suppressed css-tree lexer warnings leaking through `console.warn`, but there is a second, independent leak path with the same visible symptom: jsdom emits a `jsdomError` with `type: "css-parsing"` ("Could not parse CSS stylesheet") when a page's CSS is malformed. Without a custom `virtualConsole`, jsdom forwards that error to `console.error`, which the OpenCode TUI renders as red text near the prompt.

The trigger is not modern CSS syntax: css-tree 3.2.1 natively parses nesting, `:has()`, and `light-dark()`. The error fires only for genuinely malformed CSS (garbage tokens, broken at-rules, deeply broken declarations) that any browser would reject.

## What does this change?

- Adds `withJsdomCssParsingErrorsSuppressed()`, which installs a `VirtualConsole` that drops `css-parsing` errors and forwards all other `jsdomError`s to `console.error`.
- Both `JSDOM` construction paths in `extractFromHtml` now pass that `virtualConsole`, alongside the existing css-tree `console.warn` guard (kept unchanged).
- The lazy `getJSDOM()` dynamic import was replaced by a static import; the plugin already probes jsdom at init time, so startup behavior is unchanged.

## Why this approach?

Filtering at the source via `virtualConsole` is cleaner than extending the global `console.warn` patch to also swallow `console.error` calls: it keeps genuine jsdom errors visible and avoids growing the global-patch approach. Non-`css-parsing` jsdomErrors (e.g. `resource-loading`) still reach `console.error`.

## Verification

- [x] `bun test src/tools/smartfetch/utils.test.ts` — 10 pass, 0 fail
- [x] `bun test src/tools/smartfetch/` — 22 pass, 0 fail
- [x] `bun run typecheck`
- [x] `bun x biome check src/tools/smartfetch/utils.ts src/tools/smartfetch/utils.test.ts`
- [x] Independent runtime check: pre-fix path leaks 1 `console.error` for malformed CSS; post-fix `extractFromHtml` (both paths) emits 0 and still extracts content; clean CSS emits 0.
