### PR TITLE
feat(tasks): add task_status and task_nudge supervision tools

### DIFF
--- a/src/agents/orchestrator.ts
+++ b/src/agents/orchestrator.ts
@@ -221,6 +221,8 @@ Balance: respect dependencies, avoid parallelizing what must be sequential, and 
 - Before dispatching a specialist, check the Background Job Board and current conversation for an existing task that already covers the objective.
 - \`task_result\` returns only a completed specialist's final assistant message, and can be called by any parent session that owns the task. Never use \`task(..., task_id: ...)\` to fetch output: that resumes the child and starts new model work.
 - Before retrying completed work whose result appears missing or incomplete, retrieve it with \`task_result\`. Dispatch again only when the retrieved result does not satisfy the objective.
+- For a live child task, call \`task_status\` for read-only state inspection. There is no safe live-prompt channel: never use \`task(..., task_id: ...)\` as a progress check or instruction because it resumes model work.
+- If \`task_status\` reports \`possibly_stuck: true\`, use \`task_nudge\` once to admit a concise follow-up without resuming or aborting the child; never use it as a polling loop.
 - Prefer \`task(..., background: true)\` for delegated work that can run independently.
 - For work already chosen for delegation, launch independent specialist lanes in the background so the orchestrator stays unblocked and can reconcile results when they return.
 - Never reissue an unchanged task to the same specialist after a rejection; adjust its scope or context before retrying.

--- a/src/hooks/__snapshots__/cache-payload.snapshot.test.ts.snap
+++ b/src/hooks/__snapshots__/cache-payload.snapshot.test.ts.snap
@@ -154,6 +154,8 @@ Balance: respect dependencies, avoid parallelizing what must be sequential, and 
 - Before dispatching a specialist, check the Background Job Board and current conversation for an existing task that already covers the objective.
 - \`task_result\` returns only a completed specialist's final assistant message, and can be called by any parent session that owns the task. Never use \`task(..., task_id: ...)\` to fetch output: that resumes the child and starts new model work.
 - Before retrying completed work whose result appears missing or incomplete, retrieve it with \`task_result\`. Dispatch again only when the retrieved result does not satisfy the objective.
+- For a live child task, call \`task_status\` for read-only state inspection. There is no safe live-prompt channel: never use \`task(..., task_id: ...)\` as a progress check or instruction because it resumes model work.
+- If \`task_status\` reports \`possibly_stuck: true\`, use \`task_nudge\` once to admit a concise follow-up without resuming or aborting the child; never use it as a polling loop.
 - Prefer \`task(..., background: true)\` for delegated work that can run independently.
 - For work already chosen for delegation, launch independent specialist lanes in the background so the orchestrator stays unblocked and can reconcile results when they return.
 - Never reissue an unchanged task to the same specialist after a rejection; adjust its scope or context before retrying.

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,10 +45,13 @@ import {
   ast_grep_search,
   createAcpRunTool,
   createCancelTaskTool,
+  createTaskNudgeTool,
   createTaskResultTool,
+  createTaskStatusTool,
   createWaitForUserTool,
   createWebfetchTool,
 } from './tools';
+import { TaskActivityTracker } from './tools/task-activity';
 import { pickAgentModelRef } from './tools/smartfetch/secondary-model';
 import { recordTuiAgentModel, recordTuiAgentModels } from './tui-state';
 import {
@@ -169,6 +172,9 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
   let companionManager: CompanionManager;
   let cancelTaskTools: ReturnType<typeof createCancelTaskTool>;
   let taskResultTools: ReturnType<typeof createTaskResultTool>;
+  let taskStatusTools: ReturnType<typeof createTaskStatusTool>;
+  let taskNudgeTools: ReturnType<typeof createTaskNudgeTool>;
+  const taskActivityTracker = new TaskActivityTracker();
   let waitForUserTools: ReturnType<typeof createWaitForUserTool>;
   let acpRunTools: Record<string, ReturnType<typeof createAcpRunTool>>;
   let webfetch: ReturnType<typeof createWebfetchTool>;
@@ -440,6 +446,15 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
       input: ctx,
       backgroundJobBoard: backgroundJobCoordinator,
     });
+    taskStatusTools = createTaskStatusTool({
+      input: ctx,
+      backgroundJobBoard: backgroundJobCoordinator,
+      activityTracker: taskActivityTracker,
+    });
+    taskNudgeTools = createTaskNudgeTool({
+      input: ctx,
+      backgroundJobBoard: backgroundJobCoordinator,
+    });
     waitForUserTools = createWaitForUserTool({
       shouldManageSession: (sessionID) =>
         sessionMetadata.getAgent(sessionID) === 'orchestrator',
@@ -457,6 +472,8 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
     tools = {
       ...cancelTaskTools,
       ...taskResultTools,
+      ...taskStatusTools,
+      ...taskNudgeTools,
       ...waitForUserTools,
       ...acpRunTools,
       ...(shouldRegisterWebfetch ? { webfetch } : {}),
@@ -891,9 +908,18 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
       };
 
       const eventSessionID =
-        event.properties?.info?.id ?? event.properties?.sessionID;
+        event.properties?.info?.id ??
+        event.properties?.info?.sessionID ??
+        event.properties?.sessionID;
       const statusType = event.properties?.status?.type;
       if (eventSessionID) {
+        if (
+          event.type === 'message.updated' ||
+          event.type === 'step-finish' ||
+          (event.type === 'session.status' && (statusType === 'busy' || statusType === 'retry'))
+        ) {
+          taskActivityTracker.touch(eventSessionID);
+        }
         if (
           event.type === 'session.status' &&
           (statusType === 'busy' || statusType === 'retry')
@@ -905,6 +931,7 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
           event.type === 'session.deleted'
         ) {
           sessionMetadata.markOrchestratorIdle(eventSessionID);
+          if (event.type === 'session.deleted') taskActivityTracker.forget(eventSessionID);
         }
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,8 +51,12 @@ import {
   createWaitForUserTool,
   createWebfetchTool,
 } from './tools';
-import { TaskActivityTracker } from './tools/task-activity';
 import { pickAgentModelRef } from './tools/smartfetch/secondary-model';
+import {
+  applyActivityEvent,
+  resolveEventSessionID,
+  TaskActivityTracker,
+} from './tools/task-activity';
 import { recordTuiAgentModel, recordTuiAgentModels } from './tui-state';
 import {
   BackgroundJobBoard,
@@ -454,6 +458,7 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
     taskNudgeTools = createTaskNudgeTool({
       input: ctx,
       backgroundJobBoard: backgroundJobCoordinator,
+      activityTracker: taskActivityTracker,
     });
     waitForUserTools = createWaitForUserTool({
       shouldManageSession: (sessionID) =>
@@ -907,19 +912,14 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
         };
       };
 
-      const eventSessionID =
-        event.properties?.info?.id ??
-        event.properties?.info?.sessionID ??
-        event.properties?.sessionID;
+      // Session-scoped events (session.*) carry the session id in info.id;
+      // message/step-scoped events (message.updated, step-finish) carry the
+      // message id in info.id and the session id in info.sessionID. Resolve
+      // by session so child activity refreshes the correct stuck timer.
+      const eventSessionID = resolveEventSessionID(event);
       const statusType = event.properties?.status?.type;
       if (eventSessionID) {
-        if (
-          event.type === 'message.updated' ||
-          event.type === 'step-finish' ||
-          (event.type === 'session.status' && (statusType === 'busy' || statusType === 'retry'))
-        ) {
-          taskActivityTracker.touch(eventSessionID);
-        }
+        applyActivityEvent(taskActivityTracker, event);
         if (
           event.type === 'session.status' &&
           (statusType === 'busy' || statusType === 'retry')
@@ -931,7 +931,6 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
           event.type === 'session.deleted'
         ) {
           sessionMetadata.markOrchestratorIdle(eventSessionID);
-          if (event.type === 'session.deleted') taskActivityTracker.forget(eventSessionID);
         }
       }
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -3,5 +3,7 @@ export { createAcpRunTool } from './acp-run';
 export { ast_grep_replace, ast_grep_search } from './ast-grep';
 export { createCancelTaskTool } from './cancel-task';
 export { createWebfetchTool } from './smartfetch';
+export { createTaskNudgeTool } from './task-nudge';
 export { createTaskResultTool } from './task-result';
+export { createTaskStatusTool } from './task-status';
 export { createWaitForUserTool } from './wait-for-user';

--- a/src/tools/task-activity.test.ts
+++ b/src/tools/task-activity.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  applyActivityEvent,
+  resolveEventSessionID,
+  TaskActivityTracker,
+} from './task-activity';
+
+describe('resolveEventSessionID', () => {
+  test('keys message.updated by info.sessionID, not the message id', () => {
+    expect(
+      resolveEventSessionID({
+        type: 'message.updated',
+        properties: { info: { id: 'msg_123', sessionID: 'ses_child1' } },
+      }),
+    ).toBe('ses_child1');
+  });
+
+  test('keys step-finish by info.sessionID, not the step/message id', () => {
+    expect(
+      resolveEventSessionID({
+        type: 'step-finish',
+        properties: { info: { id: 'step_9', sessionID: 'ses_child1' } },
+      }),
+    ).toBe('ses_child1');
+  });
+
+  test('keys session-scoped events by info.id (the session id)', () => {
+    expect(
+      resolveEventSessionID({
+        type: 'session.status',
+        properties: { info: { id: 'ses_child1' }, status: { type: 'busy' } },
+      }),
+    ).toBe('ses_child1');
+    expect(
+      resolveEventSessionID({
+        type: 'session.deleted',
+        properties: { info: { id: 'ses_child1' } },
+      }),
+    ).toBe('ses_child1');
+  });
+
+  test('falls back to properties.sessionID', () => {
+    expect(
+      resolveEventSessionID({
+        type: 'session.status',
+        properties: { sessionID: 'ses_child1', status: { type: 'retry' } },
+      }),
+    ).toBe('ses_child1');
+  });
+
+  test('returns undefined without any session id', () => {
+    expect(
+      resolveEventSessionID({
+        type: 'message.updated',
+        properties: { info: { id: 'msg_1' } },
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe('TaskActivityTracker event integration', () => {
+  test('message.updated activity refreshes the child session key, never the message id', () => {
+    const tracker = new TaskActivityTracker();
+    applyActivityEvent(
+      tracker,
+      {
+        type: 'message.updated',
+        properties: { info: { id: 'msg_1', sessionID: 'ses_child1' } },
+      },
+      1_000,
+    );
+    expect(tracker.lastActivityAt('ses_child1')).toBe(1_000);
+    expect(tracker.lastActivityAt('msg_1')).toBeUndefined();
+  });
+
+  test('busy session.status, retry status, and step-finish all refresh activity', () => {
+    const tracker = new TaskActivityTracker();
+    applyActivityEvent(
+      tracker,
+      {
+        type: 'session.status',
+        properties: { info: { id: 'ses_child1' }, status: { type: 'busy' } },
+      },
+      1_000,
+    );
+    expect(tracker.lastActivityAt('ses_child1')).toBe(1_000);
+
+    applyActivityEvent(
+      tracker,
+      {
+        type: 'message.updated',
+        properties: { info: { id: 'msg_2', sessionID: 'ses_child1' } },
+      },
+      2_000,
+    );
+    expect(tracker.lastActivityAt('ses_child1')).toBe(2_000);
+
+    applyActivityEvent(
+      tracker,
+      {
+        type: 'step-finish',
+        properties: { info: { id: 'step_3', sessionID: 'ses_child1' } },
+      },
+      3_000,
+    );
+    expect(tracker.lastActivityAt('ses_child1')).toBe(3_000);
+
+    applyActivityEvent(
+      tracker,
+      {
+        type: 'session.status',
+        properties: { info: { id: 'ses_child1' }, status: { type: 'retry' } },
+      },
+      4_000,
+    );
+    expect(tracker.lastActivityAt('ses_child1')).toBe(4_000);
+  });
+
+  test('idle status does not refresh activity; session.deleted forgets it', () => {
+    const tracker = new TaskActivityTracker();
+    applyActivityEvent(
+      tracker,
+      {
+        type: 'session.status',
+        properties: { info: { id: 'ses_child1' }, status: { type: 'busy' } },
+      },
+      1_000,
+    );
+    applyActivityEvent(
+      tracker,
+      {
+        type: 'session.status',
+        properties: { info: { id: 'ses_child1' }, status: { type: 'idle' } },
+      },
+      2_000,
+    );
+    // Idle is not activity: the stuck timer keeps the last busy timestamp.
+    expect(tracker.lastActivityAt('ses_child1')).toBe(1_000);
+
+    applyActivityEvent(
+      tracker,
+      { type: 'session.deleted', properties: { info: { id: 'ses_child1' } } },
+      3_000,
+    );
+    expect(tracker.lastActivityAt('ses_child1')).toBeUndefined();
+  });
+});

--- a/src/tools/task-activity.ts
+++ b/src/tools/task-activity.ts
@@ -1,3 +1,49 @@
+/**
+ * Activity event shapes the tracker consumes. `info.id` is the session id
+ * for session-scoped events (session.*) but the message/step id for
+ * message-scoped events (message.updated, step-finish); the session id for
+ * those lives in `info.sessionID`.
+ */
+export interface ActivityEvent {
+  type: string;
+  properties?: {
+    info?: { id?: string; sessionID?: string };
+    sessionID?: string;
+    status?: { type?: string };
+  };
+}
+
+/**
+ * Resolves the session id from an event, keying message/step-scoped events
+ * by `info.sessionID` (never the message id) and session-scoped events by
+ * `info.id`. Returns undefined when no session id is present.
+ */
+export function resolveEventSessionID(
+  event: ActivityEvent,
+): string | undefined {
+  const info = event.properties?.info;
+  if (event.type === 'message.updated' || event.type === 'step-finish') {
+    return info?.sessionID ?? event.properties?.sessionID;
+  }
+  return info?.id ?? event.properties?.sessionID;
+}
+
+/** True when the event is observable child activity that refreshes the stuck timer. */
+export function shouldRecordActivity(event: ActivityEvent): boolean {
+  const statusType = event.properties?.status?.type;
+  return (
+    event.type === 'message.updated' ||
+    event.type === 'step-finish' ||
+    (event.type === 'session.status' &&
+      (statusType === 'busy' || statusType === 'retry'))
+  );
+}
+
+/** True when the session is gone and its activity bookkeeping can be dropped. */
+export function shouldForgetActivity(event: ActivityEvent): boolean {
+  return event.type === 'session.deleted';
+}
+
 export class TaskActivityTracker {
   private readonly activity = new Map<string, number>();
 
@@ -11,5 +57,24 @@ export class TaskActivityTracker {
 
   forget(sessionID: string): void {
     this.activity.delete(sessionID);
+  }
+}
+
+/**
+ * Applies an event to the tracker: records activity for live child signals
+ * keyed by session id, forgets sessions on deletion. This mirrors the wiring
+ * in src/index.ts so the event policy is testable in isolation.
+ */
+export function applyActivityEvent(
+  tracker: TaskActivityTracker,
+  event: ActivityEvent,
+  now = Date.now(),
+): void {
+  const sessionID = resolveEventSessionID(event);
+  if (!sessionID) return;
+  if (shouldRecordActivity(event)) {
+    tracker.touch(sessionID, now);
+  } else if (shouldForgetActivity(event)) {
+    tracker.forget(sessionID);
   }
 }

--- a/src/tools/task-activity.ts
+++ b/src/tools/task-activity.ts
@@ -1,0 +1,15 @@
+export class TaskActivityTracker {
+  private readonly activity = new Map<string, number>();
+
+  touch(sessionID: string, now = Date.now()): void {
+    if (sessionID) this.activity.set(sessionID, now);
+  }
+
+  lastActivityAt(sessionID: string): number | undefined {
+    return this.activity.get(sessionID);
+  }
+
+  forget(sessionID: string): void {
+    this.activity.delete(sessionID);
+  }
+}

--- a/src/tools/task-nudge.test.ts
+++ b/src/tools/task-nudge.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { BackgroundJobBoard } from '../utils/background-job-board';
+import { createTaskNudgeTool } from './task-nudge';
+
+let client: Record<string, any>;
+mock.module('../utils/opencode-client', () => ({ getClient: () => client }));
+
+describe('task_nudge', () => {
+  test('admits a parent-owned running child without resuming it', async () => {
+    const board = new BackgroundJobBoard();
+    board.registerLaunch({ taskID: 'ses_child1', parentSessionID: 'parent-1', agent: 'fixer', description: 'implement' });
+    const prompt = mock(async () => ({}));
+    client = { session: { prompt } };
+    const { task_nudge } = createTaskNudgeTool({ input: { directory: '/test' } as any, backgroundJobBoard: board, now: () => 0 });
+    await expect(task_nudge.execute({ task_id: 'ses_child1', message: 'Please continue.' }, { sessionID: 'parent-1' } as any)).resolves.toContain('without resuming');
+    expect(prompt).toHaveBeenCalledWith({ path: { id: 'ses_child1' }, body: { noReply: true, parts: [{ type: 'text', text: 'Please continue.' }] } });
+    await expect(task_nudge.execute({ task_id: 'ses_child1', message: 'Again' }, { sessionID: 'parent-1' } as any)).rejects.toThrow('nudged recently');
+  });
+});

--- a/src/tools/task-nudge.test.ts
+++ b/src/tools/task-nudge.test.ts
@@ -5,15 +5,309 @@ import { createTaskNudgeTool } from './task-nudge';
 let client: Record<string, any>;
 mock.module('../utils/opencode-client', () => ({ getClient: () => client }));
 
+function registerStuckChild(
+  board: BackgroundJobBoard,
+  taskID = 'ses_child1',
+  parent = 'parent-1',
+): void {
+  board.registerLaunch({
+    taskID,
+    parentSessionID: parent,
+    agent: 'fixer',
+    description: 'implement',
+    now: 0,
+  });
+}
+
+function busyClient(promptCalls: Array<() => Promise<unknown>> = []): void {
+  client = {
+    session: {
+      status: mock(async () => ({
+        data: { ses_child1: { type: 'busy' } },
+      })),
+      prompt: mock(async () => {
+        const next = promptCalls.shift();
+        if (next) return next();
+        return {};
+      }),
+    },
+  };
+}
+
 describe('task_nudge', () => {
-  test('admits a parent-owned running child without resuming it', async () => {
+  test('admits a parent-owned live, possibly-stuck child via noReply without resuming it', async () => {
     const board = new BackgroundJobBoard();
-    board.registerLaunch({ taskID: 'ses_child1', parentSessionID: 'parent-1', agent: 'fixer', description: 'implement' });
+    registerStuckChild(board);
     const prompt = mock(async () => ({}));
-    client = { session: { prompt } };
-    const { task_nudge } = createTaskNudgeTool({ input: { directory: '/test' } as any, backgroundJobBoard: board, now: () => 0 });
-    await expect(task_nudge.execute({ task_id: 'ses_child1', message: 'Please continue.' }, { sessionID: 'parent-1' } as any)).resolves.toContain('without resuming');
-    expect(prompt).toHaveBeenCalledWith({ path: { id: 'ses_child1' }, body: { noReply: true, parts: [{ type: 'text', text: 'Please continue.' }] } });
-    await expect(task_nudge.execute({ task_id: 'ses_child1', message: 'Again' }, { sessionID: 'parent-1' } as any)).rejects.toThrow('nudged recently');
+    client = {
+      session: {
+        status: mock(async () => ({
+          data: { ses_child1: { type: 'busy' } },
+        })),
+        prompt,
+      },
+    };
+    const { task_nudge } = createTaskNudgeTool({
+      input: { directory: '/test' } as any,
+      backgroundJobBoard: board,
+      now: () => 120_000,
+    });
+    await expect(
+      task_nudge.execute(
+        { task_id: 'ses_child1', message: 'Please continue.' },
+        { sessionID: 'parent-1' } as any,
+      ),
+    ).resolves.toContain('without resuming');
+    expect(prompt).toHaveBeenCalledTimes(1);
+    expect(prompt).toHaveBeenCalledWith({
+      path: { id: 'ses_child1' },
+      body: {
+        noReply: true,
+        parts: [{ type: 'text', text: 'Please continue.' }],
+      },
+    });
+    // The mocked client exposes no resume/promptAsync channel at all, so an
+    // admitted nudge can only have used the noReply prompt path.
+    expect((client.session as any).promptAsync).toBeUndefined();
+  });
+
+  test('rejects a second nudge within the 30s window', async () => {
+    const board = new BackgroundJobBoard();
+    registerStuckChild(board);
+    const prompt = mock(async () => ({}));
+    client = {
+      session: {
+        status: mock(async () => ({
+          data: { ses_child1: { type: 'busy' } },
+        })),
+        prompt,
+      },
+    };
+    const { task_nudge } = createTaskNudgeTool({
+      input: { directory: '/test' } as any,
+      backgroundJobBoard: board,
+      now: () => 120_000,
+    });
+    await expect(
+      task_nudge.execute({ task_id: 'ses_child1', message: 'First' }, {
+        sessionID: 'parent-1',
+      } as any),
+    ).resolves.toContain('without resuming');
+    await expect(
+      task_nudge.execute({ task_id: 'ses_child1', message: 'Second' }, {
+        sessionID: 'parent-1',
+      } as any),
+    ).rejects.toThrow('nudged recently');
+    expect(prompt).toHaveBeenCalledTimes(1);
+  });
+
+  test('concurrent nudges admit exactly one (atomic rate-limit reservation)', async () => {
+    const board = new BackgroundJobBoard();
+    registerStuckChild(board);
+    const prompt = mock(async () => ({}));
+    client = {
+      session: {
+        status: mock(async () => ({
+          data: { ses_child1: { type: 'busy' } },
+        })),
+        prompt,
+      },
+    };
+    const { task_nudge } = createTaskNudgeTool({
+      input: { directory: '/test' } as any,
+      backgroundJobBoard: board,
+      now: () => 120_000,
+    });
+    const results = await Promise.allSettled([
+      task_nudge.execute({ task_id: 'ses_child1', message: 'First' }, {
+        sessionID: 'parent-1',
+      } as any),
+      task_nudge.execute({ task_id: 'ses_child1', message: 'Second' }, {
+        sessionID: 'parent-1',
+      } as any),
+    ]);
+    const fulfilled = results.filter((result) => result.status === 'fulfilled');
+    const rejected = results.filter((result) => result.status === 'rejected');
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    expect((rejected[0] as PromiseRejectedResult).reason?.message).toContain(
+      'nudged recently',
+    );
+    expect(prompt).toHaveBeenCalledTimes(1);
+  });
+
+  test('refuses to nudge an active child that is not possibly stuck', async () => {
+    const board = new BackgroundJobBoard();
+    registerStuckChild(board);
+    const prompt = mock(async () => ({}));
+    client = {
+      session: {
+        status: mock(async () => ({
+          data: { ses_child1: { type: 'busy' } },
+        })),
+        prompt,
+      },
+    };
+    const { task_nudge } = createTaskNudgeTool({
+      input: { directory: '/test' } as any,
+      backgroundJobBoard: board,
+      now: () => 10_000, // idle for 10s: active, not possibly stuck
+    });
+    await expect(
+      task_nudge.execute({ task_id: 'ses_child1', message: 'Nudge' }, {
+        sessionID: 'parent-1',
+      } as any),
+    ).rejects.toThrow('not possibly stuck');
+    expect(prompt).not.toHaveBeenCalled();
+  });
+
+  test('refuses to nudge when the live status read fails', async () => {
+    const board = new BackgroundJobBoard();
+    registerStuckChild(board);
+    const prompt = mock(async () => ({}));
+    client = {
+      session: {
+        status: mock(async () => {
+          throw new Error('host status read failed');
+        }),
+        prompt,
+      },
+    };
+    const { task_nudge } = createTaskNudgeTool({
+      input: { directory: '/test' } as any,
+      backgroundJobBoard: board,
+      now: () => 120_000,
+    });
+    await expect(
+      task_nudge.execute({ task_id: 'ses_child1', message: 'Nudge' }, {
+        sessionID: 'parent-1',
+      } as any),
+    ).rejects.toThrow('live status unavailable');
+    expect(prompt).not.toHaveBeenCalled();
+  });
+
+  test('refuses to nudge an idle or absent child session', async () => {
+    const board = new BackgroundJobBoard();
+    registerStuckChild(board);
+    const prompt = mock(async () => ({}));
+    client = { session: { status: mock(async () => ({ data: {} })), prompt } };
+    const { task_nudge } = createTaskNudgeTool({
+      input: { directory: '/test' } as any,
+      backgroundJobBoard: board,
+      now: () => 120_000,
+    });
+    await expect(
+      task_nudge.execute({ task_id: 'ses_child1', message: 'Nudge' }, {
+        sessionID: 'parent-1',
+      } as any),
+    ).rejects.toThrow('child session is idle');
+    expect(prompt).not.toHaveBeenCalled();
+  });
+
+  test('refuses to nudge a board-terminal task', async () => {
+    const board = new BackgroundJobBoard();
+    registerStuckChild(board);
+    board.updateStatus({
+      taskID: 'ses_child1',
+      state: 'completed',
+      resultSummary: 'done',
+    });
+    const prompt = mock(async () => ({}));
+    client = {
+      session: {
+        status: mock(async () => ({
+          data: { ses_child1: { type: 'busy' } },
+        })),
+        prompt,
+      },
+    };
+    const { task_nudge } = createTaskNudgeTool({
+      input: { directory: '/test' } as any,
+      backgroundJobBoard: board,
+      now: () => 120_000,
+    });
+    await expect(
+      task_nudge.execute({ task_id: 'ses_child1', message: 'Nudge' }, {
+        sessionID: 'parent-1',
+      } as any),
+    ).rejects.toThrow('board state is completed, not running');
+    expect(prompt).not.toHaveBeenCalled();
+  });
+
+  test('rejects a task id owned by a different parent', async () => {
+    const board = new BackgroundJobBoard();
+    registerStuckChild(board);
+    const { task_nudge } = createTaskNudgeTool({
+      input: { directory: '/test' } as any,
+      backgroundJobBoard: board,
+      now: () => 120_000,
+    });
+    await expect(
+      task_nudge.execute({ task_id: 'ses_child1', message: 'Nudge' }, {
+        sessionID: 'parent-2',
+      } as any),
+    ).rejects.toThrow('Unknown task ID or alias');
+  });
+
+  test('rolls back the rate-limit reservation when the prompt fails', async () => {
+    const board = new BackgroundJobBoard();
+    registerStuckChild(board);
+    let nowValue = 120_000;
+    let failPrompt = true;
+    const prompt = mock(async () => {
+      if (failPrompt) throw new Error('prompt transport failed');
+      return {};
+    });
+    client = {
+      session: {
+        status: mock(async () => ({
+          data: { ses_child1: { type: 'busy' } },
+        })),
+        prompt,
+      },
+    };
+    const { task_nudge } = createTaskNudgeTool({
+      input: { directory: '/test' } as any,
+      backgroundJobBoard: board,
+      now: () => nowValue,
+    });
+    await expect(
+      task_nudge.execute({ task_id: 'ses_child1', message: 'First' }, {
+        sessionID: 'parent-1',
+      } as any),
+    ).rejects.toThrow('prompt transport failed');
+    // A failed nudge must not lock the task out: advance 1s and retry.
+    nowValue = 121_000;
+    failPrompt = false;
+    await expect(
+      task_nudge.execute({ task_id: 'ses_child1', message: 'Second' }, {
+        sessionID: 'parent-1',
+      } as any),
+    ).resolves.toContain('without resuming');
+    expect(prompt).toHaveBeenCalledTimes(2);
+  });
+
+  test('allows a second nudge after the 30s window elapses', async () => {
+    const board = new BackgroundJobBoard();
+    registerStuckChild(board);
+    let nowValue = 120_000;
+    busyClient();
+    const { task_nudge } = createTaskNudgeTool({
+      input: { directory: '/test' } as any,
+      backgroundJobBoard: board,
+      now: () => nowValue,
+    });
+    await expect(
+      task_nudge.execute({ task_id: 'ses_child1', message: 'First' }, {
+        sessionID: 'parent-1',
+      } as any),
+    ).resolves.toContain('without resuming');
+    nowValue = 150_000;
+    await expect(
+      task_nudge.execute({ task_id: 'ses_child1', message: 'Second' }, {
+        sessionID: 'parent-1',
+      } as any),
+    ).resolves.toContain('without resuming');
+    expect(client.session.prompt).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/tools/task-nudge.ts
+++ b/src/tools/task-nudge.ts
@@ -5,6 +5,12 @@ import {
 } from '@opencode-ai/plugin';
 import type { BackgroundJobStore } from '../utils/background-job-store';
 import { getClient } from '../utils/opencode-client';
+import { getRuntimeSessionStatusSnapshot } from '../utils/session-runtime-status';
+import type { TaskActivityTracker } from './task-activity';
+import {
+  evaluateNudgeEligibility,
+  observationFromSnapshot,
+} from './task-policy';
 
 const z = tool.schema;
 const NUDGE_INTERVAL_MS = 30_000;
@@ -12,7 +18,9 @@ const NUDGE_INTERVAL_MS = 30_000;
 export function createTaskNudgeTool(options: {
   input: PluginInput;
   backgroundJobBoard: BackgroundJobStore;
+  activityTracker?: TaskActivityTracker;
   now?: () => number;
+  statusTimeoutMs?: number;
 }): Record<'task_nudge', ToolDefinition> {
   const lastNudgeAt = new Map<string, number>();
   const now = options.now ?? Date.now;
@@ -20,27 +28,74 @@ export function createTaskNudgeTool(options: {
     description:
       'Safely send a bounded follow-up to a live child task without resuming, aborting, or starting another model run. Use only after task_status indicates the child may be stuck.',
     args: {
-      task_id: z.string().describe('Tracked live task ID or parent-scoped alias'),
-      message: z.string().min(1).max(500).describe('Short follow-up instruction'),
+      task_id: z
+        .string()
+        .describe('Tracked live task ID or parent-scoped alias'),
+      message: z
+        .string()
+        .min(1)
+        .max(500)
+        .describe('Short follow-up instruction'),
     },
     async execute(args, toolContext) {
       const parentSessionID = toolContext?.sessionID;
       if (!parentSessionID) throw new Error('task_nudge requires sessionID');
-      const job = options.backgroundJobBoard.resolve(parentSessionID, args.task_id.trim());
+      const job = options.backgroundJobBoard.resolve(
+        parentSessionID,
+        args.task_id.trim(),
+      );
       if (!job) throw new Error(`Unknown task ID or alias: ${args.task_id}`);
-      if (job.state !== 'running') {
-        throw new Error(`Task ${args.task_id} is not running and cannot be nudged`);
-      }
+
+      // Reserve the per-task rate-limit slot synchronously, before the first
+      // await, so a concurrent nudge in the same window observes it. Any
+      // failure rolls the reservation back so a refused or failed nudge
+      // cannot lock the task out for the full interval.
       const at = now();
       const previous = lastNudgeAt.get(job.taskID);
       if (previous !== undefined && at - previous < NUDGE_INTERVAL_MS) {
-        throw new Error(`Task ${args.task_id} was nudged recently; wait 30 seconds`);
+        throw new Error(
+          `Task ${args.task_id} was nudged recently; wait 30 seconds`,
+        );
       }
-      await getClient(options.input).session.prompt({
-        path: { id: job.taskID },
-        body: { noReply: true, parts: [{ type: 'text', text: args.message.trim() }] },
-      });
       lastNudgeAt.set(job.taskID, at);
+
+      try {
+        // Admission requires the same live status/activity policy as
+        // task_status: board-running, live-confirmed busy/retry, and
+        // possibly stuck. A stale board record alone never admits a nudge.
+        const snapshot = await getRuntimeSessionStatusSnapshot(options.input, {
+          timeoutMs: options.statusTimeoutMs,
+        });
+        const observation = observationFromSnapshot(snapshot, job.taskID);
+        const lastActivityAt =
+          options.activityTracker?.lastActivityAt(job.taskID) ??
+          job.lastLiveBusyAt ??
+          job.runStartedAt;
+        const eligibility = evaluateNudgeEligibility(
+          job,
+          observation,
+          lastActivityAt,
+          at,
+        );
+        if (!eligibility.eligible) {
+          throw new Error(
+            `Task ${args.task_id} cannot be nudged: ${eligibility.reason}`,
+          );
+        }
+
+        await getClient(options.input).session.prompt({
+          path: { id: job.taskID },
+          body: {
+            noReply: true,
+            parts: [{ type: 'text', text: args.message.trim() }],
+          },
+        });
+      } catch (error) {
+        if (lastNudgeAt.get(job.taskID) === at) {
+          lastNudgeAt.delete(job.taskID);
+        }
+        throw error;
+      }
       return `Nudge admitted to ${job.alias} (${job.taskID}) without resuming it.`;
     },
   });

--- a/src/tools/task-nudge.ts
+++ b/src/tools/task-nudge.ts
@@ -1,0 +1,48 @@
+import {
+  type PluginInput,
+  type ToolDefinition,
+  tool,
+} from '@opencode-ai/plugin';
+import type { BackgroundJobStore } from '../utils/background-job-store';
+import { getClient } from '../utils/opencode-client';
+
+const z = tool.schema;
+const NUDGE_INTERVAL_MS = 30_000;
+
+export function createTaskNudgeTool(options: {
+  input: PluginInput;
+  backgroundJobBoard: BackgroundJobStore;
+  now?: () => number;
+}): Record<'task_nudge', ToolDefinition> {
+  const lastNudgeAt = new Map<string, number>();
+  const now = options.now ?? Date.now;
+  const task_nudge = tool({
+    description:
+      'Safely send a bounded follow-up to a live child task without resuming, aborting, or starting another model run. Use only after task_status indicates the child may be stuck.',
+    args: {
+      task_id: z.string().describe('Tracked live task ID or parent-scoped alias'),
+      message: z.string().min(1).max(500).describe('Short follow-up instruction'),
+    },
+    async execute(args, toolContext) {
+      const parentSessionID = toolContext?.sessionID;
+      if (!parentSessionID) throw new Error('task_nudge requires sessionID');
+      const job = options.backgroundJobBoard.resolve(parentSessionID, args.task_id.trim());
+      if (!job) throw new Error(`Unknown task ID or alias: ${args.task_id}`);
+      if (job.state !== 'running') {
+        throw new Error(`Task ${args.task_id} is not running and cannot be nudged`);
+      }
+      const at = now();
+      const previous = lastNudgeAt.get(job.taskID);
+      if (previous !== undefined && at - previous < NUDGE_INTERVAL_MS) {
+        throw new Error(`Task ${args.task_id} was nudged recently; wait 30 seconds`);
+      }
+      await getClient(options.input).session.prompt({
+        path: { id: job.taskID },
+        body: { noReply: true, parts: [{ type: 'text', text: args.message.trim() }] },
+      });
+      lastNudgeAt.set(job.taskID, at);
+      return `Nudge admitted to ${job.alias} (${job.taskID}) without resuming it.`;
+    },
+  });
+  return { task_nudge };
+}

--- a/src/tools/task-policy.ts
+++ b/src/tools/task-policy.ts
@@ -1,0 +1,160 @@
+import type { BackgroundJobRecord } from '../utils/background-job-board';
+import {
+  type RuntimeSessionStatus,
+  type RuntimeSessionStatusSnapshot,
+  runtimeSessionStatus,
+} from '../utils/session-runtime-status';
+
+/** A live child is reported possibly stuck after this much time without activity. */
+export const STUCK_IDLE_THRESHOLD_MS = 120_000;
+
+/**
+ * Bounded, explicit observation of a tracked child's live session status.
+ *
+ * `ok` is true only when the host status map was read successfully (within
+ * the bounded timeout). An absent session in a valid map is `status: 'idle'`;
+ * a malformed entry is `status: undefined` with `error`; a failed or
+ * timed-out read is `ok: false` with `error`.
+ */
+export interface LiveStatusObservation {
+  ok: boolean;
+  status?: RuntimeSessionStatus;
+  error?: string;
+}
+
+export interface TaskStatusReport {
+  /** Effective state: the live-confirmed host status, or the board state. */
+  state: string;
+  /** Where `state` came from: 'live' host read or 'board' record. */
+  source: 'live' | 'board';
+  /** True when the live status could not be confirmed. */
+  uncertain: boolean;
+  lastStatusError?: string;
+  idleSeconds: number;
+  possiblyStuck: boolean;
+}
+
+export interface NudgeEligibility {
+  eligible: boolean;
+  reason: string;
+}
+
+/**
+ * Converts a bounded snapshot into a single-session observation. A failed
+ * read becomes `ok: false`; a malformed entry becomes `ok: true` with
+ * `status: undefined` and an error; a valid map reports the entry's status
+ * (absent means 'idle').
+ */
+export function observationFromSnapshot(
+  snapshot: RuntimeSessionStatusSnapshot,
+  taskID: string,
+): LiveStatusObservation {
+  if (snapshot.error) {
+    return { ok: false, error: snapshot.error };
+  }
+  if (snapshot.malformedSessionIDs.has(taskID)) {
+    return {
+      ok: true,
+      status: undefined,
+      error: 'malformed live status entry for session',
+    };
+  }
+  return { ok: true, status: runtimeSessionStatus(snapshot, taskID) };
+}
+
+/**
+ * Shared status/activity policy used by task_status. The board state is only
+ * reported with explicit uncertainty when the live read is unavailable, so a
+ * stale board record is never presented as a confident live status.
+ */
+export function summarizeTaskStatus(
+  job: BackgroundJobRecord,
+  observation: LiveStatusObservation,
+  lastActivityAt: number | undefined,
+  now: number,
+): TaskStatusReport {
+  let state: string;
+  let source: 'live' | 'board';
+  let uncertain: boolean;
+  if (observation.ok && observation.status !== undefined) {
+    state = observation.status;
+    source = 'live';
+    uncertain = false;
+  } else {
+    // Board state is only reported with explicit uncertainty when the live
+    // read is unavailable, so a stale board record is never presented as a
+    // confident live status.
+    state = job.state;
+    source = 'board';
+    uncertain = true;
+  }
+  const lastStatusError = uncertain
+    ? (observation.error ??
+      (observation.ok && observation.status === undefined
+        ? 'no live status entry for session'
+        : 'live status unavailable'))
+    : undefined;
+  const idleSeconds = Math.max(
+    0,
+    Math.floor((now - (lastActivityAt ?? now)) / 1000),
+  );
+  // possibly_stuck requires a live-confirmed busy/retry signal: an
+  // uncertain board fallback must never drive an automatic nudge admission.
+  const possiblyStuck =
+    !uncertain &&
+    (state === 'busy' || state === 'retry') &&
+    idleSeconds >= STUCK_IDLE_THRESHOLD_MS / 1000;
+  return {
+    state,
+    source,
+    uncertain,
+    lastStatusError,
+    idleSeconds,
+    possiblyStuck,
+  };
+}
+
+/**
+ * Shared nudge admission policy used by task_nudge: the child must be
+ * board-running, live-confirmed busy/retry, and reported possibly stuck by
+ * the same status/activity policy task_status exposes.
+ */
+export function evaluateNudgeEligibility(
+  job: BackgroundJobRecord,
+  observation: LiveStatusObservation,
+  lastActivityAt: number | undefined,
+  now: number,
+): NudgeEligibility {
+  if (job.state !== 'running') {
+    return {
+      eligible: false,
+      reason: `board state is ${job.state}, not running`,
+    };
+  }
+  if (!observation.ok) {
+    return {
+      eligible: false,
+      reason: `live status unavailable: ${observation.error ?? 'unknown error'}`,
+    };
+  }
+  if (observation.status === undefined) {
+    return {
+      eligible: false,
+      reason: 'child session status malformed; refusing to nudge',
+    };
+  }
+  if (observation.status === 'idle') {
+    return {
+      eligible: false,
+      reason: 'child session is idle, not live',
+    };
+  }
+  const report = summarizeTaskStatus(job, observation, lastActivityAt, now);
+  if (!report.possiblyStuck) {
+    return {
+      eligible: false,
+      reason: 'child is active and not possibly stuck; no nudge needed',
+    };
+  }
+  return { eligible: true, reason: 'confirmed live and possibly stuck' };
+}

--- a/src/tools/task-status.test.ts
+++ b/src/tools/task-status.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { BackgroundJobBoard } from '../utils/background-job-board';
+import { createTaskStatusTool } from './task-status';
+
+let client: Record<string, any>;
+mock.module('../utils/opencode-client', () => ({ getClient: () => client }));
+
+describe('task_status', () => {
+  test('reads a child status without prompting it', async () => {
+    const board = new BackgroundJobBoard();
+    board.registerLaunch({
+      taskID: 'ses_child1',
+      parentSessionID: 'parent-1',
+      agent: 'fixer',
+      description: 'implement',
+    });
+    const status = mock(async () => ({ data: { ses_child1: { type: 'busy' } } }));
+    client = { session: { status } };
+    const { task_status } = createTaskStatusTool({
+      input: { directory: '/test' } as any,
+      backgroundJobBoard: board,
+    });
+
+    await expect(
+      task_status.execute({ task_id: 'ses_child1' }, { sessionID: 'parent-1' } as any),
+    ).resolves.toContain('state: busy');
+    expect(status).toHaveBeenCalledTimes(1);
+  });
+
+  test('flags a busy child without recent activity as possibly stuck', async () => {
+    const board = new BackgroundJobBoard();
+    board.registerLaunch({ taskID: 'ses_child1', parentSessionID: 'parent-1', agent: 'fixer', description: 'implement', now: 0 });
+    client = { session: { status: mock(async () => ({ data: { ses_child1: { type: 'busy' } } })) } };
+    const { task_status } = createTaskStatusTool({ input: { directory: '/test' } as any, backgroundJobBoard: board, now: () => 120_000 });
+    await expect(task_status.execute({ task_id: 'ses_child1' }, { sessionID: 'parent-1' } as any)).resolves.toContain('possibly_stuck: true');
+  });
+});

--- a/src/tools/task-status.test.ts
+++ b/src/tools/task-status.test.ts
@@ -5,6 +5,19 @@ import { createTaskStatusTool } from './task-status';
 let client: Record<string, any>;
 mock.module('../utils/opencode-client', () => ({ getClient: () => client }));
 
+function makeTool(options: {
+  board: BackgroundJobBoard;
+  now?: () => number;
+  statusTimeoutMs?: number;
+}) {
+  return createTaskStatusTool({
+    input: { directory: '/test' } as any,
+    backgroundJobBoard: options.board,
+    now: options.now,
+    statusTimeoutMs: options.statusTimeoutMs,
+  });
+}
+
 describe('task_status', () => {
   test('reads a child status without prompting it', async () => {
     const board = new BackgroundJobBoard();
@@ -14,24 +27,165 @@ describe('task_status', () => {
       agent: 'fixer',
       description: 'implement',
     });
-    const status = mock(async () => ({ data: { ses_child1: { type: 'busy' } } }));
+    const status = mock(async () => ({
+      data: { ses_child1: { type: 'busy' } },
+    }));
     client = { session: { status } };
-    const { task_status } = createTaskStatusTool({
-      input: { directory: '/test' } as any,
-      backgroundJobBoard: board,
-    });
+    const { task_status } = makeTool({ board });
 
     await expect(
-      task_status.execute({ task_id: 'ses_child1' }, { sessionID: 'parent-1' } as any),
+      task_status.execute({ task_id: 'ses_child1' }, {
+        sessionID: 'parent-1',
+      } as any),
     ).resolves.toContain('state: busy');
     expect(status).toHaveBeenCalledTimes(1);
   });
 
   test('flags a busy child without recent activity as possibly stuck', async () => {
     const board = new BackgroundJobBoard();
-    board.registerLaunch({ taskID: 'ses_child1', parentSessionID: 'parent-1', agent: 'fixer', description: 'implement', now: 0 });
-    client = { session: { status: mock(async () => ({ data: { ses_child1: { type: 'busy' } } })) } };
-    const { task_status } = createTaskStatusTool({ input: { directory: '/test' } as any, backgroundJobBoard: board, now: () => 120_000 });
-    await expect(task_status.execute({ task_id: 'ses_child1' }, { sessionID: 'parent-1' } as any)).resolves.toContain('possibly_stuck: true');
+    board.registerLaunch({
+      taskID: 'ses_child1',
+      parentSessionID: 'parent-1',
+      agent: 'fixer',
+      description: 'implement',
+      now: 0,
+    });
+    client = {
+      session: {
+        status: mock(async () => ({
+          data: { ses_child1: { type: 'busy' } },
+        })),
+      },
+    };
+    const { task_status } = makeTool({ board, now: () => 120_000 });
+    await expect(
+      task_status.execute({ task_id: 'ses_child1' }, {
+        sessionID: 'parent-1',
+      } as any),
+    ).resolves.toContain('possibly_stuck: true');
+  });
+
+  test('surfaces a failed status read as explicit uncertainty, not a confident board fallback', async () => {
+    const board = new BackgroundJobBoard();
+    board.registerLaunch({
+      taskID: 'ses_child1',
+      parentSessionID: 'parent-1',
+      agent: 'fixer',
+      description: 'implement',
+      now: 0,
+    });
+    client = {
+      session: {
+        status: mock(async () => {
+          throw new Error('host status read failed');
+        }),
+      },
+    };
+    const { task_status } = makeTool({ board, now: () => 120_000 });
+    const output = await task_status.execute({ task_id: 'ses_child1' }, {
+      sessionID: 'parent-1',
+    } as any);
+    expect(output).toContain('state: running (unconfirmed)');
+    expect(output).toContain('status_uncertain: true');
+    expect(output).toContain('last_status_error: host status read failed');
+    // An uncertain board fallback must never drive an automatic nudge.
+    expect(output).toContain('possibly_stuck: false');
+  });
+
+  test('treats a malformed live status entry as uncertain', async () => {
+    const board = new BackgroundJobBoard();
+    board.registerLaunch({
+      taskID: 'ses_child1',
+      parentSessionID: 'parent-1',
+      agent: 'fixer',
+      description: 'implement',
+      now: 0,
+    });
+    client = {
+      session: {
+        status: mock(async () => ({
+          data: { ses_child1: { type: 'weird-state' } },
+        })),
+      },
+    };
+    const { task_status } = makeTool({ board, now: () => 120_000 });
+    const output = await task_status.execute({ task_id: 'ses_child1' }, {
+      sessionID: 'parent-1',
+    } as any);
+    expect(output).toContain('state: running (unconfirmed)');
+    expect(output).toContain('status_uncertain: true');
+    expect(output).toContain(
+      'last_status_error: malformed live status entry for session',
+    );
+    expect(output).toContain('possibly_stuck: false');
+  });
+
+  test('bounds a hanging status read with a timeout and reports uncertainty', async () => {
+    const board = new BackgroundJobBoard();
+    board.registerLaunch({
+      taskID: 'ses_child1',
+      parentSessionID: 'parent-1',
+      agent: 'fixer',
+      description: 'implement',
+      now: 0,
+    });
+    client = {
+      session: {
+        // Responds far slower than the bounded read allows; the 20ms race
+        // timer must reject first so the tool cannot hang on a stuck host.
+        status: mock(
+          () =>
+            new Promise((resolve) =>
+              setTimeout(
+                () => resolve({ data: { ses_child1: { type: 'busy' } } }),
+                200,
+              ),
+            ),
+        ),
+      },
+    };
+    const { task_status } = makeTool({ board, statusTimeoutMs: 20 });
+    const output = await task_status.execute({ task_id: 'ses_child1' }, {
+      sessionID: 'parent-1',
+    } as any);
+    expect(output).toContain('status_uncertain: true');
+    expect(output).toContain('last_status_error');
+    expect(output).toContain('timed out');
+    expect(output).toContain('possibly_stuck: false');
+  });
+
+  test('reports an absent session in a valid map as live idle', async () => {
+    const board = new BackgroundJobBoard();
+    board.registerLaunch({
+      taskID: 'ses_child1',
+      parentSessionID: 'parent-1',
+      agent: 'fixer',
+      description: 'implement',
+      now: 0,
+    });
+    client = { session: { status: mock(async () => ({ data: {} })) } };
+    const { task_status } = makeTool({ board, now: () => 120_000 });
+    const output = await task_status.execute({ task_id: 'ses_child1' }, {
+      sessionID: 'parent-1',
+    } as any);
+    expect(output).toContain('state: idle');
+    expect(output).not.toContain('status_uncertain');
+    expect(output).toContain('possibly_stuck: false');
+  });
+
+  test('rejects a task id owned by a different parent', async () => {
+    const board = new BackgroundJobBoard();
+    board.registerLaunch({
+      taskID: 'ses_child1',
+      parentSessionID: 'parent-1',
+      agent: 'fixer',
+      description: 'implement',
+    });
+    const { task_status } = makeTool({ board });
+    await expect(
+      task_status.execute({ task_id: 'ses_child1' }, {
+        sessionID: 'parent-2',
+      } as any),
+    ).rejects.toThrow('Unknown task ID or alias');
   });
 });

--- a/src/tools/task-status.ts
+++ b/src/tools/task-status.ts
@@ -4,9 +4,9 @@ import {
   tool,
 } from '@opencode-ai/plugin';
 import type { BackgroundJobStore } from '../utils/background-job-store';
-import { isRecord } from '../utils/guards';
-import { getClient } from '../utils/opencode-client';
+import { getRuntimeSessionStatusSnapshot } from '../utils/session-runtime-status';
 import type { TaskActivityTracker } from './task-activity';
+import { observationFromSnapshot, summarizeTaskStatus } from './task-policy';
 
 const z = tool.schema;
 
@@ -15,6 +15,7 @@ export function createTaskStatusTool(options: {
   backgroundJobBoard: BackgroundJobStore;
   activityTracker?: TaskActivityTracker;
   now?: () => number;
+  statusTimeoutMs?: number;
 }): Record<'task_status', ToolDefinition> {
   const task_status = tool({
     description:
@@ -28,31 +29,40 @@ export function createTaskStatusTool(options: {
       const requested = args.task_id.trim();
       if (!requested) throw new Error('task_status requires task_id');
 
-      const job = options.backgroundJobBoard.resolve(parentSessionID, requested);
+      const job = options.backgroundJobBoard.resolve(
+        parentSessionID,
+        requested,
+      );
       if (!job) throw new Error(`Unknown task ID or alias: ${requested}`);
 
-      const statuses = await getClient(options.input).session.status({
-        query: { directory: options.input.directory },
+      // Bounded live read: a failed, malformed, or timed-out host status
+      // response surfaces as explicit uncertainty instead of a confident
+      // board-state fallback.
+      const snapshot = await getRuntimeSessionStatusSnapshot(options.input, {
+        timeoutMs: options.statusTimeoutMs,
       });
-      const live = isRecord(statuses.data) ? statuses.data[job.taskID] : undefined;
-      const liveState = isRecord(live) && typeof live.type === 'string'
-        ? live.type
-        : undefined;
-      const status = liveState ?? job.state;
+      const observation = observationFromSnapshot(snapshot, job.taskID);
       const now = options.now?.() ?? Date.now();
-      const lastActivityAt = options.activityTracker?.lastActivityAt(job.taskID) ?? job.lastLiveBusyAt ?? job.runStartedAt;
-      const idleSeconds = Math.max(0, Math.floor((now - lastActivityAt) / 1000));
-      const possiblyStuck = (status === 'busy' || status === 'retry') && idleSeconds >= 120;
+      const lastActivityAt =
+        options.activityTracker?.lastActivityAt(job.taskID) ??
+        job.lastLiveBusyAt ??
+        job.runStartedAt;
+      const report = summarizeTaskStatus(job, observation, lastActivityAt, now);
+
       const details = [
         `Task ${job.alias} (${job.taskID})`,
-        `state: ${status}`,
+        `state: ${report.state}${report.uncertain ? ' (unconfirmed)' : ''}`,
         `agent: ${job.agent}`,
         `last_activity_at: ${new Date(lastActivityAt).toISOString()}`,
-        `idle_for_seconds: ${idleSeconds}`,
-        `possibly_stuck: ${possiblyStuck}`,
+        `idle_for_seconds: ${report.idleSeconds}`,
+        `possibly_stuck: ${report.possiblyStuck}`,
       ];
-      if (job.statusUncertain) details.push('status_uncertain: true');
-      if (job.lastStatusError) details.push(`last_status_error: ${job.lastStatusError}`);
+      if (report.uncertain) {
+        details.push('status_uncertain: true');
+        if (report.lastStatusError) {
+          details.push(`last_status_error: ${report.lastStatusError}`);
+        }
+      }
       return details.join('\n');
     },
   });

--- a/src/tools/task-status.ts
+++ b/src/tools/task-status.ts
@@ -1,0 +1,61 @@
+import {
+  type PluginInput,
+  type ToolDefinition,
+  tool,
+} from '@opencode-ai/plugin';
+import type { BackgroundJobStore } from '../utils/background-job-store';
+import { isRecord } from '../utils/guards';
+import { getClient } from '../utils/opencode-client';
+import type { TaskActivityTracker } from './task-activity';
+
+const z = tool.schema;
+
+export function createTaskStatusTool(options: {
+  input: PluginInput;
+  backgroundJobBoard: BackgroundJobStore;
+  activityTracker?: TaskActivityTracker;
+  now?: () => number;
+}): Record<'task_status', ToolDefinition> {
+  const task_status = tool({
+    description:
+      'Read the current status of a tracked child task without resuming, prompting, or changing it. Accepts its task ID or parent-scoped alias.',
+    args: {
+      task_id: z.string().describe('Tracked task ID or parent-scoped alias'),
+    },
+    async execute(args, toolContext) {
+      const parentSessionID = toolContext?.sessionID;
+      if (!parentSessionID) throw new Error('task_status requires sessionID');
+      const requested = args.task_id.trim();
+      if (!requested) throw new Error('task_status requires task_id');
+
+      const job = options.backgroundJobBoard.resolve(parentSessionID, requested);
+      if (!job) throw new Error(`Unknown task ID or alias: ${requested}`);
+
+      const statuses = await getClient(options.input).session.status({
+        query: { directory: options.input.directory },
+      });
+      const live = isRecord(statuses.data) ? statuses.data[job.taskID] : undefined;
+      const liveState = isRecord(live) && typeof live.type === 'string'
+        ? live.type
+        : undefined;
+      const status = liveState ?? job.state;
+      const now = options.now?.() ?? Date.now();
+      const lastActivityAt = options.activityTracker?.lastActivityAt(job.taskID) ?? job.lastLiveBusyAt ?? job.runStartedAt;
+      const idleSeconds = Math.max(0, Math.floor((now - lastActivityAt) / 1000));
+      const possiblyStuck = (status === 'busy' || status === 'retry') && idleSeconds >= 120;
+      const details = [
+        `Task ${job.alias} (${job.taskID})`,
+        `state: ${status}`,
+        `agent: ${job.agent}`,
+        `last_activity_at: ${new Date(lastActivityAt).toISOString()}`,
+        `idle_for_seconds: ${idleSeconds}`,
+        `possibly_stuck: ${possiblyStuck}`,
+      ];
+      if (job.statusUncertain) details.push('status_uncertain: true');
+      if (job.lastStatusError) details.push(`last_status_error: ${job.lastStatusError}`);
+      return details.join('\n');
+    },
+  });
+
+  return { task_status };
+}

--- a/src/utils/background-job-board.ts
+++ b/src/utils/background-job-board.ts
@@ -979,6 +979,7 @@ function singleLine(value: string): string {
 
 function promptSafe(value: string): string {
   return singleLine(value)
+    .replaceAll('\\', '/')
     .replaceAll('&', '&amp;')
     .replaceAll('<', '&lt;')
     .replaceAll('>', '&gt;');


### PR DESCRIPTION
## What changed, and why was it needed?

Background specialists run detached: the orchestrator has no read-only way to inspect a live child's state, and the only "instruction" channel (`task(..., task_id: ...)`) resumes the child and starts new model work. This adds two safe supervision tools:

- `task_status` — read-only status of a tracked child task (bounded live `/session/status` read, with explicit uncertainty when the host read fails, times out, or returns a malformed entry), with an activity-based `possibly_stuck` flag for `busy`/`retry` children that showed no `message.updated` / `step-finish` / busy-status activity for 120s. Never prompts or mutates the child.
- `task_nudge` — admits a single concise follow-up to a running child via `session.prompt(..., noReply: true)` without resuming, aborting, or starting a new model run. Rate-limited to one nudge per 30s per task, with the slot reserved atomically and rolled back on refusal/failure.

The orchestrator prompt now instructs calling `task_status` for read-only inspection and `task_nudge` once (only when `possibly_stuck`) instead of re-issuing or resuming tasks.

Supporting changes:

- `TaskActivityTracker` records session activity from `message.updated` / `step-finish` / busy `session.status` events keyed by **session id** (never the message id, which `message.updated`/`step-finish` carry in `info.id`) and forgets sessions on `session.deleted`; status timestamps flow into the `possibly_stuck` computation.
- `promptSafe` normalizes Windows backslash paths so Background Job Board renders are stable across platforms.

Both tools are strictly read-only or admission-bounded; completed and reconciled tasks are unaffected.

## Review remediation

Resolves Oracle review findings and Greptile status/nudge notes:

1. **Activity keyed by session ID** — `message.updated` / `step-finish` events carry the message id in `info.id` and the session id in `info.sessionID`; the tracker now keys by session id (extracted `resolveEventSessionID`), so child activity actually refreshes the stuck timer. Event-policy integration tests cover the wiring.
2. **Bounded, explicit status uncertainty** — `task_status` reads live status through the bounded snapshot helper (5s default timeout). A failed, timed-out, or malformed host response is reported as `status_uncertain: true` with `last_status_error` and `state: <board state> (unconfirmed)` — never presented as a confident live status — and never yields `possibly_stuck: true`.
3. **Shared live status/activity policy** — `task_nudge` admission goes through the same policy module as `task_status` (`task-policy.ts`): the child must be board-`running`, live-confirmed `busy`/`retry`, and reported `possibly_stuck`. A stale board record alone never admits a nudge.
4. **Atomic rate-limit reservation** — the per-task nudge slot is reserved synchronously before the first `await`, so concurrent nudges cannot both pass the check; any refusal or transport failure rolls the reservation back so the task is not locked out.
5. **New tests** — cross-parent ownership rejection, status failure/malformed/hang-bounded uncertainty, concurrent-nudge exclusivity, rate-limit rollback, noReply behavioral proof, and event-integration tests for the activity tracker.

## Verification

- `bun test src/tools/task-status.test.ts src/tools/task-nudge.test.ts src/tools/task-activity.test.ts src/hooks/cache-payload.snapshot.test.ts`: 28 pass, 0 fail (3 snapshots)
- `bun test src/hooks/task-session-manager/index.test.ts`: 124 pass, 0 fail (confirms cross-platform board rendering with the `promptSafe` normalization)
- `bun run typecheck`: pass
- `bun run lint`: pass
- `git diff --check`: pass
