### PR TITLE
feat(tasks): add read-only result retrieval

### DIFF
--- a/src/agents/orchestrator.ts
+++ b/src/agents/orchestrator.ts
@@ -217,7 +217,7 @@ Balance: respect dependencies, avoid parallelizing what must be sequential, and 
 
 ### Background Task Discipline
 - Before dispatching a specialist, check the Background Job Board and current conversation for an existing task that already covers the objective.
-- If the user asks for a completed specialist's prior output, call \`task_result\` with its task ID or alias. Never use \`task(..., task_id: ...)\` to fetch output: that resumes the child and starts new model work.
+- \`task_result\` returns only a completed specialist's final assistant message, and can be called by any parent session that owns the task. Never use \`task(..., task_id: ...)\` to fetch output: that resumes the child and starts new model work.
 - Before retrying completed work whose result appears missing or incomplete, retrieve it with \`task_result\`. Dispatch again only when the retrieved result does not satisfy the objective.
 - Prefer \`task(..., background: true)\` for delegated work that can run independently.
 - For work already chosen for delegation, launch independent specialist lanes in the background so the orchestrator stays unblocked and can reconcile results when they return.

--- a/src/agents/orchestrator.ts
+++ b/src/agents/orchestrator.ts
@@ -216,6 +216,9 @@ ${enabledParallelExamples}
 Balance: respect dependencies, avoid parallelizing what must be sequential, and avoid overlapping write ownership.
 
 ### Background Task Discipline
+- Before dispatching a specialist, check the Background Job Board and current conversation for an existing task that already covers the objective.
+- If the user asks for a completed specialist's prior output, call \`task_result\` with its task ID or alias. Never use \`task(..., task_id: ...)\` to fetch output: that resumes the child and starts new model work.
+- Before retrying completed work whose result appears missing or incomplete, retrieve it with \`task_result\`. Dispatch again only when the retrieved result does not satisfy the objective.
 - Prefer \`task(..., background: true)\` for delegated work that can run independently.
 - For work already chosen for delegation, launch independent specialist lanes in the background so the orchestrator stays unblocked and can reconcile results when they return.
 - Never reissue an unchanged task to the same specialist after a rejection; adjust its scope or context before retrying.

--- a/src/hooks/__snapshots__/cache-payload.snapshot.test.ts.snap
+++ b/src/hooks/__snapshots__/cache-payload.snapshot.test.ts.snap
@@ -152,7 +152,7 @@ Balance: respect dependencies, avoid parallelizing what must be sequential, and 
 
 ### Background Task Discipline
 - Before dispatching a specialist, check the Background Job Board and current conversation for an existing task that already covers the objective.
-- If the user asks for a completed specialist's prior output, call \`task_result\` with its task ID or alias. Never use \`task(..., task_id: ...)\` to fetch output: that resumes the child and starts new model work.
+- \`task_result\` returns only a completed specialist's final assistant message, and can be called by any parent session that owns the task. Never use \`task(..., task_id: ...)\` to fetch output: that resumes the child and starts new model work.
 - Before retrying completed work whose result appears missing or incomplete, retrieve it with \`task_result\`. Dispatch again only when the retrieved result does not satisfy the objective.
 - Prefer \`task(..., background: true)\` for delegated work that can run independently.
 - For work already chosen for delegation, launch independent specialist lanes in the background so the orchestrator stays unblocked and can reconcile results when they return.

--- a/src/hooks/__snapshots__/cache-payload.snapshot.test.ts.snap
+++ b/src/hooks/__snapshots__/cache-payload.snapshot.test.ts.snap
@@ -151,6 +151,9 @@ Can tasks be split into background specialist work?
 Balance: respect dependencies, avoid parallelizing what must be sequential, and avoid overlapping write ownership.
 
 ### Background Task Discipline
+- Before dispatching a specialist, check the Background Job Board and current conversation for an existing task that already covers the objective.
+- If the user asks for a completed specialist's prior output, call \`task_result\` with its task ID or alias. Never use \`task(..., task_id: ...)\` to fetch output: that resumes the child and starts new model work.
+- Before retrying completed work whose result appears missing or incomplete, retrieve it with \`task_result\`. Dispatch again only when the retrieved result does not satisfy the objective.
 - Prefer \`task(..., background: true)\` for delegated work that can run independently.
 - For work already chosen for delegation, launch independent specialist lanes in the background so the orchestrator stays unblocked and can reconcile results when they return.
 - Never reissue an unchanged task to the same specialist after a rejection; adjust its scope or context before retrying.

--- a/src/index.ts
+++ b/src/index.ts
@@ -433,8 +433,6 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
     taskResultTools = createTaskResultTool({
       input: ctx,
       backgroundJobBoard: backgroundJobCoordinator,
-      shouldManageSession: (sessionID) =>
-        sessionMetadata.getAgent(sessionID) === 'orchestrator',
     });
     waitForUserTools = createWaitForUserTool({
       shouldManageSession: (sessionID) =>

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@ import {
   ast_grep_search,
   createAcpRunTool,
   createCancelTaskTool,
+  createTaskResultTool,
   createWaitForUserTool,
   createWebfetchTool,
 } from './tools';
@@ -167,6 +168,7 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
   let interviewManager: ReturnType<typeof createInterviewManager>;
   let companionManager: CompanionManager;
   let cancelTaskTools: ReturnType<typeof createCancelTaskTool>;
+  let taskResultTools: ReturnType<typeof createTaskResultTool>;
   let waitForUserTools: ReturnType<typeof createWaitForUserTool>;
   let acpRunTools: Record<string, ReturnType<typeof createAcpRunTool>>;
   let webfetch: ReturnType<typeof createWebfetchTool>;
@@ -428,6 +430,12 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
       shouldManageSession: (sessionID) =>
         sessionMetadata.getAgent(sessionID) === 'orchestrator',
     });
+    taskResultTools = createTaskResultTool({
+      input: ctx,
+      backgroundJobBoard: backgroundJobCoordinator,
+      shouldManageSession: (sessionID) =>
+        sessionMetadata.getAgent(sessionID) === 'orchestrator',
+    });
     waitForUserTools = createWaitForUserTool({
       shouldManageSession: (sessionID) =>
         sessionMetadata.getAgent(sessionID) === 'orchestrator',
@@ -444,6 +452,7 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
     const shouldRegisterWebfetch = runtime.webfetch.enabled !== false;
     tools = {
       ...cancelTaskTools,
+      ...taskResultTools,
       ...waitForUserTools,
       ...acpRunTools,
       ...(shouldRegisterWebfetch ? { webfetch } : {}),

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -3,4 +3,5 @@ export { createAcpRunTool } from './acp-run';
 export { ast_grep_replace, ast_grep_search } from './ast-grep';
 export { createCancelTaskTool } from './cancel-task';
 export { createWebfetchTool } from './smartfetch';
+export { createTaskResultTool } from './task-result';
 export { createWaitForUserTool } from './wait-for-user';

--- a/src/tools/task-result.test.ts
+++ b/src/tools/task-result.test.ts
@@ -103,6 +103,91 @@ describe('task_result', () => {
     expect(messages).not.toHaveBeenCalled();
   });
 
+  test('rejects a tracked task that ended in error', async () => {
+    const { board, tool, messages } = createTool();
+    board.registerLaunch({
+      taskID: 'ses_child1',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+      description: 'trace bug',
+    });
+    board.updateStatus({
+      taskID: 'ses_child1',
+      state: 'error',
+      resultSummary: 'provider exploded',
+    });
+
+    await expect(
+      tool.execute({ task_id: 'exp-1' }, {
+        sessionID: 'parent-1',
+        agent: 'orchestrator',
+      } as any),
+    ).rejects.toThrow('ended in error: provider exploded');
+    expect(messages).not.toHaveBeenCalled();
+  });
+
+  test('rejects a tracked task that was cancelled', async () => {
+    const { board, tool, messages } = createTool();
+    board.registerLaunch({
+      taskID: 'ses_child1',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+      description: 'trace bug',
+    });
+    board.markCancelled('ses_child1', 'orchestrator aborted');
+
+    await expect(
+      tool.execute({ task_id: 'exp-1' }, {
+        sessionID: 'parent-1',
+        agent: 'orchestrator',
+      } as any),
+    ).rejects.toThrow('was cancelled: orchestrator aborted');
+    expect(messages).not.toHaveBeenCalled();
+  });
+
+  test('returns a reconciled task whose terminal outcome was completed', async () => {
+    const { board, tool } = createTool();
+    board.registerLaunch({
+      taskID: 'ses_child1',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+      description: 'trace bug',
+    });
+    board.updateStatus({ taskID: 'ses_child1', state: 'completed' });
+    board.markReconciled('ses_child1');
+
+    const output = await tool.execute({ task_id: 'exp-1' }, {
+      sessionID: 'parent-1',
+      agent: 'orchestrator',
+    } as any);
+
+    expect(output).toBe('complete findings');
+  });
+
+  test('rejects a reconciled task whose terminal outcome was error', async () => {
+    const { board, tool, messages } = createTool();
+    board.registerLaunch({
+      taskID: 'ses_child1',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+      description: 'trace bug',
+    });
+    board.updateStatus({
+      taskID: 'ses_child1',
+      state: 'error',
+      resultSummary: 'model unavailable',
+    });
+    board.markReconciled('ses_child1');
+
+    await expect(
+      tool.execute({ task_id: 'exp-1' }, {
+        sessionID: 'parent-1',
+        agent: 'orchestrator',
+      } as any),
+    ).rejects.toThrow('ended in error: model unavailable');
+    expect(messages).not.toHaveBeenCalled();
+  });
+
   test('rejects an untracked child whose live session is busy', async () => {
     const { tool, messages } = createTool();
     mockClient.session.status.mockImplementation(async () => ({
@@ -131,6 +216,95 @@ describe('task_result', () => {
       } as any),
     ).rejects.toThrow('still running');
     expect(messages).not.toHaveBeenCalled();
+  });
+
+  test('rejects an untracked idle session with no terminal evidence', async () => {
+    const { tool, messages } = createTool();
+    mockClient.session.messages.mockResolvedValue({
+      data: [
+        {
+          info: { role: 'assistant' },
+          parts: [{ type: 'text', text: 'partial findings' }],
+        },
+      ],
+    });
+
+    await expect(
+      tool.execute({ task_id: 'ses_child1' }, {
+        sessionID: 'parent-1',
+        agent: 'orchestrator',
+      } as any),
+    ).rejects.toThrow('no terminal evidence');
+    expect(messages).toHaveBeenCalledTimes(1);
+  });
+
+  test('rejects an untracked session idle mid-exchange', async () => {
+    const { tool } = createTool();
+    mockClient.session.messages.mockResolvedValue({
+      data: [
+        {
+          info: { role: 'assistant', time: { completed: 100 } },
+          parts: [{ type: 'text', text: 'earlier answer' }],
+        },
+        {
+          info: { role: 'user' },
+          parts: [{ type: 'text', text: 'continue' }],
+        },
+      ],
+    });
+
+    await expect(
+      tool.execute({ task_id: 'ses_child1' }, {
+        sessionID: 'parent-1',
+        agent: 'orchestrator',
+      } as any),
+    ).rejects.toThrow('no terminal evidence');
+  });
+
+  test('rejects an untracked session whose last assistant message errored', async () => {
+    const { tool } = createTool();
+    mockClient.session.messages.mockResolvedValue({
+      data: [
+        {
+          info: {
+            role: 'assistant',
+            time: { completed: 100 },
+            error: { name: 'MessageAbortedError', data: {} },
+          },
+          parts: [{ type: 'text', text: 'partial findings' }],
+        },
+      ],
+    });
+
+    await expect(
+      tool.execute({ task_id: 'ses_child1' }, {
+        sessionID: 'parent-1',
+        agent: 'orchestrator',
+      } as any),
+    ).rejects.toThrow('no terminal evidence');
+  });
+
+  test('returns an untracked session result when terminal evidence exists', async () => {
+    const { tool, messages } = createTool();
+    mockClient.session.messages.mockResolvedValue({
+      data: [
+        {
+          info: { role: 'assistant', time: { completed: 100 } },
+          parts: [
+            { type: 'reasoning', text: 'private work' },
+            { type: 'text', text: 'final findings' },
+          ],
+        },
+      ],
+    });
+
+    const output = await tool.execute({ task_id: 'ses_child1' }, {
+      sessionID: 'parent-1',
+      agent: 'orchestrator',
+    } as any);
+
+    expect(output).toBe('final findings');
+    expect(messages).toHaveBeenCalledTimes(1);
   });
 
   test('returns a tracked result through the v2 client shim', async () => {

--- a/src/tools/task-result.test.ts
+++ b/src/tools/task-result.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { BackgroundJobBoard } from '../utils/background-job-board';
+import { createTaskResultTool } from './task-result';
+
+let mockClient: Record<string, any>;
+
+mock.module('../utils/opencode-client', () => ({
+  getClient: () => mockClient,
+}));
+
+function createTool() {
+  const board = new BackgroundJobBoard();
+  const get = mock(async () => ({ data: { parentID: 'parent-1' } }));
+  const messages = mock(async () => ({
+    data: [
+      {
+        info: { role: 'assistant' },
+        parts: [
+          { type: 'reasoning', text: 'private work' },
+          { type: 'text', text: 'complete findings' },
+        ],
+      },
+    ],
+  }));
+  const status = mock(async () => ({ data: {} }));
+  mockClient = { session: { get, messages, status } };
+
+  const tools = createTaskResultTool({
+    input: { directory: '/test/project' } as any,
+    backgroundJobBoard: board,
+    shouldManageSession: (sessionID) => sessionID === 'parent-1',
+  });
+  return { board, get, messages, tool: tools.task_result };
+}
+
+describe('task_result', () => {
+  test('returns completed task text without prompting the child', async () => {
+    const { board, tool, messages } = createTool();
+    board.registerLaunch({
+      taskID: 'ses_child1',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+      description: 'trace bug',
+    });
+    board.updateStatus({ taskID: 'ses_child1', state: 'completed' });
+
+    const output = await tool.execute({ task_id: 'exp-1' }, {
+      sessionID: 'parent-1',
+      agent: 'orchestrator',
+    } as any);
+
+    expect(output).toBe('complete findings');
+    expect(messages).toHaveBeenCalledTimes(1);
+    expect(mockClient.session.prompt).toBeUndefined();
+    expect(mockClient.session.promptAsync).toBeUndefined();
+  });
+
+  test('rejects a still-running tracked task', async () => {
+    const { board, tool, messages } = createTool();
+    board.registerLaunch({
+      taskID: 'ses_child1',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+      description: 'trace bug',
+    });
+
+    await expect(
+      tool.execute({ task_id: 'exp-1' }, {
+        sessionID: 'parent-1',
+        agent: 'orchestrator',
+      } as any),
+    ).rejects.toThrow('still running');
+    expect(messages).not.toHaveBeenCalled();
+  });
+
+  test('rejects an untracked child whose live session is busy', async () => {
+    const { tool, messages } = createTool();
+    mockClient.session.status.mockImplementation(async () => ({
+      data: { ses_child1: { type: 'busy' } },
+    }));
+
+    await expect(
+      tool.execute({ task_id: 'ses_child1' }, {
+        sessionID: 'parent-1',
+        agent: 'orchestrator',
+      } as any),
+    ).rejects.toThrow('still running');
+    expect(messages).not.toHaveBeenCalled();
+  });
+
+  test('rejects a task owned by another parent session', async () => {
+    const { tool, get, messages } = createTool();
+    get.mockImplementation(async () => ({
+      data: { parentID: 'other-parent' },
+    }));
+
+    await expect(
+      tool.execute({ task_id: 'ses_child1' }, {
+        sessionID: 'parent-1',
+        agent: 'orchestrator',
+      } as any),
+    ).rejects.toThrow('does not belong to this session');
+    expect(messages).not.toHaveBeenCalled();
+  });
+});

--- a/src/tools/task-result.test.ts
+++ b/src/tools/task-result.test.ts
@@ -29,7 +29,6 @@ function createTool() {
   const tools = createTaskResultTool({
     input: { directory: '/test/project' } as any,
     backgroundJobBoard: board,
-    shouldManageSession: (sessionID) => sessionID === 'parent-1',
   });
   return { board, get, messages, tool: tools.task_result };
 }
@@ -54,6 +53,36 @@ describe('task_result', () => {
     expect(messages).toHaveBeenCalledTimes(1);
     expect(mockClient.session.prompt).toBeUndefined();
     expect(mockClient.session.promptAsync).toBeUndefined();
+  });
+
+  test('returns only the final assistant response', async () => {
+    const { board, tool } = createTool();
+    board.registerLaunch({
+      taskID: 'ses_child1',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+      description: 'trace bug',
+    });
+    board.updateStatus({ taskID: 'ses_child1', state: 'completed' });
+    mockClient.session.messages.mockResolvedValue({
+      data: [
+        {
+          info: { role: 'assistant' },
+          parts: [{ type: 'text', text: 'earlier progress' }],
+        },
+        {
+          info: { role: 'assistant' },
+          parts: [{ type: 'text', text: 'final findings' }],
+        },
+      ],
+    });
+
+    await expect(
+      tool.execute({ task_id: 'exp-1' }, {
+        sessionID: 'parent-1',
+        agent: 'fixer',
+      } as any),
+    ).resolves.toBe('final findings');
   });
 
   test('rejects a still-running tracked task', async () => {

--- a/src/tools/task-result.test.ts
+++ b/src/tools/task-result.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, mock, test } from 'bun:test';
 import { BackgroundJobBoard } from '../utils/background-job-board';
+import { buildPluginInput } from '../v2/client-shim';
 import { createTaskResultTool } from './task-result';
 
 let mockClient: Record<string, any>;
@@ -86,6 +87,45 @@ describe('task_result', () => {
       } as any),
     ).rejects.toThrow('still running');
     expect(messages).not.toHaveBeenCalled();
+  });
+
+  test('rejects an untracked child whose live session is retrying', async () => {
+    const { tool, messages } = createTool();
+    mockClient.session.status.mockImplementation(async () => ({
+      data: { ses_child1: { type: 'retry' } },
+    }));
+
+    await expect(
+      tool.execute({ task_id: 'ses_child1' }, {
+        sessionID: 'parent-1',
+        agent: 'orchestrator',
+      } as any),
+    ).rejects.toThrow('still running');
+    expect(messages).not.toHaveBeenCalled();
+  });
+
+  test('returns a tracked result through the v2 client shim', async () => {
+    const { board, tool } = createTool();
+    board.registerLaunch({
+      taskID: 'ses_child1',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+      description: 'trace bug',
+    });
+    board.updateStatus({
+      taskID: 'ses_child1',
+      state: 'completed',
+      resultSummary: 'complete findings',
+    });
+    mockClient = (buildPluginInput('/test/project') as { client: never })
+      .client;
+
+    const output = await tool.execute({ task_id: 'exp-1' }, {
+      sessionID: 'parent-1',
+      agent: 'orchestrator',
+    } as any);
+
+    expect(output).toBe('complete findings');
   });
 
   test('rejects a task owned by another parent session', async () => {

--- a/src/tools/task-result.ts
+++ b/src/tools/task-result.ts
@@ -3,6 +3,7 @@ import {
   type ToolDefinition,
   tool,
 } from '@opencode-ai/plugin';
+import type { BackgroundJobRecord } from '../utils/background-job-board';
 import type { BackgroundJobStore } from '../utils/background-job-store';
 import { isRecord } from '../utils/guards';
 import { getClient } from '../utils/opencode-client';
@@ -16,6 +17,41 @@ const z = tool.schema;
 interface TaskResultToolOptions {
   input: PluginInput;
   backgroundJobBoard: BackgroundJobStore;
+}
+
+/**
+ * Gate tracked task retrieval on the tracked terminal outcome. Only a
+ * `completed` state (or a reconciled job whose terminal outcome was
+ * `completed`) may yield a successful result; running, errored and cancelled
+ * jobs are rejected explicitly and accurately instead of leaking partial
+ * output as a final result.
+ */
+function assertRetrievableState(
+  requested: string,
+  job: BackgroundJobRecord,
+): void {
+  const terminalState =
+    job.state === 'reconciled' ? job.terminalState : job.state;
+
+  if (terminalState === 'running') {
+    throw new Error(
+      `Task ${requested} is still running. Wait for its terminal result instead of retrieving or duplicating it.`,
+    );
+  }
+  if (terminalState === 'error') {
+    throw new Error(
+      `Task ${requested} ended in error: ${job.lastStatusError ?? job.resultSummary ?? 'no error details available'}`,
+    );
+  }
+  if (terminalState === 'cancelled') {
+    const reason = job.resultSummary?.replace(/^cancelled:\s*/i, '');
+    throw new Error(
+      `Task ${requested} was cancelled${reason ? `: ${reason}` : ''}`,
+    );
+  }
+  if (terminalState !== 'completed') {
+    throw new Error(`Task ${requested} has no confirmed completed result`);
+  }
 }
 
 export function createTaskResultTool(
@@ -40,10 +76,8 @@ Use this when the user asks to see a prior task's full result, or before retryin
         parentSessionID,
         requested,
       );
-      if (tracked?.state === 'running') {
-        throw new Error(
-          `Task ${requested} is still running. Wait for its terminal result instead of retrieving or duplicating it.`,
-        );
+      if (tracked) {
+        assertRetrievableState(requested, tracked);
       }
 
       const taskID = tracked?.taskID ?? requested;
@@ -99,6 +133,11 @@ Use this when the user asks to see a prior task's full result, or before retryin
       });
       if (result.empty) {
         throw new Error(`Task ${requested} has no completed text result`);
+      }
+      if (!tracked && result.terminal !== true) {
+        throw new Error(
+          `Task ${requested} shows no terminal evidence of completion; refusing to present partial output as its final result`,
+        );
       }
 
       options.backgroundJobBoard.markUsed(parentSessionID, taskID);

--- a/src/tools/task-result.ts
+++ b/src/tools/task-result.ts
@@ -6,14 +6,16 @@ import {
 import type { BackgroundJobStore } from '../utils/background-job-store';
 import { isRecord } from '../utils/guards';
 import { getClient } from '../utils/opencode-client';
-import { extractSessionResult, SESSION_ID_PATTERN } from '../utils/session';
+import {
+  extractFinalSessionResult,
+  SESSION_ID_PATTERN,
+} from '../utils/session';
 
 const z = tool.schema;
 
 interface TaskResultToolOptions {
   input: PluginInput;
   backgroundJobBoard: BackgroundJobStore;
-  shouldManageSession: (sessionID: string) => boolean;
 }
 
 export function createTaskResultTool(
@@ -31,15 +33,6 @@ Use this when the user asks to see a prior task's full result, or before retryin
     async execute(args, toolContext) {
       const parentSessionID = toolContext?.sessionID;
       if (!parentSessionID) throw new Error('task_result requires sessionID');
-      if (toolContext.agent && toolContext.agent !== 'orchestrator') {
-        throw new Error('task_result can only be used by orchestrator');
-      }
-      if (!options.shouldManageSession(parentSessionID)) {
-        throw new Error(
-          'task_result can only be used in orchestrator sessions',
-        );
-      }
-
       const requested = args.task_id.trim();
       if (!requested) throw new Error('task_result requires task_id');
 
@@ -100,7 +93,7 @@ Use this when the user asks to see a prior task's full result, or before retryin
         return result;
       }
 
-      const result = await extractSessionResult(client, taskID, {
+      const result = await extractFinalSessionResult(client, taskID, {
         directory: options.input.directory,
         includeReasoning: false,
       });

--- a/src/tools/task-result.ts
+++ b/src/tools/task-result.ts
@@ -59,13 +59,22 @@ Use this when the user asks to see a prior task's full result, or before retryin
       }
 
       const client = getClient(options.input);
-      const session = await client.session.get({
-        path: { id: taskID },
-        query: { directory: options.input.directory },
-      });
-      const info = session.data as { parentID?: string } | undefined;
-      if (info?.parentID !== parentSessionID) {
-        throw new Error(`Task ${requested} does not belong to this session`);
+      const sessionClient = client.session as typeof client.session & {
+        get?: typeof client.session.get;
+      };
+      if (sessionClient.get) {
+        const session = await sessionClient.get({
+          path: { id: taskID },
+          query: { directory: options.input.directory },
+        });
+        const info = session.data as { parentID?: string } | undefined;
+        if (info?.parentID !== parentSessionID) {
+          throw new Error(`Task ${requested} does not belong to this session`);
+        }
+      } else if (!tracked) {
+        throw new Error(
+          `Task ${requested} is not tracked by this session and cannot be verified`,
+        );
       }
 
       const statuses = await client.session.status({
@@ -73,10 +82,22 @@ Use this when the user asks to see a prior task's full result, or before retryin
       });
       const statusMap = statuses.data;
       const status = isRecord(statusMap) ? statusMap[taskID] : undefined;
-      if (isRecord(status) && status.type === 'busy') {
+      if (
+        isRecord(status) &&
+        (status.type === 'busy' || status.type === 'retry')
+      ) {
         throw new Error(
           `Task ${requested} is still running. Wait for its terminal result instead of retrieving or duplicating it.`,
         );
+      }
+
+      if (!sessionClient.get) {
+        const result = tracked?.resultSummary?.trim();
+        if (!result) {
+          throw new Error(`Task ${requested} has no completed text result`);
+        }
+        options.backgroundJobBoard.markUsed(parentSessionID, taskID);
+        return result;
       }
 
       const result = await extractSessionResult(client, taskID, {

--- a/src/tools/task-result.ts
+++ b/src/tools/task-result.ts
@@ -1,0 +1,96 @@
+import {
+  type PluginInput,
+  type ToolDefinition,
+  tool,
+} from '@opencode-ai/plugin';
+import type { BackgroundJobStore } from '../utils/background-job-store';
+import { isRecord } from '../utils/guards';
+import { getClient } from '../utils/opencode-client';
+import { extractSessionResult, SESSION_ID_PATTERN } from '../utils/session';
+
+const z = tool.schema;
+
+interface TaskResultToolOptions {
+  input: PluginInput;
+  backgroundJobBoard: BackgroundJobStore;
+  shouldManageSession: (sessionID: string) => boolean;
+}
+
+export function createTaskResultTool(
+  options: TaskResultToolOptions,
+): Record<string, ToolDefinition> {
+  const task_result = tool({
+    description: `Retrieve the final text already produced by a specialist task without resuming or re-running it.
+
+Use this when the user asks to see a prior task's full result, or before retrying work whose completed output may already answer the request. Accepts either the native task_id/session ID or the parent-scoped alias shown in the Background Job Board. This tool is read-only and never sends a new prompt to the specialist.`,
+    args: {
+      task_id: z
+        .string()
+        .describe('Completed task ID or Background Job Board alias'),
+    },
+    async execute(args, toolContext) {
+      const parentSessionID = toolContext?.sessionID;
+      if (!parentSessionID) throw new Error('task_result requires sessionID');
+      if (toolContext.agent && toolContext.agent !== 'orchestrator') {
+        throw new Error('task_result can only be used by orchestrator');
+      }
+      if (!options.shouldManageSession(parentSessionID)) {
+        throw new Error(
+          'task_result can only be used in orchestrator sessions',
+        );
+      }
+
+      const requested = args.task_id.trim();
+      if (!requested) throw new Error('task_result requires task_id');
+
+      const tracked = options.backgroundJobBoard.resolve(
+        parentSessionID,
+        requested,
+      );
+      if (tracked?.state === 'running') {
+        throw new Error(
+          `Task ${requested} is still running. Wait for its terminal result instead of retrieving or duplicating it.`,
+        );
+      }
+
+      const taskID = tracked?.taskID ?? requested;
+      if (!SESSION_ID_PATTERN.test(taskID)) {
+        throw new Error(`Unknown task ID or alias: ${requested}`);
+      }
+
+      const client = getClient(options.input);
+      const session = await client.session.get({
+        path: { id: taskID },
+        query: { directory: options.input.directory },
+      });
+      const info = session.data as { parentID?: string } | undefined;
+      if (info?.parentID !== parentSessionID) {
+        throw new Error(`Task ${requested} does not belong to this session`);
+      }
+
+      const statuses = await client.session.status({
+        query: { directory: options.input.directory },
+      });
+      const statusMap = statuses.data;
+      const status = isRecord(statusMap) ? statusMap[taskID] : undefined;
+      if (isRecord(status) && status.type === 'busy') {
+        throw new Error(
+          `Task ${requested} is still running. Wait for its terminal result instead of retrieving or duplicating it.`,
+        );
+      }
+
+      const result = await extractSessionResult(client, taskID, {
+        directory: options.input.directory,
+        includeReasoning: false,
+      });
+      if (result.empty) {
+        throw new Error(`Task ${requested} has no completed text result`);
+      }
+
+      options.backgroundJobBoard.markUsed(parentSessionID, taskID);
+      return result.text;
+    },
+  });
+
+  return { task_result };
+}

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -163,6 +163,11 @@ function isPromptCancellationError(error: unknown): boolean {
 export interface SessionExtractionResult {
   text: string;
   empty: boolean;
+  /** True only when the last message is a completed assistant turn with no
+   *  message-level error. This is terminal evidence that the session is not
+   *  idle mid-work; callers must not present partial output as a final result
+   *  without it. */
+  terminal?: boolean;
 }
 
 /** Extract only the final assistant response to keep task retrieval bounded. */
@@ -177,7 +182,11 @@ export async function extractFinalSessionResult(
     ...(options?.directory ? { query: { directory: options.directory } } : {}),
   });
   const messages = (messagesResult.data ?? []) as Array<{
-    info?: { role: string };
+    info?: {
+      role: string;
+      time?: { completed?: number };
+      error?: unknown;
+    };
     parts?: Array<{ type: string; text?: string }>;
   }>;
   const message = messages.findLast((item) => item.info?.role === 'assistant');
