### PR TITLE
feat(herdr): add marketplace integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,25 @@ have Bun installed:
 npx oh-my-opencode-slim@latest install
 ```
 
+### Herdr
+
+The Herdr multiplexer adapter works with Herdr **0.8.0+**. Install Herdr's
+official OpenCode lifecycle integration separately:
+
+```bash
+herdr integration install opencode
+```
+
+For Marketplace discoverability, publish this repository with the required
+`herdr-plugin` repository topic, then install it with:
+
+```bash
+herdr plugin install alvinunreal/oh-my-opencode-slim
+```
+
+This Marketplace entry describes the OpenCode plugin's Herdr adapter; it does
+not install a standalone native Herdr runtime plugin or lifecycle reporter.
+
 ### Run from Master
 
 Use this if you want the latest code, easier bug fixes, or a local setup for

--- a/docs/multiplexer-integration.md
+++ b/docs/multiplexer-integration.md
@@ -131,6 +131,23 @@ Edit `~/.config/opencode/oh-my-opencode-slim.json` (or `.jsonc`):
 }
 ```
 
+The Herdr adapter works with Herdr **0.8.0+**. Install Herdr's official
+OpenCode lifecycle integration separately:
+
+```bash
+herdr integration install opencode
+```
+
+For Marketplace discoverability, publish this repository with the required
+`herdr-plugin` repository topic, then install it with:
+
+```bash
+herdr plugin install alvinunreal/oh-my-opencode-slim
+```
+
+The Marketplace entry describes this OpenCode plugin's Herdr adapter. It does
+not install a standalone native Herdr runtime plugin or lifecycle reporter.
+
 **cmux only:**
 
 ```jsonc

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,0 +1,7 @@
+id = "oh-my-opencode-slim"
+name = "oh-my-opencode-slim"
+version = "2.2.14"
+description = "OpenCode agent orchestration plugin with a Herdr multiplexer adapter"
+repository = "https://github.com/alvinunreal/oh-my-opencode-slim"
+min_herdr_version = "0.8.0"
+platforms = ["linux", "macos", "windows"]

--- a/src/multiplexer/herdr/index.test.ts
+++ b/src/multiplexer/herdr/index.test.ts
@@ -61,10 +61,12 @@ function commands(): string[][] {
 describe('HerdrMultiplexer', () => {
   const originalHerdrEnv = process.env.HERDR_ENV;
   const originalHerdrPaneId = process.env.HERDR_PANE_ID;
+  const originalHerdrBinPath = process.env.HERDR_BIN_PATH;
 
   beforeEach(() => {
     process.env.HERDR_ENV = '1';
     process.env.HERDR_PANE_ID = 'w1:p1';
+    delete process.env.HERDR_BIN_PATH;
 
     crossSpawnMock.mockReset();
     crossSpawnMock.mockImplementation((command: string[]) => {
@@ -81,6 +83,50 @@ describe('HerdrMultiplexer', () => {
   afterEach(() => {
     process.env.HERDR_ENV = originalHerdrEnv;
     process.env.HERDR_PANE_ID = originalHerdrPaneId;
+    if (originalHerdrBinPath === undefined) {
+      delete process.env.HERDR_BIN_PATH;
+    } else {
+      process.env.HERDR_BIN_PATH = originalHerdrBinPath;
+    }
+  });
+
+  test('uses HERDR_BIN_PATH without discovering herdr on PATH', async () => {
+    const configuredBinaryPath = '/custom/bin/herdr';
+    process.env.HERDR_BIN_PATH = configuredBinaryPath;
+
+    const { HerdrMultiplexer } = await importFreshHerdr();
+    const herdr = new HerdrMultiplexer('main-vertical', 60);
+
+    await herdr.spawnPane(
+      'session-1',
+      'Herdr worker',
+      'http://localhost:4096',
+      '/repo',
+    );
+
+    expect(commands().some((command) => command[0] === 'which')).toBe(false);
+    expect(commands()[0]).toEqual([
+      configuredBinaryPath,
+      'pane',
+      'split',
+      'w1:p1',
+      '--direction',
+      'right',
+      '--cwd',
+      '/repo',
+      '--no-focus',
+    ]);
+  });
+
+  test('uses PATH discovery when HERDR_BIN_PATH is empty', async () => {
+    process.env.HERDR_BIN_PATH = '';
+
+    const { HerdrMultiplexer } = await importFreshHerdr();
+    const herdr = new HerdrMultiplexer('main-vertical', 60);
+
+    await herdr.isAvailable();
+
+    expect(commands()).toEqual([['which', 'herdr']]);
   });
 
   test('spawns an opencode attach process in a herdr split pane', async () => {

--- a/src/multiplexer/herdr/index.ts
+++ b/src/multiplexer/herdr/index.ts
@@ -58,7 +58,11 @@ export class HerdrMultiplexer implements Multiplexer {
       return this.binaryPath !== null;
     }
 
-    this.binaryPath = await findBinary('herdr');
+    const configuredBinaryPath = process.env.HERDR_BIN_PATH;
+    this.binaryPath =
+      configuredBinaryPath && configuredBinaryPath.length > 0
+        ? configuredBinaryPath
+        : await findBinary('herdr');
     this.hasChecked = true;
     return this.binaryPath !== null;
   }


### PR DESCRIPTION
## Summary
- Prefer Herdr managed binary path when supplied by the Herdr environment.
- Add a Herdr Marketplace manifest and installation guidance.
- Document the separate official OpenCode lifecycle integration.

## Verification
- bun test: 2,049 passing
- bun run typecheck
- bun run build
- bunx biome check src/multiplexer/herdr

Full bun run check:ci is blocked by pre-existing unrelated formatting in src/agents/orchestrator.ts and a pre-existing warning in src/utils/session.ts.