### PR TITLE
fix(tasks): prevent premature council task shutdown

### DIFF
--- a/src/hooks/task-session-manager/index.ts
+++ b/src/hooks/task-session-manager/index.ts
@@ -43,7 +43,7 @@ export { BACKGROUND_JOB_BOARD_METADATA_KEY } from './board-injection';
  * ponytail: fixed timeout — event-driven confirmation would fully close the race but adds
  * significant complexity for a case that rarely exceeds this window in practice.
  */
-const IDLE_RECONCILE_DELAY_MS = 2_000;
+const IDLE_RECONCILE_DELAY_MS = 15_000;
 
 const RECOVERED_TASK_AGENT_FALLBACK = 'unknown';
 

--- a/src/hooks/task-session-manager/runtime-status-reconciliation.test.ts
+++ b/src/hooks/task-session-manager/runtime-status-reconciliation.test.ts
@@ -60,21 +60,41 @@ describe('runtime status reconciliation', () => {
     });
   });
 
-  test('marks an absent runtime session stopped instead of completed', async () => {
+  test('marks an absent runtime session uncertain instead of stopped', async () => {
     const { board, reconciler, contextFilesForPrompt, prune } =
       createReconciler(async () => ({ data: {} }));
 
     await reconciler.reconcile();
 
     expect(board.get('child-1')).toMatchObject({
-      state: 'stopped',
-      terminalUnreconciled: true,
-      resultSummary:
-        'Background session stopped before a terminal task result was received.',
+      state: 'running',
+      statusUncertain: true,
+      lastStatusError:
+        'Runtime status response did not contain a recognized session state.',
     });
     expect(board.resolveReusable('parent-1', 'fix-1', 'fixer')).toBeUndefined();
-    expect(contextFilesForPrompt).toHaveBeenCalledWith('child-1');
-    expect(prune).toHaveBeenCalledWith(board);
+    expect(contextFilesForPrompt).not.toHaveBeenCalled();
+    expect(prune).not.toHaveBeenCalled();
+  });
+
+  test('requires four consecutive idle observations before stopping', async () => {
+    const { board, reconciler } = createReconciler(async () => ({
+      data: { 'child-1': { type: 'idle' } },
+    }));
+
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      await reconciler.reconcile();
+      expect(board.get('child-1')).toMatchObject({
+        state: 'running',
+        statusUncertain: true,
+      });
+    }
+
+    await reconciler.reconcile();
+    expect(board.get('child-1')).toMatchObject({
+      state: 'stopped',
+      terminalUnreconciled: true,
+    });
   });
 
   test('keeps the board running but explicitly uncertain when lookup fails', async () => {
@@ -182,8 +202,8 @@ describe('runtime status reconciliation', () => {
 
     expect(status).toHaveBeenCalledTimes(2);
     expect(board.get('child-2')).toMatchObject({
-      state: 'stopped',
-      terminalUnreconciled: true,
+      state: 'running',
+      statusUncertain: true,
     });
     reconciler.dispose();
   });

--- a/src/hooks/task-session-manager/runtime-status-reconciliation.ts
+++ b/src/hooks/task-session-manager/runtime-status-reconciliation.ts
@@ -7,6 +7,7 @@ import {
 import { log } from '../../utils/logger';
 
 export const RUNTIME_STATUS_RECONCILE_DELAY_MS = 5_000;
+const RUNTIME_IDLE_CONFIRMATIONS = 4;
 
 export function createRuntimeStatusReconciler(options: {
   input: PluginInput;
@@ -24,6 +25,7 @@ export function createRuntimeStatusReconciler(options: {
   let disposed = false;
   let activeReconcile: Promise<void> | undefined;
   let rerunRequested = false;
+  const idleConfirmations = new Map<string, number>();
 
   function schedule(): void {
     if (disposed) return;
@@ -91,12 +93,26 @@ export function createRuntimeStatusReconciler(options: {
         continue;
       }
       if (status === 'busy' || status === 'retry') {
+        idleConfirmations.delete(job.taskID);
         options.backgroundJobBoard.markRunningFromLiveSession(
           job.taskID,
           observedAt,
           job.generation,
         );
         continue;
+      }
+
+      if (status === 'idle') {
+        const confirmations = (idleConfirmations.get(job.taskID) ?? 0) + 1;
+        idleConfirmations.set(job.taskID, confirmations);
+        if (confirmations < RUNTIME_IDLE_CONFIRMATIONS) {
+          options.backgroundJobBoard.markStatusUncertain(
+            job.taskID,
+            'Runtime session is idle; waiting for a terminal task result.',
+            job.generation,
+          );
+          continue;
+        }
       }
 
       const stopped = options.backgroundJobBoard.markStopped(
@@ -106,6 +122,7 @@ export function createRuntimeStatusReconciler(options: {
         job.generation,
       );
       if (stopped?.state !== 'stopped') continue;
+      idleConfirmations.delete(job.taskID);
       options.taskContextTracker.pendingManagedTaskIds.delete(job.taskID);
       options.backgroundJobBoard.addContext(
         job.taskID,

--- a/src/utils/session-runtime-status.ts
+++ b/src/utils/session-runtime-status.ts
@@ -75,7 +75,7 @@ export function runtimeSessionStatus(
   if (snapshot.error) return undefined;
   if (snapshot.malformedSessionIDs.has(sessionID)) return undefined;
   const status = snapshot.statuses.get(sessionID);
-  if (status === undefined) return 'idle';
+  if (status === undefined) return undefined;
   return status;
 }
 


### PR DESCRIPTION
Prevent background council and councillor jobs from being stopped before their terminal results are captured.

Runtime status snapshots can temporarily omit a child session while it is still running or while its terminal result is being reconciled. The previous behavior treated a missing entry as idle and stopped the job immediately. This change marks missing entries uncertain, waits for four consecutive idle observations before stopping, and extends the idle reconciliation window to 15 seconds.

Increasing only the polling delay was insufficient because a missing session was still interpreted as idle. The new behavior preserves the existing cleanup path after repeated confirmed idle states while giving late terminal results time to arrive.