### PR TITLE
fix(multiplexer): wait for child session readiness before attach

### DIFF
--- a/src/multiplexer/index.ts
+++ b/src/multiplexer/index.ts
@@ -14,6 +14,8 @@ export {
   MultiplexerSessionManager,
   TmuxSessionManager,
 } from './session-manager';
+export type { SessionReadinessOptions } from './shared';
+export { waitForSessionReady } from './shared';
 export { TmuxMultiplexer } from './tmux';
 export type { Multiplexer, PaneResult } from './types';
 export { isServerRunning } from './types';

--- a/src/multiplexer/session-manager.test.ts
+++ b/src/multiplexer/session-manager.test.ts
@@ -320,6 +320,99 @@ describe('MultiplexerSessionManager', () => {
       );
     });
 
+    test('recovers a session whose initial readiness timed out on a later busy event', async () => {
+      const ctx = createMockContext();
+      const manager = new MultiplexerSessionManager(
+        ctx,
+        defaultMultiplexerConfig,
+      );
+
+      mockWaitForSessionReady.mockResolvedValueOnce(false);
+
+      await manager.onSessionCreated({
+        type: 'session.created',
+        properties: {
+          info: {
+            id: 'child-recover-timeout',
+            parentID: 'parent-recover-timeout',
+            title: 'Recover Worker',
+          },
+        },
+      });
+
+      expect(mockMultiplexer.spawnPane).not.toHaveBeenCalled();
+
+      // The session stays known; a later busy status runs a fresh readiness
+      // pass and recovers the pane.
+      mockWaitForSessionReady.mockResolvedValueOnce(true);
+      await manager.onSessionStatus({
+        type: 'session.status',
+        properties: {
+          sessionID: 'child-recover-timeout',
+          status: { type: 'busy' },
+        },
+      });
+
+      expect(mockWaitForSessionReady).toHaveBeenCalledTimes(2);
+      expect(mockMultiplexer.spawnPane).toHaveBeenCalledTimes(1);
+      expect(mockMultiplexer.spawnPane).toHaveBeenLastCalledWith(
+        'child-recover-timeout',
+        'Recover Worker',
+        `http://localhost:${process.env.OPENCODE_PORT ?? '4096'}/`,
+        '/test/directory',
+      );
+    });
+
+    test('busy during the initial readiness wait triggers immediate recovery on timeout', async () => {
+      const ctx = createMockContext();
+      const manager = new MultiplexerSessionManager(
+        ctx,
+        defaultMultiplexerConfig,
+      );
+      const readiness = createDeferred<boolean>();
+
+      mockWaitForSessionReady.mockImplementationOnce(() => readiness.promise);
+
+      const creating = manager.onSessionCreated({
+        type: 'session.created',
+        properties: {
+          info: {
+            id: 'child-busy-during-wait',
+            parentID: 'parent-busy-during-wait',
+            title: 'Busy During Wait',
+          },
+        },
+      });
+
+      await flushPromises();
+
+      // Busy while the initial wait is in flight: deferred to the pending
+      // spawn instead of being dropped.
+      await manager.onSessionStatus({
+        type: 'session.status',
+        properties: {
+          sessionID: 'child-busy-during-wait',
+          status: { type: 'busy' },
+        },
+      });
+      expect(mockMultiplexer.spawnPane).not.toHaveBeenCalled();
+
+      // The wait times out; the deferred busy signal runs one recovery pass,
+      // which now finds the session visible and spawns the pane.
+      mockWaitForSessionReady.mockResolvedValueOnce(true);
+      readiness.resolve(false);
+      await creating;
+
+      expect(mockWaitForSessionReady).toHaveBeenCalledTimes(2);
+      expect(mockMultiplexer.spawnPane).toHaveBeenCalledTimes(1);
+      expect(mockMultiplexer.spawnPane).toHaveBeenLastCalledWith(
+        'child-busy-during-wait',
+        'Busy During Wait',
+        `http://localhost:${process.env.OPENCODE_PORT ?? '4096'}/`,
+        '/test/directory',
+      );
+    });
+
     test('respawns only after readiness when a known session goes busy', async () => {
       const ctx = createMockContext();
       const manager = new MultiplexerSessionManager(
@@ -2629,10 +2722,38 @@ describe('MultiplexerSessionManager', () => {
       });
       expect(mockMultiplexer.closePane).toHaveBeenCalledWith('%mock-pane');
     });
+
+    test('cmux adapter is excluded from the generic readiness gate', async () => {
+      mockMultiplexerType = 'cmux';
+      const probe = mock(async () => true);
+      mockWaitForSessionReady.mockClear();
+      const manager = new MultiplexerSessionManager(
+        createMockContext(),
+        cmuxConfig,
+        undefined,
+        {
+          checkSessionReady: probe,
+          readinessAttemptTimeoutMs: 5,
+          readinessDeadlineMs: 1,
+        },
+      );
+
+      await manager.onSessionCreated({
+        type: 'session.created',
+        properties: { info: { id: 'cmux-excluded', parentID: 'parent' } },
+      });
+
+      // The cmux lifecycle has its own spawn machinery (health check plus
+      // deferred spawn retry) and must never consult the generic readiness
+      // gate or its injectable probe.
+      expect(mockWaitForSessionReady).not.toHaveBeenCalled();
+      expect(probe).not.toHaveBeenCalled();
+      expect(mockMultiplexer.spawnPane).toHaveBeenCalled();
+    });
   });
 
   describe('cleanup', () => {
-    test('instance disposal cleanup is a no-op for non-cmux multiplexers', async () => {
+    test('instance disposal does not close tracked panes or fence later spawns for non-cmux', async () => {
       const manager = new MultiplexerSessionManager(
         createMockContext(),
         defaultMultiplexerConfig,
@@ -2644,6 +2765,74 @@ describe('MultiplexerSessionManager', () => {
       mockMultiplexer.closePane.mockClear();
       await manager.cleanupOnInstanceDisposed();
       expect(mockMultiplexer.closePane).not.toHaveBeenCalled();
+
+      // Disposal only fences in-flight work; the shared manager keeps
+      // spawning for later sessions.
+      await manager.onSessionCreated({
+        type: 'session.created',
+        properties: { info: { id: 'tmux-after-disposal', parentID: 'parent' } },
+      });
+      expect(mockMultiplexer.spawnPane).toHaveBeenCalledTimes(2);
+    });
+
+    test('cleanup aborts an in-flight readiness wait and prevents a late spawn', async () => {
+      const manager = new MultiplexerSessionManager(
+        createMockContext(),
+        defaultMultiplexerConfig,
+      );
+      let capturedSignal: AbortSignal | undefined;
+      const readiness = createDeferred<boolean>();
+      mockWaitForSessionReady.mockImplementationOnce((_url, _id, options) => {
+        capturedSignal = options?.signal;
+        return readiness.promise;
+      });
+
+      const creating = manager.onSessionCreated({
+        type: 'session.created',
+        properties: {
+          info: { id: 'fence-wait', parentID: 'parent' },
+        },
+      });
+
+      await flushPromises();
+      expect(capturedSignal?.aborted).toBe(false);
+
+      await manager.cleanup();
+      expect(capturedSignal?.aborted).toBe(true);
+
+      // Even a late `true` from the readiness wait cannot spawn a pane after
+      // cleanup tore the manager down.
+      readiness.resolve(true);
+      await creating;
+      expect(mockMultiplexer.spawnPane).not.toHaveBeenCalled();
+    });
+
+    test('instance disposal aborts an in-flight readiness wait', async () => {
+      const manager = new MultiplexerSessionManager(
+        createMockContext(),
+        defaultMultiplexerConfig,
+      );
+      let capturedSignal: AbortSignal | undefined;
+      const readiness = createDeferred<boolean>();
+      mockWaitForSessionReady.mockImplementationOnce((_url, _id, options) => {
+        capturedSignal = options?.signal;
+        return readiness.promise;
+      });
+
+      const creating = manager.onSessionCreated({
+        type: 'session.created',
+        properties: {
+          info: { id: 'fence-disposal', parentID: 'parent' },
+        },
+      });
+
+      await flushPromises();
+      await manager.cleanupOnInstanceDisposed();
+      expect(capturedSignal?.aborted).toBe(true);
+
+      readiness.resolve(true);
+      await creating;
+      expect(mockMultiplexer.spawnPane).not.toHaveBeenCalled();
     });
 
     test('cmux cleanup has a shutdown deadline for a hanging spawn', async () => {
@@ -2692,7 +2881,7 @@ describe('MultiplexerSessionManager', () => {
       expect(mockMultiplexer.closePane).toHaveBeenCalledWith('p2');
     });
 
-    test('clears spawning sessions during cleanup', async () => {
+    test('cleanup fences the in-flight spawn and clears spawning for later creates', async () => {
       const ctx = createMockContext();
       const manager = new MultiplexerSessionManager(
         ctx,
@@ -2720,9 +2909,12 @@ describe('MultiplexerSessionManager', () => {
       deferred.resolve({ success: true, paneId: 'p-cleanup' });
       await Promise.all([createPromise, cleanupPromise]);
 
+      // The in-flight readiness pass was fenced by cleanup: no pane spawns.
+      expect(mockMultiplexer.spawnPane).not.toHaveBeenCalled();
+
       await manager.onSessionCreated(event);
 
-      expect(mockMultiplexer.spawnPane).toHaveBeenCalledTimes(2);
+      expect(mockMultiplexer.spawnPane).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/multiplexer/session-manager.test.ts
+++ b/src/multiplexer/session-manager.test.ts
@@ -33,12 +33,14 @@ const mockMultiplexer = {
   applyLayout: mock(async () => {}),
 };
 const mockIsServerRunning = mock(async () => true);
+const mockWaitForSessionReady = mock(async () => true);
 
 // Mock the multiplexer module
 mock.module('../multiplexer', () => ({
   getMultiplexer: () => mockMultiplexer,
   isServerRunning: mockIsServerRunning,
   startAvailabilityCheck: () => {},
+  waitForSessionReady: mockWaitForSessionReady,
 }));
 
 // Mock the plugin context
@@ -106,6 +108,8 @@ describe('MultiplexerSessionManager', () => {
     mockMultiplexerType = 'tmux';
     mockIsServerRunning.mockReset();
     mockIsServerRunning.mockResolvedValue(true);
+    mockWaitForSessionReady.mockReset();
+    mockWaitForSessionReady.mockResolvedValue(true);
   });
 
   afterEach(() => {
@@ -239,11 +243,171 @@ describe('MultiplexerSessionManager', () => {
       const firstCreate = manager.onSessionCreated(event);
       const secondCreate = manager.onSessionCreated(event);
 
-      await Promise.resolve();
+      await flushPromises();
 
       expect(mockMultiplexer.spawnPane).toHaveBeenCalledTimes(1);
 
       deferred.resolve({ success: true, paneId: 'p-race' });
+
+      await Promise.all([firstCreate, secondCreate]);
+
+      expect(mockMultiplexer.spawnPane).toHaveBeenCalledTimes(1);
+    });
+
+    test('waits for child session readiness before spawning the pane', async () => {
+      const ctx = createMockContext();
+      const manager = new MultiplexerSessionManager(
+        ctx,
+        defaultMultiplexerConfig,
+      );
+      const readiness = createDeferred<boolean>();
+
+      mockWaitForSessionReady.mockImplementationOnce(() => readiness.promise);
+
+      const create = manager.onSessionCreated({
+        type: 'session.created',
+        properties: {
+          info: {
+            id: 'child-ready',
+            parentID: 'parent-ready',
+            title: 'Ready Worker',
+          },
+        },
+      });
+
+      await flushPromises();
+
+      // Readiness still pending: no pane may be spawned yet.
+      expect(mockMultiplexer.spawnPane).not.toHaveBeenCalled();
+
+      readiness.resolve(true);
+      await create;
+
+      expect(mockMultiplexer.spawnPane).toHaveBeenCalledTimes(1);
+      expect(mockMultiplexer.spawnPane).toHaveBeenCalledWith(
+        'child-ready',
+        'Ready Worker',
+        `http://localhost:${process.env.OPENCODE_PORT ?? '4096'}/`,
+        '/test/directory',
+      );
+    });
+
+    test('skips spawn when child session readiness times out', async () => {
+      const ctx = createMockContext();
+      const manager = new MultiplexerSessionManager(
+        ctx,
+        defaultMultiplexerConfig,
+      );
+
+      mockWaitForSessionReady.mockResolvedValueOnce(false);
+
+      await manager.onSessionCreated({
+        type: 'session.created',
+        properties: {
+          info: {
+            id: 'child-timeout',
+            parentID: 'parent-timeout',
+            title: 'Timeout Worker',
+          },
+        },
+      });
+
+      expect(mockMultiplexer.spawnPane).not.toHaveBeenCalled();
+      expect(mockWaitForSessionReady).toHaveBeenCalledWith(
+        `http://localhost:${process.env.OPENCODE_PORT ?? '4096'}/`,
+        'child-timeout',
+        expect.any(Object),
+      );
+    });
+
+    test('respawns only after readiness when a known session goes busy', async () => {
+      const ctx = createMockContext();
+      const manager = new MultiplexerSessionManager(
+        ctx,
+        defaultMultiplexerConfig,
+      );
+
+      await manager.onSessionCreated({
+        type: 'session.created',
+        properties: {
+          info: {
+            id: 'child-respawn',
+            parentID: 'parent-respawn',
+            title: 'Respawn Worker',
+          },
+        },
+      });
+      expect(mockMultiplexer.spawnPane).toHaveBeenCalledTimes(1);
+
+      // Idle close untracks the pane so a later busy event respawns it.
+      await manager.onSessionStatus({
+        type: 'session.status',
+        properties: {
+          sessionID: 'child-respawn',
+          status: { type: 'idle' },
+        },
+      });
+      expect(mockMultiplexer.closePane).toHaveBeenCalledTimes(1);
+
+      // First respawn attempt: readiness times out, no pane.
+      mockWaitForSessionReady.mockResolvedValueOnce(false);
+      await manager.onSessionStatus({
+        type: 'session.status',
+        properties: {
+          sessionID: 'child-respawn',
+          status: { type: 'busy' },
+        },
+      });
+      expect(mockMultiplexer.spawnPane).toHaveBeenCalledTimes(1);
+
+      // Session becomes visible; respawn proceeds.
+      await manager.onSessionStatus({
+        type: 'session.status',
+        properties: {
+          sessionID: 'child-respawn',
+          status: { type: 'busy' },
+        },
+      });
+      expect(mockMultiplexer.spawnPane).toHaveBeenCalledTimes(2);
+      expect(mockMultiplexer.spawnPane).toHaveBeenLastCalledWith(
+        'child-respawn',
+        'Respawn Worker',
+        `http://localhost:${process.env.OPENCODE_PORT ?? '4096'}/`,
+        '/test/directory',
+      );
+    });
+
+    test('duplicate create events do not double-wait or double-spawn', async () => {
+      const ctx = createMockContext();
+      const manager = new MultiplexerSessionManager(
+        ctx,
+        defaultMultiplexerConfig,
+      );
+      const readiness = createDeferred<boolean>();
+
+      mockWaitForSessionReady.mockImplementation(() => readiness.promise);
+
+      const event = {
+        type: 'session.created',
+        properties: {
+          info: {
+            id: 'child-dupe',
+            parentID: 'parent-dupe',
+            title: 'Dupe Worker',
+          },
+        },
+      };
+
+      const firstCreate = manager.onSessionCreated(event);
+      const secondCreate = manager.onSessionCreated(event);
+
+      await Promise.resolve();
+
+      // Spawning guard held: readiness is polled once, spawn deferred.
+      expect(mockWaitForSessionReady).toHaveBeenCalledTimes(1);
+      expect(mockMultiplexer.spawnPane).not.toHaveBeenCalled();
+
+      readiness.resolve(true);
 
       await Promise.all([firstCreate, secondCreate]);
 

--- a/src/multiplexer/session-manager.ts
+++ b/src/multiplexer/session-manager.ts
@@ -165,6 +165,15 @@ export class MultiplexerSessionManager {
   private enabled = false;
   private cmuxLifecycle?: CmuxSessionLifecycle;
   private readonly readiness: SessionReadinessOptions;
+  /** Abort handle for the in-flight readiness wait; cleanup/disposal abort it. */
+  private readinessAbort?: AbortController;
+  /**
+   * Sessions that signaled `busy` while a spawn/readiness pass was in flight
+   * (the busy handler defers to the pending pass). Consumed after the pass:
+   * if the pass failed to attach a pane, the session is retried immediately
+   * instead of being silently orphaned.
+   */
+  private readonly busyDuringSpawn = new Set<string>();
 
   constructor(
     ctx: PluginInput,
@@ -189,6 +198,11 @@ export class MultiplexerSessionManager {
       this.multiplexer !== null &&
       this.multiplexer.isInsideSession();
     if (this.enabled && this.multiplexer?.type === 'cmux') {
+      // cmux exclusion contract: the cmux adapter is NOT subject to the
+      // generic readiness gate. All events are delegated to
+      // CmuxSessionLifecycle, which has its own spawn machinery (server
+      // health check plus deferred spawn retry with a TTL) and never calls
+      // waitForSessionReady.
       this.cmuxLifecycle = new CmuxSessionLifecycle(
         this.instanceId,
         this.multiplexer,
@@ -210,6 +224,23 @@ export class MultiplexerSessionManager {
       trackedSessions: this.sessions.size,
       knownSessions: this.knownSessions.size,
     });
+  }
+
+  /** Fresh options for a readiness wait; the manager owns the abort signal. */
+  private readinessOptions(): SessionReadinessOptions {
+    const controller = new AbortController();
+    this.readinessAbort = controller;
+    return { ...this.readiness, signal: controller.signal };
+  }
+
+  /**
+   * Abort any in-flight readiness wait so cleanup/disposal can never be
+   * stalled by a hanging probe. The aborted wait resolves false and the
+   * pending spawn is fenced off.
+   */
+  private abortInFlightReadiness(): void {
+    this.readinessAbort?.abort();
+    this.readinessAbort = undefined;
   }
 
   async onSessionCreated(event: SessionEvent): Promise<void> {
@@ -281,12 +312,13 @@ export class MultiplexerSessionManager {
       // Attach-before-ready race: wait for the child session to appear on the
       // status endpoint before launching `opencode attach`; otherwise the
       // attach TUI falls back to the new-session picker.
+      const readinessOptions = this.readinessOptions();
       const sessionReady = await waitForSessionReady(
         serverUrl,
         sessionId,
-        this.readiness,
+        readinessOptions,
       );
-      if (!sessionReady) {
+      if (!sessionReady || readinessOptions.signal?.aborted) {
         log(
           '[multiplexer-session-manager] child session not ready, skipping spawn',
           {
@@ -365,6 +397,12 @@ export class MultiplexerSessionManager {
       this.startPolling();
     } finally {
       this.spawningSessions.delete(sessionId);
+      if (
+        this.busyDuringSpawn.delete(sessionId) &&
+        !this.sessions.has(sessionId)
+      ) {
+        await this.respawnIfKnown(sessionId);
+      }
     }
   }
 
@@ -646,6 +684,11 @@ export class MultiplexerSessionManager {
 
     if (this.permanentlyClosedSessions.has(sessionId)) return;
     if (this.isTrackedOrSpawning(sessionId)) {
+      // A busy signal while a spawn is in flight: remember it so the pending
+      // pass can recover if it fails to attach a pane.
+      if (this.spawningSessions.has(sessionId)) {
+        this.busyDuringSpawn.add(sessionId);
+      }
       return;
     }
 
@@ -681,12 +724,13 @@ export class MultiplexerSessionManager {
 
       // Same attach-before-ready guard as the initial spawn: only respawn once
       // the session is visible on the status endpoint.
+      const readinessOptions = this.readinessOptions();
       const sessionReady = await waitForSessionReady(
         serverUrl,
         sessionId,
-        this.readiness,
+        readinessOptions,
       );
-      if (!sessionReady) {
+      if (!sessionReady || readinessOptions.signal?.aborted) {
         log(
           '[multiplexer-session-manager] child session not ready, skipping respawn',
           {
@@ -766,6 +810,12 @@ export class MultiplexerSessionManager {
       this.startPolling();
     } finally {
       this.spawningSessions.delete(sessionId);
+      if (
+        this.busyDuringSpawn.delete(sessionId) &&
+        !this.sessions.has(sessionId)
+      ) {
+        await this.respawnIfKnown(sessionId);
+      }
     }
   }
 
@@ -825,6 +875,9 @@ export class MultiplexerSessionManager {
       this.permanentlyClosedSessions.clear();
       return;
     }
+    // Fence: abort an in-flight readiness wait so cleanup is not stalled by
+    // a hanging probe; the aborted wait resolves false and skips the spawn.
+    this.abortInFlightReadiness();
     this.stopPolling();
 
     if (this.closingSessions.size > 0) {
@@ -860,6 +913,7 @@ export class MultiplexerSessionManager {
 
   async cleanupOnInstanceDisposed(): Promise<void> {
     if (this.cmuxLifecycle) await this.cmuxLifecycle.cleanup();
+    else this.abortInFlightReadiness();
   }
 }
 

--- a/src/multiplexer/session-manager.ts
+++ b/src/multiplexer/session-manager.ts
@@ -5,6 +5,8 @@ import {
   getMultiplexer,
   isServerRunning,
   type Multiplexer,
+  type SessionReadinessOptions,
+  waitForSessionReady,
 } from '../multiplexer';
 import type { BackgroundJobState } from '../utils/background-job-board';
 import type { BackgroundJobStore } from '../utils/background-job-store';
@@ -96,7 +98,8 @@ export function resetMultiplexerSessionManagerState(): void {
   new CmuxSessionStore().resetForTests();
 }
 
-export type MultiplexerSessionManagerOptions = CmuxSessionLifecycleOptions;
+export type MultiplexerSessionManagerOptions = CmuxSessionLifecycleOptions &
+  SessionReadinessOptions;
 
 function validServerUrl(value: unknown): string | null {
   if (typeof value !== 'string' && !(value instanceof URL)) return null;
@@ -161,6 +164,7 @@ export class MultiplexerSessionManager {
   private pollInterval?: ReturnType<typeof setInterval>;
   private enabled = false;
   private cmuxLifecycle?: CmuxSessionLifecycle;
+  private readonly readiness: SessionReadinessOptions;
 
   constructor(
     ctx: PluginInput,
@@ -174,6 +178,7 @@ export class MultiplexerSessionManager {
     this.spawningSessions = sharedState.spawningSessions;
     this.closingSessions = sharedState.closingSessions;
     this.permanentlyClosedSessions = sharedState.permanentlyClosedSessions;
+    this.readiness = options;
 
     this.directory = ctx.directory;
     this.resolveServerUrl = createServerUrlResolver(ctx);
@@ -270,6 +275,26 @@ export class MultiplexerSessionManager {
           instanceId: this.instanceId,
           serverUrl,
         });
+        return;
+      }
+
+      // Attach-before-ready race: wait for the child session to appear on the
+      // status endpoint before launching `opencode attach`; otherwise the
+      // attach TUI falls back to the new-session picker.
+      const sessionReady = await waitForSessionReady(
+        serverUrl,
+        sessionId,
+        this.readiness,
+      );
+      if (!sessionReady) {
+        log(
+          '[multiplexer-session-manager] child session not ready, skipping spawn',
+          {
+            instanceId: this.instanceId,
+            sessionId,
+            parentId,
+          },
+        );
         return;
       }
 
@@ -649,6 +674,25 @@ export class MultiplexerSessionManager {
             instanceId: this.instanceId,
             serverUrl,
             sessionId,
+          },
+        );
+        return;
+      }
+
+      // Same attach-before-ready guard as the initial spawn: only respawn once
+      // the session is visible on the status endpoint.
+      const sessionReady = await waitForSessionReady(
+        serverUrl,
+        sessionId,
+        this.readiness,
+      );
+      if (!sessionReady) {
+        log(
+          '[multiplexer-session-manager] child session not ready, skipping respawn',
+          {
+            instanceId: this.instanceId,
+            sessionId,
+            parentId: known.parentId,
           },
         );
         return;

--- a/src/multiplexer/shared.test.ts
+++ b/src/multiplexer/shared.test.ts
@@ -253,3 +253,122 @@ describe('buildShellLaunchArgs', () => {
     }
   });
 });
+
+describe('waitForSessionReady', () => {
+  const url = 'http://127.0.0.1:7777/base';
+
+  test('returns true immediately when the session is already ready', async () => {
+    const { waitForSessionReady } = await importShared();
+    const check = mock(async () => true);
+    const delays: number[] = [];
+    const ready = await waitForSessionReady(url, 'session-1', {
+      checkSessionReady: check,
+      delay: async (ms) => void delays.push(ms),
+    });
+    expect(ready).toBe(true);
+    expect(check).toHaveBeenCalledTimes(1);
+    expect(delays).toEqual([]);
+  });
+
+  test('delayed readiness: polls until the session appears, then succeeds', async () => {
+    const { waitForSessionReady } = await importShared();
+    const seen: Array<{ url: string; sessionId: string }> = [];
+    let attempt = 0;
+    const check = mock(async (checkUrl: URL, sessionId: string) => {
+      seen.push({ url: checkUrl.href, sessionId });
+      attempt += 1;
+      return attempt >= 3;
+    });
+    const delays: number[] = [];
+    const ready = await waitForSessionReady(url, 'session-1', {
+      checkSessionReady: check,
+      delay: async (ms) => void delays.push(ms),
+    });
+    expect(ready).toBe(true);
+    expect(check).toHaveBeenCalledTimes(3);
+    expect(seen).toEqual([
+      { url: 'http://127.0.0.1:7777/session/status', sessionId: 'session-1' },
+      { url: 'http://127.0.0.1:7777/session/status', sessionId: 'session-1' },
+      { url: 'http://127.0.0.1:7777/session/status', sessionId: 'session-1' },
+    ]);
+    expect(delays).toEqual([50, 100]);
+  });
+
+  test('readiness timeout: returns false without ever succeeding', async () => {
+    const { waitForSessionReady } = await importShared();
+    const check = mock(async () => false);
+    const delays: number[] = [];
+    const ready = await waitForSessionReady(url, 'session-1', {
+      checkSessionReady: check,
+      delay: async (ms) => void delays.push(ms),
+    });
+    expect(ready).toBe(false);
+    // 8 attempts = 7 backoff delays + one final attempt
+    expect(check).toHaveBeenCalledTimes(8);
+    expect(delays).toEqual([50, 100, 200, 400, 500, 500, 250]);
+  });
+
+  test('a throwing probe is treated as not-ready and keeps polling', async () => {
+    const { waitForSessionReady } = await importShared();
+    let attempt = 0;
+    const check = mock(async () => {
+      attempt += 1;
+      if (attempt === 1) throw new Error('network');
+      return true;
+    });
+    const ready = await waitForSessionReady(url, 'session-1', {
+      checkSessionReady: check,
+      delay: async () => {},
+    });
+    expect(ready).toBe(true);
+    expect(check).toHaveBeenCalledTimes(2);
+  });
+
+  test('a hanging probe is aborted by the per-attempt timeout', async () => {
+    const { waitForSessionReady } = await importShared();
+    const check = mock(() => new Promise<boolean>(() => {}));
+    const ready = await waitForSessionReady(url, 'session-1', {
+      checkSessionReady: check,
+      delay: async () => {},
+      readinessAttemptTimeoutMs: 5,
+    });
+    expect(ready).toBe(false);
+    expect(check).toHaveBeenCalledTimes(8);
+  });
+
+  test('default probe parses the target status from /session/status', async () => {
+    const originalFetch = globalThis.fetch;
+    const requested: string[] = [];
+    globalThis.fetch = mock(async (input) => {
+      requested.push(String(input));
+      return Response.json({
+        target: { type: 'busy' },
+        other: { type: 'idle' },
+      });
+    }) as typeof fetch;
+    try {
+      const { waitForSessionReady } = await importShared();
+      expect(
+        await waitForSessionReady('http://127.0.0.1:7777/base', 'target'),
+      ).toBe(true);
+      expect(requested).toEqual(['http://127.0.0.1:7777/session/status']);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test('default probe reports false when the session is absent', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(async () =>
+      Response.json({ other: { type: 'idle' } }),
+    ) as typeof fetch;
+    try {
+      const { waitForSessionReady } = await importShared();
+      expect(
+        await waitForSessionReady('http://127.0.0.1:7777/base', 'missing'),
+      ).toBe(false);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/src/multiplexer/shared.test.ts
+++ b/src/multiplexer/shared.test.ts
@@ -336,6 +336,43 @@ describe('waitForSessionReady', () => {
     expect(check).toHaveBeenCalledTimes(8);
   });
 
+  test('absolute deadline bounds the total wait even with hanging probes', async () => {
+    const { waitForSessionReady } = await importShared();
+    let clock = 0;
+    const now = () => clock;
+    const check = mock(() => new Promise<boolean>(() => {}));
+    const delays: number[] = [];
+    const ready = await waitForSessionReady(url, 'session-1', {
+      checkSessionReady: check,
+      delay: async (ms) => {
+        delays.push(ms);
+        clock += ms;
+      },
+      readinessAttemptTimeoutMs: 5,
+      readinessDeadlineMs: 500,
+      now,
+    });
+    expect(ready).toBe(false);
+    // The deadline, not the 8-attempt schedule, stopped the wait.
+    expect(check.mock.calls.length).toBeLessThan(8);
+    // Cumulative delay never exceeds the deadline.
+    expect(delays.reduce((sum, ms) => sum + ms, 0)).toBeLessThanOrEqual(500);
+  });
+
+  test('an abort signal ends the wait promptly with false', async () => {
+    const { waitForSessionReady } = await importShared();
+    const controller = new AbortController();
+    const check = mock(() => new Promise<boolean>(() => {}));
+    const readyPromise = waitForSessionReady(url, 'session-1', {
+      checkSessionReady: check,
+      delay: async () => {},
+      readinessAttemptTimeoutMs: 10_000,
+      signal: controller.signal,
+    });
+    controller.abort();
+    await expect(readyPromise).resolves.toBe(false);
+  });
+
   test('default probe parses the target status from /session/status', async () => {
     const originalFetch = globalThis.fetch;
     const requested: string[] = [];

--- a/src/multiplexer/shared.ts
+++ b/src/multiplexer/shared.ts
@@ -245,3 +245,89 @@ export async function gracefulClosePane(
     return false;
   }
 }
+
+export interface SessionReadinessOptions {
+  /** Override the per-attempt readiness probe (default: GET /session/status). */
+  checkSessionReady?: (
+    url: URL,
+    sessionId: string,
+    signal: AbortSignal,
+  ) => Promise<boolean>;
+  /** Injectable cancellation-safe delay for backoff between attempts. */
+  delay?: (milliseconds: number) => Promise<void>;
+  /** Per-attempt abort timeout in milliseconds (default 1000). */
+  readinessAttemptTimeoutMs?: number;
+}
+
+const SESSION_READINESS_DELAYS_MS = [50, 100, 200, 400, 500, 500, 250] as const;
+
+/**
+ * Poll the OpenCode `/session/status` endpoint until the child session is
+ * attachable, with a bounded retry schedule and a per-attempt abort timeout.
+ *
+ * Prevents the attach-before-ready race where `opencode attach --session
+ * <id>` launches before the server has published the session and falls back
+ * to the new-session picker TUI. Returns false when the session never became
+ * ready within the bounded window.
+ */
+export async function waitForSessionReady(
+  serverUrl: string,
+  sessionId: string,
+  options: SessionReadinessOptions = {},
+): Promise<boolean> {
+  const check = options.checkSessionReady ?? defaultSessionReady;
+  const delay = options.delay ?? defaultDelay;
+  const attemptTimeoutMs = options.readinessAttemptTimeoutMs ?? 1_000;
+  const url = new URL('/session/status', serverUrl);
+
+  for (
+    let attempt = 0;
+    attempt <= SESSION_READINESS_DELAYS_MS.length;
+    attempt++
+  ) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), attemptTimeoutMs);
+    timeout.unref?.();
+    let ready = false;
+    try {
+      ready = await Promise.race([
+        check(url, sessionId, controller.signal),
+        new Promise<boolean>((resolve) =>
+          controller.signal.addEventListener('abort', () => resolve(false), {
+            once: true,
+          }),
+        ),
+      ]);
+    } catch {
+      // A session can briefly be unreachable while OpenCode publishes it.
+    } finally {
+      clearTimeout(timeout);
+    }
+    if (ready) return true;
+
+    const delayMs = SESSION_READINESS_DELAYS_MS[attempt];
+    if (delayMs === undefined) return false;
+    await delay(delayMs);
+  }
+  return false;
+}
+
+async function defaultSessionReady(
+  url: URL,
+  sessionId: string,
+  signal: AbortSignal,
+): Promise<boolean> {
+  const response = await fetch(url, { signal });
+  if (!response.ok) return false;
+  const statuses = (await response.json()) as Record<
+    string,
+    { type?: string } | undefined
+  >;
+  return ['idle', 'running', 'busy', 'retry'].includes(
+    statuses[sessionId]?.type ?? '',
+  );
+}
+
+function defaultDelay(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}

--- a/src/multiplexer/shared.ts
+++ b/src/multiplexer/shared.ts
@@ -257,18 +257,40 @@ export interface SessionReadinessOptions {
   delay?: (milliseconds: number) => Promise<void>;
   /** Per-attempt abort timeout in milliseconds (default 1000). */
   readinessAttemptTimeoutMs?: number;
+  /**
+   * Absolute deadline for the whole wait in milliseconds (default 2000).
+   * The wait stops once `now()` passes `deadlineMs` after the first probe,
+   * regardless of how many attempts remain, so a hanging probe can never
+   * stretch the total beyond the deadline.
+   */
+  readinessDeadlineMs?: number;
+  /** Injectable clock for deterministic deadline tests (default Date.now). */
+  now?: () => number;
+  /**
+   * Abort the whole wait (e.g. manager cleanup/disposal). Resolves false;
+   * in-flight probes are aborted through this signal.
+   */
+  signal?: AbortSignal;
 }
 
+const SESSION_READINESS_DEADLINE_MS = 2_000;
 const SESSION_READINESS_DELAYS_MS = [50, 100, 200, 400, 500, 500, 250] as const;
 
 /**
  * Poll the OpenCode `/session/status` endpoint until the child session is
- * attachable, with a bounded retry schedule and a per-attempt abort timeout.
+ * attachable, bounded by an absolute deadline (default 2s) rather than a
+ * fixed number of independently-timed attempts.
+ *
+ * Adapter contract: this gate is used by the generic pane adapters (tmux,
+ * zellij, herdr, kitty). The cmux adapter is explicitly excluded: cmux
+ * sessions are managed by CmuxSessionLifecycle, which has its own spawn
+ * machinery (server health check plus deferred spawn retry with a TTL) and
+ * never calls this function.
  *
  * Prevents the attach-before-ready race where `opencode attach --session
  * <id>` launches before the server has published the session and falls back
  * to the new-session picker TUI. Returns false when the session never became
- * ready within the bounded window.
+ * ready within the deadline or when the caller's abort signal fires.
  */
 export async function waitForSessionReady(
   serverUrl: string,
@@ -278,20 +300,43 @@ export async function waitForSessionReady(
   const check = options.checkSessionReady ?? defaultSessionReady;
   const delay = options.delay ?? defaultDelay;
   const attemptTimeoutMs = options.readinessAttemptTimeoutMs ?? 1_000;
+  const deadlineMs =
+    options.readinessDeadlineMs ?? SESSION_READINESS_DEADLINE_MS;
+  const now = options.now ?? Date.now;
+  const signal = options.signal;
+  const deadlineAt = now() + deadlineMs;
   const url = new URL('/session/status', serverUrl);
 
-  for (
-    let attempt = 0;
-    attempt <= SESSION_READINESS_DELAYS_MS.length;
-    attempt++
-  ) {
+  const abortedPromise = signal
+    ? new Promise<false>((resolve) => {
+        if (signal.aborted) resolve(false);
+        else
+          signal.addEventListener('abort', () => resolve(false), {
+            once: true,
+          });
+      })
+    : null;
+  const neverPromise = new Promise<never>(() => {});
+
+  for (let attempt = 0; ; attempt++) {
+    if (signal?.aborted) return false;
+    const remaining = deadlineAt - now();
+    if (remaining <= 0) return false;
+
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), attemptTimeoutMs);
+    const timeout = setTimeout(
+      () => controller.abort(),
+      Math.min(attemptTimeoutMs, remaining),
+    );
     timeout.unref?.();
+    const onAbort = () => controller.abort();
+    signal?.addEventListener('abort', onAbort, { once: true });
+
     let ready = false;
     try {
       ready = await Promise.race([
         check(url, sessionId, controller.signal),
+        abortedPromise ?? neverPromise,
         new Promise<boolean>((resolve) =>
           controller.signal.addEventListener('abort', () => resolve(false), {
             once: true,
@@ -302,14 +347,22 @@ export async function waitForSessionReady(
       // A session can briefly be unreachable while OpenCode publishes it.
     } finally {
       clearTimeout(timeout);
+      signal?.removeEventListener('abort', onAbort);
     }
     if (ready) return true;
+    if (signal?.aborted) return false;
 
+    // Recompute against the deadline so a slow probe can never push the
+    // total delay past it.
+    const remainingAfterProbe = deadlineAt - now();
+    if (remainingAfterProbe <= 0) return false;
     const delayMs = SESSION_READINESS_DELAYS_MS[attempt];
     if (delayMs === undefined) return false;
-    await delay(delayMs);
+    await Promise.race([
+      delay(Math.min(delayMs, remainingAfterProbe)),
+      abortedPromise ?? neverPromise,
+    ]);
   }
-  return false;
 }
 
 async function defaultSessionReady(


### PR DESCRIPTION
## What changed, and why was it needed?

Refs code-yeongyu/oh-my-openagent#3505 and anomalyco/opencode#9099 (attach-before-ready races).

When a child session was created, `MultiplexerSessionManager` launched `opencode attach --session <id>` immediately. If the child had not yet been published on the server's `/session/status` endpoint, the attach TUI fell back to the new-session picker — the pane attached to the wrong session or nothing. The same race existed on respawn after an idle close.

This change gates both the initial spawn and the respawn on `waitForSessionReady`:

- probes `GET /session/status` for the child session (`idle`/`running`/`busy`/`retry`) with a per-attempt abort timeout (default 1s) so a hanging probe cannot stall the event handler;
- **absolute bounded deadline (default 2s):** the wait is bounded by a wall-clock deadline from the first probe, not by 8 independent 1s attempts — a hanging status endpoint can no longer stall the sequential event stream for ~10s. Per-attempt timeouts and backoff delays are capped by the remaining budget so the total never exceeds the deadline;
- **lifecycle cancellation/disposal fencing:** cleanup and per-instance disposal abort any in-flight readiness wait via an AbortSignal, so teardown is never blocked by a hanging probe, and a late-ready result after cleanup cannot spawn a stale pane;
- **safe recovery after initial readiness timeout:** a timed-out session stays known and is recovered by a later `busy` status event with a fresh readiness pass; a `busy` observed *during* the in-flight wait is deferred and triggers an immediate recovery pass when the wait fails, instead of being silently orphaned;
- **explicit cmux exclusion contract:** the cmux adapter is excluded from this gate — cmux sessions go through `CmuxSessionLifecycle`, which has its own spawn machinery (server health check plus deferred spawn retry with a TTL). Contract is documented on `waitForSessionReady` and pinned by an adapter-contract test;
- deduplicates concurrent `session.created` events so duplicate creates neither double-wait nor double-spawn;
- exposes `waitForSessionReady` / `SessionReadinessOptions` from the multiplexer index for reuse; probe, delay, deadline clock, and abort signal are injectable for tests.

## Verification

- `bun test src/multiplexer/session-manager.test.ts src/multiplexer/shared.test.ts`: 107 pass, 0 fail (adds deadline-bound, abort-signal, cleanup-during-wait, disposal-during-wait, initial-timeout recovery, busy-during-wait recovery, and cmux adapter-contract tests; 30 pre-existing herdr/kitty/tmux adapter failures confirmed base-red on the base commit)
- `bun run typecheck`: pass
- `bunx @biomejs/biome check` on changed files: pass
- `git diff --check`: pass