### PR TITLE
fix(smartfetch): defer timed-out session cleanup

### DIFF
--- a/src/tools/smartfetch/secondary-model.test.ts
+++ b/src/tools/smartfetch/secondary-model.test.ts
@@ -266,4 +266,100 @@ describe('smartfetch/secondary-model', () => {
       _testConfig.secondaryModelTimeoutMs = originalTimeout;
     }
   });
+
+  test('does not create another session while timed-out cleanup is pending', async () => {
+    const originalTimeout = _testConfig.secondaryModelTimeoutMs;
+    _testConfig.secondaryModelTimeoutMs = 0;
+
+    let resolvePrompt!: (value: {
+      data: { parts: Array<{ type: string; text: string }> };
+    }) => void;
+    const pendingPrompt = new Promise<{
+      data: { parts: Array<{ type: string; text: string }> };
+    }>((resolve) => {
+      resolvePrompt = resolve;
+    });
+    let promptCalls = 0;
+    let createCalls = 0;
+    let resolveDelete!: () => void;
+    const deleted = new Promise<void>((resolve) => {
+      resolveDelete = resolve;
+    });
+
+    mockV2Session = {
+      abort: mock(async () => {
+        throw new Error('abort failed');
+      }),
+      create: mock(async () => ({
+        data: { id: `session-${createCalls++}` },
+      })),
+      prompt: mock(() => {
+        promptCalls++;
+        if (promptCalls === 1) return pendingPrompt;
+        return Promise.resolve({
+          data: { parts: [{ type: 'text', text: 'Recovered answer' }] },
+        });
+      }),
+      delete: mock(async () => {
+        setTimeout(resolveDelete, 0);
+        return { data: true };
+      }),
+    };
+    mockV2Tool = {
+      ids: mock(async () => ({ data: ['read'] })),
+    };
+    mockV2Client = {
+      session: mockV2Session,
+      tool: mockV2Tool,
+    };
+
+    const settledResult = {
+      data: { parts: [{ type: 'text', text: 'Late answer' }] },
+    };
+    try {
+      await expect(
+        runSecondaryModelWithFallback(
+          testInput,
+          [models[0]],
+          'Summarize',
+          'This is enough fetched content to clear the short-content guard.',
+        ),
+      ).rejects.toThrow('Secondary model timed out');
+
+      expect(mockV2Session.create).toHaveBeenCalledTimes(1);
+      expect(mockV2Session.prompt).toHaveBeenCalledTimes(1);
+      expect(mockV2Session.delete).toHaveBeenCalledTimes(0);
+
+      await expect(
+        runSecondaryModelWithFallback(
+          testInput,
+          [models[0]],
+          'Summarize again',
+          'This is enough fetched content to clear the short-content guard.',
+        ),
+      ).rejects.toThrow('cleanup is still pending');
+
+      expect(mockV2Session.create).toHaveBeenCalledTimes(1);
+      expect(mockV2Session.prompt).toHaveBeenCalledTimes(1);
+      expect(mockV2Session.delete).toHaveBeenCalledTimes(0);
+
+      resolvePrompt(settledResult);
+      await deleted;
+      expect(mockV2Session.delete).toHaveBeenCalledTimes(1);
+
+      const recovered = await runSecondaryModelWithFallback(
+        testInput,
+        [models[0]],
+        'Summarize after cleanup',
+        'This is enough fetched content to clear the short-content guard.',
+      );
+      expect(recovered.text).toBe('Recovered answer');
+      expect(mockV2Session.create).toHaveBeenCalledTimes(2);
+      expect(mockV2Session.prompt).toHaveBeenCalledTimes(2);
+      expect(mockV2Session.delete).toHaveBeenCalledTimes(2);
+    } finally {
+      resolvePrompt(settledResult);
+      _testConfig.secondaryModelTimeoutMs = originalTimeout;
+    }
+  });
 });

