### PR TITLE
fix(tui-state): skip unchanged writes and write atomically

### DIFF
--- a/src/tui-state.test.ts
+++ b/src/tui-state.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, spyOn, test } from 'bun:test';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -144,5 +144,69 @@ describe('tui-state persistence', () => {
       fs.rmSync(dirA, { recursive: true, force: true });
       fs.rmSync(dirB, { recursive: true, force: true });
     }
+  });
+
+  test('skips the disk write when the recorded value is unchanged', () => {
+    recordTuiAgentModel(
+      { agentName: 'explorer', model: 'openai/gpt-5.6-luna' },
+      tempDir,
+    );
+
+    const filePath = getTuiStatePath(tempDir);
+    const oldMtime = new Date('2000-01-01T00:00:00Z');
+    fs.utimesSync(filePath, oldMtime, oldMtime);
+    const baselineMtime = fs.statSync(filePath).mtimeMs;
+
+    // Same agent, same model: nothing changed, so the file must not be
+    // rewritten (a write would bump the mtime from 2000 back to "now").
+    recordTuiAgentModel(
+      { agentName: 'explorer', model: 'openai/gpt-5.6-luna' },
+      tempDir,
+    );
+
+    expect(fs.statSync(filePath).mtimeMs).toBe(baselineMtime);
+  });
+
+  test('keeps the final file intact when the atomic rename fails', async () => {
+    recordTuiAgentModel(
+      { agentName: 'explorer', model: 'openai/gpt-5.6-luna' },
+      tempDir,
+    );
+
+    const fsModule = await import('node:fs');
+    const renameSpy = spyOn(fsModule, 'renameSync').mockImplementation(() => {
+      throw new Error('rename failed');
+    });
+
+    try {
+      recordTuiAgentModel(
+        { agentName: 'explorer', model: 'openai/gpt-5.6' },
+        tempDir,
+      );
+    } finally {
+      renameSpy.mockRestore();
+    }
+
+    // The previously written state must still be readable in full.
+    expect(readTuiSnapshot(tempDir).agentModels).toEqual({
+      explorer: 'openai/gpt-5.6-luna',
+    });
+
+    const stateDir = path.dirname(getTuiStatePath(tempDir));
+    expect(
+      fs.readdirSync(stateDir).filter((name) => name.endsWith('.tmp')),
+    ).toEqual([]);
+  });
+
+  test('leaves no temp files behind on the happy path', () => {
+    recordTuiAgentModel(
+      { agentName: 'explorer', model: 'openai/gpt-5.6-luna' },
+      tempDir,
+    );
+
+    const stateDir = path.dirname(getTuiStatePath(tempDir));
+    expect(
+      fs.readdirSync(stateDir).filter((name) => name.endsWith('.tmp')),
+    ).toEqual([]);
   });
 });

--- a/src/tui-state.ts
+++ b/src/tui-state.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -84,7 +84,19 @@ function writeTuiSnapshot(snapshot: TuiSnapshot, projectDir: string): void {
   try {
     const filePath = getTuiStatePath(projectDir);
     fs.mkdirSync(path.dirname(filePath), { recursive: true });
-    fs.writeFileSync(filePath, `${JSON.stringify(snapshot)}\n`);
+    const tmpPath = `${filePath}.${process.pid}.${randomUUID()}.tmp`;
+    try {
+      fs.writeFileSync(tmpPath, `${JSON.stringify(snapshot)}\n`);
+      fs.renameSync(tmpPath, filePath);
+    } finally {
+      // Remove temp residue on the failure path; hard crashes are out of
+      // reach, and readers only ever open the final file.
+      try {
+        if (fs.existsSync(tmpPath)) fs.unlinkSync(tmpPath);
+      } catch {
+        // best-effort
+      }
+    }
   } catch {
     // TUI state is best-effort only.
   }
@@ -95,7 +107,15 @@ function updateSnapshot(
   mutator: (snapshot: TuiSnapshot) => void,
 ): void {
   const snapshot = readTuiSnapshot(projectDir);
+  const beforeModels = JSON.stringify(snapshot.agentModels);
+  const beforeVariants = JSON.stringify(snapshot.agentVariants);
   mutator(snapshot);
+  if (
+    JSON.stringify(snapshot.agentModels) === beforeModels &&
+    JSON.stringify(snapshot.agentVariants) === beforeVariants
+  ) {
+    return; // state unchanged — skip the disk write
+  }
   snapshot.updatedAt = Date.now();
   writeTuiSnapshot(snapshot, projectDir);
 }


### PR DESCRIPTION
﻿## What problem are you solving?

`tui-state.json` is rewritten on every `message.updated` that carries agent/model info, even when nothing changed (streaming updates re-report the same agent+model), and the direct `writeFileSync` leaves the file half-written if the process crashes mid-write.

## What does this change?

- [x] `src/tui-state.ts`: `updateSnapshot` serializes the state before the mutator and skips the disk write (and `updatedAt`) when nothing changed — streaming re-reports of the same agent/model no longer rewrite the file.
- [x] `src/tui-state.ts`: `writeTuiSnapshot` writes to a same-directory temp file (`<path>.<pid>.<uuid>.tmp`) and `renameSync`s it over the target, so readers only ever see a complete snapshot; failure paths clean up temp residue.
- [x] `src/tui-state.test.ts`: tests for unchanged-value skip (mtime baseline), rename failure keeping the old complete state, and no temp residue on the happy path.

Behavior and API are unchanged: both record functions stay synchronous, `index.ts` is untouched, and `updatedAt` now means "last state change" (no other consumers in the repo).

## Why this approach?

The state file is best-effort TUI state, so the fix stays minimal: avoid redundant I/O and make the write atomic. A promise queue or inter-process lock would be over-engineering here — single-process synchronous read-modify-write is already atomic, and cross-process consistency is out of scope for best-effort state.

## Verification

- [x] `bun test src/tui-state.test.ts` — 8 pass (5 existing + 3 new)
- [x] `bun run typecheck`
- [x] scoped Biome check on the 2 changed files
- [ ] `bun run check:ci` / full `bun test` — not run on Windows (known CRLF noise; scoped checks passed)
