### PR TITLE
fix: preserve primary model variant for subagents

### DIFF
--- a/src/agents/index.test.ts
+++ b/src/agents/index.test.ts
@@ -260,6 +260,31 @@ describe('orchestrator agent', () => {
 });
 
 describe('per-model variant in array config', () => {
+  test('generic subagents propagate primary inline variants to SDK configs', () => {
+    const config: PluginConfig = {
+      agents: {
+        explorer: {
+          model: [
+            { id: 'google/gemini-3-flash', variant: 'low' },
+            'openai/gpt-4o-mini',
+          ],
+        },
+        librarian: {
+          model: [
+            { id: 'anthropic/claude-haiku-4-5', variant: 'fast' },
+            'openai/gpt-4o-mini',
+          ],
+        },
+      },
+    };
+    const configs = getAgentConfigs(runtimeFor(config));
+
+    expect(configs.explorer.model).toBe('google/gemini-3-flash');
+    expect(configs.explorer.variant).toBe('low');
+    expect(configs.librarian.model).toBe('anthropic/claude-haiku-4-5');
+    expect(configs.librarian.variant).toBe('fast');
+  });
+
   test('subagent stores model array with per-model variants', () => {
     const config: PluginConfig = {
       agents: {
@@ -278,6 +303,24 @@ describe('per-model variant in array config', () => {
       { id: 'openai/gpt-4o-mini' },
     ]);
     expect(explorer?.config.model).toBe('google/gemini-3-flash');
+  });
+
+  test('explicit agent-level variant overrides the primary inline variant', () => {
+    const configs = getAgentConfigs(
+      runtimeFor({
+        agents: {
+          librarian: {
+            model: [
+              { id: 'anthropic/claude-haiku-4-5', variant: 'fast' },
+              'openai/gpt-4o-mini',
+            ],
+            variant: 'high',
+          },
+        },
+      }),
+    );
+
+    expect(configs.librarian.variant).toBe('high');
   });
 
   test('top-level variant preserved alongside per-model variants', () => {

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -127,7 +127,8 @@ function isSafeDisplayName(displayName: string): boolean {
  * Apply user-provided overrides to an agent's configuration.
  * Supports overriding model (string or priority array), variant, and temperature.
  * When model is an array, stores it as _modelArray for runtime fallback resolution
- * and clears config.model so OpenCode does not pre-resolve a stale value.
+ * and selects its primary entry for ephemeral subagents. The orchestrator leaves
+ * config.model unset so its live runtime selection is not overwritten.
  */
 function applyOverrides(
   agent: AgentDefinition,
@@ -138,6 +139,7 @@ function applyOverrides(
       agent._modelArray = override.model.map((m) =>
         typeof m === 'string' ? { id: m } : m,
       );
+      const primaryModel = agent._modelArray[0];
       // Subagents are ephemeral, freshly-created sessions with no prior
       // runtime state to preserve, so giving them a concrete config.model
       // at launch time (the array's primary entry) is safe — see #9100e59.
@@ -155,7 +157,16 @@ function applyOverrides(
       // added by #639). Leaving it undefined for the orchestrator lets
       // that later, precedence-aware guard be the sole source of truth.
       agent.config.model =
-        agent.name === 'orchestrator' ? undefined : agent._modelArray[0].id;
+        agent.name === 'orchestrator' ? undefined : primaryModel.id;
+      // Subagents launch with the primary model, so carry its inline variant
+      // into the OpenCode config too. An explicit agent-level variant below
+      // intentionally takes precedence.
+      if (
+        override.variant === undefined &&
+        primaryModel.variant !== undefined
+      ) {
+        agent.config.variant = primaryModel.variant;
+      }
     } else {
       agent.config.model = override.model;
     }

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -162,6 +162,7 @@ function applyOverrides(
       // into the OpenCode config too. An explicit agent-level variant below
       // intentionally takes precedence.
       if (
+        agent.name !== 'orchestrator' &&
         override.variant === undefined &&
         primaryModel.variant !== undefined
       ) {


### PR DESCRIPTION
## Summary
- propagate the primary model array entry's inline variant into generic subagent SDK configs
- keep explicit agent-level variants higher priority
- add coverage for explorer and librarian model arrays

## Verification
- bun test v1.3.14 (0d9b296a) (106 passed)
- 
- Bundled 225 modules in 35ms

  index.js  1.50 MB  (entry point)
  tui.js    72.1 KB  (entry point)

Bundled 373 modules in 46ms

  server.js  2.42 MB  (entry point)

Bundled 25 modules in 20ms

  index.js  132.53 KB  (entry point)

✅ Schema written to C:\Users\Zhang\oh-my-opencode-slim\oh-my-opencode-slim.schema.json
- Checked 2 files in 21ms. No fixes applied.

Full bun test v1.3.14 (0d9b296a)
Usage: oh-my-opencode-slim doctor [OPTIONS]

Options:
  --json              Print diagnostics as JSON
  -h, --help          Show this help message
Project: C:\Users\Zhang\AppData\Local\Temp\doctor-cli-test-LXb30n\project

[user] No config file found
[project] No config file found
Project: C:\Users\Zhang\AppData\Local\Temp\doctor-cli-test-ZwjpaP\project

[user] No config file found
[project] C:\Users\Zhang\AppData\Local\Temp\doctor-cli-test-ZwjpaP\project\.opencode\oh-my-opencode-slim.json ✗
  Invalid JSON: JSON Parse error: Expected '}'
[34m[i][0m Dry run mode - would ask to install the desktop companion (default: no).
[34m[i][0m Dry run mode - would ask to install the desktop companion (default: no).

=== SCENARIO A: injected message layout per turn ===
turn 1: [USER(msg_u1), BOARD(oh-my-opencode-slim:background-job-board:ses_08f6be16dffednbwYD8dNDIfOI:0)]
turn 2: [USER(msg_u1), BOARD(oh-my-opencode-slim:background-job-board:ses_08f6be16dffednbwYD8dNDIfOI:0), ASSISTANT(msg_a1), BOARD(oh-my-opencode-slim:background-job-board:ses_08f6be16dffednbwYD8dNDIfOI:1)]
turn 3: [USER(msg_u1), BOARD(oh-my-opencode-slim:background-job-board:ses_08f6be16dffednbwYD8dNDIfOI:0), ASSISTANT(msg_a1), BOARD(oh-my-opencode-slim:background-job-board:ses_08f6be16dffednbwYD8dNDIfOI:1), ASSISTANT(msg_a2), BOARD(oh-my-opencode-slim:background-job-board:ses_08f6be16dffednbwYD8dNDIfOI:2)]
turn 4: [USER(msg_u1), BOARD(oh-my-opencode-slim:background-job-board:ses_08f6be16dffednbwYD8dNDIfOI:0), ASSISTANT(msg_a1), BOARD(oh-my-opencode-slim:background-job-board:ses_08f6be16dffednbwYD8dNDIfOI:1), ASSISTANT(msg_a2), BOARD(oh-my-opencode-slim:background-job-board:ses_08f6be16dffednbwYD8dNDIfOI:2), ASSISTANT(msg_a3), BOARD(oh-my-opencode-slim:background-job-board:ses_08f6be16dffednbwYD8dNDIfOI:3)]
turn 5: [USER(msg_u1), BOARD(oh-my-opencode-slim:background-job-board:ses_08f6be16dffednbwYD8dNDIfOI:0), ASSISTANT(msg_a1), BOARD(oh-my-opencode-slim:background-job-board:ses_08f6be16dffednbwYD8dNDIfOI:1), ASSISTANT(msg_a2), BOARD(oh-my-opencode-slim:background-job-board:ses_08f6be16dffednbwYD8dNDIfOI:2), ASSISTANT(msg_a3), BOARD(oh-my-opencode-slim:background-job-board:ses_08f6be16dffednbwYD8dNDIfOI:3), ASSISTANT(msg_a4), BOARD(oh-my-opencode-slim:background-job-board:ses_08f6be16dffednbwYD8dNDIfOI:4)]

=== SCENARIO A: provider-byte transitions ===
{
  "label": "turn 1 -> turn 2",
  "safe": true,
  "lcp": 605,
  "prevLength": 605
}
{
  "label": "turn 2 -> turn 3",
  "safe": true,
  "lcp": 1269,
  "prevLength": 1269
}
{
  "label": "turn 3 -> turn 4",
  "safe": true,
  "lcp": 1973,
  "prevLength": 1973
}
{
  "label": "turn 4 -> turn 5",
  "safe": true,
  "lcp": 2708,
  "prevLength": 2708
}

SCENARIO A RESULT: 0/4 transitions break the provider byte prefix

=== SCENARIO B: same snapshot S1 across turns ===
turn1 S1 message: {"info":{"agent":"orchestrator","id":"oh-my-opencode-slim:background-job-board:ses_08f6be16dffednbwYD8dNDIfOI:0","model":{"modelID":"gpt-5.6-luna","providerID":"github-copilot"},"role":"user","sessionID":"ses_08f6be16dffednbwYD8dNDIfOI","time":{"created":1752968000000}},"parts":[{"metadata":{"oh-my-opencode-slim.backgroundJobBoard":true,"sessionID":"ses_08f6be16dffednbwYD8dNDIfOI","snapshotID":"oh
turn2 S1 message: {"info":{"agent":"orchestrator","id":"oh-my-opencode-slim:background-job-board:ses_08f6be16dffednbwYD8dNDIfOI:0","model":{"modelID":"gpt-5.6-luna","providerID":"github-copilot"},"role":"user","sessionID":"ses_08f6be16dffednbwYD8dNDIfOI","time":{"created":1752968120000}},"parts":[{"metadata":{"oh-my-opencode-slim.backgroundJobBoard":true,"sessionID":"ses_08f6be16dffednbwYD8dNDIfOI","snapshotID":"oh
transform-level divergence at byte 262:
  turn1: ...nbwYD8dNDIfOI","time":{"created":1752968000000}},"parts":[{"metadata":{"oh-my-opencode-slim.backgrou
  turn2: ...nbwYD8dNDIfOI","time":{"created":1752968120000}},"parts":[{"metadata":{"oh-my-opencode-slim.backgrou
provider transition: {
  "label": "turn1 -> turn2 (provider bytes)",
  "safe": true,
  "lcp": 605,
  "prevLength": 605
}
provider bytes mention time.created value? false
provider bytes mention snapshotID/metadata/cost? false false false

=== SCENARIO C: injected layout per turn ===
turn 1: [USER(msg_u1), BOARD(oh-my-opencode-slim:background-job-board:ses_08f6be16dffednbwYD8dNDIfOI:0)]
turn 2: [USER(msg_u1), BOARD(oh-my-opencode-slim:background-job-board:ses_08f6be16dffednbwYD8dNDIfOI:0), ASSISTANT(msg_a1), USER(msg_u2)]
turn 3: [USER(msg_u1), BOARD(oh-my-opencode-slim:background-job-board:ses_08f6be16dffednbwYD8dNDIfOI:0), ASSISTANT(msg_a1), USER(msg_u2), USER(msg_u3)]
turn 4: [USER(msg_u1), BOARD(oh-my-opencode-slim:background-job-board:ses_08f6be16dffednbwYD8dNDIfOI:0), ASSISTANT(msg_a1), USER(msg_u2), USER(msg_u3), ASSISTANT(msg_a2), BOARD(oh-my-opencode-slim:background-job-board:ses_08f6be16dffednbwYD8dNDIfOI:1)]
{
  "label": "turn1 -> turn2",
  "safe": true,
  "lcp": 605,
  "prevLength": 605
}
{
  "label": "turn2 -> turn3",
  "safe": true,
  "lcp": 799,
  "prevLength": 799
}
{
  "label": "turn3 -> turn4",
  "safe": true,
  "lcp": 875,
  "prevLength": 875
}
Migrated .slim/cartography.json -> .slim/codemap.json and repository-wide The number of diagnostics exceeds the limit allowed. Use --max-diagnostics to increase it.
Diagnostics not shown: 294.
Checked 315 files in 201ms. No fixes applied.
Found 312 errors.
Found 1 warning.
Found 1 info. still report pre-existing Windows-specific path, permission, and CRLF failures outside the changed files.

Fixes #1021