--- a/src/tools/smartfetch/secondary-model.test.ts
+++ b/src/tools/smartfetch/secondary-model.test.ts
@@ -11,6 +11,7 @@ type PromptStep = {
 // The variable is reassigned per-test to control behavior.
 let mockV2Client: Record<string, unknown>;
 let mockV2Session: {
+  abort: ReturnType<typeof mock>;
   create: ReturnType<typeof mock>;
   prompt: ReturnType<typeof mock>;
   delete: ReturnType<typeof mock>;
@@ -35,6 +36,7 @@ function createV2ClientMock(
   const failTimes = deleteBehavior?.failTimes ?? 0;
 
   mockV2Session = {
+    abort: mock(async () => ({ data: true })),
     create: mock(async () => ({ data: { id: `session-${createCount++}` } })),
     prompt: mock(async () => {
       const step = steps[promptCount++] ?? {};
@@ -171,6 +173,7 @@ describe('smartfetch/secondary-model', () => {
 
   test('falls back to next model when prompt times out', async () => {
     mockV2Session = {
+      abort: mock(async () => ({ data: true })),
       create: mock(async () => ({ data: { id: 'session-timeout' } })),
       prompt: mock(async (opts: unknown) => {
         const model = (opts as { body?: { model?: { modelID?: string } } })
@@ -223,6 +226,7 @@ describe('smartfetch/secondary-model', () => {
     });
 
     mockV2Session = {
+      abort: mock(async () => ({ data: true })),
       create: mock(async () => ({ data: { id: 'session-timeout' } })),
       prompt: mock(() => promptResult),
       delete: mock(async () => {
@@ -251,6 +255,7 @@ describe('smartfetch/secondary-model', () => {
         ),
       ).rejects.toThrow('Secondary model timed out');
 
+      expect(mockV2Session.abort).toHaveBeenCalledTimes(1);
       expect(mockV2Session.delete).toHaveBeenCalledTimes(0);
 
       resolvePrompt(settledResult);

--- a/src/tools/smartfetch/secondary-model.test.ts
+++ b/src/tools/smartfetch/secondary-model.test.ts
@@ -204,4 +204,61 @@ describe('smartfetch/secondary-model', () => {
     expect(result.text).toBe('Fallback answer');
     expect(result.model).toEqual(models[1]);
   });
+
+  test('waits for a timed-out prompt to settle before deleting its session', async () => {
+    const originalTimeout = _testConfig.secondaryModelTimeoutMs;
+    _testConfig.secondaryModelTimeoutMs = 0;
+
+    let resolvePrompt!: (value: {
+      data: { parts: Array<{ type: string; text: string }> };
+    }) => void;
+    const promptResult = new Promise<{
+      data: { parts: Array<{ type: string; text: string }> };
+    }>((resolve) => {
+      resolvePrompt = resolve;
+    });
+    let resolveDelete!: () => void;
+    const deleted = new Promise<void>((resolve) => {
+      resolveDelete = resolve;
+    });
+
+    mockV2Session = {
+      create: mock(async () => ({ data: { id: 'session-timeout' } })),
+      prompt: mock(() => promptResult),
+      delete: mock(async () => {
+        resolveDelete();
+        return { data: true };
+      }),
+    };
+    mockV2Tool = {
+      ids: mock(async () => ({ data: ['read'] })),
+    };
+    mockV2Client = {
+      session: mockV2Session,
+      tool: mockV2Tool,
+    };
+
+    const settledResult = {
+      data: { parts: [{ type: 'text', text: 'Late answer' }] },
+    };
+    try {
+      await expect(
+        runSecondaryModelWithFallback(
+          testInput,
+          [models[0]],
+          'Summarize',
+          'This is enough fetched content to clear the short-content guard.',
+        ),
+      ).rejects.toThrow('Secondary model timed out');
+
+      expect(mockV2Session.delete).toHaveBeenCalledTimes(0);
+
+      resolvePrompt(settledResult);
+      await deleted;
+      expect(mockV2Session.delete).toHaveBeenCalledTimes(1);
+    } finally {
+      resolvePrompt(settledResult);
+      _testConfig.secondaryModelTimeoutMs = originalTimeout;
+    }
+  });
 });

--- a/src/tools/smartfetch/secondary-model.ts
+++ b/src/tools/smartfetch/secondary-model.ts
@@ -135,6 +135,23 @@ function isUsableSecondaryText(text: string) {
 const SESSION_DELETE_RETRIES = 3;
 const SESSION_DELETE_RETRY_DELAY_MS = 500;
 const SECONDARY_MODEL_TIMEOUT_MS = 30_000;
+const activeSecondaryModelClients = new WeakSet<object>();
+
+function acquireSecondaryModelLease(client: object): () => void {
+  if (activeSecondaryModelClients.has(client)) {
+    throw new Error(
+      'A secondary model session cleanup is still pending; using fetched content without starting another session',
+    );
+  }
+
+  activeSecondaryModelClients.add(client);
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    activeSecondaryModelClients.delete(client);
+  };
+}
 
 /**
  * Exposed for tests so they can avoid real wall-clock sleeps.
@@ -190,36 +207,37 @@ async function runSecondaryModel(
 ) {
   const client = getClient(input);
   const directory = input.directory;
-
-  const sessionResponse = await client.session.create({
-    query: { directory },
-    body: { title: 'smartfetch-secondary' },
-    throwOnError: true,
-  });
-
-  const session = sessionResponse.data;
-  const sessionId = session?.id;
-  if (!sessionId) {
-    const errorDetail =
-      sessionResponse && 'error' in sessionResponse
-        ? `: ${JSON.stringify(sessionResponse.error)}`
-        : '';
-    throw new Error(
-      `Secondary model session did not return an id${errorDetail}`,
-    );
-  }
-
-  const sourceChars = content.length;
-  const truncatedContent = content.slice(0, MAX_MODEL_CONTENT_CHARS);
-  const inputChars = truncatedContent.length;
-  const inputTruncated = inputChars < sourceChars;
-  const effectivePrompt = inputTruncated
-    ? `${prompt}\n\nNote: only the first ${inputChars} characters of a longer fetched document were provided.`
-    : prompt;
+  const releaseLease = acquireSecondaryModelLease(client);
+  let sessionId: string | undefined;
   let promptPromise: Promise<unknown> | undefined;
   let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
   let promptTimedOut = false;
   try {
+    const sessionResponse = await client.session.create({
+      query: { directory },
+      body: { title: 'smartfetch-secondary' },
+      throwOnError: true,
+    });
+
+    const session = sessionResponse.data;
+    sessionId = session?.id;
+    if (!sessionId) {
+      const errorDetail =
+        sessionResponse && 'error' in sessionResponse
+          ? `: ${JSON.stringify(sessionResponse.error)}`
+          : '';
+      throw new Error(
+        `Secondary model session did not return an id${errorDetail}`,
+      );
+    }
+
+    const sourceChars = content.length;
+    const truncatedContent = content.slice(0, MAX_MODEL_CONTENT_CHARS);
+    const inputChars = truncatedContent.length;
+    const inputTruncated = inputChars < sourceChars;
+    const effectivePrompt = inputTruncated
+      ? `${prompt}\n\nNote: only the first ${inputChars} characters of a longer fetched document were provided.`
+      : prompt;
     const toolIDsResponse = await client.tool.ids({
       query: { directory },
     });
@@ -274,7 +292,7 @@ async function runSecondaryModel(
       sourceChars,
     };
   } catch (error) {
-    if (promptTimedOut) {
+    if (promptTimedOut && sessionId) {
       try {
         await abortSessionWithTimeout(client, sessionId);
       } catch {
@@ -285,12 +303,20 @@ async function runSecondaryModel(
     throw error;
   } finally {
     if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
-    if (promptTimedOut && promptPromise) {
+    const cleanupSessionId = sessionId;
+    if (promptTimedOut && promptPromise && cleanupSessionId) {
       void promptPromise
         .catch(() => undefined)
-        .then(() => deleteSessionSafely(input, sessionId));
+        .then(() => deleteSessionSafely(input, cleanupSessionId))
+        .finally(releaseLease);
+    } else if (cleanupSessionId) {
+      try {
+        await deleteSessionSafely(input, cleanupSessionId);
+      } finally {
+        releaseLease();
+      }
     } else {
-      await deleteSessionSafely(input, sessionId);
+      releaseLease();
     }
   }
 }

--- a/src/tools/smartfetch/secondary-model.ts
+++ b/src/tools/smartfetch/secondary-model.ts
@@ -1,5 +1,6 @@
 import type { PluginInput } from '@opencode-ai/plugin';
 import { getClient } from '../../utils/opencode-client';
+import { abortSessionWithTimeout } from '../../utils/session';
 import { MAX_MODEL_CONTENT_CHARS } from './constants';
 import type { CachedFetch, SecondaryModel } from './types';
 
@@ -272,6 +273,16 @@ async function runSecondaryModel(
       inputChars,
       sourceChars,
     };
+  } catch (error) {
+    if (promptTimedOut) {
+      try {
+        await abortSessionWithTimeout(client, sessionId);
+      } catch {
+        // Keep the original timeout error. Cleanup remains gated on the
+        // prompt settling so a failed abort cannot recreate the FK race.
+      }
+    }
+    throw error;
   } finally {
     if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
     if (promptTimedOut && promptPromise) {

--- a/src/tools/smartfetch/secondary-model.ts
+++ b/src/tools/smartfetch/secondary-model.ts
@@ -141,6 +141,7 @@ const SECONDARY_MODEL_TIMEOUT_MS = 30_000;
  */
 export const _testConfig = {
   deleteRetryDelayMs: SESSION_DELETE_RETRY_DELAY_MS,
+  secondaryModelTimeoutMs: SECONDARY_MODEL_TIMEOUT_MS,
 };
 
 /**
@@ -214,6 +215,9 @@ async function runSecondaryModel(
   const effectivePrompt = inputTruncated
     ? `${prompt}\n\nNote: only the first ${inputChars} characters of a longer fetched document were provided.`
     : prompt;
+  let promptPromise: Promise<unknown> | undefined;
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+  let promptTimedOut = false;
   try {
     const toolIDsResponse = await client.tool.ids({
       query: { directory },
@@ -224,33 +228,34 @@ async function runSecondaryModel(
     );
 
     const { variant, ...modelOnly } = model;
+    promptPromise = client.session.prompt({
+      path: { id: sessionId },
+      query: { directory },
+      body: {
+        model: modelOnly,
+        // The v1 runtime reads the variant from the body top level and
+        // strips unknown keys from `model`; the SDK type omits it, so
+        // spread it through the body shape directly.
+        ...(variant ? { variant } : {}),
+        system:
+          'Answer only from the supplied content. Do not use tools or outside knowledge.',
+        tools: disabledTools,
+        parts: [
+          {
+            type: 'text',
+            text: buildPrompt(truncatedContent, effectivePrompt),
+          },
+        ],
+      },
+    });
     const result = await Promise.race([
-      client.session.prompt({
-        path: { id: sessionId },
-        query: { directory },
-        body: {
-          model: modelOnly,
-          // The v1 runtime reads the variant from the body top level and
-          // strips unknown keys from `model`; the SDK type omits it, so
-          // spread it through the body shape directly.
-          ...(variant ? { variant } : {}),
-          system:
-            'Answer only from the supplied content. Do not use tools or outside knowledge.',
-          tools: disabledTools,
-          parts: [
-            {
-              type: 'text',
-              text: buildPrompt(truncatedContent, effectivePrompt),
-            },
-          ],
-        },
+      promptPromise,
+      new Promise<never>((_, reject) => {
+        timeoutHandle = setTimeout(() => {
+          promptTimedOut = true;
+          reject(new Error('Secondary model timed out'));
+        }, _testConfig.secondaryModelTimeoutMs);
       }),
-      new Promise<never>((_, reject) =>
-        setTimeout(
-          () => reject(new Error('Secondary model timed out')),
-          SECONDARY_MODEL_TIMEOUT_MS,
-        ),
-      ),
     ]);
 
     const parts =
@@ -268,7 +273,14 @@ async function runSecondaryModel(
       sourceChars,
     };
   } finally {
-    await deleteSessionSafely(input, sessionId);
+    if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
+    if (promptTimedOut && promptPromise) {
+      void promptPromise
+        .catch(() => undefined)
+        .then(() => deleteSessionSafely(input, sessionId));
+    } else {
+      await deleteSessionSafely(input, sessionId);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- keep timed-out SmartFetch sessions alive until their original prompt has stopped writing, preventing the SQLite foreign-key race
- cap cleanup-in-doubt to one temporary session per OpenCode client with a single-flight lease acquired before `session.create`
- fail fast and fall back to fetched content while that lease is held, then allow new calls after prompt settlement, deletion, and lease release
- preserve synchronous cleanup for normal success, normal failure, and pre-prompt errors

## Root cause

SmartFetch raced `session.prompt()` against a 30-second timeout, then originally deleted the temporary session immediately when the timeout won. The still-running prompt could persist parts or messages against the deleted session, producing the foreign-key errors reported in #990.

Deferring deletion until the original prompt settles closes that race, but a failed abort plus a never-settling prompt could otherwise let repeated calls accumulate sessions without bound. Abort success and an absent status entry are not safe deletion proofs because OpenCode can still be in pre-run persistence. The per-client lease therefore keeps deletion settlement-gated while preventing any second temporary session from being created during that ambiguous state.

## Tests

- fail-before/pass-after deferred-prompt regression: timeout returns first and deletion remains zero until the prompt settles
- abort-failure/open-circuit regression: a second call is rejected before create/prompt/delete; after the first prompt settles and cleanup finishes, a third call succeeds
- `bun test src/tools/smartfetch/secondary-model.test.ts` (7 passed)
- `bun run check:ci`
- `bun run typecheck`
- `bun run build`
- `git diff --check`

Fixes #990