### PR TITLE
fix(orchestrator): prevent wait_for_user loop for background tasks

### DIFF
--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -537,6 +537,7 @@ export function createAgents(
     disabled,
     councillorAgents.length > 0 ? ['council'] : undefined,
     !runtime.disabledTools.includes('wait_for_user'),
+    runtime.backgroundJobs.orchestratorWake.enabled,
   );
 
   const inlineOrchestratorPrompt = orchestratorOverride?.prompt;

--- a/src/agents/orchestrator.test.ts
+++ b/src/agents/orchestrator.test.ts
@@ -18,6 +18,7 @@ describe('orchestrator prompt', () => {
     expect(prompt).toContain('call `wait_for_user` as your final tool action');
     expect(prompt).toContain('give the user concrete manual steps');
     expect(prompt).toContain('end the turn');
+    expect(prompt).toContain('never use `wait_for_user` to await them');
     expect(prompt).toContain('Do not rely on ordinary text alone');
   });
 
@@ -31,5 +32,13 @@ describe('orchestrator prompt', () => {
     expect(prompt).toContain(
       'use the `question` tool as the blocking boundary',
     );
+  });
+
+  test('omits end-turn instruction when wake scheduler is disabled', () => {
+    const prompt = buildOrchestratorPrompt(undefined, undefined, true, false);
+
+    expect(prompt).toContain('call `wait_for_user` as your final tool action');
+    expect(prompt).not.toContain('End Turn After Background Tasks');
+    expect(prompt).toContain('Do not immediately wait after spawning');
   });
 });

