### PR TITLE
fix(foreground-fallback): protect managed child sessions and skip replay after streamed output

### DIFF
--- a/src/hooks/foreground-fallback/index.test.ts
+++ b/src/hooks/foreground-fallback/index.test.ts
@@ -3,9 +3,10 @@ import { isInternalInitiatorPart } from '../../utils';
 import { SessionLifecycle } from '../session-lifecycle';
 import {
   ForegroundFallbackManager,
-  hasMeaningfulAssistantOutput,
+  hasAssistantActivity,
   isFailoverError,
   isRetryableError,
+  isUnsettledAssistantMessage,
 } from './index';
 
 // ACCEPTANCE GAP: config() hook behaviour is not covered by CI — verify live.
@@ -332,13 +333,13 @@ describe('isFailoverError', () => {
 });
 
 // ---------------------------------------------------------------------------
-// hasMeaningfulAssistantOutput
+// hasAssistantActivity
 // ---------------------------------------------------------------------------
 
-describe('hasMeaningfulAssistantOutput', () => {
+describe('hasAssistantActivity', () => {
   test('true for v2 assistant message with text', () => {
     expect(
-      hasMeaningfulAssistantOutput({
+      hasAssistantActivity({
         type: 'assistant',
         text: 'Here is my partial answer',
       }),
@@ -347,7 +348,7 @@ describe('hasMeaningfulAssistantOutput', () => {
 
   test('true for v1 assistant message with text part', () => {
     expect(
-      hasMeaningfulAssistantOutput({
+      hasAssistantActivity({
         info: { role: 'assistant' },
         parts: [{ type: 'text', text: 'partial' }],
       }),
@@ -355,41 +356,113 @@ describe('hasMeaningfulAssistantOutput', () => {
   });
 
   test('false for assistant message with empty or whitespace-only text', () => {
-    expect(hasMeaningfulAssistantOutput({ type: 'assistant', text: '' })).toBe(
+    expect(hasAssistantActivity({ type: 'assistant', text: '' })).toBe(false);
+    expect(hasAssistantActivity({ type: 'assistant', text: '   ' })).toBe(
       false,
     );
     expect(
-      hasMeaningfulAssistantOutput({ type: 'assistant', text: '   ' }),
-    ).toBe(false);
-    expect(
-      hasMeaningfulAssistantOutput({
+      hasAssistantActivity({
         info: { role: 'assistant' },
         parts: [{ type: 'text', text: ' \n ' }],
       }),
     ).toBe(false);
   });
 
-  test('false for assistant message with tool parts only', () => {
+  test('true for assistant message with tool-call parts (tool activity blocks replay)', () => {
+    // Replaying a turn whose attempt already issued tool calls would
+    // re-execute those tools with duplicate side effects, so tool parts
+    // count as activity even without any text.
     expect(
-      hasMeaningfulAssistantOutput({
+      hasAssistantActivity({
         type: 'assistant',
         parts: [{ type: 'tool', tool: 'bash', input: {} }],
+      }),
+    ).toBe(true);
+    expect(
+      hasAssistantActivity({
+        info: { role: 'assistant' },
+        parts: [
+          { type: 'reasoning', text: 'thinking...' },
+          { type: 'tool', tool: 'webfetch', input: { url: 'x' } },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  test('false for assistant message with reasoning/retry parts only', () => {
+    // Reasoning and runtime retry markers are not user-visible output and do
+    // not represent side effects, so they do not block replay.
+    expect(
+      hasAssistantActivity({
+        type: 'assistant',
+        parts: [{ type: 'reasoning', text: 'thinking...' }],
+      }),
+    ).toBe(false);
+    expect(
+      hasAssistantActivity({
+        type: 'assistant',
+        parts: [{ type: 'retry', attempt: 1, error: { message: 'rl' } }],
       }),
     ).toBe(false);
   });
 
   test('false for non-assistant messages and non-messages', () => {
-    expect(hasMeaningfulAssistantOutput({ type: 'user', text: 'hello' })).toBe(
-      false,
-    );
+    expect(hasAssistantActivity({ type: 'user', text: 'hello' })).toBe(false);
     expect(
-      hasMeaningfulAssistantOutput({
+      hasAssistantActivity({
         info: { role: 'user' },
         parts: [{ type: 'text', text: 'hello' }],
       }),
     ).toBe(false);
-    expect(hasMeaningfulAssistantOutput(null)).toBe(false);
-    expect(hasMeaningfulAssistantOutput('assistant text')).toBe(false);
+    expect(hasAssistantActivity(null)).toBe(false);
+    expect(hasAssistantActivity('assistant text')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isUnsettledAssistantMessage
+// ---------------------------------------------------------------------------
+
+describe('isUnsettledAssistantMessage', () => {
+  test('true for assistant message that started but has not completed', () => {
+    expect(
+      isUnsettledAssistantMessage({
+        type: 'assistant',
+        time: { created: 1 },
+        parts: [],
+      }),
+    ).toBe(true);
+    expect(
+      isUnsettledAssistantMessage({
+        info: { role: 'assistant', time: { created: 1 } },
+        parts: [],
+      }),
+    ).toBe(true);
+  });
+
+  test('false for completed assistant messages', () => {
+    expect(
+      isUnsettledAssistantMessage({
+        type: 'assistant',
+        time: { created: 1, completed: 2 },
+      }),
+    ).toBe(false);
+  });
+
+  test('false for messages without timing info and non-assistant messages', () => {
+    expect(isUnsettledAssistantMessage({ type: 'assistant', parts: [] })).toBe(
+      false,
+    );
+    expect(isUnsettledAssistantMessage({ type: 'user', text: 'hello' })).toBe(
+      false,
+    );
+    expect(
+      isUnsettledAssistantMessage({
+        type: 'assistant',
+        text: 'settled text',
+      }),
+    ).toBe(false);
+    expect(isUnsettledAssistantMessage(null)).toBe(false);
   });
 });
 
@@ -2203,7 +2276,9 @@ describe('ForegroundFallbackManager replay guard', () => {
     expect(call[0].body.model.modelID).toBe('gpt-4o');
   });
 
-  test('falls back normally when the attempt only emitted tool calls', async () => {
+  test('skips replay when the attempt emitted tool calls', async () => {
+    // A failed attempt that issued tool calls must not be replayed: replaying
+    // the user turn would re-execute those tools with duplicate side effects.
     const { mocks } = createMockClient({
       messagesData: [
         { type: 'user', text: 'hello' },
@@ -2221,7 +2296,7 @@ describe('ForegroundFallbackManager replay guard', () => {
 
     await mgr.handleEvent(ERROR_EVENT);
 
-    expect(mocks.promptAsync).toHaveBeenCalledTimes(1);
+    expect(mocks.promptAsync).not.toHaveBeenCalled();
   });
 
   test('does not guard on assistant output from an earlier completed turn', async () => {
@@ -2243,6 +2318,213 @@ describe('ForegroundFallbackManager replay guard', () => {
     await mgr.handleEvent(ERROR_EVENT);
 
     expect(mocks.promptAsync).toHaveBeenCalledTimes(1);
+  });
+
+  test('sequential events: skipped replay does not consume the fallback model', async () => {
+    // Regression: execFallback used to mark nextModel as tried (and clear the
+    // retry budget) BEFORE the replay guard ran. When the guard then skipped
+    // the replay, a later retryable failure would bypass or exhaust a model
+    // that was never actually attempted. The fallback model must only be
+    // consumed when the replay really happens.
+    let messagesData: unknown[] = [
+      { type: 'user', text: 'hello' },
+      {
+        type: 'assistant',
+        text: 'partial answer before rate limit',
+        error: { message: 'rate limit' },
+      },
+    ];
+    const messages = mock(async () => ({ data: messagesData }));
+    const promptAsync = mock(async () => ({}));
+    const abort = mock(async () => ({}));
+    const session: Record<string, unknown> = { messages, abort, promptAsync };
+    currentMockSession = session;
+    installGetClientMock();
+
+    const mgr = new ForegroundFallbackManager(makeChains(), true, {
+      directory: '/test',
+    } as any);
+    await seedModel(mgr);
+
+    // First incident: the failed attempt already emitted output → replay
+    // skipped. The fallback model (openai/gpt-4o) must NOT be consumed.
+    await mgr.handleEvent(ERROR_EVENT);
+    expect(promptAsync).not.toHaveBeenCalled();
+
+    // The user retries the turn; the conversation is clean again. The next
+    // failure must still fall back to openai/gpt-4o (first untried model),
+    // not skip it as if it had already been attempted.
+    messagesData = [
+      { type: 'user', text: 'hello' },
+      { type: 'assistant', text: '', error: { message: 'rate limit' } },
+    ];
+    const realNowFn = Date.now;
+    let fakeNow = realNowFn();
+    Date.now = () => fakeNow;
+    try {
+      fakeNow += 6_000; // skip the 5s dedup window
+      await mgr.handleEvent(ERROR_EVENT);
+
+      expect(promptAsync).toHaveBeenCalledTimes(1);
+      const call = promptAsync.mock.calls[0] as [
+        { body: { model: { providerID: string; modelID: string } } },
+      ];
+      expect(call[0].body.model.providerID).toBe('openai');
+      expect(call[0].body.model.modelID).toBe('gpt-4o');
+    } finally {
+      Date.now = realNowFn;
+    }
+  });
+
+  test('waits for stream settlement and skips replay when output lands', async () => {
+    // Stream-settlement race: the error event can fire while the failed
+    // attempt's stream is still settling, so session.messages() may not yet
+    // contain the partial output. When an attempt message is open (started,
+    // not completed), the guard waits once and re-checks before replaying.
+    let messagesData: unknown[] = [
+      { type: 'user', text: 'hello' },
+      { type: 'assistant', time: { created: 1 }, parts: [] },
+    ];
+    const messages = mock(async () => {
+      const data = messagesData;
+      return { data };
+    });
+    const promptAsync = mock(async () => ({}));
+    const session: Record<string, unknown> = { messages, promptAsync };
+    currentMockSession = session;
+    installGetClientMock();
+
+    const mgr = new ForegroundFallbackManager(makeChains(), true, {
+      directory: '/test',
+    } as any);
+    await seedModel(mgr);
+
+    // After the settle wait, the streamed output lands in the message list.
+    setTimeout(() => {
+      messagesData = [
+        { type: 'user', text: 'hello' },
+        {
+          type: 'assistant',
+          time: { created: 1, completed: 2 },
+          parts: [{ type: 'text', text: 'output that landed late' }],
+        },
+      ];
+    }, 25);
+
+    await mgr.handleEvent(ERROR_EVENT);
+
+    expect(promptAsync).not.toHaveBeenCalled();
+    expect(messages).toHaveBeenCalledTimes(2);
+  });
+
+  test('replays after settlement when the attempt still shows no activity', async () => {
+    // The settle wait must not block legitimate fallbacks: when the attempt
+    // message settles without any output, the replay proceeds.
+    let messagesData: unknown[] = [
+      { type: 'user', text: 'hello' },
+      { type: 'assistant', time: { created: 1 }, parts: [] },
+    ];
+    const messages = mock(async () => ({ data: messagesData }));
+    const promptAsync = mock(async () => ({}));
+    const session: Record<string, unknown> = { messages, promptAsync };
+    currentMockSession = session;
+    installGetClientMock();
+
+    const mgr = new ForegroundFallbackManager(makeChains(), true, {
+      directory: '/test',
+    } as any);
+    await seedModel(mgr);
+
+    setTimeout(() => {
+      messagesData = [
+        { type: 'user', text: 'hello' },
+        { type: 'assistant', time: { created: 1, completed: 2 }, parts: [] },
+      ];
+    }, 25);
+
+    await mgr.handleEvent(ERROR_EVENT);
+
+    expect(promptAsync).toHaveBeenCalledTimes(1);
+    const call = promptAsync.mock.calls[0] as [
+      { body: { model: { providerID: string; modelID: string } } },
+    ];
+    expect(call[0].body.model.providerID).toBe('openai');
+    expect(call[0].body.model.modelID).toBe('gpt-4o');
+  });
+
+  test('wiring/order: ownership predicate gates the fallback before any state is consumed', async () => {
+    // The shouldHandleSession predicate must be consulted before the abort
+    // and replay paths consume any fallback state: a managed child session's
+    // error leaves the chain untouched for later use.
+    const { mocks } = createMockClient();
+    const managed = new Set(['managed-child']);
+    const mgr = new ForegroundFallbackManager(
+      makeChains(),
+      true,
+      { directory: '/test' } as any,
+      3,
+      undefined,
+      { shouldHandleSession: (sessionID) => !managed.has(sessionID) },
+    );
+
+    await mgr.handleEvent({
+      type: 'message.updated',
+      properties: {
+        info: {
+          sessionID: 'managed-child',
+          providerID: 'anthropic',
+          modelID: 'claude-opus-4-5',
+          role: 'assistant',
+        },
+      },
+    });
+
+    // Managed: the error must be skipped entirely (no abort, no replay).
+    await mgr.handleEvent({
+      type: 'session.status',
+      properties: {
+        sessionID: 'managed-child',
+        status: {
+          type: 'retry',
+          attempt: 1,
+          message: 'rate limit, retrying...',
+        },
+      },
+    });
+    expect(mocks.abort).not.toHaveBeenCalled();
+    expect(mocks.promptAsync).not.toHaveBeenCalled();
+
+    // Ownership ends (parent completed): the very same session's next
+    // failure must fall back to the first untried model — proving the
+    // skipped incident consumed nothing.
+    managed.delete('managed-child');
+    const realNowFn = Date.now;
+    let fakeNow = realNowFn();
+    Date.now = () => fakeNow;
+    try {
+      fakeNow += 6_000;
+      await mgr.handleEvent({
+        type: 'session.status',
+        properties: {
+          sessionID: 'managed-child',
+          status: {
+            type: 'retry',
+            attempt: 1,
+            message: 'rate limit, retrying...',
+          },
+        },
+      });
+
+      expect(mocks.abort).toHaveBeenCalledTimes(1);
+      expect(mocks.promptAsync).toHaveBeenCalledTimes(1);
+      const call = mocks.promptAsync.mock.calls[0] as [
+        { body: { model: { providerID: string; modelID: string } } },
+      ];
+      expect(call[0].body.model.providerID).toBe('openai');
+      expect(call[0].body.model.modelID).toBe('gpt-4o');
+    } finally {
+      Date.now = realNowFn;
+    }
   });
 });
 

--- a/src/hooks/foreground-fallback/index.test.ts
+++ b/src/hooks/foreground-fallback/index.test.ts
@@ -3,6 +3,7 @@ import { isInternalInitiatorPart } from '../../utils';
 import { SessionLifecycle } from '../session-lifecycle';
 import {
   ForegroundFallbackManager,
+  hasMeaningfulAssistantOutput,
   isFailoverError,
   isRetryableError,
 } from './index';
@@ -331,6 +332,68 @@ describe('isFailoverError', () => {
 });
 
 // ---------------------------------------------------------------------------
+// hasMeaningfulAssistantOutput
+// ---------------------------------------------------------------------------
+
+describe('hasMeaningfulAssistantOutput', () => {
+  test('true for v2 assistant message with text', () => {
+    expect(
+      hasMeaningfulAssistantOutput({
+        type: 'assistant',
+        text: 'Here is my partial answer',
+      }),
+    ).toBe(true);
+  });
+
+  test('true for v1 assistant message with text part', () => {
+    expect(
+      hasMeaningfulAssistantOutput({
+        info: { role: 'assistant' },
+        parts: [{ type: 'text', text: 'partial' }],
+      }),
+    ).toBe(true);
+  });
+
+  test('false for assistant message with empty or whitespace-only text', () => {
+    expect(hasMeaningfulAssistantOutput({ type: 'assistant', text: '' })).toBe(
+      false,
+    );
+    expect(
+      hasMeaningfulAssistantOutput({ type: 'assistant', text: '   ' }),
+    ).toBe(false);
+    expect(
+      hasMeaningfulAssistantOutput({
+        info: { role: 'assistant' },
+        parts: [{ type: 'text', text: ' \n ' }],
+      }),
+    ).toBe(false);
+  });
+
+  test('false for assistant message with tool parts only', () => {
+    expect(
+      hasMeaningfulAssistantOutput({
+        type: 'assistant',
+        parts: [{ type: 'tool', tool: 'bash', input: {} }],
+      }),
+    ).toBe(false);
+  });
+
+  test('false for non-assistant messages and non-messages', () => {
+    expect(hasMeaningfulAssistantOutput({ type: 'user', text: 'hello' })).toBe(
+      false,
+    );
+    expect(
+      hasMeaningfulAssistantOutput({
+        info: { role: 'user' },
+        parts: [{ type: 'text', text: 'hello' }],
+      }),
+    ).toBe(false);
+    expect(hasMeaningfulAssistantOutput(null)).toBe(false);
+    expect(hasMeaningfulAssistantOutput('assistant text')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // ForegroundFallbackManager - disabled
 // ---------------------------------------------------------------------------
 
@@ -366,6 +429,63 @@ describe('ForegroundFallbackManager session.error', () => {
     mgr = new ForegroundFallbackManager(makeChains(), true, {
       directory: '/test',
     } as any);
+  });
+
+  test('does not detach fallback for externally owned sessions', async () => {
+    const { mocks } = createMockClient();
+    const managedSessions = new Set(['background-child']);
+    const manager = new ForegroundFallbackManager(
+      makeChains(),
+      true,
+      { directory: '/test' } as any,
+      3,
+      undefined,
+      { shouldHandleSession: (sessionID) => !managedSessions.has(sessionID) },
+    );
+
+    await manager.handleEvent({
+      type: 'message.updated',
+      properties: {
+        info: {
+          sessionID: 'background-child',
+          providerID: 'anthropic',
+          modelID: 'claude-opus-4-5',
+          role: 'assistant',
+        },
+      },
+    });
+    await manager.handleEvent({
+      type: 'session.error',
+      properties: {
+        sessionID: 'background-child',
+        error: { message: 'Rate limit exceeded' },
+      },
+    });
+
+    expect(mocks.promptAsync).not.toHaveBeenCalled();
+  });
+
+  test('does not abort externally owned sessions on retry status', async () => {
+    const { mocks } = createMockClient();
+    const manager = new ForegroundFallbackManager(
+      makeChains(),
+      true,
+      { directory: '/test' } as any,
+      3,
+      undefined,
+      { shouldHandleSession: () => false },
+    );
+
+    await manager.handleEvent({
+      type: 'session.status',
+      properties: {
+        sessionID: 'background-child',
+        status: { type: 'retry', message: 'Rate limit exceeded' },
+      },
+    });
+
+    expect(mocks.abort).not.toHaveBeenCalled();
+    expect(mocks.promptAsync).not.toHaveBeenCalled();
   });
 
   test('triggers fallback on rate-limit session.error', async () => {
@@ -624,14 +744,15 @@ describe('ForegroundFallbackManager session.error', () => {
     // OpenCode 1.18+ session.messages() returns v2 SessionMessage objects
     // ({ type, text }) instead of the v1 { info, parts } shape. The fallback
     // must locate and re-submit the v2 user text even when an assistant
-    // message appears after it.
+    // message appears after it (here: a failed attempt that emitted no
+    // output, so the replay guard does not apply).
     ({ mocks } = createMockClient({
       messagesData: [
         { id: 'm1', type: 'user', text: 'v2 prompt' },
         {
           id: 'm2',
           type: 'assistant',
-          parts: [{ type: 'text', text: 'reply' }],
+          parts: [],
         },
       ],
     }));
@@ -1992,6 +2113,136 @@ describe('ForegroundFallbackManager deduplication', () => {
         }),
       }),
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ForegroundFallbackManager - replay guard
+// ---------------------------------------------------------------------------
+
+describe('ForegroundFallbackManager replay guard', () => {
+  const ERROR_EVENT = {
+    type: 'session.error',
+    properties: { sessionID: 'sess-guard', error: { message: 'rate limit' } },
+  };
+
+  async function seedModel(mgr: ForegroundFallbackManager): Promise<void> {
+    await mgr.handleEvent({
+      type: 'message.updated',
+      properties: {
+        info: {
+          sessionID: 'sess-guard',
+          providerID: 'anthropic',
+          modelID: 'claude-opus-4-5',
+          role: 'assistant',
+        },
+      },
+    });
+  }
+
+  test('skips replay when the failed attempt already emitted text output (v2 shape)', async () => {
+    const { mocks } = createMockClient({
+      messagesData: [
+        { type: 'user', text: 'hello' },
+        {
+          type: 'assistant',
+          text: 'Here is the partial answer before the rate limit.',
+          error: { message: 'rate limit' },
+        },
+      ],
+    });
+    const mgr = new ForegroundFallbackManager(makeChains(), true, {
+      directory: '/test',
+    } as any);
+    await seedModel(mgr);
+
+    await mgr.handleEvent(ERROR_EVENT);
+
+    expect(mocks.promptAsync).not.toHaveBeenCalled();
+  });
+
+  test('skips replay when the failed attempt already emitted text output (v1 shape)', async () => {
+    const { mocks } = createMockClient({
+      messagesData: [
+        { info: { role: 'user' }, parts: [{ type: 'text', text: 'hello' }] },
+        {
+          info: { role: 'assistant' },
+          parts: [{ type: 'text', text: 'partial answer' }],
+        },
+      ],
+    });
+    const mgr = new ForegroundFallbackManager(makeChains(), true, {
+      directory: '/test',
+    } as any);
+    await seedModel(mgr);
+
+    await mgr.handleEvent(ERROR_EVENT);
+
+    expect(mocks.promptAsync).not.toHaveBeenCalled();
+  });
+
+  test('falls back normally when the attempt failed before emitting output', async () => {
+    const { mocks } = createMockClient({
+      messagesData: [
+        { type: 'user', text: 'hello' },
+        { type: 'assistant', text: '', error: { message: 'rate limit' } },
+      ],
+    });
+    const mgr = new ForegroundFallbackManager(makeChains(), true, {
+      directory: '/test',
+    } as any);
+    await seedModel(mgr);
+
+    await mgr.handleEvent(ERROR_EVENT);
+
+    expect(mocks.promptAsync).toHaveBeenCalledTimes(1);
+    const call = mocks.promptAsync.mock.calls[0] as [
+      { body: { model: { providerID: string; modelID: string } } },
+    ];
+    expect(call[0].body.model.providerID).toBe('openai');
+    expect(call[0].body.model.modelID).toBe('gpt-4o');
+  });
+
+  test('falls back normally when the attempt only emitted tool calls', async () => {
+    const { mocks } = createMockClient({
+      messagesData: [
+        { type: 'user', text: 'hello' },
+        {
+          type: 'assistant',
+          parts: [{ type: 'tool', tool: 'bash', input: {} }],
+          error: { message: 'rate limit' },
+        },
+      ],
+    });
+    const mgr = new ForegroundFallbackManager(makeChains(), true, {
+      directory: '/test',
+    } as any);
+    await seedModel(mgr);
+
+    await mgr.handleEvent(ERROR_EVENT);
+
+    expect(mocks.promptAsync).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not guard on assistant output from an earlier completed turn', async () => {
+    // Assistant output BEFORE the last user message belongs to a previous
+    // turn; only the attempt after the replayed user message matters.
+    const { mocks } = createMockClient({
+      messagesData: [
+        { type: 'user', text: 'first turn' },
+        { type: 'assistant', text: 'completed answer' },
+        { type: 'user', text: 'second turn' },
+        { type: 'assistant', text: '', error: { message: 'rate limit' } },
+      ],
+    });
+    const mgr = new ForegroundFallbackManager(makeChains(), true, {
+      directory: '/test',
+    } as any);
+    await seedModel(mgr);
+
+    await mgr.handleEvent(ERROR_EVENT);
+
+    expect(mocks.promptAsync).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/hooks/foreground-fallback/index.ts
+++ b/src/hooks/foreground-fallback/index.ts
@@ -28,6 +28,11 @@ import {
 import type { SessionLifecycle } from '../session-lifecycle';
 import { isReplayableUserMessage, partsFromReplayMessage } from '../types';
 
+interface ForegroundFallbackOptions {
+  /** Skip sessions whose background-task lifecycle owns completion delivery. */
+  shouldHandleSession?: (sessionID: string) => boolean;
+}
+
 // ---------------------------------------------------------------------------
 // Retryable error detection
 // ---------------------------------------------------------------------------
@@ -254,6 +259,45 @@ export function isInlineFailoverError(error: unknown): boolean {
   );
 }
 
+/**
+ * True when an assistant message carries meaningful (non-whitespace) text
+ * output. Used by the replay guard: when the failed attempt already emitted
+ * a partial answer before the error (e.g. a mid-stream rate limit), replaying
+ * the user turn would duplicate that output in the conversation.
+ *
+ * Handles both the v2 HTTP shape (`{ type: 'assistant', text }` and
+ * `{ type: 'assistant', parts }`) and the v1 transform shape
+ * (`{ info: { role: 'assistant' }, parts }`). Tool-only parts are not
+ * meaningful output.
+ */
+export function hasMeaningfulAssistantOutput(message: unknown): boolean {
+  if (!message || typeof message !== 'object') return false;
+  const candidate = message as {
+    type?: unknown;
+    info?: { role?: unknown };
+    text?: unknown;
+    parts?: unknown;
+  };
+  const isAssistant =
+    candidate.type === 'assistant' || candidate.info?.role === 'assistant';
+  if (!isAssistant) return false;
+  if (typeof candidate.text === 'string' && candidate.text.trim().length > 0) {
+    return true;
+  }
+  if (Array.isArray(candidate.parts)) {
+    return candidate.parts.some((part): boolean => {
+      if (!part || typeof part !== 'object') return false;
+      const p = part as { type?: unknown; text?: unknown };
+      return (
+        p.type === 'text' &&
+        typeof p.text === 'string' &&
+        p.text.trim().length > 0
+      );
+    });
+  }
+  return false;
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -365,6 +409,7 @@ export class ForegroundFallbackManager {
     /** Consecutive 429s tolerated on the same model before swap/abort. */
     private readonly maxRetries: number = 3,
     coordinator?: SessionLifecycle,
+    private readonly options: ForegroundFallbackOptions = {},
   ) {
     if (coordinator) {
       coordinator.onSessionDeleted((id) => {
@@ -582,6 +627,12 @@ export class ForegroundFallbackManager {
 
   private async tryFallback(sessionID: string, error?: unknown): Promise<void> {
     if (!sessionID) return;
+    if (this.options.shouldHandleSession?.(sessionID) === false) {
+      log('[foreground-fallback] skipped externally owned session', {
+        sessionID,
+      });
+      return;
+    }
     if (this.inProgress.has(sessionID)) return;
     // No chain → no fallback. Skip before dedup so we don't stamp lastTrigger
     // for sessions we will never re-prompt (e.g. councillor via CouncilManager).
@@ -616,6 +667,12 @@ export class ForegroundFallbackManager {
     error?: unknown,
   ): Promise<void> {
     if (!sessionID) return;
+    if (this.options.shouldHandleSession?.(sessionID) === false) {
+      log('[foreground-fallback] skipped externally owned session', {
+        sessionID,
+      });
+      return;
+    }
     if (this.inProgress.has(sessionID)) return;
     if (!this.hasFallbackChain(sessionID)) return;
     if (this.isDeduped(sessionID)) return;
@@ -757,6 +814,30 @@ export class ForegroundFallbackManager {
           messageCount: messages.length,
           requestError: result.error ?? undefined,
         });
+        return;
+      }
+
+      // Replay guard: when the failed attempt already emitted meaningful
+      // assistant output before the error (e.g. a partial answer streamed
+      // before a mid-stream rate limit), re-queuing the user turn would
+      // duplicate that output in the conversation. Keep the partial output
+      // and skip the replay. Fallback still applies when the attempt failed
+      // before producing any output (first-token rate limits, pre-stream
+      // errors), because then there is nothing to duplicate.
+      const lastUserIndex = messages.indexOf(lastUser);
+      const failedAttempt = messages
+        .slice(lastUserIndex + 1)
+        .reverse()
+        .find(hasMeaningfulAssistantOutput);
+      if (failedAttempt) {
+        log(
+          '[foreground-fallback] skipping replay: failed attempt already emitted output',
+          {
+            sessionID,
+            agentName,
+            currentModel,
+          },
+        );
         return;
       }
 

--- a/src/hooks/foreground-fallback/index.ts
+++ b/src/hooks/foreground-fallback/index.ts
@@ -260,17 +260,19 @@ export function isInlineFailoverError(error: unknown): boolean {
 }
 
 /**
- * True when an assistant message carries meaningful (non-whitespace) text
- * output. Used by the replay guard: when the failed attempt already emitted
- * a partial answer before the error (e.g. a mid-stream rate limit), replaying
- * the user turn would duplicate that output in the conversation.
+ * True when an assistant message shows the failed attempt was active: it
+ * already emitted meaningful (non-whitespace) text output, or it issued a
+ * tool call. Used by the replay guard: when the failed attempt produced
+ * output before the error (e.g. a mid-stream rate limit), replaying the user
+ * turn would duplicate that output; when it issued tool calls, replaying
+ * would re-execute those tools with duplicate side effects.
  *
  * Handles both the v2 HTTP shape (`{ type: 'assistant', text }` and
  * `{ type: 'assistant', parts }`) and the v1 transform shape
- * (`{ info: { role: 'assistant' }, parts }`). Tool-only parts are not
- * meaningful output.
+ * (`{ info: { role: 'assistant' }, parts }`). Reasoning/retry parts are not
+ * user-visible output and do not count as activity.
  */
-export function hasMeaningfulAssistantOutput(message: unknown): boolean {
+export function hasAssistantActivity(message: unknown): boolean {
   if (!message || typeof message !== 'object') return false;
   const candidate = message as {
     type?: unknown;
@@ -288,6 +290,7 @@ export function hasMeaningfulAssistantOutput(message: unknown): boolean {
     return candidate.parts.some((part): boolean => {
       if (!part || typeof part !== 'object') return false;
       const p = part as { type?: unknown; text?: unknown };
+      if (p.type === 'tool') return true;
       return (
         p.type === 'text' &&
         typeof p.text === 'string' &&
@@ -298,6 +301,29 @@ export function hasMeaningfulAssistantOutput(message: unknown): boolean {
   return false;
 }
 
+/**
+ * True when an assistant message has started streaming but not completed
+ * (`time.created` present without `time.completed`). Such a message is still
+ * settling: its partial output may not have landed in `session.messages()`
+ * yet, so a replay decision made right now could duplicate output that
+ * arrives a moment later.
+ */
+export function isUnsettledAssistantMessage(message: unknown): boolean {
+  if (!message || typeof message !== 'object') return false;
+  const candidate = message as {
+    type?: unknown;
+    info?: { role?: unknown; time?: unknown };
+    time?: unknown;
+  };
+  const isAssistant =
+    candidate.type === 'assistant' || candidate.info?.role === 'assistant';
+  if (!isAssistant) return false;
+  const time = candidate.time ?? candidate.info?.time;
+  if (!time || typeof time !== 'object') return false;
+  const t = time as { created?: unknown; completed?: unknown };
+  return typeof t.created === 'number' && typeof t.completed !== 'number';
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -305,6 +331,14 @@ export function hasMeaningfulAssistantOutput(message: unknown): boolean {
 /** Prevent re-triggering within this window for the same session. */
 const DEDUP_WINDOW_MS = 5_000;
 const REPROMPT_DELAY_MS = 500;
+/**
+ * How long to wait for a failed attempt's stream to settle before deciding
+ * to replay. When the error event races the persistence of the streamed
+ * output, the replay guard may not see the partial text yet; waiting once
+ * closes that race without adding a fixed delay to every fallback (the wait
+ * only happens when an unsettled assistant message is present).
+ */
+const STREAM_SETTLE_DELAY_MS = 150;
 const FALLBACK_IN_PROGRESS_KEY = Symbol.for(
   'oh-my-opencode-slim.foreground-fallback.in-progress',
 );
@@ -785,10 +819,6 @@ export class ForegroundFallbackManager {
           return;
         }
       }
-      tried.add(nextModel);
-      // Reset retry count on model switch — the new model starts fresh.
-      this.sessionRetries.delete(sessionID);
-
       const ref = parseModelReference(nextModel);
       if (!ref) {
         log('[foreground-fallback] invalid model format', {
@@ -818,18 +848,16 @@ export class ForegroundFallbackManager {
       }
 
       // Replay guard: when the failed attempt already emitted meaningful
-      // assistant output before the error (e.g. a partial answer streamed
-      // before a mid-stream rate limit), re-queuing the user turn would
-      // duplicate that output in the conversation. Keep the partial output
-      // and skip the replay. Fallback still applies when the attempt failed
-      // before producing any output (first-token rate limits, pre-stream
-      // errors), because then there is nothing to duplicate.
+      // assistant output or tool calls before the error (e.g. a partial
+      // answer streamed before a mid-stream rate limit), re-queuing the user
+      // turn would duplicate that output or re-execute those tools. Keep the
+      // partial output and skip the replay. Fallback still applies when the
+      // attempt failed before producing any activity (first-token rate
+      // limits, pre-stream errors), because then there is nothing to
+      // duplicate.
       const lastUserIndex = messages.indexOf(lastUser);
-      const failedAttempt = messages
-        .slice(lastUserIndex + 1)
-        .reverse()
-        .find(hasMeaningfulAssistantOutput);
-      if (failedAttempt) {
+      const attemptMessages = messages.slice(lastUserIndex + 1);
+      if (attemptMessages.some(hasAssistantActivity)) {
         log(
           '[foreground-fallback] skipping replay: failed attempt already emitted output',
           {
@@ -840,6 +868,48 @@ export class ForegroundFallbackManager {
         );
         return;
       }
+
+      // Stream-settlement hardening: the failed attempt's stream may still
+      // be settling when the error event fires, so its partial output may
+      // not have landed in session.messages() yet. When an attempt message
+      // is open (started but not completed), wait once for it to settle and
+      // re-check before replaying — replaying into a settling stream
+      // duplicates output that arrives a moment later. No fixed delay is
+      // added when nothing is in flight.
+      if (attemptMessages.some(isUnsettledAssistantMessage)) {
+        await new Promise((resolve) =>
+          setTimeout(resolve, STREAM_SETTLE_DELAY_MS),
+        );
+        const refreshed = await session.messages({ path: { id: sessionID } });
+        const refreshedMessages = (refreshed.data ?? []) as unknown[];
+        const refreshedLastUser = [...refreshedMessages]
+          .reverse()
+          .find(isReplayableUserMessage);
+        if (refreshedLastUser) {
+          const refreshedAttempt = refreshedMessages.slice(
+            refreshedMessages.indexOf(refreshedLastUser) + 1,
+          );
+          if (refreshedAttempt.some(hasAssistantActivity)) {
+            log(
+              '[foreground-fallback] skipping replay: partial output landed during stream settlement',
+              {
+                sessionID,
+                agentName,
+                currentModel,
+              },
+            );
+            return;
+          }
+        }
+      }
+
+      // The replay is going to happen: only now consume the fallback model
+      // (record it as tried) and reset the retry budget. Skipping the replay
+      // above must not consume either — a later retryable failure would
+      // otherwise bypass or exhaust a model that was never actually attempted.
+      tried.add(nextModel);
+      // Reset retry count on model switch — the new model starts fresh.
+      this.sessionRetries.delete(sessionID);
 
       // promptAsync queues the prompt and returns immediately - this avoids
       // blocking the event handler while waiting for a full LLM response.

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -35,4 +35,7 @@ export { createPhaseReminderHook } from './phase-reminder';
 export { createPostFileToolNudgeHook } from './post-file-tool-nudge';
 export { createReflectCommandHook } from './reflect';
 export { SessionLifecycle } from './session-lifecycle';
-export { createTaskSessionManagerHook } from './task-session-manager';
+export {
+  collectManagedChildSessionIDs,
+  createTaskSessionManagerHook,
+} from './task-session-manager';

--- a/src/hooks/task-session-manager/index.test.ts
+++ b/src/hooks/task-session-manager/index.test.ts
@@ -106,6 +106,7 @@ type HookOptions = {
   strategy?: 'latest' | 'checkpoint-compatible';
   maxRetainedSnapshots?: number;
   backgroundJobBoard?: BackgroundJobBoard;
+  managedTaskSessionIDs?: Set<string>;
   sessionStatus?: unknown;
   sessionClient?: Record<string, unknown>;
   idleReconcileDelayMs?: number;
@@ -136,6 +137,7 @@ function createHook(options?: HookOptions) {
       readContextMinLines: options?.readContextMinLines,
       readContextMaxFiles: options?.readContextMaxFiles,
       backgroundJobBoard: options?.backgroundJobBoard,
+      managedTaskSessionIDs: options?.managedTaskSessionIDs,
       backgroundJobSupervisor: options?.backgroundJobSupervisor,
       shouldManageSession: options?.shouldManageSession ?? (() => true),
       registerSessionAsOrchestrator: options?.registerSessionAsOrchestrator,
@@ -234,6 +236,23 @@ describe('task-session-manager hook', () => {
   beforeEach(() => {
     // Process-global gate only — never reset inside createHook/production paths.
     resetUserWaitGateForTests();
+  });
+
+  test('tracks background child sessions before task output registration', async () => {
+    const managedTaskSessionIDs = new Set<string>();
+    const { hook } = createHook({
+      managedTaskSessionIDs,
+      shouldManageSession: () => false,
+    });
+
+    await hook.event({
+      event: {
+        type: 'session.created',
+        properties: { info: { id: 'child-1', parentID: 'parent-1' } },
+      },
+    });
+
+    expect(managedTaskSessionIDs.has('child-1')).toBe(true);
   });
 
   test('ignores messages without OpenCode info or parts', async () => {

--- a/src/hooks/task-session-manager/index.test.ts
+++ b/src/hooks/task-session-manager/index.test.ts
@@ -15,6 +15,7 @@ import {
 import { createPostFileToolNudgeHook } from '../post-file-tool-nudge';
 import {
   BACKGROUND_JOB_BOARD_METADATA_KEY,
+  collectManagedChildSessionIDs,
   createTaskSessionManagerHook,
 } from './index';
 import { resetUserWaitGateForTests } from './user-wait-gate';
@@ -253,6 +254,42 @@ describe('task-session-manager hook', () => {
     });
 
     expect(managedTaskSessionIDs.has('child-1')).toBe(true);
+  });
+
+  test('restart recovery: collects pre-existing child session ids from a session list snapshot', () => {
+    // After a plugin reload, pre-existing child sessions do not re-emit
+    // session.created; ownership must be seeded from session.list() so
+    // foreground fallback leaves them to their task lifecycle.
+    expect(
+      collectManagedChildSessionIDs([
+        { id: 'child-1', parentID: 'parent-1' },
+        { id: 'child-2', parentID: 'specialist-1' },
+        // Sessions without a parent are not task-owned.
+        { id: 'root-session', parentID: undefined },
+        // Malformed entries are ignored.
+        { id: undefined, parentID: 'parent-2' },
+        undefined,
+      ]),
+    ).toEqual(['child-1', 'child-2']);
+  });
+
+  test('restart recovery: seeded ownership is removed when the child session is deleted', async () => {
+    const managedTaskSessionIDs = new Set<string>(
+      collectManagedChildSessionIDs([{ id: 'child-1', parentID: 'parent-1' }]),
+    );
+    const { hook } = createHook({
+      managedTaskSessionIDs,
+      shouldManageSession: () => false,
+    });
+
+    await hook.event({
+      event: {
+        type: 'session.deleted',
+        properties: { info: { id: 'child-1', parentID: 'parent-1' } },
+      },
+    });
+
+    expect(managedTaskSessionIDs.has('child-1')).toBe(false);
   });
 
   test('ignores messages without OpenCode info or parts', async () => {

--- a/src/hooks/task-session-manager/index.ts
+++ b/src/hooks/task-session-manager/index.ts
@@ -151,6 +151,8 @@ export function createTaskSessionManagerHook(
     readContextMaxFiles?: number;
     backgroundJobBoard?: BackgroundJobStore;
     backgroundJobSupervisor?: BackgroundJobSupervisor;
+    /** Background-task child sessions must not be re-prompted by foreground fallback. */
+    managedTaskSessionIDs?: Set<string>;
     shouldManageSession: (sessionID: string) => boolean;
     /** Register a session as orchestrator when the transform hook detects
      *  an orchestrator message but the session isn't in the agent map yet. */
@@ -502,11 +504,26 @@ export function createTaskSessionManagerHook(
         };
       };
     }): Promise<void> => {
+      if (input.event.type === 'session.created') {
+        const info = input.event.properties?.info;
+        // Every OpenCode child session is owned by its parent task lifecycle.
+        // Do not limit this to orchestrator parents: a specialist may itself
+        // dispatch a child, and foreground fallback would otherwise abort and
+        // re-prompt that child outside its task awaiter.
+        if (info?.id && info.parentID) {
+          options.managedTaskSessionIDs?.add(info.id);
+        }
+      }
+
       if (input.event.type === 'session.deleted') {
         const sessionID =
           input.event.properties?.info?.id ?? input.event.properties?.sessionID;
         if (sessionID) {
           deferredInlineErrors.delete(sessionID);
+          options.managedTaskSessionIDs?.delete(sessionID);
+          for (const childJob of backgroundJobBoard.list(sessionID)) {
+            options.managedTaskSessionIDs?.delete(childJob.taskID);
+          }
           if (!options.isFallbackInProgress?.(sessionID)) {
             const hardTimedOut =
               backgroundJobBoard.field(sessionID, 'deadlineExceededAt') !==

--- a/src/hooks/task-session-manager/index.ts
+++ b/src/hooks/task-session-manager/index.ts
@@ -41,6 +41,26 @@ import {
 export { BACKGROUND_JOB_BOARD_METADATA_KEY } from './board-injection';
 
 /**
+ * Collect the IDs of sessions owned by a parent task lifecycle from a
+ * `session.list()` snapshot. Used for restart recovery: after a plugin reload
+ * (OpenCode restart or config change), pre-existing child sessions do not
+ * re-emit `session.created`, so without seeding they would be treated as
+ * unmanaged and foreground fallback could abort/re-prompt them outside their
+ * task awaiter.
+ */
+export function collectManagedChildSessionIDs(
+  sessions: ReadonlyArray<{ id?: string; parentID?: string } | undefined>,
+): string[] {
+  const ids: string[] = [];
+  for (const session of sessions) {
+    if (session?.id && session.parentID) {
+      ids.push(session.id);
+    }
+  }
+  return ids;
+}
+
+/**
  * Delay before recording an idle observation on a child job. The observation
  * remains provisional; terminal task output is the only path that establishes
  * completed/error/cancelled state.

--- a/src/index.ts
+++ b/src/index.ts
@@ -162,6 +162,7 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
   let reflectCommandHook: ReturnType<typeof createReflectCommandHook>;
   let loopCommandHook: ReturnType<typeof createLoopCommandHook>;
   let taskSessionManagerHook: ReturnType<typeof createTaskSessionManagerHook>;
+  let managedBackgroundTaskSessionIDs: Set<string>;
   let orchestratorWakeScheduler: ReturnType<
     typeof createOrchestratorWakeScheduler
   >;
@@ -317,6 +318,7 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
     backgroundJobCoordinator.addTerminalOutcomeListener((record) => {
       revivedRunTracker.onTerminal(record);
     });
+    managedBackgroundTaskSessionIDs = new Set<string>();
 
     // Initialize MultiplexerSessionManager to handle OpenCode's built-in
     // Task tool sessions
@@ -354,6 +356,11 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
       ctx,
       runtime.fallback.maxRetries,
       sessionLifecycle,
+      {
+        shouldHandleSession: (sessionID) =>
+          !backgroundJobCoordinator.get(sessionID) &&
+          !managedBackgroundTaskSessionIDs.has(sessionID),
+      },
     );
 
     deepworkCommandHook = createDeepworkCommandHook();
@@ -367,6 +374,7 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
       readContextMaxFiles: runtime.backgroundJobs.readContextMaxFiles,
       backgroundJobBoard: backgroundJobCoordinator,
       backgroundJobSupervisor,
+      managedTaskSessionIDs: managedBackgroundTaskSessionIDs,
       shouldManageSession: (sessionID) =>
         sessionMetadata.getAgent(sessionID) === 'orchestrator',
       registerSessionAsOrchestrator: (sessionID) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import { RuntimeConfig } from './config/runtime';
 import { applyOrchestratorModelConfig } from './config/strip-orchestrator-model';
 import { HEALTH_CHECK, minimumExpectedToolCount } from './health-check';
 import {
+  collectManagedChildSessionIDs,
   createApplyPatchHook,
   createAutoUpdateCheckerHook,
   createCacheMonitorHook,
@@ -319,6 +320,29 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
       revivedRunTracker.onTerminal(record);
     });
     managedBackgroundTaskSessionIDs = new Set<string>();
+
+    // Restart recovery: after a plugin reload (OpenCode restart or config
+    // change), pre-existing child sessions do not re-emit session.created,
+    // so foreground fallback would treat them as unmanaged and could abort
+    // or re-prompt them outside their task awaiter. Seed ownership from the
+    // session list snapshot; live session.created tracking covers new
+    // children. Best-effort: a failed list call only disables seeding, never
+    // plugin init.
+    void ctx.client.session
+      .list({ query: {} })
+      .then((result) => {
+        for (const id of collectManagedChildSessionIDs(result.data ?? [])) {
+          managedBackgroundTaskSessionIDs.add(id);
+        }
+        log('[task-session-manager] seeded managed child session ownership', {
+          count: managedBackgroundTaskSessionIDs.size,
+        });
+      })
+      .catch((err) => {
+        log('[task-session-manager] could not seed managed child sessions', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
 
     // Initialize MultiplexerSessionManager to handle OpenCode's built-in
     // Task tool sessions


### PR DESCRIPTION
## What changed, and why was it needed?

Relates to #595 and #560 (orphaned/resumed background tasks). Two failure modes remain when a managed child session errors:

1. **Detachment:** the foreground-fallback manager aborted and re-prompted *every* session on a retryable error, including background-task child sessions whose completion delivery is owned by their parent's task awaiter. Re-prompting a managed child outside its task lifecycle detaches it from that awaiter.
2. **Duplicate output / re-executed tools:** when a session streamed a partial answer or issued tool calls and then hit a mid-stream retryable error, the fallback replayed the user turn, duplicating the already-emitted assistant output or re-executing the tools with duplicate side effects.

This change narrows the fallback's blast radius. It does **not** claim to fully fix orphan-result handling — that remains owned by the background-task lifecycle (#595/#560):

- `ForegroundFallbackManager` now accepts a `shouldHandleSession` predicate. Sessions owned by the background-task lifecycle (registered on `session.created` with a `parentID`, present on the background job board, or seeded from `session.list()` at init) are skipped by both the abort path and the replay path, so fallback no longer detaches managed child sessions. After a plugin reload, pre-existing child sessions do not re-emit `session.created`, so ownership is also seeded from the session list snapshot at init (`collectManagedChildSessionIDs`) — a restart can no longer leave an in-flight child unprotected.
- A replay guard (`hasAssistantActivity`) blocks re-queueing the user turn when the failed attempt already produced activity after the last user message: meaningful text (v1 and v2 shapes) **or tool-call parts**. Reasoning/retry parts do not count as activity. Fallback still applies when the attempt failed before producing any activity (first-token rate limits, pre-stream errors).
- The fallback model and retry budget are only consumed **when the replay actually happens**. A skipped replay no longer records the next model as tried or resets the retry count, so a later retryable failure can still use the fallback model (regression-covered by a sequential-event test).
- Stream-settlement hardening: the error event can race the persistence of the streamed output, so when the failed attempt's message is still open (`time.created` without `time.completed`), the guard waits once (150 ms) and re-checks `session.messages()` before deciding to replay. No fixed delay is added when nothing is in flight.

## Verification

- `bun test src/hooks/foreground-fallback/index.test.ts`: 109 pass, 0 fail (includes managed-child detachment guards, replay-guard text/tool/settlement tests, sequential-event state-consumption regression, and predicate wiring/order tests)
- `bun test -t "restart recovery|tracks background child sessions" src/hooks/task-session-manager/index.test.ts`: 3 pass, 0 fail
- `bun run typecheck`: pass
- `bun run check:ci`: only pre-existing failures (see below) — changed files are Biome-clean
- `git diff --check`: pass

Known pre-existing failures (present at base, not introduced here; both are Windows-only path-separator issues and pass on Linux CI):
- `task-session-manager` "reads before and after launch attach with unique-line counts and caps" hard-codes a forward-slash path (`src/large.ts` vs `src\large.ts`).
- `cache-safety` "every hook module defining a message transform is covered here" compares `Bun.Glob` results against forward-slash expectations and sees backslash paths on Windows.