### PR TITLE
fix(smartfetch): dedupe cache size accounting for llms.txt results (#992)

### DIFF
--- a/src/tools/smartfetch/cache.test.ts
+++ b/src/tools/smartfetch/cache.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from 'bun:test';
-import { buildCacheKey } from './cache';
+import { LRUCache } from 'lru-cache';
+import { buildCacheKey, calculateCacheSize } from './cache';
+import type { BinaryFetch, CachedFetch, FetchResult } from './types';
 
 describe('smartfetch/cache', () => {
   test('includes save_binary but not format in the cache key', () => {
@@ -31,4 +33,133 @@ describe('smartfetch/cache', () => {
       saveBinary: true,
     });
   });
+
+  test('llms.txt-shaped result is charged once for its content', () => {
+    const llmsTxt = Array.from(
+      { length: 64 },
+      (_, i) => `# Section ${i}\nhttps://example.com/doc-${i}`,
+    ).join('\n');
+    const result = makeCached({
+      rawContent: llmsTxt,
+      html: llmsTxt,
+      markdown: llmsTxt,
+      text: llmsTxt,
+    });
+
+    expect(calculateCacheSize(result)).toBe(Buffer.byteLength(llmsTxt));
+  });
+
+  test('text-page result with equal content in distinct references is charged once', () => {
+    const content = 'plain text line'.repeat(512);
+    const result = makeCached({
+      rawContent: content,
+      html: content.slice(0),
+      markdown: `\n${content}\n`.trim(),
+      text: ` ${content} `.slice(1, -1),
+    });
+
+    expect(calculateCacheSize(result)).toBe(Buffer.byteLength(content));
+  });
+
+  test('html result with four distinct fields is charged for all four', () => {
+    const rawContent = 'raw html source'.repeat(50);
+    const html = '<html><body>markup</body></html>'.repeat(50);
+    const markdown = '# heading\ntext'.repeat(50);
+    const text = 'plain extract'.repeat(50);
+    const result = makeCached({ rawContent, html, markdown, text });
+
+    expect(calculateCacheSize(result)).toBe(
+      Buffer.byteLength(rawContent) +
+        Buffer.byteLength(html) +
+        Buffer.byteLength(markdown) +
+        Buffer.byteLength(text),
+    );
+  });
+
+  test('binary result is charged for its data byteLength', () => {
+    const data = new Uint8Array(4096);
+    expect(calculateCacheSize(makeBinary(data))).toBe(4096);
+  });
+
+  test('binary result without data falls back to 1024 bytes', () => {
+    expect(calculateCacheSize(makeBinary())).toBe(1024);
+  });
+
+  test('real LRUCache holds ~4x more plain-text entries with deduped accounting', () => {
+    const maxSize = 20 * 1024 * 1024;
+    const entryBytes = 128 * 1024;
+    const content = 'x'.repeat(entryBytes);
+    const entry = makeCached({
+      rawContent: content,
+      html: content,
+      markdown: content,
+      text: content,
+    });
+
+    const deduped = new LRUCache<string, FetchResult>({
+      maxSize,
+      sizeCalculation: calculateCacheSize,
+    });
+    const naive = new LRUCache<string, FetchResult>({
+      maxSize,
+      sizeCalculation: (value: FetchResult) => {
+        const cached = value as CachedFetch;
+        return (
+          Buffer.byteLength(cached.rawContent) +
+          Buffer.byteLength(cached.html) +
+          Buffer.byteLength(cached.markdown) +
+          Buffer.byteLength(cached.text)
+        );
+      },
+    });
+
+    for (let i = 0; i < 500; i++) {
+      const key = `https://example.com/doc-${i}`;
+      deduped.set(key, entry);
+      naive.set(key, entry);
+    }
+
+    // 20MiB / 128KiB = 160 entries; allow a small implementation margin.
+    expect(deduped.size).toBeGreaterThanOrEqual(150);
+    expect(deduped.size).toBeLessThanOrEqual(161);
+    // Old accounting charges 4x per entry: 20MiB / 512KiB = 40.
+    expect(naive.size).toBeLessThanOrEqual(50);
+    expect(deduped.size).toBeGreaterThan(naive.size * 3);
+  });
 });
+
+function makeCached(overrides: Partial<CachedFetch>): CachedFetch {
+  return {
+    requestedUrl: 'https://example.com/',
+    finalUrl: 'https://example.com/',
+    statusCode: 200,
+    contentType: 'text/plain',
+    rawContent: '',
+    markdown: '',
+    text: '',
+    html: '',
+    extractedMain: false,
+    usedLlmsTxt: false,
+    sourceKind: 'text',
+    upgradedToHttps: false,
+    redirectChain: [],
+    truncated: false,
+    wordCount: 0,
+    ...overrides,
+  };
+}
+
+function makeBinary(data?: Uint8Array): BinaryFetch {
+  return {
+    requestedUrl: 'https://example.com/file',
+    finalUrl: 'https://example.com/file',
+    statusCode: 200,
+    contentType: 'application/pdf',
+    redirectChain: [],
+    upgradedToHttps: false,
+    truncated: false,
+    binary: true,
+    binaryKind: 'pdf',
+    data,
+  };
+}

--- a/src/tools/smartfetch/cache.ts
+++ b/src/tools/smartfetch/cache.ts
@@ -2,20 +2,25 @@ import { LRUCache } from 'lru-cache';
 import { canUseCanonicalCacheAlias, isHtmlLikeContentType } from './network';
 import type { FetchResult } from './types';
 
+export function calculateCacheSize(value: FetchResult): number {
+  if ('binary' in value) return value.data?.byteLength ?? 1024;
+  // llms.txt and plain-text pages point all four fields at the same
+  // content, so charge bytes once per distinct string value.
+  const refs = [value.rawContent, value.html, value.markdown, value.text];
+  const seen = new Set<string>();
+  let total = 0;
+  for (const ref of refs) {
+    if (typeof ref !== 'string' || seen.has(ref)) continue;
+    seen.add(ref);
+    total += Buffer.byteLength(ref);
+  }
+  return total;
+}
+
 export const CACHE = new LRUCache<string, FetchResult>({
   maxSize: 50 * 1024 * 1024,
   ttl: 15 * 60 * 1000,
-  sizeCalculation: (value: FetchResult) => {
-    if ('binary' in value) return value.data?.byteLength ?? 1024;
-    const rawContent =
-      value.rawContent ?? value.html ?? value.markdown ?? value.text ?? '';
-    return (
-      Buffer.byteLength(rawContent) +
-      Buffer.byteLength(value.html) +
-      Buffer.byteLength(value.markdown) +
-      Buffer.byteLength(value.text)
-    );
-  },
+  sizeCalculation: calculateCacheSize,
 });
 
 export function buildCacheKey(

--- a/src/tools/smartfetch/tool.ts
+++ b/src/tools/smartfetch/tool.ts
@@ -456,16 +456,19 @@ export function createWebfetchTool(
                         finalUrl,
                         args.extract_main,
                       )
-                    : {
-                        title: undefined,
-                        rawContent: cleanFetchedText(rawText),
-                        html: cleanFetchedText(rawText),
-                        text: cleanFetchedText(rawText),
-                        markdown: cleanFetchedText(rawText),
-                        extractedMain: false,
-                        canonicalUrl: undefined,
-                        headings: [],
-                      };
+                    : (() => {
+                        const cleaned = cleanFetchedText(rawText);
+                        return {
+                          title: undefined,
+                          rawContent: cleaned,
+                          html: cleaned,
+                          text: cleaned,
+                          markdown: cleaned,
+                          extractedMain: false,
+                          canonicalUrl: undefined,
+                          headings: [],
+                        };
+                      })();
 
                   fetchResult = {
                     requestedUrl: args.url,


### PR DESCRIPTION
﻿Fixes #992

## What problem are you solving?

`smartfetch`'s cache `sizeCalculation` charges bytes four times for llms.txt and plain-text results. Those results point all four fields (`rawContent`/`html`/`markdown`/`text`) at the same content, so the 50MiB `CACHE` only holds ~12.5MiB of real content and evicts entries early — the same page gets re-fetched over the network repeatedly.

Measured: 500 × 128KiB llms.txt-shaped entries keep only **99** in the 50MiB cache with the old accounting, versus **399** with deduped accounting (~4x effective capacity for these result shapes).

## What does this change?

- [x] Extract `calculateCacheSize` in `src/tools/smartfetch/cache.ts` and charge bytes once per distinct string value (Set dedupe, SameValueZero) instead of summing all four fields.
- [x] Reuse a single `cleanFetchedText` pass in the non-HTML branch of `src/tools/smartfetch/tool.ts` so the four fields share one reference (behavior unchanged, cleaning cost 4x → 1x).
- [x] Add regression tests for llms.txt / plain-text / HTML / binary shapes plus a real LRUCache capacity check.

HTML results (four genuinely different fields) are still charged for all four — only duplicated content is deduped.

## Why this approach?

The cache's job is to estimate retained memory; identical content is held once, so charging it four times overstates usage by 4x and defeats the 50MiB budget. Value-based dedupe is exact for both the same-reference (llms.txt) and same-content-different-reference (pre-fix plain-text) shapes, and leaves HTML accounting untouched.

## Verification

- [x] `bun test src/tools/smartfetch/cache.test.ts` — 7 pass
- [x] `bun test src/tools/smartfetch/` — 38 pass (full dir regression)
- [x] `bun run typecheck`
- [x] scoped Biome check on the 3 changed files
- [x] Independent reproduction: old 524288B vs new 131072B per 128KiB entry; real 50MiB LRUCache 99 → 399 entries
- [ ] `bun run check:ci` / full `bun test` — not run on Windows (known CRLF noise; scoped checks passed)