@@ -191,7 +200,14 @@ export async function extractFinalSessionResult(
     .map((part) => part.text!)
     .join('\n\n');
 
-  return { text, empty: text.length === 0 };
+  const last = messages[messages.length - 1];
+  const terminal =
+    last !== undefined &&
+    last === message &&
+    typeof last.info?.time?.completed === 'number' &&
+    last.info?.error === undefined;
+
+  return { text, empty: text.length === 0, terminal };
 }
 
 /**

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -165,6 +165,35 @@ export interface SessionExtractionResult {
   empty: boolean;
 }
 
+/** Extract only the final assistant response to keep task retrieval bounded. */
+export async function extractFinalSessionResult(
+  client: OpencodeClient,
+  sessionId: string,
+  options?: { directory?: string; includeReasoning?: boolean },
+): Promise<SessionExtractionResult> {
+  const includeReasoning = options?.includeReasoning ?? true;
+  const messagesResult = await client.session.messages({
+    path: { id: sessionId },
+    ...(options?.directory ? { query: { directory: options.directory } } : {}),
+  });
+  const messages = (messagesResult.data ?? []) as Array<{
+    info?: { role: string };
+    parts?: Array<{ type: string; text?: string }>;
+  }>;
+  const message = messages.findLast((item) => item.info?.role === 'assistant');
+  const text = (message?.parts ?? [])
+    .filter(
+      (part) =>
+        (includeReasoning
+          ? part.type === 'text' || part.type === 'reasoning'
+          : part.type === 'text') && Boolean(part.text),
+    )
+    .map((part) => part.text!)
+    .join('\n\n');
+
+  return { text, empty: text.length === 0 };
+}
+
 /**
  * Extract the result text from a session.
  * Collects all assistant messages and concatenates their text parts.


### PR DESCRIPTION
## What changed, and why was it needed?

Closes #828.

A completed specialist result can already exist in the child session while the orchestrator no longer has the full tool payload in its active context. Passing that child's `task_id` back to `task()` does not retrieve the saved result: it resumes and re-prompts the child. In the reproduced #828 failure mode, this ambiguity led to duplicate specialist work.

`task_result` is a read-only retrieval tool that returns **only the final assistant message** of a completed child session — bounded and non-resuming — and may be called by **any parent agent session that owns the task** (not only the orchestrator):

- accepts a parent-scoped board alias or native child session ID;
- verifies the child belongs to the calling parent session (board ownership resolution or `parentID` check);
- rejects tracked running, errored and cancelled tasks with accurate per-state errors, and live `busy`/`retry` sessions;
- returns just the last assistant message via `extractFinalSessionResult`, excluding reasoning parts and earlier assistant turns; untracked sessions are only presented as final when terminal evidence exists (last message is a completed assistant turn with no message-level error);
- falls back to the persisted parent-scoped `resultSummary` when the client has no session read path;
- marks tracked sessions as used after successful retrieval;
- never calls `prompt` or `promptAsync`.

The orchestrator prompt now checks existing work before dispatch and uses `task_result` before retrying completed work. It also clarifies that `task(..., task_id: ...)` is resume, not fetch.

## Verification

Follow-up review remediation (`540bfbc`) tightened result-finality semantics: tracked retrieval now requires the tracked terminal outcome to be `completed` (reconciled jobs honor their recorded terminal state), errored/cancelled jobs fail with explicit accurate errors instead of leaking partial output, and untracked idle sessions are rejected unless the last assistant message carries terminal evidence (`time.completed`, no `error`). New regression coverage added for all three behaviors.

- `bun test src/hooks/cache-payload.snapshot.test.ts src/tools/task-result.test.ts src/tools/cancel-task.test.ts`: 40 pass, 0 fail; 3 snapshots pass
- `bun run typecheck`: pass
- `git diff --check`: pass

Both Greptile findings were addressed with regression coverage and their review threads are resolved.

Issue confirmation and follow-up: https://github.com/alvinunreal/oh-my-opencode-slim/issues/828#issuecomment-5253827008