--- a/src/agents/orchestrator.ts
+++ b/src/agents/orchestrator.ts
@@ -124,12 +124,14 @@ const PARALLEL_DELEGATION_EXAMPLES = [
  * Build the orchestrator prompt with dynamic agent filtering.
  * @param disabledAgents - Set of disabled agent names to exclude from the prompt
  * @param waitForUserEnabled - Whether explicit text-only HITL waiting is available
+ * @param wakeSchedulerEnabled - Whether the orchestrator wake scheduler can resume the session after idle
  * @returns The complete orchestrator prompt string
  */
 export function buildOrchestratorPrompt(
   disabledAgents?: ReadonlySet<string>,
   excludeDescriptions?: string[],
   waitForUserEnabled = true,
+  wakeSchedulerEnabled = true,
 ): string {
   // Filter agent descriptions
   const enabledAgents = Object.entries(AGENT_DESCRIPTIONS)
@@ -148,7 +150,7 @@ export function buildOrchestratorPrompt(
   ).join('\n');
 
   const externalManualWaitInstruction = waitForUserEnabled
-    ? '- When work must pause while the user completes an external manual operation, first give the user concrete manual steps, then call `wait_for_user` as your final tool action and end the turn. Do not rely on ordinary text alone to mark this waiting state, and do not call more tools after `wait_for_user`.'
+    ? '- When work must pause while the user completes an external manual operation, first give the user concrete manual steps, then call `wait_for_user` as your final tool action and end the turn. Do not rely on ordinary text alone to mark this waiting state, and do not call more tools after `wait_for_user`. Background tasks are not external manual work — never use `wait_for_user` to await them; the system resumes automatically via the Background Job Board and orchestrator wake scheduler.'
     : '- When work must pause while the user completes an external manual operation, first give the user concrete manual steps, then use the `question` tool as the blocking boundary and ask them to respond when finished. `wait_for_user` is disabled, so do not reference or call it.';
 
   return `<Role>
@@ -225,7 +227,10 @@ Balance: respect dependencies, avoid parallelizing what must be sequential, and 
 - Use \`cancel_task\` only when the user asks, or when a running lane is obsolete, wrong, or conflicts with a safer replacement plan.
 - Cancellation is not rollback: if cancelling a writer, inspect and reconcile partial file changes before launching a replacement lane.
 
-### Active Task Amendments
+${wakeSchedulerEnabled ? `#### End Turn After Background Tasks
+After spawning all independent background tasks and any remaining non-overlapping work, end the turn immediately with a brief status message. Do not call \`wait_for_user\` to await background task completion — the system notifies you automatically via the Background Job Board when tasks finish, and the orchestrator wake scheduler resumes you. Do not poll for status with repeated tool calls. The correct flow is: launch tasks → brief status → end turn → completion hook or wake scheduler resumes → reconcile results.
+
+` : ''}### Active Task Amendments
 - A task in the Active / Unreconciled section is still running and cannot receive another \`task\` call, even with its \`task_id\`. Do not try to resume, replace, or cancel it merely because the user adds to its existing scope.
 - For an additive request to a running lane, record the amendment in the parent conversation, tell the user it is queued, and wait for that lane's terminal result. Then resume the same specialist only after its session appears in Reusable Sessions.
 - Cancel a running task only when its current objective is genuinely obsolete or must be replaced. Never create-and-cancel speculative duplicate sessions.
@@ -300,11 +305,13 @@ export function createOrchestratorAgent(
   disabledAgents?: Set<string>,
   excludeDescriptions?: string[],
   waitForUserEnabled = true,
+  wakeSchedulerEnabled = true,
 ): AgentDefinition {
   const basePrompt = buildOrchestratorPrompt(
     disabledAgents,
     excludeDescriptions,
     waitForUserEnabled,
+    wakeSchedulerEnabled,
   );
   const prompt = resolvePrompt(
     'orchestrator',

--- a/src/hooks/__snapshots__/cache-payload.snapshot.test.ts.snap
+++ b/src/hooks/__snapshots__/cache-payload.snapshot.test.ts.snap
@@ -160,6 +160,9 @@ Balance: respect dependencies, avoid parallelizing what must be sequential, and 
 - Use \`cancel_task\` only when the user asks, or when a running lane is obsolete, wrong, or conflicts with a safer replacement plan.
 - Cancellation is not rollback: if cancelling a writer, inspect and reconcile partial file changes before launching a replacement lane.
 
+#### End Turn After Background Tasks
+After spawning all independent background tasks and any remaining non-overlapping work, end the turn immediately with a brief status message. Do not call \`wait_for_user\` to await background task completion — the system notifies you automatically via the Background Job Board when tasks finish, and the orchestrator wake scheduler resumes you. Do not poll for status with repeated tool calls. The correct flow is: launch tasks → brief status → end turn → completion hook or wake scheduler resumes → reconcile results.
+
 ### Active Task Amendments
 - A task in the Active / Unreconciled section is still running and cannot receive another \`task\` call, even with its \`task_id\`. Do not try to resume, replace, or cancel it merely because the user adds to its existing scope.
 - For an additive request to a running lane, record the amendment in the parent conversation, tell the user it is queued, and wait for that lane's terminal result. Then resume the same specialist only after its session appears in Reusable Sessions.
@@ -197,7 +200,7 @@ Balance: respect dependencies, avoid parallelizing what must be sequential, and 
 - Don't guess at critical details (file paths, API choices, architectural decisions)
 - Do make reasonable assumptions for minor details and state them briefly
 - When user input is required before work can continue and the user can answer immediately—including clarification, permission, a choice, or pasted command output—use the \`question\` tool. Enable custom input, request a concise pasted response or command output, and provide a small bounded set of options whenever the tool schema requires options.
-- When work must pause while the user completes an external manual operation, first give the user concrete manual steps, then call \`wait_for_user\` as your final tool action and end the turn. Do not rely on ordinary text alone to mark this waiting state, and do not call more tools after \`wait_for_user\`.
+- When work must pause while the user completes an external manual operation, first give the user concrete manual steps, then call \`wait_for_user\` as your final tool action and end the turn. Do not rely on ordinary text alone to mark this waiting state, and do not call more tools after \`wait_for_user\`. Background tasks are not external manual work — never use \`wait_for_user\` to await them; the system resumes automatically via the Background Job Board and orchestrator wake scheduler.
 - For ordinary dialogue that does not block work, answer normally and do not use the question tool gratuitously.
 
 ## Concise Execution

--- a/src/tools/wait-for-user.ts
+++ b/src/tools/wait-for-user.ts
@@ -15,7 +15,7 @@ export function createWaitForUserTool(
   const wait_for_user = tool({
     description: `Pause automatic continuation while waiting for external human action.
 
-Use this only as the final tool action after you have already given the user concrete manual steps. The next distinct external user message resumes normal continuation. For an immediate answer, choice, clarification, or pasted output, use the question tool instead.`,
+Use this only as the final tool action after you have already given the user concrete manual steps. The next distinct external user message resumes normal continuation. For an immediate answer, choice, clarification, or pasted output, use the question tool instead. Background tasks are not external manual work — do not use this tool to await them; the system resumes automatically via the Background Job Board and orchestrator wake scheduler.`,
     args: {
       reason: z
         .string()


### PR DESCRIPTION
Fix for issue: https://github.com/alvinunreal/oh-my-opencode-slim/issues/1000

Root cause: orchestrator prompt says 'wait for completion' without specifying how, so model invents wait_for_user as its wait mechanism. Session evidence shows agent correctly ended turn after spawning bg tasks, then orchestrator-wake re-engaged it and loop began.

Changes:
- Add 'End Turn After Background Tasks' subsection with explicit flow: launch tasks → brief status → end turn → hook/wake resumes
- Clarify wait_for_user is NEVER for background task completion in both orchestrator prompt and tool description
- Update test assertion for new prompt text
