### PR TITLE
fix(tasks): harden background task lifecycle

### DIFF
--- a/src/hooks/task-session-manager/board-injection.ts
+++ b/src/hooks/task-session-manager/board-injection.ts
@@ -10,9 +10,14 @@
 import { createHash } from 'node:crypto';
 import type {
   BackgroundJobExecution,
+  BackgroundJobInjectedCompletionFence,
+  BackgroundJobLifecycleLedger,
   BackgroundJobRecord,
   BackgroundJobStore,
+  BackgroundJobSyntheticTerminalOccurrence,
+  BackgroundJobSyntheticTerminalOccurrencePhase,
   ContextFile,
+  TaskStatusOutput,
 } from '../../utils';
 import {
   isInternalInitiatorPart,
@@ -48,8 +53,6 @@ export const BACKGROUND_JOB_BOARD_METADATA_KEY =
 
 const BACKGROUND_COMPLETION_COMPLETED = /^Background task completed: /;
 const BACKGROUND_COMPLETION_FAILED = /^Background task failed: /;
-
-export const MAX_PROCESSED_INJECTED_COMPLETIONS = 500;
 
 type RetainedBoardSnapshot = {
   anchorKey: string;
@@ -99,18 +102,40 @@ export type InjectedTerminalJobs = {
   promptShapeKey: string;
 };
 
+export type InjectedCompletionFence = BackgroundJobInjectedCompletionFence;
+
+export type SyntheticTerminalOccurrencePhase =
+  BackgroundJobSyntheticTerminalOccurrencePhase;
+
+export type SyntheticTerminalOccurrenceOrigin =
+  BackgroundJobSyntheticTerminalOccurrence;
+
 export interface InjectionState {
   backgroundJobBoard: BackgroundJobStore;
+  lifecycleLedger: BackgroundJobLifecycleLedger;
   maxRetainedSnapshots: number;
   strategy: 'latest' | 'checkpoint-compatible';
   processedInjectedCompletions: Set<string>;
   processedInjectedCompletionOrder: string[];
+  /**
+   * Completion occurrences persist with the board so a recreated hook cannot
+   * replay an old synthetic result into a newer task generation.
+   */
+  injectedCompletionFences?: Map<string, InjectedCompletionFence>;
+  /**
+   * Synthetic terminal parts observed by the runtime event stream. This is
+   * separate from processed fences because an event may arrive before the
+   * message transform that consumes the part.
+   */
+  syntheticTerminalOccurrences?: Map<string, SyntheticTerminalOccurrenceOrigin>;
+  syntheticTerminalOccurrenceOrder?: string[];
+  getLifecycleEpoch?: () => number;
+  getDeletionEpoch?: (taskID: string) => number | undefined;
   terminalJobsInjectedByParent: Map<string, InjectedTerminalJobs>;
   pendingInjectedTerminalJobsByParent: Map<
     string,
     Map<string, BackgroundJobExecution>
   >;
-  maxProcessedInjectedCompletions: number;
   metadataKey: string;
   shouldManageSession: (sessionID: string) => boolean;
   taskContextTracker: {
@@ -177,8 +202,9 @@ function createOccurrenceId(
   message: MessageWithParts,
   partIndex: number,
 ): string {
-  if (typeof part.id === 'string') {
-    return part.id;
+  const explicitOccurrenceID = getExplicitOccurrenceID(part);
+  if (explicitOccurrenceID) {
+    return explicitOccurrenceID;
   }
 
   if (typeof message.info.id === 'string') {
@@ -197,6 +223,256 @@ function createOccurrenceId(
 
   const hash = djb2Hash(`${sessionID}:${content}`);
   return `anon:${hash}`;
+}
+
+function injectedCompletionKey(taskID: string, occurrenceId: string): string {
+  return `${taskID}\u001f${occurrenceId}`;
+}
+
+function getExplicitOccurrenceID(part: MessagePart): string | undefined {
+  for (const key of ['occurrenceID', 'occurrenceId', 'id']) {
+    const value = part[key];
+    if (typeof value === 'string' && value.trim() !== '') return value;
+  }
+  return undefined;
+}
+
+function isProcessableSyntheticTerminal(
+  text: string,
+  status: TaskStatusOutput,
+): boolean {
+  if (status.state !== 'completed' && status.state !== 'error') return false;
+
+  const summary = extractTaskSummary(text);
+  const isCompleted = summary
+    ? BACKGROUND_COMPLETION_COMPLETED.test(summary)
+    : status.state === 'completed';
+  const isFailed = summary
+    ? BACKGROUND_COMPLETION_FAILED.test(summary)
+    : status.state === 'error';
+  return (
+    (!summary || isCompleted || isFailed) &&
+    (!isCompleted || status.state === 'completed') &&
+    (!isFailed || status.state === 'error')
+  );
+}
+
+function observationOccurrenceID(
+  part: MessagePart,
+  status: TaskStatusOutput,
+): { occurrenceID: string; reliable: boolean } {
+  const explicitOccurrenceID = getExplicitOccurrenceID(part);
+  if (explicitOccurrenceID) {
+    return { occurrenceID: explicitOccurrenceID, reliable: true };
+  }
+
+  const messageID =
+    typeof part.messageID === 'string' ? part.messageID : 'unknown-message';
+  return {
+    occurrenceID: `ambiguous:${djb2Hash(
+      `${messageID}:${status.taskID}:${part.text ?? ''}`,
+    )}`,
+    reliable: false,
+  };
+}
+
+function rememberSyntheticTerminalOccurrence(
+  state: InjectionState,
+  origin: SyntheticTerminalOccurrenceOrigin,
+): void {
+  const occurrences = state.syntheticTerminalOccurrences;
+  const order = state.syntheticTerminalOccurrenceOrder;
+  if (!occurrences || !order) return;
+
+  const key = injectedCompletionKey(origin.taskID, origin.occurrenceID);
+  const existing = occurrences.get(key);
+  if (existing) {
+    // The first observation owns the lifecycle provenance. A later event for
+    // the same part must not refresh an old occurrence into a new generation.
+    if (existing.phase === 'processed') return;
+    if (existing.phase === 'observed') return;
+    // An ambiguous first observation is a permanent fail-closed decision. A
+    // late event can be an old part replayed after a same-ID relaunch, so it
+    // must never upgrade the occurrence with the current generation.
+    return;
+  }
+
+  occurrences.set(key, { ...origin });
+  order.push(key);
+}
+
+function findSyntheticTerminalOccurrence(
+  state: InjectionState,
+  taskID: string,
+  occurrenceID: string,
+): SyntheticTerminalOccurrenceOrigin | undefined {
+  const occurrences = state.syntheticTerminalOccurrences;
+  if (!occurrences) return undefined;
+
+  const direct = occurrences.get(injectedCompletionKey(taskID, occurrenceID));
+  if (direct) return direct;
+
+  // Older/runtime-derived parts may lack an id in the transform payload even
+  // though the event hook saw the same terminal text. Only use an ambiguous
+  // fallback when there is exactly one candidate for this task.
+  const candidates = [...occurrences.values()].filter(
+    (origin) =>
+      origin.taskID === taskID && origin.occurrenceID.startsWith('ambiguous:'),
+  );
+  return candidates.length === 1 ? candidates[0] : undefined;
+}
+
+function rememberProcessedSyntheticTerminal(
+  state: InjectionState,
+  taskID: string,
+  occurrenceID: string,
+  origin: SyntheticTerminalOccurrenceOrigin | undefined,
+  generation: number | undefined,
+): void {
+  if (origin) {
+    origin.phase = 'processed';
+    return;
+  }
+
+  rememberSyntheticTerminalOccurrence(state, {
+    taskID,
+    occurrenceID,
+    generationAtObservation: generation,
+    lifecycleEpochAtObservation: state.getLifecycleEpoch?.() ?? 0,
+    phase: 'processed',
+  });
+}
+
+function failClosedSyntheticTerminal(
+  state: InjectionState,
+  status: TaskStatusOutput,
+  occurrenceID: string,
+  existing: BackgroundJobRecord | undefined,
+  reason: string,
+): void {
+  rememberSyntheticTerminalOccurrence(state, {
+    taskID: status.taskID,
+    occurrenceID,
+    generationAtObservation: existing?.generation,
+    lifecycleEpochAtObservation: state.getLifecycleEpoch?.() ?? 0,
+    phase: 'ambiguous',
+  });
+
+  if (existing?.state === 'running') {
+    markSyntheticTerminalUncertain(
+      state,
+      status.taskID,
+      existing,
+      `Synthetic terminal task output origin is ambiguous: ${reason}`,
+    );
+  }
+
+  log('[task-session-manager] skipped ambiguous synthetic completion', {
+    taskID: status.taskID,
+    occurrenceID,
+    generation: existing?.generation,
+    lifecycleEpoch: state.getLifecycleEpoch?.() ?? 0,
+    reason,
+  });
+}
+
+function markSyntheticTerminalUncertain(
+  state: InjectionState,
+  taskID: string,
+  existing: BackgroundJobRecord,
+  reason: string,
+): void {
+  state.backgroundJobBoard.markStatusUncertain(
+    taskID,
+    reason,
+    existing.generation,
+  );
+}
+
+/**
+ * Record a terminal synthetic task part at the runtime event boundary. The
+ * part can be transformed later, after deletion and a same-ID relaunch, so
+ * payload fields alone are not sufficient to recover its original generation.
+ */
+export function observeSyntheticTerminalPart(
+  state: InjectionState,
+  value: unknown,
+): void {
+  if (!isRecord(value)) return;
+  const part = value as MessagePart;
+  if (part.type !== 'text' || part.synthetic !== true) return;
+  if (typeof part.text !== 'string') return;
+
+  const status = parseTaskStatusOutput(part.text);
+  if (!status || !isProcessableSyntheticTerminal(part.text, status)) return;
+
+  const { occurrenceID, reliable } = observationOccurrenceID(part, status);
+  const existing = state.backgroundJobBoard.get(status.taskID);
+  const lifecycleEpoch = state.getLifecycleEpoch?.() ?? 0;
+  const deletionEpoch = state.getDeletionEpoch?.(status.taskID);
+  const occurrenceKey = injectedCompletionKey(status.taskID, occurrenceID);
+  const priorOccurrence =
+    state.syntheticTerminalOccurrences?.get(occurrenceKey);
+  const hasPreDeletionProvenance =
+    deletionEpoch === undefined ||
+    (priorOccurrence !== undefined &&
+      priorOccurrence.lifecycleEpochAtObservation < deletionEpoch &&
+      priorOccurrence.phase !== 'ambiguous');
+  const phase: SyntheticTerminalOccurrencePhase =
+    !reliable || !hasPreDeletionProvenance ? 'ambiguous' : 'observed';
+
+  rememberSyntheticTerminalOccurrence(state, {
+    taskID: status.taskID,
+    occurrenceID,
+    generationAtObservation: existing?.generation,
+    lifecycleEpochAtObservation: lifecycleEpoch,
+    phase,
+  });
+}
+
+function hasRememberedInjectedCompletion(
+  state: InjectionState,
+  taskID: string,
+  occurrenceId: string,
+  currentGeneration: number | undefined,
+): boolean {
+  const fence = state.injectedCompletionFences?.get(
+    injectedCompletionKey(taskID, occurrenceId),
+  );
+  if (!fence) return false;
+
+  const deletionEpoch = state.getDeletionEpoch?.(taskID);
+  const staleGeneration =
+    currentGeneration !== undefined && currentGeneration !== fence.generation;
+  const staleLifecycle =
+    deletionEpoch !== undefined && fence.lifecycleEpoch < deletionEpoch;
+  if (staleGeneration || staleLifecycle) {
+    log('[task-session-manager] skipped stale injected completion', {
+      taskID,
+      occurrenceId,
+      recordedGeneration: fence.generation,
+      currentGeneration,
+      recordedLifecycleEpoch: fence.lifecycleEpoch,
+      deletionEpoch,
+    });
+  }
+
+  // A known occurrence is either a duplicate in the same lifecycle or stale
+  // history from an older generation. Neither may update the current board.
+  return true;
+}
+
+function rememberInjectedCompletionFence(
+  state: InjectionState,
+  occurrenceId: string,
+  fence: InjectedCompletionFence,
+): void {
+  const fences = state.injectedCompletionFences;
+  if (!fences) return;
+
+  fences.set(injectedCompletionKey(fence.taskID, occurrenceId), {
+    ...fence,
+  });
 }
 
 // ── Exported functions ─────────────────────────────────────────────────
@@ -292,6 +568,79 @@ export function updateFromInjectedCompletion(
   const occurrenceId = createOccurrenceId(part, message, partIndex);
 
   const existing = state.backgroundJobBoard.get(status.taskID);
+  const origin = findSyntheticTerminalOccurrence(
+    state,
+    status.taskID,
+    occurrenceId,
+  );
+  const deletionEpoch = state.getDeletionEpoch?.(status.taskID);
+
+  if (origin?.phase === 'processed') return undefined;
+
+  if (origin?.phase === 'ambiguous') {
+    failClosedSyntheticTerminal(
+      state,
+      status,
+      occurrenceId,
+      existing,
+      'message.part.updated origin was permanently ambiguous',
+    );
+    return undefined;
+  }
+
+  if (origin?.phase === 'observed') {
+    const generationChanged =
+      origin.generationAtObservation !== undefined &&
+      existing?.generation !== origin.generationAtObservation;
+    const observationPredatesDeletion =
+      deletionEpoch !== undefined &&
+      origin.lifecycleEpochAtObservation < deletionEpoch;
+    if (generationChanged || observationPredatesDeletion) {
+      if (existing?.state === 'running') {
+        markSyntheticTerminalUncertain(
+          state,
+          status.taskID,
+          existing,
+          'Synthetic terminal task output belongs to an older lifecycle.',
+        );
+      }
+      log(
+        '[task-session-manager] skipped stale observed synthetic completion',
+        {
+          taskID: status.taskID,
+          occurrenceId,
+          observedGeneration: origin.generationAtObservation,
+          currentGeneration: existing?.generation,
+          observationEpoch: origin.lifecycleEpochAtObservation,
+          deletionEpoch,
+        },
+      );
+      return undefined;
+    }
+  }
+
+  if (deletionEpoch !== undefined && origin === undefined) {
+    failClosedSyntheticTerminal(
+      state,
+      status,
+      occurrenceId,
+      existing,
+      'no message.part.updated origin was observed',
+    );
+    return undefined;
+  }
+
+  if (
+    hasRememberedInjectedCompletion(
+      state,
+      status.taskID,
+      occurrenceId,
+      existing?.generation,
+    )
+  ) {
+    return undefined;
+  }
+
   if (isFailed && isLateCancelledTaskError(existing, status.state)) {
     part.text = formatCancelledTaskStatusOutput(
       status.taskID,
@@ -305,7 +654,18 @@ export function updateFromInjectedCompletion(
       terminalState: existing?.terminalState,
       result: status.result,
     });
-    rememberProcessedInjectedCompletion(state, occurrenceId);
+    rememberProcessedInjectedCompletion(state, status.taskID, occurrenceId, {
+      taskID: status.taskID,
+      generation: existing?.generation ?? 0,
+      lifecycleEpoch: state.getLifecycleEpoch?.() ?? 0,
+    });
+    rememberProcessedSyntheticTerminal(
+      state,
+      status.taskID,
+      occurrenceId,
+      origin,
+      existing?.generation,
+    );
     if (existing?.terminalUnreconciled && existing?.parentSessionID) {
       rememberPendingInjectedTerminalJob(state, existing.parentSessionID, {
         taskID: existing.taskID,
@@ -318,7 +678,13 @@ export function updateFromInjectedCompletion(
   if (isCompleted && status.state !== 'completed') return undefined;
   if (isFailed && status.state !== 'error') return undefined;
 
-  if (state.processedInjectedCompletions.has(occurrenceId)) return undefined;
+  const processedOccurrenceKey = injectedCompletionKey(
+    status.taskID,
+    occurrenceId,
+  );
+  if (state.processedInjectedCompletions.has(processedOccurrenceKey)) {
+    return undefined;
+  }
 
   const updated = updateBackgroundJobFromOutput(
     part.text,
@@ -342,24 +708,33 @@ export function updateFromInjectedCompletion(
     occurrenceId,
   });
 
-  rememberProcessedInjectedCompletion(state, occurrenceId);
+  rememberProcessedSyntheticTerminal(
+    state,
+    updated.taskID,
+    occurrenceId,
+    origin,
+    updated.generation,
+  );
+  rememberProcessedInjectedCompletion(state, status.taskID, occurrenceId, {
+    taskID: updated.taskID,
+    generation: updated.generation,
+    lifecycleEpoch: state.getLifecycleEpoch?.() ?? 0,
+  });
   return updated;
 }
 
 export function rememberProcessedInjectedCompletion(
   state: InjectionState,
-  signature: string,
+  taskID: string,
+  occurrenceId: string,
+  fence?: InjectedCompletionFence,
 ): void {
+  const signature = injectedCompletionKey(taskID, occurrenceId);
   state.processedInjectedCompletions.add(signature);
   state.processedInjectedCompletionOrder.push(signature);
 
-  while (
-    state.processedInjectedCompletionOrder.length >
-    state.maxProcessedInjectedCompletions
-  ) {
-    const evicted = state.processedInjectedCompletionOrder.shift();
-    if (!evicted) break;
-    state.processedInjectedCompletions.delete(evicted);
+  if (fence) {
+    rememberInjectedCompletionFence(state, occurrenceId, fence);
   }
 }
 

--- a/src/hooks/task-session-manager/board-injection.ts
+++ b/src/hooks/task-session-manager/board-injection.ts
@@ -110,6 +110,16 @@ export type SyntheticTerminalOccurrencePhase =
 export type SyntheticTerminalOccurrenceOrigin =
   BackgroundJobSyntheticTerminalOccurrence;
 
+type SyntheticTerminalOccurrenceLookup =
+  | {
+      kind: 'matched';
+      origin: SyntheticTerminalOccurrenceOrigin;
+    }
+  | {
+      kind: 'ambiguous';
+      reason: string;
+    };
+
 export interface InjectionState {
   backgroundJobBoard: BackgroundJobStore;
   lifecycleLedger: BackgroundJobLifecycleLedger;
@@ -305,21 +315,31 @@ function findSyntheticTerminalOccurrence(
   state: InjectionState,
   taskID: string,
   occurrenceID: string,
-): SyntheticTerminalOccurrenceOrigin | undefined {
+): SyntheticTerminalOccurrenceLookup | undefined {
   const occurrences = state.syntheticTerminalOccurrences;
   if (!occurrences) return undefined;
 
   const direct = occurrences.get(injectedCompletionKey(taskID, occurrenceID));
-  if (direct) return direct;
+  if (direct) return { kind: 'matched', origin: direct };
 
   // Older/runtime-derived parts may lack an id in the transform payload even
   // though the event hook saw the same terminal text. Only use an ambiguous
-  // fallback when there is exactly one candidate for this task.
+  // fallback when there is exactly one candidate for this task. Multiple
+  // candidates cannot establish ownership and must remain fail-closed.
   const candidates = [...occurrences.values()].filter(
     (origin) =>
       origin.taskID === taskID && origin.occurrenceID.startsWith('ambiguous:'),
   );
-  return candidates.length === 1 ? candidates[0] : undefined;
+  if (candidates.length === 1) {
+    return { kind: 'matched', origin: candidates[0] };
+  }
+  if (candidates.length > 1) {
+    return {
+      kind: 'ambiguous',
+      reason: `multiple ambiguous message.part.updated origins (${candidates.length}) could not be uniquely matched`,
+    };
+  }
+  return undefined;
 }
 
 function rememberProcessedSyntheticTerminal(
@@ -419,7 +439,9 @@ export function observeSyntheticTerminalPart(
       priorOccurrence.lifecycleEpochAtObservation < deletionEpoch &&
       priorOccurrence.phase !== 'ambiguous');
   const phase: SyntheticTerminalOccurrencePhase =
-    !reliable || !hasPreDeletionProvenance ? 'ambiguous' : 'observed';
+    !reliable || !existing || !hasPreDeletionProvenance
+      ? 'ambiguous'
+      : 'observed';
 
   rememberSyntheticTerminalOccurrence(state, {
     taskID: status.taskID,
@@ -568,12 +590,25 @@ export function updateFromInjectedCompletion(
   const occurrenceId = createOccurrenceId(part, message, partIndex);
 
   const existing = state.backgroundJobBoard.get(status.taskID);
-  const origin = findSyntheticTerminalOccurrence(
+  const occurrenceLookup = findSyntheticTerminalOccurrence(
     state,
     status.taskID,
     occurrenceId,
   );
+  const origin =
+    occurrenceLookup?.kind === 'matched' ? occurrenceLookup.origin : undefined;
   const deletionEpoch = state.getDeletionEpoch?.(status.taskID);
+
+  if (occurrenceLookup?.kind === 'ambiguous') {
+    failClosedSyntheticTerminal(
+      state,
+      status,
+      occurrenceId,
+      existing,
+      occurrenceLookup.reason,
+    );
+    return undefined;
+  }
 
   if (origin?.phase === 'processed') return undefined;
 

--- a/src/hooks/task-session-manager/event-router-generation.test.ts
+++ b/src/hooks/task-session-manager/event-router-generation.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { BackgroundJobBoard } from '../../utils/background-job-board';
+import { handleEvent } from './event-router';
+
+function createDeps(board: BackgroundJobBoard, now: () => number) {
+  const backgroundJobSupervisor = {
+    onSessionDeleted: mock((sessionID: string) => {
+      board.drop(sessionID);
+    }),
+  };
+
+  return {
+    inputWaits: {
+      trackInputWait: mock(() => {}),
+      clearInputWaits: mock(() => {}),
+      waitsByParent: new Map<string, Set<string | symbol>>(),
+    },
+    idleSessionTokens: {
+      clearSession: mock(() => {}),
+      invalidate: mock(() => {}),
+      disposeLocalState: mock(() => {}),
+      sessionTokens: new Map<string, symbol>(),
+    },
+    options: {
+      shouldManageSession: () => true,
+      now,
+    },
+    idleReconciler: {
+      scheduleIdleReconciliation: mock(() => {}),
+      scheduleChildIdleReconciliation: mock(() => {}),
+      scheduleErrorTerminalize: mock(() => {}),
+      clearIdleTimers: mock(() => {}),
+      clearAllTimers: mock(() => []),
+    },
+    deferredInlineErrors: new Set<string>(),
+    backgroundJobBoard: board,
+    pendingCallTracker: {
+      peekByParentAndAgent: mock(() => undefined),
+      clearSession: mock(() => {}),
+    },
+    taskContextTracker: {
+      pendingManagedTaskIds: new Set<string>(),
+      clearSession: mock(() => {}),
+      prune: mock(() => {}),
+    },
+    terminalJobsInjectedByParent: new Map(),
+    pendingInjectedTerminalJobsByParent: new Map(),
+    retainedBoardSnapshots: new Map(),
+    backgroundJobSupervisor,
+  };
+}
+
+async function route(
+  deps: ReturnType<typeof createDeps>,
+  type: string,
+  properties: Record<string, unknown>,
+): Promise<void> {
+  await handleEvent(
+    {
+      event: { type, properties },
+    } as never,
+    deps as never,
+  );
+}
+
+describe('task session event generation fences', () => {
+  test('quarantines an interleaved old idle/error/busy sequence after same-ID relaunch', async () => {
+    let clock = 100;
+    const board = new BackgroundJobBoard();
+    board.registerLaunch({
+      taskID: 'child-1',
+      parentSessionID: 'parent-1',
+      agent: 'fixer',
+      description: 'generation one',
+      now: clock,
+    });
+    const deps = createDeps(board, () => clock);
+
+    await route(deps, 'session.status', {
+      sessionID: 'child-1',
+      status: { type: 'busy' },
+    });
+
+    clock = 200;
+    board.registerLaunch({
+      taskID: 'child-1',
+      parentSessionID: 'parent-1',
+      agent: 'fixer',
+      description: 'generation two',
+      now: clock,
+    });
+    const generationTwo = board.get('child-1');
+    expect(generationTwo).toMatchObject({ generation: 2, state: 'running' });
+
+    // OpenCode v1 does not attach a run generation to these events. Once the
+    // router first observes the new board generation, it quarantines the
+    // lifecycle sequence until a fresh busy activity fence is observed.
+    await route(deps, 'session.idle', { sessionID: 'child-1' });
+    await route(deps, 'session.error', {
+      sessionID: 'child-1',
+      error: { name: 'UnknownError', message: 'late generation one error' },
+    });
+    await route(deps, 'session.status', {
+      sessionID: 'child-1',
+      status: { type: 'busy' },
+    });
+
+    expect(
+      deps.idleReconciler.scheduleChildIdleReconciliation,
+    ).not.toHaveBeenCalled();
+    expect(deps.idleReconciler.scheduleErrorTerminalize).not.toHaveBeenCalled();
+    expect(board.get('child-1')).toMatchObject({
+      generation: 2,
+      state: 'running',
+      description: 'generation two',
+      lastLiveBusyAt: 200,
+    });
+
+    // A later busy observation belongs to the now-established generation and
+    // can update its activity timestamp normally.
+    clock = 201;
+    await route(deps, 'session.status', {
+      sessionID: 'child-1',
+      status: { type: 'busy' },
+    });
+    expect(board.get('child-1')).toMatchObject({ lastLiveBusyAt: 201 });
+  });
+
+  test('rejects explicitly stale generation/activity metadata for all lifecycle signals', async () => {
+    let clock = 100;
+    const board = new BackgroundJobBoard();
+    board.registerLaunch({
+      taskID: 'child-1',
+      parentSessionID: 'parent-1',
+      agent: 'fixer',
+      description: 'generation one',
+      now: clock,
+    });
+    const deps = createDeps(board, () => clock);
+    await route(deps, 'session.status', {
+      sessionID: 'child-1',
+      status: { type: 'busy' },
+      generation: 1,
+      activityAt: 100,
+    });
+
+    clock = 200;
+    board.registerLaunch({
+      taskID: 'child-1',
+      parentSessionID: 'parent-1',
+      agent: 'fixer',
+      description: 'generation two',
+      now: clock,
+    });
+    const before = board.get('child-1');
+
+    await route(deps, 'session.idle', {
+      sessionID: 'child-1',
+      generation: 1,
+      activityAt: 150,
+    });
+    await route(deps, 'session.error', {
+      sessionID: 'child-1',
+      generation: 1,
+      activityAt: 160,
+      error: { name: 'UnknownError', message: 'stale error' },
+    });
+    await route(deps, 'session.status', {
+      sessionID: 'child-1',
+      generation: 1,
+      activityAt: 170,
+      status: { type: 'busy' },
+    });
+
+    expect(
+      deps.idleReconciler.scheduleChildIdleReconciliation,
+    ).not.toHaveBeenCalled();
+    expect(deps.idleReconciler.scheduleErrorTerminalize).not.toHaveBeenCalled();
+    expect(board.get('child-1')).toEqual(before);
+  });
+
+  test('keeps G2 when an unproven session.deleted arrives after same-ID relaunch', async () => {
+    let clock = 100;
+    const board = new BackgroundJobBoard();
+    board.registerLaunch({
+      taskID: 'child-1',
+      parentSessionID: 'parent-1',
+      agent: 'fixer',
+      description: 'generation one',
+      now: clock,
+    });
+    const deps = createDeps(board, () => clock);
+
+    // Establish that the router has observed G1 before the native session ID
+    // is reused. The deletion below intentionally has no host provenance.
+    await route(deps, 'session.status', {
+      sessionID: 'child-1',
+      status: { type: 'busy' },
+    });
+
+    clock = 200;
+    board.registerLaunch({
+      taskID: 'child-1',
+      parentSessionID: 'parent-1',
+      agent: 'fixer',
+      description: 'generation two',
+      now: clock,
+    });
+
+    await route(deps, 'session.deleted', { sessionID: 'child-1' });
+
+    expect(
+      deps.backgroundJobSupervisor.onSessionDeleted,
+    ).not.toHaveBeenCalled();
+    expect(board.get('child-1')).toMatchObject({
+      generation: 2,
+      state: 'running',
+      description: 'generation two',
+    });
+    expect(deps.idleSessionTokens.clearSession).not.toHaveBeenCalled();
+    expect(deps.pendingCallTracker.clearSession).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/task-session-manager/event-router.ts
+++ b/src/hooks/task-session-manager/event-router.ts
@@ -30,6 +30,7 @@ export async function handleEvent(
         sessionID?: string;
         status?: { type?: string };
         error?: { name?: string };
+        part?: unknown;
       };
     };
   },
@@ -84,6 +85,7 @@ export async function handleEvent(
         agentHint?: string,
       ): PendingTaskCall | undefined;
       clearSession(sessionID: string): void;
+      clearAll?(): void;
     };
     taskContextTracker: {
       pendingManagedTaskIds: Set<string>;
@@ -97,9 +99,15 @@ export async function handleEvent(
     >;
     retainedBoardSnapshots: Map<string, RetainedBoardSnapshotState>;
     backgroundJobSupervisor?: BackgroundJobSupervisor;
+    observeSyntheticTerminalPart?: (part: unknown) => void;
   },
 ): Promise<void> {
   deps.inputWaits.trackInputWait(input.event);
+
+  if (input.event.type === 'message.part.updated') {
+    deps.observeSyntheticTerminalPart?.(input.event.properties?.part);
+    return;
+  }
 
   if (input.event.type === 'session.created') {
     const info = input.event.properties?.info;
@@ -132,31 +140,48 @@ export async function handleEvent(
         info.parentID,
         info.agent,
       );
-      if (
-        pending &&
-        !pending.resumedTaskId &&
-        !deps.backgroundJobBoard.get(info.id)
-      ) {
-        const record = deps.backgroundJobBoard.registerLaunch({
-          taskID: info.id,
-          parentSessionID: pending.parentSessionId,
-          agent: pending.agentType,
-          description: pending.label,
-          objective: pending.label,
-          // session.created has no reliable call identity. Keep this
-          // registration tentative so an unrelated foreground call cannot
-          // accidentally arm wall-clock supervision.
-          background: false,
-        });
-        log(
-          '[task-session-manager] tentative early board registration from session.created',
-          {
-            taskID: record.taskID,
-            alias: record.alias,
-            parentSessionID: record.parentSessionID,
-            agent: record.agent,
-          },
-        );
+      if (pending && !pending.resumedTaskId && !pending.earlyRegisteredTaskID) {
+        if (deps.backgroundJobBoard.get(info.id)) {
+          pending.earlyRegistrationRejected = true;
+          log(
+            '[task-session-manager] refused early registration for an existing task ID',
+            { taskID: info.id, parentSessionID: info.parentID },
+          );
+        } else {
+          try {
+            const record = deps.backgroundJobBoard.registerLaunch({
+              taskID: info.id,
+              parentSessionID: pending.parentSessionId,
+              agent: pending.agentType,
+              description: pending.label,
+              objective: pending.label,
+              // session.created has no reliable call identity. Keep this
+              // registration tentative so an unrelated foreground call cannot
+              // accidentally arm wall-clock supervision.
+              background: false,
+            });
+            pending.earlyRegisteredTaskID = record.taskID;
+            log(
+              '[task-session-manager] tentative early board registration from session.created',
+              {
+                taskID: record.taskID,
+                alias: record.alias,
+                parentSessionID: record.parentSessionID,
+                agent: record.agent,
+              },
+            );
+          } catch (error) {
+            pending.earlyRegistrationRejected = true;
+            log(
+              '[task-session-manager] refused fenced early registration from session.created',
+              {
+                taskID: info.id,
+                parentSessionID: info.parentID,
+                error: error instanceof Error ? error.message : String(error),
+              },
+            );
+          }
+        }
       }
     }
     return;
@@ -164,6 +189,7 @@ export async function handleEvent(
 
   if (input.event.type === 'server.instance.disposed') {
     deps.backgroundJobSupervisor?.dispose();
+    deps.pendingCallTracker.clearAll?.();
     deps.retainedBoardSnapshots.clear();
     const idleSessionIds = deps.idleReconciler.clearAllTimers();
     // Local-only: drop idle tokens. Process-global wait_for_user stays armed.
@@ -362,6 +388,7 @@ export async function handleEvent(
     deps.idleSessionTokens.clearSession(sessionId);
   }
   deps.inputWaits.clearInputWaits(sessionId);
+  deps.pendingCallTracker.clearSession(sessionId);
   deps.retainedBoardSnapshots.delete(sessionId);
   const fallbackInProgress =
     deps.options.isFallbackInProgress?.(sessionId) === true;

--- a/src/hooks/task-session-manager/event-router.ts
+++ b/src/hooks/task-session-manager/event-router.ts
@@ -67,7 +67,11 @@ export async function handleEvent(
         idleObservedAt: number,
         observedGeneration: number,
       ): void;
-      scheduleErrorTerminalize(sessionID: string, idleObservedAt: number): void;
+      scheduleErrorTerminalize(
+        sessionID: string,
+        idleObservedAt: number,
+        observedGeneration: number,
+      ): void;
       clearIdleTimers(sessionID: string): void;
       clearAllTimers(): string[];
     };
@@ -209,7 +213,11 @@ export async function handleEvent(
         // A persistent 401/410 was deferred for fallback recovery but the
         // session ended without one: terminalize as error instead of the
         // false completion the child-idle path would record.
-        deps.idleReconciler.scheduleErrorTerminalize(sessionId, Date.now());
+        deps.idleReconciler.scheduleErrorTerminalize(
+          sessionId,
+          Date.now(),
+          job.generation,
+        );
       } else {
         deps.idleReconciler.scheduleChildIdleReconciliation(
           sessionId,

--- a/src/hooks/task-session-manager/event-router.ts
+++ b/src/hooks/task-session-manager/event-router.ts
@@ -19,15 +19,200 @@ import type {
 } from './board-injection';
 import type { PendingTaskCall } from './pending-call-tracker';
 
+type BackgroundJobRecord = NonNullable<ReturnType<BackgroundJobStore['get']>>;
+
+interface SessionEventGenerationFence {
+  generation: number;
+  /** A new generation must see a live activity fence before lifecycle events. */
+  awaitingActivity: boolean;
+}
+
+interface SessionEventObservation {
+  sessionID: string;
+  job?: BackgroundJobRecord;
+  generation?: number;
+  observedAt: number;
+  stale: boolean;
+  /** Busy establishes the new local fence but does not mutate the board. */
+  activityFenceOnly: boolean;
+}
+
+/**
+ * OpenCode's v1 lifecycle events do not carry a run generation or a CAS token.
+ * Keep the strongest local fence available: a board generation transition
+ * quarantines the first unproven lifecycle sequence, while explicit host
+ * provenance/timestamps (when present) are checked against the current run.
+ * This cannot prove the origin of a same-ID event after the host has omitted
+ * that provenance; callers must not treat this as remote atomicity.
+ */
+const sessionEventFences = new WeakMap<
+  object,
+  Map<string, SessionEventGenerationFence>
+>();
+
+function eventFenceMap(
+  backgroundJobBoard: BackgroundJobStore,
+): Map<string, SessionEventGenerationFence> {
+  const key = backgroundJobBoard as object;
+  const existing = sessionEventFences.get(key);
+  if (existing) return existing;
+  const created = new Map<string, SessionEventGenerationFence>();
+  sessionEventFences.set(key, created);
+  return created;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function finiteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function eventGeneration(input: {
+  event: { properties?: Record<string, unknown> };
+}): number | undefined {
+  const properties = input.event.properties;
+  const info = isRecord(properties?.info) ? properties.info : undefined;
+  const direct = properties?.generation;
+  if (finiteNumber(direct)) return direct;
+  return finiteNumber(info?.generation) ? info.generation : undefined;
+}
+
+function eventActivityAt(
+  input: { event: { properties?: Record<string, unknown> } },
+  fallback: number,
+): number {
+  const properties = input.event.properties;
+  const info = isRecord(properties?.info) ? properties.info : undefined;
+  const infoTime = isRecord(info?.time) ? info.time : undefined;
+  const directCandidates = [
+    properties?.activityAt,
+    properties?.timestamp,
+    properties?.time,
+    info?.activityAt,
+    info?.timestamp,
+    infoTime?.updated,
+  ];
+  const observed = directCandidates.find(finiteNumber);
+  return observed === undefined ? fallback : observed;
+}
+
+function rememberSessionGeneration(
+  backgroundJobBoard: BackgroundJobStore,
+  sessionID: string,
+): void {
+  const job = backgroundJobBoard.get(sessionID);
+  if (!job) return;
+  const fences = eventFenceMap(backgroundJobBoard);
+  const previous = fences.get(sessionID);
+  if (!previous || previous.generation !== job.generation) {
+    fences.set(sessionID, {
+      generation: job.generation,
+      awaitingActivity: previous !== undefined,
+    });
+  }
+}
+
+function observeSessionEvent(
+  backgroundJobBoard: BackgroundJobStore,
+  input: { event: { properties?: Record<string, unknown> } },
+  sessionID: string,
+  observedAt: number,
+  isBusy: boolean,
+): SessionEventObservation {
+  const job = backgroundJobBoard.get(sessionID);
+  if (!job) {
+    eventFenceMap(backgroundJobBoard).delete(sessionID);
+    return {
+      sessionID,
+      observedAt,
+      stale: false,
+      activityFenceOnly: false,
+    };
+  }
+
+  const fences = eventFenceMap(backgroundJobBoard);
+  const previous = fences.get(sessionID);
+  const generationChanged =
+    previous !== undefined && previous.generation !== job.generation;
+  const fence = generationChanged
+    ? {
+        generation: job.generation,
+        awaitingActivity: true,
+      }
+    : (previous ?? {
+        generation: job.generation,
+        awaitingActivity: false,
+      });
+  fences.set(sessionID, fence);
+
+  const suppliedGeneration = eventGeneration(input);
+  const suppliedCurrentGeneration =
+    suppliedGeneration !== undefined && suppliedGeneration === job.generation;
+  const activityIsBeforeRun = observedAt < job.runStartedAt;
+  const activityIsBeforeCurrentBusy =
+    job.lastLiveBusyAt !== undefined && job.lastLiveBusyAt > observedAt;
+  const stale =
+    (suppliedGeneration !== undefined && !suppliedCurrentGeneration) ||
+    activityIsBeforeRun ||
+    activityIsBeforeCurrentBusy ||
+    (fence.awaitingActivity && !isBusy && !suppliedCurrentGeneration);
+
+  // A host event without provenance can only establish a local activity
+  // boundary. Do not let that first post-relaunch busy observation mutate G2;
+  // a later event runs after the boundary has been established.
+  const activityFenceOnly =
+    !stale && fence.awaitingActivity && isBusy && !suppliedCurrentGeneration;
+  if (!stale && (activityFenceOnly || suppliedCurrentGeneration)) {
+    fence.awaitingActivity = false;
+  }
+
+  return {
+    sessionID,
+    job,
+    generation: job.generation,
+    observedAt,
+    stale,
+    activityFenceOnly,
+  };
+}
+
+function isCurrentSessionObservation(
+  backgroundJobBoard: BackgroundJobStore,
+  observation: SessionEventObservation,
+): boolean {
+  if (!observation.job || observation.generation === undefined) return true;
+  const current = backgroundJobBoard.get(observation.sessionID);
+  if (!current || current.generation !== observation.generation) return false;
+  if (current.runStartedAt > observation.observedAt) return false;
+  return !(
+    current.lastLiveBusyAt !== undefined &&
+    current.lastLiveBusyAt > observation.observedAt
+  );
+}
+
 export async function handleEvent(
   input: {
     event: {
       type: string;
       properties?: {
-        info?: { id?: string; parentID?: string; agent?: string };
+        info?: {
+          id?: string;
+          parentID?: string;
+          agent?: string;
+          generation?: number;
+          activityAt?: number;
+          timestamp?: number;
+          time?: { updated?: number };
+        };
         id?: string;
         requestID?: string;
         sessionID?: string;
+        generation?: number;
+        activityAt?: number;
+        timestamp?: number;
+        time?: { updated?: number };
         status?: { type?: string };
         error?: { name?: string };
         part?: unknown;
@@ -60,6 +245,8 @@ export async function handleEvent(
       isFallbackInProgress?: (sessionID: string) => boolean;
       /** True when foreground fallback could still recover the session. */
       willAttemptFallback?: (sessionID: string) => boolean;
+      /** Test seam; production uses event-arrival wall-clock time. */
+      now?: () => number;
     };
     idleReconciler: {
       scheduleIdleReconciliation(sessionID: string): void;
@@ -112,6 +299,9 @@ export async function handleEvent(
   if (input.event.type === 'session.created') {
     const info = input.event.properties?.info;
     if (info?.id) deps.retainedBoardSnapshots.delete(info.id);
+    if (info?.id) {
+      rememberSessionGeneration(deps.backgroundJobBoard, info.id);
+    }
     log('[task-session-manager] session.created observed', {
       sessionID: info?.id,
       parentSessionID: info?.parentID,
@@ -191,6 +381,7 @@ export async function handleEvent(
     deps.backgroundJobSupervisor?.dispose();
     deps.pendingCallTracker.clearAll?.();
     deps.retainedBoardSnapshots.clear();
+    eventFenceMap(deps.backgroundJobBoard).clear();
     const idleSessionIds = deps.idleReconciler.clearAllTimers();
     // Local-only: drop idle tokens. Process-global wait_for_user stays armed.
     const waitSessionIDs = new Set([
@@ -213,7 +404,21 @@ export async function handleEvent(
   ) {
     const sessionId =
       input.event.properties?.info?.id || input.event.properties?.sessionID;
-    const job = sessionId ? deps.backgroundJobBoard.get(sessionId) : undefined;
+    const observedAt = eventActivityAt(
+      input,
+      deps.options.now?.() ?? Date.now(),
+    );
+    const observation = sessionId
+      ? observeSessionEvent(
+          deps.backgroundJobBoard,
+          input,
+          sessionId,
+          observedAt,
+          false,
+        )
+      : undefined;
+    if (observation?.stale || observation?.activityFenceOnly) return;
+    const job = observation?.job;
     log('[task-session-manager] idle/status idle observed', {
       sessionID: sessionId,
       managesSession: sessionId
@@ -241,13 +446,13 @@ export async function handleEvent(
         // false completion the child-idle path would record.
         deps.idleReconciler.scheduleErrorTerminalize(
           sessionId,
-          Date.now(),
+          observedAt,
           job.generation,
         );
       } else {
         deps.idleReconciler.scheduleChildIdleReconciliation(
           sessionId,
-          Date.now(),
+          observedAt,
           job.generation,
         );
       }
@@ -258,6 +463,27 @@ export async function handleEvent(
   if (input.event.type === 'session.error') {
     const sessionId =
       input.event.properties?.info?.id || input.event.properties?.sessionID;
+    const observedAt = eventActivityAt(
+      input,
+      deps.options.now?.() ?? Date.now(),
+    );
+    const observation = sessionId
+      ? observeSessionEvent(
+          deps.backgroundJobBoard,
+          input,
+          sessionId,
+          observedAt,
+          false,
+        )
+      : undefined;
+    if (
+      observation?.stale ||
+      observation?.activityFenceOnly ||
+      (observation &&
+        !isCurrentSessionObservation(deps.backgroundJobBoard, observation))
+    ) {
+      return;
+    }
     if (sessionId) {
       deps.idleSessionTokens.invalidate(sessionId);
     }
@@ -285,8 +511,18 @@ export async function handleEvent(
         deps.pendingInjectedTerminalJobsByParent.delete(sessionId);
         // Record non-retryable errors on the job board so the
         // orchestrator sees the failure instead of a false completion.
-        const job = deps.backgroundJobBoard.get(sessionId);
+        const job = observation?.job ?? deps.backgroundJobBoard.get(sessionId);
         if (job && job.state === 'running') {
+          // BackgroundJobStore has no expected-generation/CAS form for
+          // updateStatus. The check immediately above is the strongest
+          // synchronous boundary available; a remote event cannot be made
+          // atomic with a later relaunch through this API.
+          if (
+            observation &&
+            !isCurrentSessionObservation(deps.backgroundJobBoard, observation)
+          ) {
+            return;
+          }
           deps.backgroundJobBoard.updateStatus({
             taskID: sessionId,
             state: 'error',
@@ -309,8 +545,16 @@ export async function handleEvent(
       // nothing to retry into, so surface the failure on the board.
       const props = input.event.properties as { error?: unknown } | undefined;
       if (deps.options.isFallbackInProgress?.(sessionId)) return;
-      const job = deps.backgroundJobBoard.get(sessionId);
+      const job = observation?.job ?? deps.backgroundJobBoard.get(sessionId);
       if (job && job.state === 'running') {
+        // This is a final synchronous generation check, not a claim that
+        // updateStatus is a CAS operation; the store API cannot provide that.
+        if (
+          observation &&
+          !isCurrentSessionObservation(deps.backgroundJobBoard, observation)
+        ) {
+          return;
+        }
         deps.backgroundJobBoard.updateStatus({
           taskID: sessionId,
           state: 'error',
@@ -330,10 +574,31 @@ export async function handleEvent(
     const statusType = (
       input.event.properties as { status?: { type?: string } } | undefined
     )?.status?.type;
-    if (sessionId) deps.idleSessionTokens.invalidate(sessionId);
     if (statusType !== 'busy') {
+      if (sessionId) deps.idleSessionTokens.invalidate(sessionId);
       return;
     }
+    const observedAt = eventActivityAt(
+      input,
+      deps.options.now?.() ?? Date.now(),
+    );
+    const observation = sessionId
+      ? observeSessionEvent(
+          deps.backgroundJobBoard,
+          input,
+          sessionId,
+          observedAt,
+          true,
+        )
+      : undefined;
+    if (observation?.stale || observation?.activityFenceOnly) return;
+    if (
+      observation &&
+      !isCurrentSessionObservation(deps.backgroundJobBoard, observation)
+    ) {
+      return;
+    }
+    if (sessionId) deps.idleSessionTokens.invalidate(sessionId);
     // Live busy cancels a pending child idle-reconcile — the session
     // recovered (FG re-prompt or continued work).
     // Note: invalidate above already cleared the parent idle-reconcile
@@ -345,10 +610,14 @@ export async function handleEvent(
       deps.deferredInlineErrors.delete(sessionId);
     }
     const before = sessionId
-      ? deps.backgroundJobBoard.get(sessionId)
+      ? (observation?.job ?? deps.backgroundJobBoard.get(sessionId))
       : undefined;
     const updated = sessionId
-      ? deps.backgroundJobBoard.markRunningFromLiveSession(sessionId)
+      ? deps.backgroundJobBoard.markRunningFromLiveSession(
+          sessionId,
+          observedAt,
+          observation?.generation,
+        )
       : undefined;
     if (before?.cancellationRequested) {
       log('[task-session-manager] busy observed after cancel request', {
@@ -380,6 +649,44 @@ export async function handleEvent(
     input.event.properties?.info?.id || input.event.properties?.sessionID;
   if (!sessionId) return;
 
+  const observedAt = eventActivityAt(input, deps.options.now?.() ?? Date.now());
+  const observation = observeSessionEvent(
+    deps.backgroundJobBoard,
+    input,
+    sessionId,
+    observedAt,
+    false,
+  );
+  const suppliedGeneration = eventGeneration(input);
+  const hasCurrentGenerationProvenance =
+    suppliedGeneration !== undefined &&
+    observation.generation !== undefined &&
+    suppliedGeneration === observation.generation;
+  const ambiguousRelaunchDeletion =
+    observation.job !== undefined &&
+    observation.job.generation > 1 &&
+    !hasCurrentGenerationProvenance;
+  if (
+    observation.stale ||
+    observation.activityFenceOnly ||
+    !isCurrentSessionObservation(deps.backgroundJobBoard, observation) ||
+    ambiguousRelaunchDeletion
+  ) {
+    log(
+      '[task-session-manager] ignored session.deleted without current-generation proof',
+      {
+        sessionID: sessionId,
+        currentGeneration: observation.generation,
+        eventGeneration: suppliedGeneration,
+        observedAt,
+        reason: ambiguousRelaunchDeletion
+          ? 'OpenCode event has no generation/CAS provenance after relaunch'
+          : 'generation or activity fence rejected deletion',
+      },
+    );
+    return;
+  }
+
   // Foreground-fallback teardown recreates the session; keep process-global
   // wait_for_user. Genuine deletion clears wait state for the session.
   if (deps.options.isFallbackInProgress?.(sessionId)) {
@@ -400,4 +707,5 @@ export async function handleEvent(
   log('[task-session-manager] session.deleted observed', {
     sessionID: sessionId,
   });
+  eventFenceMap(deps.backgroundJobBoard).delete(sessionId);
 }

--- a/src/hooks/task-session-manager/generation-fence.test.ts
+++ b/src/hooks/task-session-manager/generation-fence.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { BackgroundJobBoard } from '../../utils';
+import { createTaskSessionManagerHook } from './index';
+
+const PARENT_SESSION_ID = 'parent-generation-fence';
+
+function createHook(board: BackgroundJobBoard) {
+  return createTaskSessionManagerHook(
+    {
+      client: {
+        session: { status: mock(async () => ({ data: {} })) },
+      },
+      directory: '/tmp',
+      worktree: '/tmp',
+    } as never,
+    {
+      maxSessionsPerAgent: 2,
+      maxRetainedSnapshots: 4,
+      backgroundJobBoard: board,
+      shouldManageSession: () => true,
+      runtimeStatusReconcileDelayMs: 60_000,
+    },
+  );
+}
+
+function completionPart(taskID: string, occurrenceID: string, result: string) {
+  return {
+    type: 'text',
+    id: occurrenceID,
+    synthetic: true,
+    text: [
+      `<task id="${taskID}" state="completed">`,
+      '<summary>Background task completed: delayed result</summary>',
+      '<task_result>',
+      result,
+      '</task_result>',
+      '</task>',
+    ].join('\n'),
+  };
+}
+
+function completionMessage(part: ReturnType<typeof completionPart>) {
+  return {
+    info: {
+      role: 'user',
+      agent: 'orchestrator',
+      sessionID: PARENT_SESSION_ID,
+    },
+    parts: [part],
+  };
+}
+
+function ambiguousCompletionPart(
+  taskID: string,
+  messageID: string,
+  result: string,
+) {
+  return {
+    type: 'text',
+    synthetic: true,
+    messageID,
+    text: [
+      `<task id="${taskID}" state="completed">`,
+      '<summary>Background task completed: delayed result</summary>',
+      '<task_result>',
+      result,
+      '</task_result>',
+      '</task>',
+    ].join('\n'),
+  };
+}
+
+describe('task generation fences', () => {
+  test('does not apply a terminal part observed before any generation to G2', async () => {
+    const board = new BackgroundJobBoard();
+    const hook = createHook(board);
+    const oldCompletion = completionPart(
+      'same-task-id',
+      'generation-one-completion',
+      'G1 result',
+    );
+
+    // Runtime observation wins the race before task registration, so no
+    // generation can safely be associated with this occurrence.
+    await hook.event({
+      event: {
+        type: 'message.part.updated',
+        properties: { part: oldCompletion },
+      },
+    });
+
+    board.registerLaunch({
+      taskID: 'same-task-id',
+      parentSessionID: PARENT_SESSION_ID,
+      agent: 'explorer',
+      description: 'G1',
+    });
+    board.updateStatus({
+      taskID: 'same-task-id',
+      state: 'completed',
+      resultSummary: 'G1 result',
+    });
+    const generationTwo = board.registerLaunch({
+      taskID: 'same-task-id',
+      parentSessionID: PARENT_SESSION_ID,
+      agent: 'explorer',
+      description: 'G2',
+    });
+
+    await hook['experimental.chat.messages.transform']({}, {
+      messages: [completionMessage(oldCompletion)],
+    } as never);
+
+    expect(board.get('same-task-id')).toMatchObject({
+      generation: generationTwo.generation,
+      state: 'running',
+      statusUncertain: true,
+      resultSummary: undefined,
+    });
+  });
+
+  test('does not apply delayed native G1 output after G2 relaunch', async () => {
+    const board = new BackgroundJobBoard();
+    const hook = createHook(board);
+
+    await hook['tool.execute.before'](
+      {
+        tool: 'task',
+        sessionID: PARENT_SESSION_ID,
+        callID: 'generation-one-call',
+      },
+      {
+        args: {
+          subagent_type: 'explorer',
+          background: true,
+          description: 'G1',
+        },
+      },
+    );
+    await hook.event({
+      event: {
+        type: 'session.created',
+        properties: {
+          info: {
+            id: 'same-task-id',
+            parentID: PARENT_SESSION_ID,
+            agent: 'explorer',
+          },
+        },
+      },
+    });
+
+    const generationOne = board.get('same-task-id');
+    if (!generationOne) throw new Error('G1 was not registered');
+    board.updateStatus({
+      taskID: 'same-task-id',
+      state: 'completed',
+      resultSummary: 'G1 result',
+    });
+    const generationTwo = board.registerLaunch({
+      taskID: 'same-task-id',
+      parentSessionID: PARENT_SESSION_ID,
+      agent: 'explorer',
+      description: 'G2',
+    });
+
+    await hook['tool.execute.after'](
+      {
+        tool: 'task',
+        sessionID: PARENT_SESSION_ID,
+        callID: 'generation-one-call',
+      },
+      {
+        output: [
+          'task_id: same-task-id',
+          'state: completed',
+          '',
+          '<task_result>',
+          'late G1 result',
+          '</task_result>',
+        ].join('\n'),
+      },
+    );
+
+    expect(board.get('same-task-id')).toMatchObject({
+      generation: generationTwo.generation,
+      state: 'running',
+      resultSummary: undefined,
+    });
+    expect(generationTwo.generation).toBe(generationOne.generation + 1);
+  });
+
+  test('keeps an interleaved old completion fail-closed with multiple ambiguous origins', async () => {
+    const board = new BackgroundJobBoard();
+    const hook = createHook(board);
+    const terminalListener = mock(() => {});
+    board.addTerminalStateListener(terminalListener);
+
+    board.registerLaunch({
+      taskID: 'same-task-id',
+      parentSessionID: PARENT_SESSION_ID,
+      agent: 'explorer',
+      description: 'G1',
+    });
+    const oldCompletion = ambiguousCompletionPart(
+      'same-task-id',
+      'generation-one-part-a',
+      'G1 result A',
+    );
+    await hook.event({
+      event: {
+        type: 'message.part.updated',
+        properties: { part: oldCompletion },
+      },
+    });
+
+    const generationTwo = board.registerLaunch({
+      taskID: 'same-task-id',
+      parentSessionID: PARENT_SESSION_ID,
+      agent: 'explorer',
+      description: 'G2',
+    });
+    const delayedOldCompletion = ambiguousCompletionPart(
+      'same-task-id',
+      'generation-one-part-b',
+      'G1 result B',
+    );
+    await hook.event({
+      event: {
+        type: 'message.part.updated',
+        properties: { part: delayedOldCompletion },
+      },
+    });
+
+    await hook['experimental.chat.messages.transform']({}, {
+      messages: [completionMessage(oldCompletion)],
+    } as never);
+
+    expect(board.get('same-task-id')).toMatchObject({
+      generation: generationTwo.generation,
+      state: 'running',
+      statusUncertain: true,
+      resultSummary: undefined,
+      terminalUnreconciled: false,
+    });
+    expect(terminalListener).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/task-session-manager/idle-reconciliation.ts
+++ b/src/hooks/task-session-manager/idle-reconciliation.ts
@@ -74,25 +74,19 @@ export function createIdleReconciler(options: {
         return;
       }
 
-      log('[task-session-manager] observed runtime-stopped job from idle', {
+      // Idle is a quiescent runner observation, not proof that the background
+      // task ended. Keep the job live so a late terminal task result can win.
+      log('[task-session-manager] observed quiescent job from idle', {
         sessionID,
         alias: job.alias,
         parentSessionID: job.parentSessionID,
       });
-      options.backgroundJobBoard.markStopped(
+      options.backgroundJobBoard.markStatusUncertain(
         sessionID,
-        'Background session stopped before a terminal task result was received.',
-        // The idle event itself happened after the last busy event. Preserve
-        // that ordering when timestamps share millisecond precision.
-        idleObservedAt + 1,
+        'Runtime session is idle; task termination is unconfirmed.',
         observedGeneration,
+        idleObservedAt,
       );
-      options.taskContextTracker.pendingManagedTaskIds.delete(sessionID);
-      options.backgroundJobBoard.addContext(
-        sessionID,
-        options.taskContextTracker.contextFilesForPrompt(sessionID),
-      );
-      options.taskContextTracker.prune(options.backgroundJobBoard);
     }, options.idleReconcileDelayMs).unref?.();
     childIdleReconcileTimers.set(sessionID, timer);
   }
@@ -103,11 +97,12 @@ export function createIdleReconciler(options: {
    * not) recover. Mirrors scheduleChildIdleReconciliation: delayed so a
    * fallback re-prompt can claim the session first, and cancelled by
    * live-busy recovery. Without this, a silent fallback failure leaves
-   * the job 'running' and idle reconciliation would mark it 'completed'.
+   * the job 'running' indefinitely.
    */
   function scheduleErrorTerminalize(
     sessionID: string,
     idleObservedAt: number,
+    observedGeneration: number,
   ): void {
     if (errorTerminalizeTimers.has(sessionID)) return;
     // If a fallback attempt is still in flight, defer to the timer
@@ -125,7 +120,9 @@ export function createIdleReconciler(options: {
         }
 
         const job = options.backgroundJobBoard.get(sessionID);
-        if (job?.state !== 'running') return;
+        if (job?.state !== 'running' || job.generation !== observedGeneration) {
+          return;
+        }
 
         // Busy after the idle means the session recovered (e.g. FG re-prompt).
         if (

--- a/src/hooks/task-session-manager/index.test.ts
+++ b/src/hooks/task-session-manager/index.test.ts
@@ -273,7 +273,7 @@ describe('task-session-manager hook', () => {
     );
   });
 
-  test('rehydrates historical background tasks and reconciles stopped children immediately', async () => {
+  test('rehydrates historical background tasks and keeps absent children provisional', async () => {
     const board = new BackgroundJobBoard();
     const status = mock(async () => ({ data: {} }));
     const { hook } = createHook({
@@ -297,15 +297,15 @@ describe('task-session-manager hook', () => {
     await transformMessages(hook, messages as never);
 
     expect(board.get('historical-child')).toMatchObject({
-      state: 'stopped',
-      terminalUnreconciled: true,
+      state: 'running',
+      statusUncertain: true,
       background: true,
       agent: 'explorer',
       description: 'recover scheduler task',
       objective: 'recover scheduler task',
     });
     expect(boardText(messages)).toContain(
-      'historical-child / explorer / stopped, unreconciled',
+      'historical-child / explorer / running, status uncertain',
     );
   });
 
@@ -331,8 +331,8 @@ describe('task-session-manager hook', () => {
     await transformMessages(hook, messages as never);
 
     expect(board.get('completed-call-child')).toMatchObject({
-      state: 'stopped',
-      terminalUnreconciled: true,
+      state: 'running',
+      statusUncertain: true,
     });
   });
 
@@ -498,7 +498,8 @@ describe('task-session-manager hook', () => {
     expect(second).toMatchObject({
       alias: first?.alias,
       generation: first?.generation,
-      state: 'stopped',
+      state: 'running',
+      statusUncertain: true,
     });
     expect(status).toHaveBeenCalledTimes(1);
   });
@@ -4540,7 +4541,7 @@ describe('task-session-manager hook', () => {
     expect(messages.messages[0].parts[0].text).toBe('do something');
   });
 
-  test('marks a running child as stopped when idle has no terminal task result', async () => {
+  test('keeps a running child provisional when idle has no terminal task result', async () => {
     const board = new BackgroundJobBoard();
     board.registerLaunch({
       taskID: 'child-1',
@@ -4562,10 +4563,53 @@ describe('task-session-manager hook', () => {
     await flushChildIdleReconcile();
 
     expect(board.get('child-1')).toMatchObject({
-      state: 'stopped',
-      terminalUnreconciled: true,
-      resultSummary:
-        'Background session stopped before a terminal task result was received.',
+      state: 'running',
+      statusUncertain: true,
+      lastStatusError:
+        'Runtime session is idle; task termination is unconfirmed.',
+    });
+  });
+
+  test('idle timer does not notify terminal listeners before a late completion', async () => {
+    const board = new BackgroundJobBoard();
+    board.registerLaunch({
+      taskID: 'child-late',
+      parentSessionID: 'parent-1',
+      agent: 'fixer',
+      description: 'late completion',
+    });
+    const listener = mock(() => {});
+    board.addTerminalStateListener(listener);
+    const { hook } = createHook({
+      backgroundJobBoard: board,
+      shouldManageSession: (id) => id === 'parent-1',
+      idleReconcileDelayMs: 0,
+    });
+
+    await hook.event({
+      event: {
+        type: 'session.idle',
+        properties: { sessionID: 'child-late' },
+      },
+    });
+    await flushChildIdleReconcile();
+
+    expect(board.get('child-late')).toMatchObject({
+      state: 'running',
+      statusUncertain: true,
+    });
+    expect(listener).not.toHaveBeenCalled();
+
+    board.updateStatus({
+      taskID: 'child-late',
+      state: 'completed',
+      resultSummary: 'late completion won',
+    });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(board.get('child-late')).toMatchObject({
+      state: 'completed',
+      resultSummary: 'late completion won',
     });
   });
 
@@ -4625,8 +4669,8 @@ describe('task-session-manager hook', () => {
     await flushChildIdleReconcile();
 
     expect(board.get('child-1')).toMatchObject({
-      state: 'stopped',
-      terminalUnreconciled: true,
+      state: 'running',
+      statusUncertain: true,
     });
   });
 
@@ -4729,7 +4773,123 @@ describe('task-session-manager hook', () => {
     expect(board.get('child-2')).toBeUndefined();
   });
 
-  test('marks stopped from idle when fallback guard passes', async () => {
+  test('does not rehydrate a deleted historical running task as a new alias', async () => {
+    const coordinator = new SessionLifecycle(() => {});
+    const board = new BackgroundJobBoard();
+    board.registerLaunch({
+      taskID: 'child-deleted',
+      parentSessionID: 'parent-1',
+      agent: 'fixer',
+      description: 'deleted task',
+    });
+    const { hook } = createHook({
+      backgroundJobBoard: board,
+      coordinator,
+      runtimeStatusReconcileDelayMs: 60_000,
+    });
+
+    coordinator.dispatchSessionDeleted('child-deleted');
+    expect(board.get('child-deleted')).toBeUndefined();
+
+    const messages = {
+      messages: [
+        {
+          info: {
+            role: 'assistant',
+            agent: 'orchestrator',
+            sessionID: 'parent-1',
+          },
+          parts: [historicalRunningTaskPart('child-deleted')],
+        },
+        ...createMessages('parent-1', 'continue').messages,
+      ],
+    };
+
+    await transformMessages(hook, messages as never);
+
+    expect(board.get('child-deleted')).toBeUndefined();
+    expect(board.list()).toHaveLength(0);
+  });
+
+  test('clears a delete tombstone for a legitimate subsequent launch', async () => {
+    const coordinator = new SessionLifecycle(() => {});
+    const board = new BackgroundJobBoard();
+    board.registerLaunch({
+      taskID: 'child-relaunched',
+      parentSessionID: 'parent-1',
+      agent: 'fixer',
+      description: 'first run',
+    });
+    const { hook } = createHook({
+      backgroundJobBoard: board,
+      coordinator,
+      runtimeStatusReconcileDelayMs: 60_000,
+    });
+
+    await hook['tool.execute.before'](
+      { tool: 'task', sessionID: 'parent-1', callID: 'old-call' },
+      {
+        args: {
+          subagent_type: 'fixer',
+          background: true,
+          description: 'old run',
+        },
+      },
+    );
+    coordinator.dispatchSessionDeleted('child-relaunched');
+    expect(board.get('child-relaunched')).toBeUndefined();
+
+    await hook['tool.execute.after'](
+      { tool: 'task', sessionID: 'parent-1', callID: 'old-call' },
+      { output: taskLaunchOutput('child-relaunched') },
+    );
+    expect(board.get('child-relaunched')).toBeUndefined();
+
+    await hook['tool.execute.before'](
+      { tool: 'task', sessionID: 'parent-1', callID: 'new-call' },
+      {
+        args: {
+          subagent_type: 'fixer',
+          background: true,
+          description: 'second run',
+        },
+      },
+    );
+    await hook['tool.execute.after'](
+      { tool: 'task', sessionID: 'parent-1', callID: 'new-call' },
+      { output: taskLaunchOutput('child-relaunched') },
+    );
+
+    expect(board.get('child-relaunched')).toMatchObject({
+      state: 'running',
+      generation: 2,
+      description: 'second run',
+    });
+
+    const messages = {
+      messages: [
+        {
+          info: {
+            role: 'assistant',
+            agent: 'orchestrator',
+            sessionID: 'parent-1',
+          },
+          parts: [historicalRunningTaskPart('child-relaunched')],
+        },
+        ...createMessages('parent-1', 'continue').messages,
+      ],
+    };
+    await transformMessages(hook, messages as never);
+
+    expect(board.get('child-relaunched')).toMatchObject({
+      state: 'running',
+      generation: 2,
+      description: 'second run',
+    });
+    expect(board.list()).toHaveLength(1);
+  });
+
+  test('marks idle as provisional when fallback guard passes', async () => {
     const board = new BackgroundJobBoard();
     board.registerLaunch({
       taskID: 'child-1',
@@ -4753,8 +4913,8 @@ describe('task-session-manager hook', () => {
     await flushChildIdleReconcile();
 
     expect(board.get('child-1')).toMatchObject({
-      state: 'stopped',
-      terminalUnreconciled: true,
+      state: 'running',
+      statusUncertain: true,
     });
   });
 
@@ -4794,7 +4954,7 @@ describe('task-session-manager hook', () => {
     });
     expect(board.get('child-1')).toMatchObject({ state: 'running' });
 
-    // Second idle stops the child without an explicit task result.
+    // Second idle remains provisional without an explicit task result.
     const hook2 = createHook({
       backgroundJobBoard: board,
       shouldManageSession: () => false,
@@ -4806,8 +4966,8 @@ describe('task-session-manager hook', () => {
     });
     await flushChildIdleReconcile();
     expect(board.get('child-1')).toMatchObject({
-      state: 'stopped',
-      terminalUnreconciled: true,
+      state: 'running',
+      statusUncertain: true,
     });
   });
 
@@ -4925,15 +5085,15 @@ describe('task-session-manager hook', () => {
     });
 
     // Simulate parent tool never firing tool.execute.after (cancelled).
-    // Child goes idle without task output — board must stop waiting.
+    // Child goes idle without task output — board remains provisional.
     await hook.event({
       event: { type: 'session.idle', properties: { sessionID: 'child-1' } },
     });
     await flushChildIdleReconcile();
 
     expect(board.get('child-1')).toMatchObject({
-      state: 'stopped',
-      terminalUnreconciled: true,
+      state: 'running',
+      statusUncertain: true,
     });
   });
 
@@ -5285,7 +5445,7 @@ describe('task-session-manager hook', () => {
     expect(job?.state).toBe('cancelled');
   });
 
-  test('idle via session.status path marks the job stopped', async () => {
+  test('idle via session.status path remains provisional', async () => {
     const board = new BackgroundJobBoard();
     board.registerLaunch({
       taskID: 'child-1',
@@ -5310,8 +5470,8 @@ describe('task-session-manager hook', () => {
     await flushChildIdleReconcile();
 
     expect(board.get('child-1')).toMatchObject({
-      state: 'stopped',
-      terminalUnreconciled: true,
+      state: 'running',
+      statusUncertain: true,
     });
   });
 

--- a/src/hooks/task-session-manager/index.test.ts
+++ b/src/hooks/task-session-manager/index.test.ts
@@ -5,6 +5,7 @@ import {
   BackgroundJobBoard,
   BackgroundJobSupervisor,
   createInternalAgentTextPart,
+  getBackgroundJobLifecycleLedger,
   SLIM_INTERNAL_INITIATOR_MARKER,
 } from '../../utils';
 import {
@@ -1545,6 +1546,178 @@ describe('task-session-manager hook', () => {
       timedOut: false,
       recoverableAfterLiveBusy: true,
     });
+  });
+
+  test('holds a relaunch lease through after and releases it after registration', async () => {
+    const board = new BackgroundJobBoard();
+    setupCompletedJob(board, {
+      taskID: 'child-1',
+      parentSessionID: 'parent-1',
+    });
+    board.markReconciled('child-1');
+    const { hook } = createHook({ backgroundJobBoard: board });
+    const resume = {
+      args: { subagent_type: 'oracle', task_id: 'ora-1' },
+    };
+
+    await hook['tool.execute.before'](
+      { tool: 'task', sessionID: 'parent-1', callID: 'resume-1' },
+      resume,
+    );
+    await hook['tool.execute.after'](
+      { tool: 'task', sessionID: 'parent-1', callID: 'resume-1' },
+      { output: ['task_id: child-1', 'state: running'].join('\n') },
+    );
+
+    const relaunched = board.get('child-1');
+    expect(resume.args.task_id).toBe('child-1');
+    expect(relaunched).toMatchObject({ generation: 2, state: 'running' });
+    const cancellationLease = board.acquireCancellationLease(
+      'child-1',
+      relaunched?.generation ?? -1,
+    );
+    expect(cancellationLease).toBeDefined();
+    if (!cancellationLease) {
+      throw new Error('cancellation lease was not acquired');
+    }
+    board.releaseLease(cancellationLease);
+  });
+
+  test('session.created cannot early-register over a live cancellation lease', async () => {
+    const board = new BackgroundJobBoard();
+    const first = board.registerLaunch({
+      taskID: 'child-1',
+      parentSessionID: 'parent-1',
+      agent: 'oracle',
+    });
+    const cancellationLease = board.acquireCancellationLease(
+      first.taskID,
+      first.generation,
+    );
+    expect(cancellationLease).toBeDefined();
+    const { hook } = createHook({ backgroundJobBoard: board });
+
+    await hook['tool.execute.before'](
+      { tool: 'task', sessionID: 'parent-1', callID: 'new-call' },
+      { args: { subagent_type: 'oracle', background: true } },
+    );
+    await hook.event({
+      event: {
+        type: 'session.created',
+        properties: {
+          info: { id: 'child-1', parentID: 'parent-1', agent: 'oracle' },
+        },
+      },
+    });
+    await hook['tool.execute.after'](
+      { tool: 'task', sessionID: 'parent-1', callID: 'new-call' },
+      { output: ['task_id: child-1', 'state: running'].join('\n') },
+    );
+
+    expect(board.get('child-1')).toMatchObject({
+      generation: first.generation,
+      state: 'running',
+    });
+    expect(board.acquireRelaunchLease('child-1', first.generation)).toBe(
+      undefined,
+    );
+    if (!cancellationLease) {
+      throw new Error('cancellation lease was not acquired');
+    }
+    board.releaseLease(cancellationLease);
+  });
+
+  test('tool.execute.before refuses a relaunch while cancellation owns the generation', async () => {
+    const board = new BackgroundJobBoard();
+    const first = board.registerLaunch({
+      taskID: 'child-1',
+      parentSessionID: 'parent-1',
+      agent: 'fixer',
+    });
+    board.updateStatus({
+      taskID: first.taskID,
+      state: 'running',
+      timedOut: true,
+    });
+    board.markRunningFromLiveSession(
+      first.taskID,
+      Date.now(),
+      first.generation,
+    );
+    const cancellationLease = board.acquireCancellationLease(
+      first.taskID,
+      first.generation,
+    );
+    expect(cancellationLease).toBeDefined();
+    const { hook } = createHook({ backgroundJobBoard: board });
+    const resume = { args: { subagent_type: 'fixer', task_id: 'fix-1' } };
+
+    await expect(
+      hook['tool.execute.before'](
+        { tool: 'task', sessionID: 'parent-1', callID: 'blocked-resume' },
+        resume,
+      ),
+    ).rejects.toThrow('cannot be resumed safely');
+    expect(resume.args.task_id).toBe('fix-1');
+    expect(board.get(first.taskID)?.generation).toBe(first.generation);
+    if (!cancellationLease) {
+      throw new Error('cancellation lease was not acquired');
+    }
+    board.releaseLease(cancellationLease);
+  });
+
+  test('after output errors still release a pending relaunch lease', async () => {
+    const board = new BackgroundJobBoard();
+    setupCompletedJob(board, {
+      taskID: 'child-1',
+      parentSessionID: 'parent-1',
+    });
+    const { hook } = createHook({ backgroundJobBoard: board });
+
+    await hook['tool.execute.before'](
+      { tool: 'task', sessionID: 'parent-1', callID: 'resume-error' },
+      { args: { subagent_type: 'oracle', task_id: 'ora-1' } },
+    );
+    await hook['tool.execute.after'](
+      { tool: 'task', sessionID: 'parent-1', callID: 'resume-error' },
+      { output: undefined },
+    );
+
+    const secondLease = board.acquireRelaunchLease('child-1', 1);
+    expect(secondLease).toBeDefined();
+    if (!secondLease) throw new Error('relaunch lease was not released');
+    board.releaseLease(secondLease);
+  });
+
+  test('after handler exceptions release a pending relaunch lease', async () => {
+    const board = new BackgroundJobBoard();
+    setupCompletedJob(board, {
+      taskID: 'child-1',
+      parentSessionID: 'parent-1',
+    });
+    board.markReconciled('child-1');
+    board.addContext = () => {
+      throw new Error('context tracking failed');
+    };
+    const { hook } = createHook({ backgroundJobBoard: board });
+
+    await hook['tool.execute.before'](
+      { tool: 'task', sessionID: 'parent-1', callID: 'resume-throw' },
+      { args: { subagent_type: 'oracle', task_id: 'ora-1' } },
+    );
+    await expect(
+      hook['tool.execute.after'](
+        { tool: 'task', sessionID: 'parent-1', callID: 'resume-throw' },
+        { output: ['task_id: child-1', 'state: running'].join('\n') },
+      ),
+    ).rejects.toThrow('context tracking failed');
+
+    const cancellationLease = board.acquireCancellationLease('child-1', 2);
+    expect(cancellationLease).toBeDefined();
+    if (!cancellationLease) {
+      throw new Error('cancellation lease was not acquired');
+    }
+    board.releaseLease(cancellationLease);
   });
 
   test('does not bypass live busy recovery gate for known raw session ids', async () => {
@@ -4887,6 +5060,678 @@ describe('task-session-manager hook', () => {
       description: 'second run',
     });
     expect(board.list()).toHaveLength(1);
+  });
+
+  test('fences a re-injected generation-one completion after deletion', async () => {
+    const coordinator = new SessionLifecycle(() => {});
+    const board = new BackgroundJobBoard();
+    const terminalListener = mock(() => {});
+    board.addTerminalStateListener(terminalListener);
+    const first = createHook({
+      backgroundJobBoard: board,
+      coordinator,
+      runtimeStatusReconcileDelayMs: 60_000,
+    });
+    board.registerLaunch({
+      taskID: 'child-relaunch',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+      description: 'first run',
+    });
+
+    const oldCompletion = {
+      messages: [
+        {
+          info: {
+            role: 'user',
+            agent: 'orchestrator',
+            sessionID: 'parent-1',
+          },
+          parts: [
+            {
+              type: 'text',
+              id: 'generation-one-completion',
+              synthetic: true,
+              text: [
+                '<task id="child-relaunch" state="completed">',
+                '<summary>Background task completed: first run</summary>',
+                '<task_result>',
+                'old result',
+                '</task_result>',
+                '</task>',
+              ].join('\n'),
+            },
+          ],
+        },
+      ],
+    };
+
+    await first.hook.event({
+      event: {
+        type: 'message.part.updated',
+        properties: { part: oldCompletion.messages[0].parts[0] },
+      },
+    });
+    expect(board.get('child-relaunch')).toMatchObject({
+      generation: 1,
+      state: 'running',
+    });
+
+    // The runtime event observed P1, but its message has not reached the
+    // transform hook yet.
+    expect(terminalListener).not.toHaveBeenCalled();
+    await first.hook.event({
+      event: {
+        type: 'session.deleted',
+        properties: { sessionID: 'child-relaunch' },
+      },
+    });
+    coordinator.dispatchSessionDeleted('child-relaunch');
+    expect(board.get('child-relaunch')).toBeUndefined();
+
+    // A recreated hook shares the board's lifecycle fence, while its local
+    // processed-occurrence set is intentionally fresh.
+    const { hook } = createHook({
+      backgroundJobBoard: board,
+      runtimeStatusReconcileDelayMs: 60_000,
+    });
+    await hook['tool.execute.before'](
+      { tool: 'task', sessionID: 'parent-1', callID: 'generation-two' },
+      {
+        args: {
+          subagent_type: 'explorer',
+          background: true,
+          description: 'second run',
+        },
+      },
+    );
+    await hook['tool.execute.after'](
+      { tool: 'task', sessionID: 'parent-1', callID: 'generation-two' },
+      { output: taskLaunchOutput('child-relaunch') },
+    );
+
+    expect(board.get('child-relaunch')).toMatchObject({
+      generation: 2,
+      state: 'running',
+    });
+    expect(board.get('child-relaunch')?.resultSummary).toBeUndefined();
+    expect(terminalListener).not.toHaveBeenCalled();
+
+    const replayedCompletion = {
+      messages: JSON.parse(JSON.stringify(oldCompletion.messages)),
+    };
+    await hook['experimental.chat.messages.transform'](
+      {},
+      replayedCompletion as never,
+    );
+
+    expect(board.get('child-relaunch')).toMatchObject({
+      generation: 2,
+      state: 'running',
+      statusUncertain: true,
+    });
+    expect(board.get('child-relaunch')?.resultSummary).toBeUndefined();
+
+    await hook['tool.execute.before'](
+      { tool: 'task', sessionID: 'parent-1', callID: 'generation-two-result' },
+      {
+        args: {
+          subagent_type: 'explorer',
+          background: true,
+          description: 'second run result',
+        },
+      },
+    );
+    await hook['tool.execute.after'](
+      { tool: 'task', sessionID: 'parent-1', callID: 'generation-two-result' },
+      {
+        output: [
+          'task_id: child-relaunch',
+          'state: completed',
+          '',
+          '<task_result>',
+          'new result',
+          '</task_result>',
+        ].join('\n'),
+      },
+    );
+
+    expect(board.get('child-relaunch')).toMatchObject({
+      generation: 2,
+      state: 'completed',
+      resultSummary: 'new result',
+      statusUncertain: false,
+    });
+    expect(terminalListener).toHaveBeenCalledTimes(1);
+  });
+
+  test('keeps an ambiguous old completion fail-closed after a late event', async () => {
+    const coordinator = new SessionLifecycle(() => {});
+    const board = new BackgroundJobBoard();
+    const terminalListener = mock(() => {});
+    board.addTerminalStateListener(terminalListener);
+    const first = createHook({
+      backgroundJobBoard: board,
+      coordinator,
+      runtimeStatusReconcileDelayMs: 60_000,
+    });
+    board.registerLaunch({
+      taskID: 'child-relaunch',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+      description: 'first run',
+    });
+
+    const oldCompletion = {
+      type: 'text',
+      id: 'generation-one-completion',
+      synthetic: true,
+      text: [
+        '<task id="child-relaunch" state="completed">',
+        '<summary>Background task completed: first run</summary>',
+        '<task_result>',
+        'old result',
+        '</task_result>',
+        '</task>',
+      ].join('\n'),
+    };
+
+    await first.hook.event({
+      event: {
+        type: 'session.deleted',
+        properties: { sessionID: 'child-relaunch' },
+      },
+    });
+    coordinator.dispatchSessionDeleted('child-relaunch');
+    expect(board.get('child-relaunch')).toBeUndefined();
+
+    // The first event arrives after deletion, with no live board record to
+    // establish which generation produced the terminal part.
+    await first.hook.event({
+      event: {
+        type: 'message.part.updated',
+        properties: { part: oldCompletion },
+      },
+    });
+
+    const { hook } = createHook({
+      backgroundJobBoard: board,
+      runtimeStatusReconcileDelayMs: 60_000,
+    });
+    await hook['tool.execute.before'](
+      { tool: 'task', sessionID: 'parent-1', callID: 'generation-two' },
+      {
+        args: {
+          subagent_type: 'explorer',
+          background: true,
+          description: 'second run',
+        },
+      },
+    );
+    await hook['tool.execute.after'](
+      { tool: 'task', sessionID: 'parent-1', callID: 'generation-two' },
+      { output: taskLaunchOutput('child-relaunch') },
+    );
+    expect(board.get('child-relaunch')).toMatchObject({
+      generation: 2,
+      state: 'running',
+    });
+
+    // A late event for the old P1 part must not replace the ambiguous origin
+    // with G2 provenance.
+    await hook.event({
+      event: {
+        type: 'message.part.updated',
+        properties: { part: oldCompletion },
+      },
+    });
+
+    const replay = {
+      messages: [
+        {
+          info: {
+            role: 'user',
+            agent: 'orchestrator',
+            sessionID: 'parent-1',
+          },
+          parts: [oldCompletion],
+        },
+      ],
+    };
+    await hook['experimental.chat.messages.transform']({}, replay as never);
+
+    expect(board.get('child-relaunch')).toMatchObject({
+      generation: 2,
+      state: 'running',
+      statusUncertain: true,
+      terminalUnreconciled: false,
+    });
+    expect(board.get('child-relaunch')?.resultSummary).toBeUndefined();
+    expect(terminalListener).not.toHaveBeenCalled();
+  });
+
+  test('fails closed for a newly observed synthetic completion after deletion', async () => {
+    const coordinator = new SessionLifecycle(() => {});
+    const board = new BackgroundJobBoard();
+    const first = createHook({
+      backgroundJobBoard: board,
+      coordinator,
+      runtimeStatusReconcileDelayMs: 60_000,
+    });
+    board.registerLaunch({
+      taskID: 'child-relaunch',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+      description: 'first run',
+    });
+
+    await first.hook.event({
+      event: {
+        type: 'session.deleted',
+        properties: { sessionID: 'child-relaunch' },
+      },
+    });
+    coordinator.dispatchSessionDeleted('child-relaunch');
+
+    const { hook } = createHook({
+      backgroundJobBoard: board,
+      runtimeStatusReconcileDelayMs: 60_000,
+    });
+    board.registerLaunch({
+      taskID: 'child-relaunch',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+      description: 'second run',
+    });
+
+    const completion = {
+      type: 'text',
+      id: 'generation-two-completion',
+      synthetic: true,
+      sessionID: 'parent-1',
+      messageID: 'message-generation-two',
+      text: [
+        '<task id="child-relaunch" state="completed">',
+        '<summary>Background task completed: second run</summary>',
+        '<task_result>',
+        'new synthetic result',
+        '</task_result>',
+        '</task>',
+      ].join('\n'),
+    };
+    await hook.event({
+      event: {
+        type: 'message.part.updated',
+        properties: { part: completion },
+      },
+    });
+    await hook['experimental.chat.messages.transform']({}, {
+      messages: [
+        {
+          info: {
+            role: 'user',
+            agent: 'orchestrator',
+            sessionID: 'parent-1',
+          },
+          parts: [completion],
+        },
+      ],
+    } as never);
+
+    expect(board.get('child-relaunch')).toMatchObject({
+      generation: 2,
+      state: 'running',
+      statusUncertain: true,
+      terminalUnreconciled: false,
+    });
+    expect(board.get('child-relaunch')?.resultSummary).toBeUndefined();
+  });
+
+  test('allows an observed synthetic completion in the same generation', async () => {
+    const board = new BackgroundJobBoard();
+    const terminalListener = mock(() => {});
+    board.addTerminalStateListener(terminalListener);
+    const { hook } = createHook({
+      backgroundJobBoard: board,
+      runtimeStatusReconcileDelayMs: 60_000,
+    });
+    board.registerLaunch({
+      taskID: 'child-same-generation',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+      description: 'same generation',
+    });
+
+    const completion = {
+      type: 'text',
+      id: 'same-generation-completion',
+      synthetic: true,
+      text: [
+        '<task id="child-same-generation" state="completed">',
+        '<summary>Background task completed: same generation</summary>',
+        '<task_result>',
+        'same generation result',
+        '</task_result>',
+        '</task>',
+      ].join('\n'),
+    };
+    await hook.event({
+      event: {
+        type: 'message.part.updated',
+        properties: { part: completion },
+      },
+    });
+    await hook['experimental.chat.messages.transform']({}, {
+      messages: [
+        {
+          info: {
+            role: 'user',
+            agent: 'orchestrator',
+            sessionID: 'parent-1',
+          },
+          parts: [completion],
+        },
+      ],
+    } as never);
+
+    expect(board.get('child-same-generation')).toMatchObject({
+      state: 'completed',
+      resultSummary: 'same generation result',
+    });
+    expect(terminalListener).toHaveBeenCalledTimes(1);
+  });
+
+  test('fails closed for an unobserved synthetic completion after deletion', async () => {
+    const coordinator = new SessionLifecycle(() => {});
+    const board = new BackgroundJobBoard();
+    const terminalListener = mock(() => {});
+    board.addTerminalStateListener(terminalListener);
+    const first = createHook({
+      backgroundJobBoard: board,
+      coordinator,
+      runtimeStatusReconcileDelayMs: 60_000,
+    });
+    board.registerLaunch({
+      taskID: 'child-relaunch',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+      description: 'first run',
+    });
+
+    await first.hook.event({
+      event: {
+        type: 'session.deleted',
+        properties: { sessionID: 'child-relaunch' },
+      },
+    });
+    coordinator.dispatchSessionDeleted('child-relaunch');
+
+    const { hook } = createHook({
+      backgroundJobBoard: board,
+      runtimeStatusReconcileDelayMs: 60_000,
+    });
+    board.registerLaunch({
+      taskID: 'child-relaunch',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+      description: 'second run',
+    });
+
+    const replay = {
+      messages: [
+        {
+          info: {
+            role: 'user',
+            agent: 'orchestrator',
+            sessionID: 'parent-1',
+          },
+          parts: [
+            {
+              type: 'text',
+              id: 'unobserved-completion',
+              synthetic: true,
+              text: [
+                '<task id="child-relaunch" state="completed">',
+                '<summary>Background task completed: unknown origin</summary>',
+                '<task_result>',
+                'ambiguous result',
+                '</task_result>',
+                '</task>',
+              ].join('\n'),
+            },
+          ],
+        },
+      ],
+    };
+    await hook['experimental.chat.messages.transform']({}, replay as never);
+
+    expect(board.get('child-relaunch')).toMatchObject({
+      generation: 2,
+      state: 'running',
+      statusUncertain: true,
+      terminalUnreconciled: false,
+    });
+    expect(terminalListener).not.toHaveBeenCalled();
+  });
+
+  test('does not upgrade an ambiguous occurrence without a deletion epoch', async () => {
+    const board = new BackgroundJobBoard();
+    const terminalListener = mock(() => {});
+    board.addTerminalStateListener(terminalListener);
+    const { hook } = createHook({
+      backgroundJobBoard: board,
+      runtimeStatusReconcileDelayMs: 60_000,
+    });
+    board.registerLaunch({
+      taskID: 'child-ambiguous',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+      description: 'ambiguous observation',
+    });
+
+    const completion = {
+      type: 'text',
+      synthetic: true,
+      messageID: 'ambiguous-message',
+      text: [
+        '<task id="child-ambiguous" state="completed">',
+        '<summary>Background task completed: uncertain</summary>',
+        '<task_result>',
+        'uncertain result',
+        '</task_result>',
+        '</task>',
+      ].join('\n'),
+    };
+    await hook.event({
+      event: {
+        type: 'message.part.updated',
+        properties: { part: completion },
+      },
+    });
+    await hook['experimental.chat.messages.transform']({}, {
+      messages: [
+        {
+          info: {
+            role: 'user',
+            agent: 'orchestrator',
+            sessionID: 'parent-1',
+          },
+          parts: [completion],
+        },
+      ],
+    } as never);
+
+    expect(board.get('child-ambiguous')).toMatchObject({
+      state: 'running',
+      statusUncertain: true,
+      terminalUnreconciled: false,
+    });
+    expect(terminalListener).not.toHaveBeenCalled();
+  });
+
+  test('retains an old occurrence provenance after more than 500 later occurrences', async () => {
+    const board = new BackgroundJobBoard();
+    const terminalListener = mock(() => {});
+    board.addTerminalStateListener(terminalListener);
+    const { hook } = createHook({
+      backgroundJobBoard: board,
+      runtimeStatusReconcileDelayMs: 60_000,
+    });
+
+    board.registerLaunch({
+      taskID: 'child-occurrence-ledger',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+      description: 'generation one',
+    });
+
+    const completion = (id: string, result: string) => ({
+      type: 'text',
+      id,
+      synthetic: true,
+      text: [
+        '<task id="child-occurrence-ledger" state="completed">',
+        '<summary>Background task completed: occurrence</summary>',
+        '<task_result>',
+        result,
+        '</task_result>',
+        '</task>',
+      ].join('\n'),
+    });
+
+    const firstCompletion = completion('p1-occurrence', 'old result');
+    await hook.event({
+      event: {
+        type: 'message.part.updated',
+        properties: { part: firstCompletion },
+      },
+    });
+
+    for (let index = 0; index < 501; index += 1) {
+      board.registerLaunch({
+        taskID: 'child-occurrence-ledger',
+        parentSessionID: 'parent-1',
+        agent: 'explorer',
+        description: `generation ${index + 2}`,
+      });
+      const laterCompletion = completion(
+        `later-occurrence-${index}`,
+        `result ${index}`,
+      );
+      await hook.event({
+        event: {
+          type: 'message.part.updated',
+          properties: { part: laterCompletion },
+        },
+      });
+      await hook['experimental.chat.messages.transform']({}, {
+        messages: [
+          {
+            info: {
+              role: 'user',
+              agent: 'orchestrator',
+              sessionID: 'parent-1',
+            },
+            parts: [laterCompletion],
+          },
+        ],
+      } as never);
+    }
+
+    terminalListener.mockClear();
+    const current = board.registerLaunch({
+      taskID: 'child-occurrence-ledger',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+      description: 'current generation',
+    });
+    expect(current.generation).toBe(503);
+
+    const replay = {
+      messages: [
+        {
+          info: {
+            role: 'user',
+            agent: 'orchestrator',
+            sessionID: 'parent-1',
+          },
+          parts: [JSON.parse(JSON.stringify(firstCompletion))],
+        },
+      ],
+    };
+    await hook['experimental.chat.messages.transform']({}, replay as never);
+
+    expect(board.get('child-occurrence-ledger')).toMatchObject({
+      generation: current.generation,
+      state: 'running',
+      statusUncertain: true,
+      resultSummary: undefined,
+    });
+    expect(terminalListener).not.toHaveBeenCalled();
+  });
+
+  test('direct drop suppresses historical rehydrate until a new launch clears it', async () => {
+    const board = new BackgroundJobBoard();
+    const { hook } = createHook({
+      backgroundJobBoard: board,
+      runtimeStatusReconcileDelayMs: 60_000,
+    });
+    board.registerLaunch({
+      taskID: 'child-direct-drop',
+      parentSessionID: 'parent-1',
+      agent: 'fixer',
+      description: 'dropped run',
+    });
+
+    board.drop('child-direct-drop');
+    const ledger = getBackgroundJobLifecycleLedger(board);
+    expect(ledger.tombstones.has('child-direct-drop')).toBe(true);
+
+    const historical = {
+      messages: [
+        {
+          info: {
+            role: 'assistant',
+            agent: 'orchestrator',
+            sessionID: 'parent-1',
+          },
+          parts: [historicalRunningTaskPart('child-direct-drop')],
+        },
+        ...createMessages('parent-1', 'continue').messages,
+      ],
+    };
+    await hook['experimental.chat.messages.transform']({}, historical as never);
+    expect(board.get('child-direct-drop')).toBeUndefined();
+
+    const relaunched = board.registerLaunch({
+      taskID: 'child-direct-drop',
+      parentSessionID: 'parent-1',
+      agent: 'fixer',
+      description: 'new run',
+    });
+    expect(relaunched.generation).toBe(2);
+    expect(ledger.tombstones.has('child-direct-drop')).toBe(false);
+
+    const replay = {
+      messages: [
+        {
+          info: {
+            role: 'assistant',
+            agent: 'orchestrator',
+            sessionID: 'parent-1',
+          },
+          parts: [historicalRunningTaskPart('child-direct-drop')],
+        },
+        ...createMessages('parent-1', 'continue again').messages,
+      ],
+    };
+    await hook['experimental.chat.messages.transform']({}, replay as never);
+
+    expect(board.get('child-direct-drop')).toMatchObject({
+      generation: 2,
+      state: 'running',
+      description: 'new run',
+    });
   });
 
   test('marks idle as provisional when fallback guard passes', async () => {

--- a/src/hooks/task-session-manager/index.ts
+++ b/src/hooks/task-session-manager/index.ts
@@ -4,10 +4,13 @@ import {
   type BackgroundJobExecution,
   type BackgroundJobStore,
   type BackgroundJobSupervisor,
+  clearBackgroundJobSuppression,
   deriveTaskSessionLabel,
+  getBackgroundJobLifecycleLedger,
   isInternalInitiatorPart,
   parseTaskIdFromTaskOutput,
   parseTaskStateFromOutput,
+  recordBackgroundJobSuppression,
 } from '../../utils';
 import { isRecord as isObjectRecord } from '../../utils/guards';
 import type { SessionLifecycle } from '../session-lifecycle';
@@ -17,7 +20,7 @@ import {
   type InjectedTerminalJobs,
   type InjectionState,
   injectBackgroundJobBoard,
-  MAX_PROCESSED_INJECTED_COMPLETIONS,
+  observeSyntheticTerminalPart,
   reconcileInjectedTerminalJobs,
   stabilizeRunningTaskParts,
   updateFromInjectedCompletion,
@@ -44,34 +47,6 @@ export { BACKGROUND_JOB_BOARD_METADATA_KEY } from './board-injection';
 const IDLE_RECONCILE_DELAY_MS = 2_000;
 
 const RECOVERED_TASK_AGENT_FALLBACK = 'unknown';
-const MAX_REHYDRATE_TOMBSTONES = 512;
-
-interface RehydrateTombstoneState {
-  tombstones: Set<string>;
-  deletionEpochs: Map<string, number>;
-  nextEpoch: number;
-}
-
-// Board instances can outlive a hook instance. Keep deletion guards alongside
-// the board so a recreated hook does not rehydrate an invalidated running part.
-const rehydrateTombstonesByBoard = new WeakMap<
-  BackgroundJobStore,
-  RehydrateTombstoneState
->();
-
-function rehydrateTombstonesFor(
-  backgroundJobBoard: BackgroundJobStore,
-): RehydrateTombstoneState {
-  const existing = rehydrateTombstonesByBoard.get(backgroundJobBoard);
-  if (existing) return existing;
-  const state: RehydrateTombstoneState = {
-    tombstones: new Set<string>(),
-    deletionEpochs: new Map<string, number>(),
-    nextEpoch: 0,
-  };
-  rehydrateTombstonesByBoard.set(backgroundJobBoard, state);
-  return state;
-}
 
 function rehydrateHistoricalRunningTasks(
   messages: unknown[],
@@ -204,21 +179,12 @@ export function createTaskSessionManagerHook(
       readContextMinLines: options.readContextMinLines,
       readContextMaxFiles: options.readContextMaxFiles,
     });
-  const rehydrateState = rehydrateTombstonesFor(backgroundJobBoard);
+  const rehydrateState = getBackgroundJobLifecycleLedger(backgroundJobBoard);
   const rehydrateTombstones = rehydrateState.tombstones;
 
   const rememberDeletedSession = (sessionID: string): void => {
     const remember = (taskID: string): void => {
-      if (rehydrateTombstones.has(taskID)) return;
-      if (rehydrateTombstones.size >= MAX_REHYDRATE_TOMBSTONES) {
-        const oldest = rehydrateTombstones.values().next().value;
-        if (oldest) {
-          rehydrateTombstones.delete(oldest);
-          rehydrateState.deletionEpochs.delete(oldest);
-        }
-      }
-      rehydrateTombstones.add(taskID);
-      rehydrateState.deletionEpochs.set(taskID, ++rehydrateState.nextEpoch);
+      recordBackgroundJobSuppression(backgroundJobBoard, taskID);
     };
 
     // The delete event itself is the lifecycle boundary. Keep a tombstone
@@ -229,11 +195,11 @@ export function createTaskSessionManagerHook(
     }
   };
 
-  const pendingCallTracker = createPendingCallTracker();
+  const pendingCallTracker = createPendingCallTracker({
+    releaseLease: (lease) => backgroundJobBoard.releaseLease(lease),
+  });
   const taskContextTracker = createTaskContextTracker();
 
-  const processedInjectedCompletions = new Set<string>();
-  const processedInjectedCompletionOrder: string[] = [];
   const terminalJobsInjectedByParent = new Map<string, InjectedTerminalJobs>();
   const pendingInjectedTerminalJobsByParent = new Map<
     string,
@@ -337,11 +303,18 @@ export function createTaskSessionManagerHook(
     backgroundJobBoard,
     maxRetainedSnapshots: options.maxRetainedSnapshots,
     strategy: options.strategy ?? 'latest',
-    processedInjectedCompletions,
-    processedInjectedCompletionOrder,
+    lifecycleLedger: rehydrateState,
+    processedInjectedCompletions: rehydrateState.processedInjectedCompletions,
+    processedInjectedCompletionOrder:
+      rehydrateState.processedInjectedCompletionOrder,
+    injectedCompletionFences: rehydrateState.injectedCompletionFences,
+    syntheticTerminalOccurrences: rehydrateState.syntheticTerminalOccurrences,
+    syntheticTerminalOccurrenceOrder:
+      rehydrateState.syntheticTerminalOccurrenceOrder,
+    getLifecycleEpoch: () => rehydrateState.nextEpoch,
+    getDeletionEpoch: (taskID) => rehydrateState.deletionEpochs.get(taskID),
     terminalJobsInjectedByParent,
     pendingInjectedTerminalJobsByParent,
-    maxProcessedInjectedCompletions: MAX_PROCESSED_INJECTED_COMPLETIONS,
     metadataKey: BACKGROUND_JOB_BOARD_METADATA_KEY,
     shouldManageSession: options.shouldManageSession,
     taskContextTracker,
@@ -429,10 +402,12 @@ export function createTaskSessionManagerHook(
         directory: _ctx.directory,
         backgroundJobBoard,
         backgroundJobSupervisor: options.backgroundJobSupervisor,
+        recordLifecycleSuppression: (taskID) =>
+          recordBackgroundJobSuppression(backgroundJobBoard, taskID),
         pendingCallTracker,
         taskContextTracker,
         clearRehydrateTombstone: (taskID) => {
-          rehydrateTombstones.delete(taskID);
+          clearBackgroundJobSuppression(backgroundJobBoard, taskID);
         },
         isStaleDeletedTaskOutput: (taskID, lifecycleEpoch) => {
           const deletionEpoch = rehydrateState.deletionEpochs.get(taskID);
@@ -509,6 +484,7 @@ export function createTaskSessionManagerHook(
           sessionID?: string;
           status?: { type?: string };
           error?: { name?: string };
+          part?: unknown;
         };
       };
     }): Promise<void> => {
@@ -542,6 +518,8 @@ export function createTaskSessionManagerHook(
         pendingInjectedTerminalJobsByParent,
         retainedBoardSnapshots: injectionState.retainedBoardSnapshots,
         backgroundJobSupervisor: options.backgroundJobSupervisor,
+        observeSyntheticTerminalPart: (part) =>
+          observeSyntheticTerminalPart(injectionState, part),
       }).then(() => runtimeStatusReconciler.schedule());
     },
   };

--- a/src/hooks/task-session-manager/index.ts
+++ b/src/hooks/task-session-manager/index.ts
@@ -37,21 +37,48 @@ import {
 export { BACKGROUND_JOB_BOARD_METADATA_KEY } from './board-injection';
 
 /**
- * Delay before reconciling idle sessions.
- * Gives late injected completions time to arrive within this window.
- * Completions arriving after the window are still dropped (the race is reduced, not eliminated).
- * ponytail: fixed timeout — event-driven confirmation would fully close the race but adds
- * significant complexity for a case that rarely exceeds this window in practice.
+ * Delay before recording an idle observation on a child job. The observation
+ * remains provisional; terminal task output is the only path that establishes
+ * completed/error/cancelled state.
  */
 const IDLE_RECONCILE_DELAY_MS = 2_000;
 
 const RECOVERED_TASK_AGENT_FALLBACK = 'unknown';
+const MAX_REHYDRATE_TOMBSTONES = 512;
+
+interface RehydrateTombstoneState {
+  tombstones: Set<string>;
+  deletionEpochs: Map<string, number>;
+  nextEpoch: number;
+}
+
+// Board instances can outlive a hook instance. Keep deletion guards alongside
+// the board so a recreated hook does not rehydrate an invalidated running part.
+const rehydrateTombstonesByBoard = new WeakMap<
+  BackgroundJobStore,
+  RehydrateTombstoneState
+>();
+
+function rehydrateTombstonesFor(
+  backgroundJobBoard: BackgroundJobStore,
+): RehydrateTombstoneState {
+  const existing = rehydrateTombstonesByBoard.get(backgroundJobBoard);
+  if (existing) return existing;
+  const state: RehydrateTombstoneState = {
+    tombstones: new Set<string>(),
+    deletionEpochs: new Map<string, number>(),
+    nextEpoch: 0,
+  };
+  rehydrateTombstonesByBoard.set(backgroundJobBoard, state);
+  return state;
+}
 
 function rehydrateHistoricalRunningTasks(
   messages: unknown[],
   backgroundJobBoard: BackgroundJobStore,
   shouldManageSession: (sessionID: string) => boolean,
   registerSessionAsOrchestrator?: (sessionID: string) => void,
+  rehydrateTombstones?: ReadonlySet<string>,
 ): number {
   let rehydrated = 0;
   const managedOrchestratorSessionIDs = new Set<string>();
@@ -92,6 +119,11 @@ function rehydrateHistoricalRunningTasks(
 
       const taskID = parseTaskIdFromTaskOutput(state.output);
       if (!taskID || parseTaskStateFromOutput(state.output) !== 'running') {
+        continue;
+      }
+      if (rehydrateTombstones?.has(taskID)) {
+        // A real session.deleted already invalidated this run. Do not turn its
+        // persisted running tool part into a fresh alias on the next request.
         continue;
       }
       if (backgroundJobBoard.get(taskID)) continue;
@@ -172,6 +204,30 @@ export function createTaskSessionManagerHook(
       readContextMinLines: options.readContextMinLines,
       readContextMaxFiles: options.readContextMaxFiles,
     });
+  const rehydrateState = rehydrateTombstonesFor(backgroundJobBoard);
+  const rehydrateTombstones = rehydrateState.tombstones;
+
+  const rememberDeletedSession = (sessionID: string): void => {
+    const remember = (taskID: string): void => {
+      if (rehydrateTombstones.has(taskID)) return;
+      if (rehydrateTombstones.size >= MAX_REHYDRATE_TOMBSTONES) {
+        const oldest = rehydrateTombstones.values().next().value;
+        if (oldest) {
+          rehydrateTombstones.delete(oldest);
+          rehydrateState.deletionEpochs.delete(oldest);
+        }
+      }
+      rehydrateTombstones.add(taskID);
+      rehydrateState.deletionEpochs.set(taskID, ++rehydrateState.nextEpoch);
+    };
+
+    // The delete event itself is the lifecycle boundary. Keep a tombstone
+    // even if an earlier cleanup already removed the board record.
+    remember(sessionID);
+    for (const job of backgroundJobBoard.list(sessionID)) {
+      remember(job.taskID);
+    }
+  };
 
   const pendingCallTracker = createPendingCallTracker();
   const taskContextTracker = createTaskContextTracker();
@@ -259,7 +315,10 @@ export function createTaskSessionManagerHook(
         const hardTimedOut =
           backgroundJobBoard.field(sessionId, 'deadlineExceededAt') !==
           undefined;
-        if (!hardTimedOut) backgroundJobBoard.drop(sessionId);
+        if (!hardTimedOut) {
+          rememberDeletedSession(sessionId);
+          backgroundJobBoard.drop(sessionId);
+        }
         options.backgroundJobSupervisor?.clearParent(sessionId);
         backgroundJobBoard.clearParent(sessionId);
         if (!hardTimedOut) options.backgroundJobSupervisor?.drop(sessionId);
@@ -359,6 +418,7 @@ export function createTaskSessionManagerHook(
         backgroundJobSupervisor: options.backgroundJobSupervisor,
         pendingCallTracker,
         taskContextTracker,
+        getLifecycleEpoch: () => rehydrateState.nextEpoch,
       }),
 
     'tool.execute.after': async (
@@ -371,6 +431,13 @@ export function createTaskSessionManagerHook(
         backgroundJobSupervisor: options.backgroundJobSupervisor,
         pendingCallTracker,
         taskContextTracker,
+        clearRehydrateTombstone: (taskID) => {
+          rehydrateTombstones.delete(taskID);
+        },
+        isStaleDeletedTaskOutput: (taskID, lifecycleEpoch) => {
+          const deletionEpoch = rehydrateState.deletionEpochs.get(taskID);
+          return deletionEpoch !== undefined && lifecycleEpoch < deletionEpoch;
+        },
       });
       runtimeStatusReconciler.schedule();
     },
@@ -391,6 +458,7 @@ export function createTaskSessionManagerHook(
         backgroundJobBoard,
         options.shouldManageSession,
         options.registerSessionAsOrchestrator,
+        rehydrateTombstones,
       );
 
       for (const [messageIndex, message] of messages.entries()) {
@@ -449,6 +517,12 @@ export function createTaskSessionManagerHook(
           input.event.properties?.info?.id ?? input.event.properties?.sessionID;
         if (sessionID) {
           deferredInlineErrors.delete(sessionID);
+          if (!options.isFallbackInProgress?.(sessionID)) {
+            const hardTimedOut =
+              backgroundJobBoard.field(sessionID, 'deadlineExceededAt') !==
+              undefined;
+            if (!hardTimedOut) rememberDeletedSession(sessionID);
+          }
         }
       }
 

--- a/src/hooks/task-session-manager/pending-call-tracker.ts
+++ b/src/hooks/task-session-manager/pending-call-tracker.ts
@@ -4,6 +4,8 @@ export interface PendingTaskCall {
   agentType: string;
   label: string;
   background: boolean;
+  /** Deletion epoch observed when this native task call started. */
+  lifecycleEpoch: number;
   resumedTaskId?: string;
 }
 

--- a/src/hooks/task-session-manager/pending-call-tracker.ts
+++ b/src/hooks/task-session-manager/pending-call-tracker.ts
@@ -1,3 +1,5 @@
+import type { BackgroundJobLease } from '../../utils/background-job-board';
+
 export interface PendingTaskCall {
   callId: string;
   parentSessionId: string;
@@ -7,22 +9,35 @@ export interface PendingTaskCall {
   /** Deletion epoch observed when this native task call started. */
   lifecycleEpoch: number;
   resumedTaskId?: string;
+  relaunchLease?: BackgroundJobLease;
+  earlyRegisteredTaskID?: string;
+  earlyRegistrationRejected?: boolean;
 }
 
 const MAX_PENDING_TASK_CALLS = 100;
 
-export function createPendingCallTracker() {
+export function createPendingCallTracker(
+  options: { releaseLease?: (lease: BackgroundJobLease) => boolean } = {},
+) {
   const pendingCalls = new Map<string, PendingTaskCall>();
   let anonymousPendingCallId = 0;
 
+  const releaseCallLease = (call: PendingTaskCall): void => {
+    if (call.relaunchLease) options.releaseLease?.(call.relaunchLease);
+  };
+
   return {
     add(call: PendingTaskCall) {
+      const replaced = pendingCalls.get(call.callId);
+      if (replaced) releaseCallLease(replaced);
       pendingCalls.delete(call.callId);
       pendingCalls.set(call.callId, call);
       while (pendingCalls.size > MAX_PENDING_TASK_CALLS) {
         const firstKey = pendingCalls.keys().next().value;
         if (firstKey === undefined) break;
+        const evicted = pendingCalls.get(firstKey);
         pendingCalls.delete(firstKey);
+        if (evicted) releaseCallLease(evicted);
       }
     },
 
@@ -42,10 +57,20 @@ export function createPendingCallTracker() {
       return pending;
     },
 
+    release(call: PendingTaskCall) {
+      releaseCallLease(call);
+    },
+
     /** Peek oldest pending call for a parent without removing it. */
     peekByParent(parentSessionId: string) {
       for (const call of pendingCalls.values()) {
-        if (call.parentSessionId === parentSessionId) return call;
+        if (
+          call.parentSessionId === parentSessionId &&
+          !call.earlyRegisteredTaskID &&
+          !call.earlyRegistrationRejected
+        ) {
+          return call;
+        }
       }
       return undefined;
     },
@@ -65,6 +90,9 @@ export function createPendingCallTracker() {
       let fallback: PendingTaskCall | undefined;
       for (const call of pendingCalls.values()) {
         if (call.parentSessionId !== parentSessionId) continue;
+        if (call.earlyRegisteredTaskID || call.earlyRegistrationRejected) {
+          continue;
+        }
         if (!fallback) fallback = call;
         if (call.agentType === agentHint) return call;
       }
@@ -75,8 +103,14 @@ export function createPendingCallTracker() {
       for (const [callId, pending] of pendingCalls.entries()) {
         if (pending.parentSessionId === sessionId) {
           pendingCalls.delete(callId);
+          releaseCallLease(pending);
         }
       }
+    },
+
+    clearAll() {
+      for (const pending of pendingCalls.values()) releaseCallLease(pending);
+      pendingCalls.clear();
     },
 
     pendingCallId(sessionID?: string, callID?: string) {

--- a/src/hooks/task-session-manager/runtime-status-reconciliation.test.ts
+++ b/src/hooks/task-session-manager/runtime-status-reconciliation.test.ts
@@ -60,21 +60,66 @@ describe('runtime status reconciliation', () => {
     });
   });
 
-  test('marks an absent runtime session stopped instead of completed', async () => {
+  test('keeps an absent runtime session provisional instead of stopping it', async () => {
     const { board, reconciler, contextFilesForPrompt, prune } =
       createReconciler(async () => ({ data: {} }));
 
     await reconciler.reconcile();
 
     expect(board.get('child-1')).toMatchObject({
-      state: 'stopped',
-      terminalUnreconciled: true,
-      resultSummary:
-        'Background session stopped before a terminal task result was received.',
+      state: 'running',
+      statusUncertain: true,
+      lastStatusError:
+        'Runtime status response did not contain a live session state; task termination is unconfirmed.',
     });
     expect(board.resolveReusable('parent-1', 'fix-1', 'fixer')).toBeUndefined();
-    expect(contextFilesForPrompt).toHaveBeenCalledWith('child-1');
-    expect(prune).toHaveBeenCalledWith(board);
+    expect(contextFilesForPrompt).not.toHaveBeenCalled();
+    expect(prune).not.toHaveBeenCalled();
+  });
+
+  test('does not let idle runtime observation win over a late completion', async () => {
+    const { board, reconciler } = createReconciler(async () => ({
+      data: { 'child-1': { type: 'idle' } },
+    }));
+    const listener = mock(() => {});
+    board.addTerminalStateListener(listener);
+
+    await reconciler.reconcile();
+    expect(board.get('child-1')).toMatchObject({
+      state: 'running',
+      statusUncertain: true,
+    });
+
+    board.updateStatus({
+      taskID: 'child-1',
+      state: 'completed',
+      resultSummary: 'late result',
+    });
+
+    expect(board.get('child-1')).toMatchObject({
+      state: 'completed',
+      resultSummary: 'late result',
+    });
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  test('clears provisional uncertainty when a missing session becomes busy', async () => {
+    let liveStatus: unknown = { data: {} };
+    const { board, reconciler } = createReconciler(async () => liveStatus);
+
+    await reconciler.reconcile();
+    expect(board.get('child-1')).toMatchObject({
+      state: 'running',
+      statusUncertain: true,
+    });
+
+    liveStatus = { data: { 'child-1': { type: 'busy' } } };
+    await reconciler.reconcile();
+
+    expect(board.get('child-1')).toMatchObject({
+      state: 'running',
+      statusUncertain: false,
+    });
   });
 
   test('keeps the board running but explicitly uncertain when lookup fails', async () => {
@@ -182,8 +227,8 @@ describe('runtime status reconciliation', () => {
 
     expect(status).toHaveBeenCalledTimes(2);
     expect(board.get('child-2')).toMatchObject({
-      state: 'stopped',
-      terminalUnreconciled: true,
+      state: 'running',
+      statusUncertain: true,
     });
     reconciler.dispose();
   });

--- a/src/hooks/task-session-manager/runtime-status-reconciliation.ts
+++ b/src/hooks/task-session-manager/runtime-status-reconciliation.ts
@@ -51,7 +51,6 @@ export function createRuntimeStatusReconciler(options: {
       .filter((job) => job.state === 'running');
     if (running.length === 0) return;
 
-    const requestStartedAt = Date.now();
     const snapshot = await getRuntimeSessionStatusSnapshot(options.input, {
       timeoutMs: options.statusTimeoutMs,
     });
@@ -85,7 +84,9 @@ export function createRuntimeStatusReconciler(options: {
       if (status === undefined) {
         options.backgroundJobBoard.markStatusUncertain(
           job.taskID,
-          'Runtime status response did not contain a recognized session state.',
+          snapshot.malformedSessionIDs.has(job.taskID)
+            ? 'Runtime status response did not contain a recognized session state.'
+            : 'Runtime status response did not contain a live session state; task termination is unconfirmed.',
           job.generation,
         );
         continue;
@@ -99,24 +100,21 @@ export function createRuntimeStatusReconciler(options: {
         continue;
       }
 
-      const stopped = options.backgroundJobBoard.markStopped(
+      // Idle only says that the runner is currently quiescent. It is not
+      // terminal evidence for a background task: a task result can arrive
+      // after this observation.
+      options.backgroundJobBoard.markStatusUncertain(
         job.taskID,
-        'Background session stopped before a terminal task result was received.',
-        requestStartedAt,
+        'Runtime session is idle; task termination is unconfirmed.',
         job.generation,
       );
-      if (stopped?.state !== 'stopped') continue;
-      options.taskContextTracker.pendingManagedTaskIds.delete(job.taskID);
-      options.backgroundJobBoard.addContext(
-        job.taskID,
-        options.taskContextTracker.contextFilesForPrompt(job.taskID),
+      log(
+        '[task-session-manager] runtime session quiescent; terminal result pending',
+        {
+          taskID: job.taskID,
+          generation: job.generation,
+        },
       );
-      options.taskContextTracker.prune(options.backgroundJobBoard);
-      log('[task-session-manager] reconciled runtime-stopped job', {
-        taskID: stopped.taskID,
-        alias: stopped.alias,
-        parentSessionID: stopped.parentSessionID,
-      });
     }
   }
 

--- a/src/hooks/task-session-manager/tool-execute-hooks.ts
+++ b/src/hooks/task-session-manager/tool-execute-hooks.ts
@@ -129,14 +129,31 @@ export async function handleToolExecuteBefore(
         delete args.task_id;
       }
     } else {
+      const relaunchLease = deps.backgroundJobBoard.acquireRelaunchLease(
+        remembered.taskID,
+        remembered.generation,
+      );
+      if (!relaunchLease) {
+        throw new Error(
+          `Task ${requested} cannot be resumed safely: its current generation is already owned by another lifecycle operation. Do not launch a duplicate with the same task_id.`,
+        );
+      }
       args.task_id = remembered.taskID;
       deps.taskContextTracker.pendingManagedTaskIds.add(remembered.taskID);
       deps.backgroundJobBoard.markUsed(input.sessionID, remembered.taskID);
       pendingCall.resumedTaskId = remembered.taskID;
+      pendingCall.relaunchLease = relaunchLease;
     }
   }
 
-  deps.pendingCallTracker.add(pendingCall);
+  try {
+    deps.pendingCallTracker.add(pendingCall);
+  } catch (error) {
+    if (pendingCall.relaunchLease) {
+      deps.backgroundJobBoard.releaseLease(pendingCall.relaunchLease);
+    }
+    throw error;
+  }
   log(
     '[task-session-manager] tool.execute.before task — pending call created',
     {
@@ -158,6 +175,7 @@ export async function handleToolExecuteAfter(
     backgroundJobBoard: BackgroundJobStore;
     pendingCallTracker: {
       take(callID?: string, sessionID?: string): PendingTaskCall | undefined;
+      release?(call: PendingTaskCall): void;
     };
     taskContextTracker: {
       pendingManagedTaskIds: Set<string>;
@@ -166,6 +184,8 @@ export async function handleToolExecuteAfter(
       prune(board: { taskIDs(): Set<string> }): void;
     };
     backgroundJobSupervisor?: BackgroundJobSupervisor;
+    /** Record direct task cleanup even when the store is a thin facade. */
+    recordLifecycleSuppression?: (taskID: string) => void;
     /** Clear a deletion guard when a new native task output proves a run exists. */
     clearRehydrateTombstone?: (taskID: string) => void;
     isStaleDeletedTaskOutput?: (
@@ -212,121 +232,181 @@ export async function handleToolExecuteAfter(
         : undefined,
   });
 
-  if (!pending || typeof output.output !== 'string') return;
-  const launch = parseTaskLaunchOutput(output.output);
-  if (launch && !launch.result?.match(/Timed out after \d+ms/i)) {
-    if (
-      deps.isStaleDeletedTaskOutput?.(launch.taskID, pending.lifecycleEpoch)
-    ) {
-      log('[task-session-manager] ignored stale task launch after deletion', {
-        taskID: launch.taskID,
-        callID: pending.callId,
-        lifecycleEpoch: pending.lifecycleEpoch,
-      });
+  if (!pending) return;
+
+  try {
+    if (typeof output.output !== 'string') return;
+    if (pending.earlyRegistrationRejected) {
+      log(
+        '[task-session-manager] ignored task output after fenced early registration',
+        { callID: pending.callId },
+      );
       return;
     }
-    deps.clearRehydrateTombstone?.(launch.taskID);
-    const record = deps.backgroundJobBoard.registerLaunch({
-      taskID: launch.taskID,
+
+    const launch = parseTaskLaunchOutput(output.output);
+    if (launch && !launch.result?.match(/Timed out after \d+ms/i)) {
+      const record = registerTaskOutputLaunch(
+        launch.taskID,
+        pending,
+        exactCallConfirmed,
+        deps,
+      );
+      if (!record) return;
+      deps.clearRehydrateTombstone?.(launch.taskID);
+      if (exactCallConfirmed) deps.backgroundJobSupervisor?.onLaunch(record);
+      log('[task-session-manager] background task launch registered', {
+        taskID: record.taskID,
+        alias: record.alias,
+        parentSessionID: record.parentSessionID,
+        agent: record.agent,
+        description: record.description,
+        state: record.state,
+      });
+      deps.taskContextTracker.pendingManagedTaskIds.add(launch.taskID);
+      deps.backgroundJobBoard.addContext(
+        launch.taskID,
+        deps.taskContextTracker.contextFilesForPrompt(launch.taskID),
+      );
+      return;
+    }
+
+    const status = parseTaskStatusOutput(output.output);
+    if (status) {
+      const record = registerTaskOutputLaunch(
+        status.taskID,
+        pending,
+        exactCallConfirmed,
+        deps,
+      );
+      if (!record) return;
+      deps.clearRehydrateTombstone?.(status.taskID);
+      normalizeLateCancelledTaskOutput(output, deps.backgroundJobBoard);
+      if (exactCallConfirmed) deps.backgroundJobSupervisor?.onLaunch(record);
+      const updated = deps.backgroundJobBoard.updateStatus({
+        taskID: status.taskID,
+        state: status.state,
+        timedOut: status.timedOut,
+        resultSummary: status.result,
+      });
+      log('[task-session-manager] foreground task status registered', {
+        taskID: status.taskID,
+        alias: updated?.alias ?? record.alias,
+        parentSessionID: pending.parentSessionId,
+        agent: pending.agentType,
+        state: updated?.state ?? record.state,
+      });
+      deps.taskContextTracker.pendingManagedTaskIds.delete(status.taskID);
+      deps.backgroundJobBoard.addContext(
+        status.taskID,
+        deps.taskContextTracker.contextFilesForPrompt(status.taskID),
+      );
+      deps.taskContextTracker.prune(deps.backgroundJobBoard);
+      return;
+    }
+
+    const taskId = parseTaskIdFromTaskOutput(output.output);
+    if (!taskId) {
+      if (
+        pending.resumedTaskId &&
+        isMissingRememberedSessionError(output.output)
+      ) {
+        deps.recordLifecycleSuppression?.(pending.resumedTaskId);
+        deps.backgroundJobBoard.drop(pending.resumedTaskId);
+        deps.backgroundJobSupervisor?.drop(pending.resumedTaskId);
+      }
+      return;
+    }
+
+    if (pending.resumedTaskId && pending.resumedTaskId !== taskId) {
+      log(
+        '[task-session-manager] ignored task output with mismatched resumed task ID',
+        {
+          expectedTaskID: pending.resumedTaskId,
+          observedTaskID: taskId,
+          callID: pending.callId,
+        },
+      );
+      return;
+    }
+
+    deps.taskContextTracker.pendingManagedTaskIds.delete(taskId);
+    deps.backgroundJobBoard.addContext(
+      taskId,
+      deps.taskContextTracker.contextFilesForPrompt(taskId),
+    );
+    deps.taskContextTracker.prune(deps.backgroundJobBoard);
+  } finally {
+    deps.pendingCallTracker.release?.(pending);
+    if (pending.relaunchLease) {
+      deps.backgroundJobBoard.releaseLease(pending.relaunchLease);
+    }
+  }
+}
+
+function registerTaskOutputLaunch(
+  taskID: string,
+  pending: PendingTaskCall,
+  exactCallConfirmed: boolean,
+  deps: {
+    backgroundJobBoard: BackgroundJobStore;
+    backgroundJobSupervisor?: BackgroundJobSupervisor;
+    isStaleDeletedTaskOutput?: (
+      taskID: string,
+      lifecycleEpoch: number,
+    ) => boolean;
+  },
+): ReturnType<BackgroundJobStore['get']> {
+  if (deps.isStaleDeletedTaskOutput?.(taskID, pending.lifecycleEpoch)) {
+    log('[task-session-manager] ignored stale task output after deletion', {
+      taskID,
+      callID: pending.callId,
+      lifecycleEpoch: pending.lifecycleEpoch,
+    });
+    return undefined;
+  }
+
+  const resumed = pending.resumedTaskId !== undefined;
+  if (resumed && pending.resumedTaskId !== taskID) return undefined;
+
+  const existing = deps.backgroundJobBoard.get(taskID);
+  if (resumed && pending.relaunchLease === undefined) {
+    log(
+      '[task-session-manager] refused resumed task output without relaunch lease',
+      { taskID, callID: pending.callId },
+    );
+    return undefined;
+  }
+  if (!resumed && existing && pending.earlyRegistrationRejected) {
+    log(
+      '[task-session-manager] refused task output that collided with an existing task ID',
+      { taskID, callID: pending.callId },
+    );
+    return undefined;
+  }
+  if (pending.earlyRegisteredTaskID && !existing) return undefined;
+
+  try {
+    return deps.backgroundJobBoard.registerLaunch({
+      taskID,
       parentSessionID: pending.parentSessionId,
       agent: pending.agentType,
       description: pending.label,
       objective: pending.label,
       background: exactCallConfirmed && pending.background,
-      preserveRun: pending.resumedTaskId === undefined,
+      preserveRun:
+        pending.earlyRegisteredTaskID === taskID ||
+        pending.resumedTaskId === undefined,
+      ...(pending.relaunchLease
+        ? { relaunchLease: pending.relaunchLease }
+        : {}),
     });
-    if (exactCallConfirmed) deps.backgroundJobSupervisor?.onLaunch(record);
-    log('[task-session-manager] background task launch registered', {
-      taskID: record.taskID,
-      alias: record.alias,
-      parentSessionID: record.parentSessionID,
-      agent: record.agent,
-      description: record.description,
-      state: record.state,
+  } catch (error) {
+    log('[task-session-manager] refused task output launch registration', {
+      taskID,
+      callID: pending.callId,
+      error: error instanceof Error ? error.message : String(error),
     });
-    deps.taskContextTracker.pendingManagedTaskIds.add(launch.taskID);
-    deps.backgroundJobBoard.addContext(
-      launch.taskID,
-      deps.taskContextTracker.contextFilesForPrompt(launch.taskID),
-    );
-    return;
+    return undefined;
   }
-
-  normalizeLateCancelledTaskOutput(output, deps.backgroundJobBoard);
-  const status = parseTaskStatusOutput(output.output);
-  if (status) {
-    if (
-      deps.isStaleDeletedTaskOutput?.(status.taskID, pending.lifecycleEpoch)
-    ) {
-      log('[task-session-manager] ignored stale task status after deletion', {
-        taskID: status.taskID,
-        callID: pending.callId,
-        lifecycleEpoch: pending.lifecycleEpoch,
-        state: status.state,
-      });
-      return;
-    }
-    deps.clearRehydrateTombstone?.(status.taskID);
-    const existing = deps.backgroundJobBoard.get(status.taskID);
-    const record =
-      existing ??
-      deps.backgroundJobBoard.registerLaunch({
-        taskID: status.taskID,
-        parentSessionID: pending.parentSessionId,
-        agent: pending.agentType,
-        description: pending.label,
-        objective: pending.label,
-        background: exactCallConfirmed && pending.background,
-        preserveRun: pending.resumedTaskId === undefined,
-      });
-    if (exactCallConfirmed) deps.backgroundJobSupervisor?.onLaunch(record);
-    const updated = deps.backgroundJobBoard.updateStatus({
-      taskID: status.taskID,
-      state: status.state,
-      timedOut: status.timedOut,
-      resultSummary: status.result,
-    });
-    log('[task-session-manager] foreground task status registered', {
-      taskID: status.taskID,
-      alias: updated?.alias ?? record.alias,
-      parentSessionID: pending.parentSessionId,
-      agent: pending.agentType,
-      state: updated?.state ?? record.state,
-    });
-    if (pending.resumedTaskId && pending.resumedTaskId !== status.taskID) {
-      deps.backgroundJobBoard.drop(pending.resumedTaskId);
-      deps.backgroundJobSupervisor?.drop(pending.resumedTaskId);
-    }
-    deps.taskContextTracker.pendingManagedTaskIds.delete(status.taskID);
-    deps.backgroundJobBoard.addContext(
-      status.taskID,
-      deps.taskContextTracker.contextFilesForPrompt(status.taskID),
-    );
-    deps.taskContextTracker.prune(deps.backgroundJobBoard);
-    return;
-  }
-
-  const taskId = parseTaskIdFromTaskOutput(output.output);
-  if (!taskId) {
-    if (
-      pending.resumedTaskId &&
-      isMissingRememberedSessionError(output.output)
-    ) {
-      deps.backgroundJobBoard.drop(pending.resumedTaskId);
-      deps.backgroundJobSupervisor?.drop(pending.resumedTaskId);
-    }
-    return;
-  }
-
-  if (pending.resumedTaskId && pending.resumedTaskId !== taskId) {
-    deps.backgroundJobBoard.drop(pending.resumedTaskId);
-    deps.backgroundJobSupervisor?.drop(pending.resumedTaskId);
-  }
-
-  deps.taskContextTracker.pendingManagedTaskIds.delete(taskId);
-  deps.backgroundJobBoard.addContext(
-    taskId,
-    deps.taskContextTracker.contextFilesForPrompt(taskId),
-  );
-  deps.taskContextTracker.prune(deps.backgroundJobBoard);
 }

--- a/src/hooks/task-session-manager/tool-execute-hooks.ts
+++ b/src/hooks/task-session-manager/tool-execute-hooks.ts
@@ -45,6 +45,7 @@ export async function handleToolExecuteBefore(
     };
     taskContextTracker: { pendingManagedTaskIds: Set<string> };
     backgroundJobSupervisor?: BackgroundJobSupervisor;
+    getLifecycleEpoch?: () => number;
   },
 ): Promise<void> {
   const toolName = input.tool.toLowerCase();
@@ -93,6 +94,7 @@ export async function handleToolExecuteBefore(
     agentType,
     label,
     background,
+    lifecycleEpoch: deps.getLifecycleEpoch?.() ?? 0,
   };
   if (typeof args.task_id === 'string' && args.task_id.trim() !== '') {
     const requested = args.task_id.trim();
@@ -164,6 +166,12 @@ export async function handleToolExecuteAfter(
       prune(board: { taskIDs(): Set<string> }): void;
     };
     backgroundJobSupervisor?: BackgroundJobSupervisor;
+    /** Clear a deletion guard when a new native task output proves a run exists. */
+    clearRehydrateTombstone?: (taskID: string) => void;
+    isStaleDeletedTaskOutput?: (
+      taskID: string,
+      lifecycleEpoch: number,
+    ) => boolean;
   },
 ): Promise<void> {
   if (input.tool.toLowerCase() === 'read') {
@@ -207,6 +215,17 @@ export async function handleToolExecuteAfter(
   if (!pending || typeof output.output !== 'string') return;
   const launch = parseTaskLaunchOutput(output.output);
   if (launch && !launch.result?.match(/Timed out after \d+ms/i)) {
+    if (
+      deps.isStaleDeletedTaskOutput?.(launch.taskID, pending.lifecycleEpoch)
+    ) {
+      log('[task-session-manager] ignored stale task launch after deletion', {
+        taskID: launch.taskID,
+        callID: pending.callId,
+        lifecycleEpoch: pending.lifecycleEpoch,
+      });
+      return;
+    }
+    deps.clearRehydrateTombstone?.(launch.taskID);
     const record = deps.backgroundJobBoard.registerLaunch({
       taskID: launch.taskID,
       parentSessionID: pending.parentSessionId,
@@ -236,6 +255,18 @@ export async function handleToolExecuteAfter(
   normalizeLateCancelledTaskOutput(output, deps.backgroundJobBoard);
   const status = parseTaskStatusOutput(output.output);
   if (status) {
+    if (
+      deps.isStaleDeletedTaskOutput?.(status.taskID, pending.lifecycleEpoch)
+    ) {
+      log('[task-session-manager] ignored stale task status after deletion', {
+        taskID: status.taskID,
+        callID: pending.callId,
+        lifecycleEpoch: pending.lifecycleEpoch,
+        state: status.state,
+      });
+      return;
+    }
+    deps.clearRehydrateTombstone?.(status.taskID);
     const existing = deps.backgroundJobBoard.get(status.taskID);
     const record =
       existing ??

--- a/src/hooks/task-session-manager/tool-execute-hooks.ts
+++ b/src/hooks/task-session-manager/tool-execute-hooks.ts
@@ -32,6 +32,33 @@ interface TaskArgs {
   background?: unknown;
 }
 
+const earlyRegistrationGenerations = new WeakMap<PendingTaskCall, number>();
+
+/**
+ * session.created writes earlyRegisteredTaskID through the pending-call
+ * object. Capture the generation at that boundary so a delayed native result
+ * cannot reuse the current record after a same-ID relaunch.
+ */
+function installEarlyRegistrationGenerationFence(
+  pending: PendingTaskCall,
+  backgroundJobBoard: BackgroundJobStore,
+): void {
+  let earlyRegisteredTaskID = pending.earlyRegisteredTaskID;
+  Object.defineProperty(pending, 'earlyRegisteredTaskID', {
+    configurable: true,
+    enumerable: true,
+    get: () => earlyRegisteredTaskID,
+    set: (taskID: string | undefined) => {
+      earlyRegisteredTaskID = taskID;
+      if (!taskID) return;
+      const generation = backgroundJobBoard.get(taskID)?.generation;
+      if (generation !== undefined) {
+        earlyRegistrationGenerations.set(pending, generation);
+      }
+    },
+  });
+}
+
 export async function handleToolExecuteBefore(
   input: { tool: string; sessionID?: string; callID?: string },
   output: { args?: unknown },
@@ -96,6 +123,7 @@ export async function handleToolExecuteBefore(
     background,
     lifecycleEpoch: deps.getLifecycleEpoch?.() ?? 0,
   };
+  installEarlyRegistrationGenerationFence(pendingCall, deps.backgroundJobBoard);
   if (typeof args.task_id === 'string' && args.task_id.trim() !== '') {
     const requested = args.task_id.trim();
     const remembered =
@@ -286,6 +314,7 @@ export async function handleToolExecuteAfter(
       const updated = deps.backgroundJobBoard.updateStatus({
         taskID: status.taskID,
         state: status.state,
+        expectedGeneration: record.generation,
         timedOut: status.timedOut,
         resultSummary: status.result,
       });
@@ -370,6 +399,20 @@ function registerTaskOutputLaunch(
   if (resumed && pending.resumedTaskId !== taskID) return undefined;
 
   const existing = deps.backgroundJobBoard.get(taskID);
+  const earlyRegistrationGeneration = earlyRegistrationGenerations.get(pending);
+  if (
+    pending.earlyRegisteredTaskID === taskID &&
+    earlyRegistrationGeneration !== undefined &&
+    existing?.generation !== earlyRegistrationGeneration
+  ) {
+    log('[task-session-manager] ignored stale native task output', {
+      taskID,
+      callID: pending.callId,
+      registeredGeneration: earlyRegistrationGeneration,
+      currentGeneration: existing?.generation,
+    });
+    return undefined;
+  }
   if (resumed && pending.relaunchLease === undefined) {
     log(
       '[task-session-manager] refused resumed task output without relaunch lease',

--- a/src/multiplexer/cmux/session-lifecycle.test.ts
+++ b/src/multiplexer/cmux/session-lifecycle.test.ts
@@ -193,6 +193,7 @@ describe('CmuxSessionLifecycle races', () => {
       parent: 'p',
       title: 'agent',
       directory: '/repo',
+      serverUrl: 'http://server/',
       paneId: 'orphan-pane',
       spawnState: 'attached',
       lifecycle: 'orphaned',
@@ -202,7 +203,7 @@ describe('CmuxSessionLifecycle races', () => {
     });
     const mux = multiplexer();
     mux.closePane.mockResolvedValue(false);
-    new CmuxSessionLifecycle(
+    const lifecycle = new CmuxSessionLifecycle(
       'new',
       mux,
       () => 'http://server',
@@ -212,6 +213,7 @@ describe('CmuxSessionLifecycle races', () => {
         closeRetryMaxAttempts: 1,
       },
     );
+    await lifecycle.onSessionStatus({ type: 'session.status' });
     await Promise.resolve();
     await Promise.resolve();
     expect(mux.closePane).toHaveBeenCalledTimes(1);
@@ -220,6 +222,61 @@ describe('CmuxSessionLifecycle races', () => {
       lifecycle: 'orphaned',
       paneId: 'orphan-pane',
     });
+  });
+
+  test('defers initial orphan recovery until the first poll', async () => {
+    let serverUrl = 'http://server';
+    let getterCalls = 0;
+    for (const [session, scope] of [
+      ['lazy-orphan', 'http://server/'],
+      ['later-orphan', 'http://other/'],
+    ] as const) {
+      store.claimCreated({
+        session,
+        owner: 'old',
+        parent: 'p',
+        title: 'agent',
+        directory: '/repo',
+        serverUrl: scope,
+        paneId: `${session}-pane`,
+        spawnState: 'attached',
+        lifecycle: 'orphaned',
+        lastActivityAt: 0,
+        activityVersion: 0,
+        idleConsecutive: 0,
+      });
+    }
+
+    const close = deferred<boolean>();
+    const mux = multiplexer();
+    mux.closePane.mockImplementation(() => close.promise);
+    const lifecycle = new CmuxSessionLifecycle(
+      'new',
+      mux,
+      () => {
+        getterCalls += 1;
+        return serverUrl;
+      },
+      '/repo',
+      undefined,
+      { fetchStatuses: async () => ({}) },
+    );
+
+    expect(getterCalls).toBe(0);
+    await lifecycle.pollOnce();
+    expect(getterCalls).toBeGreaterThan(0);
+    expect(store.get('lazy-orphan')).toMatchObject({ owner: 'new' });
+    expect(mux.closePane).toHaveBeenCalledWith('lazy-orphan-pane');
+
+    const callsAfterFirstPoll = getterCalls;
+    serverUrl = 'http://other';
+    await lifecycle.pollOnce();
+    expect(getterCalls).toBe(callsAfterFirstPoll + 1);
+    expect(store.get('later-orphan')).toMatchObject({ owner: 'old' });
+
+    close.resolve(true);
+    for (let index = 0; index < 8; index++) await Promise.resolve();
+    await lifecycle.cleanup();
   });
 
   test('terminal tracked orphan gets a fresh close budget when claimed', async () => {
@@ -234,6 +291,7 @@ describe('CmuxSessionLifecycle races', () => {
       parent: 'p',
       title: 'agent',
       directory: '/repo',
+      serverUrl: 'http://server/',
       paneId: 'pane',
       spawnState: 'attached',
       lifecycle: 'orphaned',
@@ -244,7 +302,7 @@ describe('CmuxSessionLifecycle races', () => {
     });
     const mux = multiplexer();
     mux.closePane.mockResolvedValue(false);
-    new CmuxSessionLifecycle(
+    const lifecycle = new CmuxSessionLifecycle(
       'new',
       mux,
       () => 'http://server',
@@ -254,6 +312,7 @@ describe('CmuxSessionLifecycle races', () => {
         closeRetryMaxAttempts: 1,
       },
     );
+    await lifecycle.onSessionStatus({ type: 'session.status' });
     await Promise.resolve();
     expect(mux.closePane).toHaveBeenCalledTimes(1);
     expect(store.get('spent')?.owner).toBe('new');
@@ -307,6 +366,7 @@ describe('CmuxSessionLifecycle races', () => {
         parent: 'p',
         title: 'agent',
         directory: '/repo',
+        serverUrl: 'http://server/',
         paneId: 'pane',
         spawnState: 'attached',
         lifecycle: 'orphaned',
@@ -317,11 +377,17 @@ describe('CmuxSessionLifecycle races', () => {
       const oldMux = multiplexer();
       const close = deferred<boolean>();
       oldMux.closePane.mockImplementationOnce(() => close.promise);
-      new CmuxSessionLifecycle('old', oldMux, () => 'http://server', '/repo');
+      const old = new CmuxSessionLifecycle(
+        'old',
+        oldMux,
+        () => 'http://server',
+        '/repo',
+      );
+      await old.onSessionStatus({ type: 'session.status' });
       await Promise.resolve();
       const newMux = multiplexer();
       newMux.closePane.mockResolvedValue(false);
-      new CmuxSessionLifecycle(
+      const next = new CmuxSessionLifecycle(
         'new',
         newMux,
         () => 'http://server',
@@ -331,6 +397,7 @@ describe('CmuxSessionLifecycle races', () => {
           closeRetryMaxAttempts: 1,
         },
       );
+      await next.onSessionStatus({ type: 'session.status' });
       await Promise.resolve();
       const currentIntent = store.get('race')?.closeIntent;
       close.resolve(result);
@@ -349,6 +416,7 @@ describe('CmuxSessionLifecycle races', () => {
         parent: 'p',
         title: 'agent',
         directory: '/repo',
+        serverUrl: 'http://server/',
         paneId: 'pane',
         spawnState: 'attached',
         lifecycle: 'active',
@@ -372,7 +440,7 @@ describe('CmuxSessionLifecycle races', () => {
       store.markOrphaned('cleanup-race');
       const newMux = multiplexer();
       newMux.closePane.mockResolvedValue(false);
-      new CmuxSessionLifecycle(
+      const next = new CmuxSessionLifecycle(
         'new',
         newMux,
         () => 'http://server',
@@ -380,6 +448,7 @@ describe('CmuxSessionLifecycle races', () => {
         undefined,
         { closeRetryMaxAttempts: 1 },
       );
+      await next.onSessionStatus({ type: 'session.status' });
       await Promise.resolve();
       const currentIntent = store.get('cleanup-race')?.closeIntent;
       expect(newMux.closePane).not.toHaveBeenCalled();
@@ -411,7 +480,10 @@ describe('CmuxSessionLifecycle races', () => {
       () => 'http://server',
       '/repo',
       undefined,
-      { delay: async () => {}, isServerRunning: async () => true },
+      {
+        delay: async () => {},
+        isServerRunning: async () => true,
+      },
     );
     const creating = old.onSessionCreated({
       type: 'session.created',
@@ -424,7 +496,7 @@ describe('CmuxSessionLifecycle races', () => {
     if (existing) existing.paneId = 'new-pane';
     const newMux = multiplexer();
     newMux.closePane.mockResolvedValue(false);
-    new CmuxSessionLifecycle(
+    const next = new CmuxSessionLifecycle(
       'new',
       newMux,
       () => 'http://server',
@@ -432,6 +504,7 @@ describe('CmuxSessionLifecycle races', () => {
       undefined,
       { closeRetryMaxAttempts: 1 },
     );
+    await next.onSessionStatus({ type: 'session.status' });
     await Promise.resolve();
     const currentIntent = store.get('late-race')?.closeIntent;
     spawn.resolve({ success: true, paneId: 'old-late-pane' });
@@ -626,6 +699,7 @@ describe('CmuxSessionLifecycle races', () => {
       undefined,
       { isServerRunning: async () => true },
     );
+    await lifecycle.onSessionStatus({ type: 'session.status' });
     for (let index = 0; index < 8; index++) await Promise.resolve();
 
     expect(store.get('wrong-directory')?.owner).toBe('old');
@@ -674,6 +748,7 @@ describe('CmuxSessionLifecycle races', () => {
         now: () => now,
       },
     );
+    await lifecycle.onSessionStatus({ type: 'session.status' });
 
     expect(store.get('existing-late')).toMatchObject({
       owner: 'new',
@@ -707,6 +782,7 @@ describe('CmuxSessionLifecycle races', () => {
         parent: 'p',
         title: 'agent',
         directory: '/repo',
+        serverUrl: 'http://server/',
         paneId: `pane-${result}`,
         spawnState: 'attached',
         lifecycle: 'orphaned',
@@ -722,6 +798,7 @@ describe('CmuxSessionLifecycle races', () => {
         undefined,
         { closeRetryMaxAttempts: 1, isServerRunning: async () => true },
       );
+      await old.onSessionStatus({ type: 'session.status' });
       for (let index = 0; index < 8; index++) await Promise.resolve();
       const pending = store.get(session)?.closePromise;
       if (!pending) throw new Error('expected pending close');
@@ -743,6 +820,7 @@ describe('CmuxSessionLifecycle races', () => {
         undefined,
         { closeRetryMaxAttempts: 1, isServerRunning: async () => true },
       );
+      await next.onSessionStatus({ type: 'session.status' });
       expect(newMux.closePane).not.toHaveBeenCalled();
 
       close.resolve(result);
@@ -765,4 +843,150 @@ describe('CmuxSessionLifecycle races', () => {
       await old.cleanup();
     });
   }
+
+  test('older observer cannot claim a newer owner late pane', async () => {
+    const oldMux = multiplexer();
+    oldMux.closePane.mockResolvedValue(false);
+    const old = new CmuxSessionLifecycle(
+      'old',
+      oldMux,
+      () => 'http://server',
+      '/repo',
+      undefined,
+      {
+        closeRetryMaxAttempts: 1,
+        delay: async () => {},
+        isServerRunning: async () => true,
+      },
+    );
+
+    const spawn = deferred<{ success: true; paneId: string }>();
+    const newMux = multiplexer();
+    newMux.spawnPane.mockImplementationOnce(() => spawn.promise);
+    newMux.closePane.mockResolvedValue(false);
+    const next = new CmuxSessionLifecycle(
+      'new',
+      newMux,
+      () => 'http://server',
+      '/repo',
+      undefined,
+      {
+        isServerRunning: async () => true,
+        shutdownTimeoutMs: 1,
+      },
+    );
+    const creating = next.onSessionCreated({
+      type: 'session.created',
+      properties: { info: { id: 'new-late-owner', parentID: 'p' } },
+    });
+
+    await Promise.resolve();
+    await next.cleanup();
+    spawn.resolve({ success: true, paneId: 'new-owner-pane' });
+    await creating;
+    for (let index = 0; index < 16; index++) await Promise.resolve();
+
+    expect(newMux.closePane).toHaveBeenCalledWith('new-owner-pane');
+    expect(oldMux.closePane).not.toHaveBeenCalled();
+    expect(store.get('new-late-owner\0late\0new-owner-pane')).toMatchObject({
+      owner: 'new',
+      lifecycle: 'orphaned',
+    });
+
+    await old.cleanup();
+  });
+
+  test('ordinary orphan takeover requires the matching server scope', async () => {
+    store.claimCreated({
+      session: 'wrong-scope-orphan',
+      owner: 'old',
+      parent: 'p',
+      title: 'agent',
+      directory: '/repo',
+      serverUrl: 'http://other/',
+      paneId: 'wrong-scope-pane',
+      spawnState: 'attached',
+      lifecycle: 'orphaned',
+      lastActivityAt: 0,
+      activityVersion: 0,
+      idleConsecutive: 0,
+    });
+    const mux = multiplexer();
+    const lifecycle = new CmuxSessionLifecycle(
+      'new',
+      mux,
+      () => 'http://server',
+      '/repo',
+      undefined,
+      { isServerRunning: async () => true },
+    );
+    await lifecycle.onSessionStatus({ type: 'session.status' });
+    for (let index = 0; index < 8; index++) await Promise.resolve();
+
+    expect(store.get('wrong-scope-orphan')).toMatchObject({
+      owner: 'old',
+      paneId: 'wrong-scope-pane',
+    });
+    expect(mux.closePane).not.toHaveBeenCalled();
+    await lifecycle.cleanup();
+  });
+
+  test('busy reactivates a claimed exhausted orphan before close settles', async () => {
+    const policy = new CmuxClosePolicy(1, 1);
+    let exhausted = policy.request('cleanup', 0, 0);
+    exhausted = policy.failed(exhausted, 1);
+    exhausted = policy.failed(policy.resume(exhausted, 30_001), 30_002);
+    exhausted = policy.failed(policy.resume(exhausted, 90_002), 90_003);
+
+    store.claimCreated({
+      session: 'busy-orphan',
+      owner: 'old',
+      parent: 'p',
+      title: 'agent',
+      directory: '/repo',
+      serverUrl: 'http://server/',
+      paneId: 'busy-orphan-pane',
+      spawnState: 'attached',
+      lifecycle: 'orphaned',
+      lastActivityAt: 0,
+      activityVersion: 0,
+      idleConsecutive: 0,
+      closeIntent: exhausted,
+    });
+
+    const close = deferred<boolean>();
+    const mux = multiplexer();
+    mux.closePane.mockImplementationOnce(() => close.promise);
+    const lifecycle = new CmuxSessionLifecycle(
+      'new',
+      mux,
+      () => 'http://server',
+      '/repo',
+      undefined,
+      { isServerRunning: async () => true },
+    );
+    await lifecycle.onSessionStatus({ type: 'session.status' });
+    for (let index = 0; index < 8; index++) await Promise.resolve();
+    expect(mux.closePane).toHaveBeenCalledTimes(1);
+
+    await lifecycle.onSessionStatus({
+      type: 'session.status',
+      properties: { sessionID: 'busy-orphan', status: { type: 'busy' } },
+    });
+    expect(store.get('busy-orphan')).toMatchObject({
+      owner: 'new',
+      lifecycle: 'active',
+      paneId: 'busy-orphan-pane',
+    });
+    expect(store.get('busy-orphan')?.closeIntent).toBeUndefined();
+
+    close.resolve(false);
+    for (let index = 0; index < 8; index++) await Promise.resolve();
+    expect(mux.closePane).toHaveBeenCalledTimes(1);
+    expect(store.get('busy-orphan')).toMatchObject({
+      lifecycle: 'active',
+      paneId: 'busy-orphan-pane',
+    });
+    await lifecycle.cleanup();
+  });
 });

--- a/src/multiplexer/cmux/session-lifecycle.test.ts
+++ b/src/multiplexer/cmux/session-lifecycle.test.ts
@@ -6,8 +6,12 @@ import { CmuxSessionStore } from './session-state';
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>((done) => (resolve = done));
-  return { promise, resolve };
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((done, fail) => {
+    resolve = done;
+    reject = fail;
+  });
+  return { promise, resolve, reject };
 }
 
 function multiplexer() {
@@ -931,7 +935,7 @@ describe('CmuxSessionLifecycle races', () => {
     await lifecycle.cleanup();
   });
 
-  test('busy reactivates a claimed exhausted orphan before close settles', async () => {
+  test('busy does not clear a claimed orphan close before it settles', async () => {
     const policy = new CmuxClosePolicy(1, 1);
     let exhausted = policy.request('cleanup', 0, 0);
     exhausted = policy.failed(exhausted, 1);
@@ -975,18 +979,194 @@ describe('CmuxSessionLifecycle races', () => {
     });
     expect(store.get('busy-orphan')).toMatchObject({
       owner: 'new',
-      lifecycle: 'active',
+      lifecycle: 'orphaned',
       paneId: 'busy-orphan-pane',
     });
-    expect(store.get('busy-orphan')?.closeIntent).toBeUndefined();
+    expect(store.get('busy-orphan')?.closeIntent).toMatchObject({
+      reason: 'cleanup',
+      phase: 'pending',
+    });
 
     close.resolve(false);
     for (let index = 0; index < 8; index++) await Promise.resolve();
     expect(mux.closePane).toHaveBeenCalledTimes(1);
     expect(store.get('busy-orphan')).toMatchObject({
-      lifecycle: 'active',
+      lifecycle: 'orphaned',
       paneId: 'busy-orphan-pane',
     });
     await lifecycle.cleanup();
   });
+
+  for (const result of [true, false]) {
+    test(`cleanup close timeout retains an existing close until ${result ? 'success' : 'retry'}`, async () => {
+      const mux = multiplexer();
+      const close = deferred<boolean>();
+      mux.closePane.mockImplementationOnce(() => close.promise);
+      const lifecycle = new CmuxSessionLifecycle(
+        'owner',
+        mux,
+        () => 'http://server',
+        '/repo',
+        undefined,
+        {
+          closeRetryMs: 0,
+          isServerRunning: async () => true,
+          shutdownTimeoutMs: 1,
+        },
+      );
+
+      await lifecycle.onSessionCreated({
+        type: 'session.created',
+        properties: { info: { id: 'cleanup-existing', parentID: 'p' } },
+      });
+      const deleting = lifecycle.onSessionDeleted({
+        type: 'session.deleted',
+        properties: { sessionID: 'cleanup-existing' },
+      });
+      for (let index = 0; index < 8; index++) await Promise.resolve();
+
+      const beforeCleanup = store.get('cleanup-existing');
+      const closePromise = beforeCleanup?.closePromise;
+      expect(closePromise).toBeDefined();
+      expect(mux.closePane).toHaveBeenCalledTimes(1);
+
+      await lifecycle.cleanup();
+
+      const retained = store.get('cleanup-existing');
+      expect(retained).toBe(beforeCleanup);
+      expect(retained).toMatchObject({ paneId: 'pane' });
+      expect(retained?.closePromise).toBe(closePromise);
+      expect(mux.closePane).toHaveBeenCalledTimes(1);
+
+      close.resolve(result);
+      await deleting;
+      if (result) {
+        expect(store.get('cleanup-existing')).toBeUndefined();
+      } else {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        expect(mux.closePane).toHaveBeenCalledTimes(2);
+        expect(store.get('cleanup-existing')).toBeUndefined();
+      }
+    });
+  }
+
+  for (const settlement of ['false', 'reject'] as const) {
+    test(`cleanup timeout retries a cleanup-started close after ${settlement}`, async () => {
+      const mux = multiplexer();
+      const close = deferred<boolean>();
+      mux.closePane
+        .mockImplementationOnce(() => close.promise)
+        .mockResolvedValueOnce(true);
+      const lifecycle = new CmuxSessionLifecycle(
+        'owner',
+        mux,
+        () => 'http://server',
+        '/repo',
+        undefined,
+        {
+          closeRetryMs: 0,
+          isServerRunning: async () => true,
+          shutdownTimeoutMs: 1,
+        },
+      );
+      const session = `cleanup-pending-${settlement}`;
+
+      await lifecycle.onSessionCreated({
+        type: 'session.created',
+        properties: { info: { id: session, parentID: 'p' } },
+      });
+      await lifecycle.cleanup();
+
+      const retained = store.get(session);
+      expect(mux.closePane).toHaveBeenCalledTimes(1);
+      expect(retained).toMatchObject({
+        paneId: 'pane',
+        lifecycle: 'orphaned',
+      });
+      expect(retained?.closePromise).toBeDefined();
+
+      if (settlement === 'false') close.resolve(false);
+      else close.reject(new Error('cleanup socket'));
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(mux.closePane).toHaveBeenCalledTimes(2);
+      expect(mux.closePane).toHaveBeenLastCalledWith('pane');
+      expect(store.get(session)).toBeUndefined();
+    });
+  }
+
+  for (const result of [true, false]) {
+    test(`late cleanup ${result ? 'success' : 'failure'} cannot close a new owner twice`, async () => {
+      store.claimCreated({
+        session: 'cleanup-handoff',
+        owner: 'old',
+        parent: 'p',
+        title: 'agent',
+        directory: '/repo',
+        serverUrl: 'http://server/',
+        paneId: 'shared-pane',
+        spawnState: 'attached',
+        lifecycle: 'active',
+        lastActivityAt: 0,
+        activityVersion: 0,
+        idleConsecutive: 0,
+      });
+      const oldMux = multiplexer();
+      const close = deferred<boolean>();
+      oldMux.closePane.mockImplementationOnce(() => close.promise);
+      const old = new CmuxSessionLifecycle(
+        'old',
+        oldMux,
+        () => 'http://server',
+        '/repo',
+        undefined,
+        { shutdownTimeoutMs: 1 },
+      );
+
+      await old.cleanup();
+      const pending = store.get('cleanup-handoff');
+      expect(pending).toMatchObject({
+        owner: 'old',
+        paneId: 'shared-pane',
+        lifecycle: 'orphaned',
+      });
+      expect(oldMux.closePane).toHaveBeenCalledTimes(1);
+
+      const newMux = multiplexer();
+      newMux.closePane.mockResolvedValue(true);
+      const next = new CmuxSessionLifecycle(
+        'new',
+        newMux,
+        () => 'http://server',
+        '/repo',
+      );
+      await next.onSessionStatus({ type: 'session.status' });
+      await next.onSessionCreated({
+        type: 'session.created',
+        properties: {
+          info: { id: 'cleanup-handoff', parentID: 'p' },
+        },
+      });
+
+      expect(store.get('cleanup-handoff')).toBe(pending);
+      expect(store.get('cleanup-handoff')).toMatchObject({
+        owner: 'new',
+        paneId: 'shared-pane',
+      });
+      expect(newMux.closePane).not.toHaveBeenCalled();
+
+      close.resolve(result);
+      for (let index = 0; index < 16; index++) await Promise.resolve();
+
+      expect(oldMux.closePane).toHaveBeenCalledTimes(1);
+      if (result) {
+        expect(store.get('cleanup-handoff')).toBeUndefined();
+      } else {
+        expect(newMux.closePane).toHaveBeenCalledTimes(1);
+        expect(newMux.closePane).toHaveBeenCalledWith('shared-pane');
+        expect(store.get('cleanup-handoff')).toBeUndefined();
+      }
+      await next.cleanup();
+    });
+  }
 });

--- a/src/multiplexer/cmux/session-lifecycle.test.ts
+++ b/src/multiplexer/cmux/session-lifecycle.test.ts
@@ -382,13 +382,21 @@ describe('CmuxSessionLifecycle races', () => {
       );
       await Promise.resolve();
       const currentIntent = store.get('cleanup-race')?.closeIntent;
+      expect(newMux.closePane).not.toHaveBeenCalled();
       close.resolve(result);
       await cleaning;
-      expect(store.get('cleanup-race')).toMatchObject({
-        owner: 'new',
-        paneId: 'pane',
-      });
-      expect(store.get('cleanup-race')?.closeIntent).toBe(currentIntent);
+      for (let index = 0; index < 8; index++) await Promise.resolve();
+      if (result) {
+        expect(store.get('cleanup-race')).toBeUndefined();
+      } else {
+        expect(store.get('cleanup-race')).toMatchObject({
+          owner: 'new',
+          paneId: 'pane',
+          closeIntent: { phase: 'cooldown' },
+        });
+        expect(store.get('cleanup-race')?.closeIntent).not.toBe(currentIntent);
+        expect(newMux.closePane).toHaveBeenCalledWith('pane');
+      }
     });
   }
 
@@ -396,7 +404,7 @@ describe('CmuxSessionLifecycle races', () => {
     const oldMux = multiplexer();
     const spawn = deferred<{ success: true; paneId: string }>();
     oldMux.spawnPane.mockImplementationOnce(() => spawn.promise);
-    oldMux.closePane.mockResolvedValue(false);
+    oldMux.closePane.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
     const old = new CmuxSessionLifecycle(
       'old',
       oldMux,
@@ -433,8 +441,328 @@ describe('CmuxSessionLifecycle races', () => {
       paneId: 'new-pane',
     });
     expect(store.get('late-race')?.closeIntent).toBe(currentIntent);
+    expect(oldMux.closePane).toHaveBeenCalledWith('old-late-pane');
+    for (let index = 0; index < 8; index++) await Promise.resolve();
+    expect(oldMux.closePane).toHaveBeenCalledTimes(1);
     expect(
       store.ownedBy('old').some((record) => record.paneId === 'old-late-pane'),
-    ).toBe(true);
+    ).toBe(false);
+    expect(store.get('late-race')).toMatchObject({
+      owner: 'new',
+      paneId: 'new-pane',
+    });
+    expect(newMux.closePane).toHaveBeenCalledWith('new-pane');
   });
+
+  test('new owner retries a failed late cleanup after disposed owner cooldown', async () => {
+    let now = 0;
+    const oldMux = multiplexer();
+    const spawn = deferred<{ success: true; paneId: string }>();
+    oldMux.spawnPane.mockImplementationOnce(() => spawn.promise);
+    oldMux.closePane.mockResolvedValue(false);
+    const old = new CmuxSessionLifecycle(
+      'old',
+      oldMux,
+      () => 'http://server',
+      '/repo',
+      undefined,
+      {
+        closeRetryMaxAttempts: 1,
+        delay: async () => {},
+        isServerRunning: async () => true,
+        now: () => now,
+        shutdownTimeoutMs: 1,
+      },
+    );
+    const creating = old.onSessionCreated({
+      type: 'session.created',
+      properties: { info: { id: 'disposed-late', parentID: 'p' } },
+    });
+    await Promise.resolve();
+    await old.cleanup();
+
+    const cooldowns: Array<() => void> = [];
+    const newMux = multiplexer();
+    newMux.closePane.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    const next = new CmuxSessionLifecycle(
+      'new',
+      newMux,
+      () => 'http://server',
+      '/repo',
+      undefined,
+      {
+        closeRetryMaxAttempts: 1,
+        delay: () =>
+          new Promise<void>((resolve) => {
+            cooldowns.push(resolve);
+          }),
+        isServerRunning: async () => true,
+        now: () => now,
+      },
+    );
+
+    spawn.resolve({ success: true, paneId: 'old-late-pane' });
+    await creating;
+
+    const lateSession = 'disposed-late\0late\0old-late-pane';
+    expect(oldMux.closePane).toHaveBeenCalledTimes(1);
+
+    for (let index = 0; index < 8; index++) await Promise.resolve();
+
+    expect(store.get(lateSession)).toMatchObject({
+      owner: 'new',
+      paneId: 'old-late-pane',
+      closeIntent: { phase: 'cooldown', cooldowns: 1 },
+    });
+    expect(store.get(lateSession)?.closeTimer).toBeDefined();
+    expect(cooldowns).toHaveLength(1);
+
+    now = 30_000;
+    cooldowns.shift()?.();
+    for (let index = 0; index < 8; index++) await Promise.resolve();
+    expect(newMux.closePane).toHaveBeenCalledTimes(1);
+    expect(newMux.closePane).toHaveBeenCalledWith('old-late-pane');
+    expect(store.get(lateSession)).toMatchObject({
+      owner: 'new',
+      closeIntent: { phase: 'cooldown', cooldowns: 2 },
+    });
+    expect(store.get(lateSession)?.closeTimer).toBeDefined();
+    expect(cooldowns).toHaveLength(1);
+
+    now = 150_000;
+    cooldowns.shift()?.();
+    for (let index = 0; index < 8; index++) await Promise.resolve();
+    expect(newMux.closePane).toHaveBeenCalledTimes(2);
+    expect(store.get(lateSession)).toBeUndefined();
+    await next.cleanup();
+  });
+
+  test('late orphan observer does not claim a pane while its close is pending', async () => {
+    const oldMux = multiplexer();
+    const spawn = deferred<{ success: true; paneId: string }>();
+    const close = deferred<boolean>();
+    oldMux.spawnPane.mockImplementationOnce(() => spawn.promise);
+    oldMux.closePane.mockImplementationOnce(() => close.promise);
+    const old = new CmuxSessionLifecycle(
+      'old',
+      oldMux,
+      () => 'http://server',
+      '/repo',
+      undefined,
+      {
+        closeRetryMaxAttempts: 1,
+        delay: async () => {},
+        isServerRunning: async () => true,
+        shutdownTimeoutMs: 1,
+      },
+    );
+    const creating = old.onSessionCreated({
+      type: 'session.created',
+      properties: { info: { id: 'pending-late', parentID: 'p' } },
+    });
+    await Promise.resolve();
+    await old.cleanup();
+
+    const newMux = multiplexer();
+    newMux.closePane.mockResolvedValue(true);
+    const next = new CmuxSessionLifecycle(
+      'new',
+      newMux,
+      () => 'http://server',
+      '/repo',
+      undefined,
+      { isServerRunning: async () => true },
+    );
+
+    spawn.resolve({ success: true, paneId: 'pending-late-pane' });
+    for (let index = 0; index < 8; index++) await Promise.resolve();
+    expect(oldMux.closePane).toHaveBeenCalledTimes(1);
+    expect(newMux.closePane).not.toHaveBeenCalled();
+    expect(store.get('pending-late\0late\0pending-late-pane')).toMatchObject({
+      owner: 'old',
+    });
+    expect(
+      store.get('pending-late\0late\0pending-late-pane')?.closePromise,
+    ).toBeDefined();
+
+    close.resolve(false);
+    await creating;
+    for (let index = 0; index < 8; index++) await Promise.resolve();
+    expect(newMux.closePane).not.toHaveBeenCalled();
+    expect(store.get('pending-late\0late\0pending-late-pane')).toMatchObject({
+      owner: 'new',
+      closeIntent: { phase: 'cooldown' },
+    });
+    await next.cleanup();
+  });
+
+  test('late orphan observer keeps directory and server fences', async () => {
+    const mux = multiplexer();
+    for (const [session, directory, serverUrl] of [
+      ['wrong-directory', '/other', 'http://server/'],
+      ['wrong-server', '/repo', 'http://other/'],
+    ] as const) {
+      store.claimCreated({
+        session,
+        owner: 'old',
+        parent: 'p',
+        title: 'agent',
+        directory,
+        serverUrl,
+        paneId: `${session}-pane`,
+        spawnState: 'attached',
+        lifecycle: 'orphaned',
+        lastActivityAt: 0,
+        activityVersion: 0,
+        idleConsecutive: 0,
+        latePaneCleanup: true,
+      });
+    }
+    const lifecycle = new CmuxSessionLifecycle(
+      'new',
+      mux,
+      () => 'http://server',
+      '/repo',
+      undefined,
+      { isServerRunning: async () => true },
+    );
+    for (let index = 0; index < 8; index++) await Promise.resolve();
+
+    expect(store.get('wrong-directory')?.owner).toBe('old');
+    expect(store.get('wrong-server')?.owner).toBe('old');
+    expect(mux.closePane).not.toHaveBeenCalled();
+    await lifecycle.cleanup();
+  });
+
+  test('new owner claims an existing late cooldown without an event', async () => {
+    let now = 0;
+    const policy = new CmuxClosePolicy(1, 1);
+    const closeIntent = policy.failed(policy.request('cleanup', 0, now), now);
+    store.claimCreated({
+      session: 'existing-late',
+      owner: 'old',
+      parent: 'p',
+      title: 'agent',
+      directory: '/repo',
+      serverUrl: 'http://server/',
+      paneId: 'existing-late-pane',
+      spawnState: 'attached',
+      lifecycle: 'orphaned',
+      lastActivityAt: 0,
+      activityVersion: 0,
+      idleConsecutive: 0,
+      closeIntent,
+      latePaneCleanup: true,
+    });
+
+    const cooldowns: Array<() => void> = [];
+    const mux = multiplexer();
+    mux.closePane.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    const lifecycle = new CmuxSessionLifecycle(
+      'new',
+      mux,
+      () => 'http://server',
+      '/repo',
+      undefined,
+      {
+        closeRetryMaxAttempts: 1,
+        delay: () =>
+          new Promise<void>((resolve) => {
+            cooldowns.push(resolve);
+          }),
+        isServerRunning: async () => true,
+        now: () => now,
+      },
+    );
+
+    expect(store.get('existing-late')).toMatchObject({
+      owner: 'new',
+      closeIntent: { phase: 'cooldown', cooldowns: 1 },
+    });
+    expect(cooldowns).toHaveLength(1);
+
+    now = 30_000;
+    cooldowns.shift()?.();
+    for (let index = 0; index < 8; index++) await Promise.resolve();
+    expect(mux.closePane).toHaveBeenCalledTimes(1);
+    expect(mux.closePane).toHaveBeenCalledWith('existing-late-pane');
+
+    now = 150_000;
+    cooldowns.shift()?.();
+    for (let index = 0; index < 8; index++) await Promise.resolve();
+    expect(mux.closePane).toHaveBeenCalledTimes(2);
+    expect(store.get('existing-late')).toBeUndefined();
+    await lifecycle.cleanup();
+  });
+
+  for (const result of [true, false]) {
+    test(`session.created handoff consumes settled ${result ? 'success' : 'failure'}`, async () => {
+      const session = `settled-handoff-${result}`;
+      const oldMux = multiplexer();
+      const close = deferred<boolean>();
+      oldMux.closePane.mockImplementationOnce(() => close.promise);
+      store.claimCreated({
+        session,
+        owner: 'old',
+        parent: 'p',
+        title: 'agent',
+        directory: '/repo',
+        paneId: `pane-${result}`,
+        spawnState: 'attached',
+        lifecycle: 'orphaned',
+        lastActivityAt: 0,
+        activityVersion: 0,
+        idleConsecutive: 0,
+      });
+      const old = new CmuxSessionLifecycle(
+        'old',
+        oldMux,
+        () => 'http://server',
+        '/repo',
+        undefined,
+        { closeRetryMaxAttempts: 1, isServerRunning: async () => true },
+      );
+      for (let index = 0; index < 8; index++) await Promise.resolve();
+      const pending = store.get(session)?.closePromise;
+      if (!pending) throw new Error('expected pending close');
+
+      let next!: CmuxSessionLifecycle;
+      const created = pending.then(() =>
+        next.onSessionCreated({
+          type: 'session.created',
+          properties: { info: { id: session, parentID: 'p' } },
+        }),
+      );
+      const newMux = multiplexer();
+      newMux.closePane.mockResolvedValue(false);
+      next = new CmuxSessionLifecycle(
+        'new',
+        newMux,
+        () => 'http://server',
+        '/repo',
+        undefined,
+        { closeRetryMaxAttempts: 1, isServerRunning: async () => true },
+      );
+      expect(newMux.closePane).not.toHaveBeenCalled();
+
+      close.resolve(result);
+      await created;
+      for (let index = 0; index < 8; index++) await Promise.resolve();
+      expect(oldMux.closePane).toHaveBeenCalledTimes(1);
+      if (result) {
+        expect(newMux.closePane).not.toHaveBeenCalled();
+        expect(store.get(session)).toBeUndefined();
+      } else {
+        expect(newMux.closePane).toHaveBeenCalledTimes(1);
+        expect(newMux.closePane).toHaveBeenCalledWith(`pane-${result}`);
+        expect(store.get(session)).toMatchObject({
+          owner: 'new',
+          paneId: `pane-${result}`,
+          closeIntent: { phase: 'cooldown' },
+        });
+      }
+      await next.cleanup();
+      await old.cleanup();
+    });
+  }
 });

--- a/src/multiplexer/cmux/session-lifecycle.test.ts
+++ b/src/multiplexer/cmux/session-lifecycle.test.ts
@@ -56,6 +56,103 @@ describe('CmuxSessionLifecycle races', () => {
     await lifecycle.cleanup();
   });
 
+  test('status absence never confirms deletion or closes a cmux pane', async () => {
+    const mux = multiplexer();
+    let now = 0;
+    const lifecycle = new CmuxSessionLifecycle(
+      'owner',
+      mux,
+      () => 'http://server',
+      '/repo',
+      undefined,
+      {
+        now: () => now,
+        isServerRunning: async () => true,
+        fetchStatuses: async () => ({}),
+      },
+    );
+
+    await lifecycle.onSessionCreated({
+      type: 'session.created',
+      properties: { info: { id: 'missing', parentID: 'p' } },
+    });
+    for (let index = 0; index < 5; index++) {
+      now += 60_000;
+      await lifecycle.pollOnce();
+    }
+
+    expect(mux.closePane).not.toHaveBeenCalled();
+    await lifecycle.cleanup();
+  });
+
+  test('false cmux close keeps the record and retries after settlement', async () => {
+    const mux = multiplexer();
+    const retry = deferred<void>();
+    mux.closePane.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    const lifecycle = new CmuxSessionLifecycle(
+      'owner',
+      mux,
+      () => 'http://server',
+      '/repo',
+      undefined,
+      {
+        delay: () => retry.promise,
+        isServerRunning: async () => true,
+      },
+    );
+
+    await lifecycle.onSessionCreated({
+      type: 'session.created',
+      properties: { info: { id: 'false-close', parentID: 'p' } },
+    });
+    await lifecycle.onSessionDeleted({
+      type: 'session.deleted',
+      properties: { sessionID: 'false-close' },
+    });
+
+    expect(mux.closePane).toHaveBeenCalledTimes(1);
+    expect(store.get('false-close')?.paneId).toBe('pane');
+    retry.resolve();
+    for (let index = 0; index < 8; index++) await Promise.resolve();
+    expect(mux.closePane).toHaveBeenCalledTimes(2);
+    expect(store.get('false-close')).toBeUndefined();
+  });
+
+  test('thrown cmux close keeps the record and retries after settlement', async () => {
+    const mux = multiplexer();
+    const retry = deferred<void>();
+    mux.closePane
+      .mockRejectedValueOnce(new Error('socket'))
+      .mockResolvedValueOnce(true);
+    const lifecycle = new CmuxSessionLifecycle(
+      'owner',
+      mux,
+      () => 'http://server',
+      '/repo',
+      undefined,
+      {
+        delay: () => retry.promise,
+        isServerRunning: async () => true,
+      },
+    );
+
+    await lifecycle.onSessionCreated({
+      type: 'session.created',
+      properties: { info: { id: 'thrown-close', parentID: 'p' } },
+    });
+    await lifecycle.onSessionDeleted({
+      type: 'session.deleted',
+      properties: { sessionID: 'thrown-close' },
+    });
+
+    expect(mux.closePane).toHaveBeenCalledTimes(1);
+    expect(store.get('thrown-close')?.paneId).toBe('pane');
+    retry.resolve();
+    for (let index = 0; index < 8; index++) await Promise.resolve();
+    expect(mux.closePane).toHaveBeenCalledTimes(2);
+    expect(store.get('thrown-close')).toBeUndefined();
+  });
+
   test('dispose gate closes a late successful spawn and never marks it active', async () => {
     const mux = multiplexer();
     const spawn = deferred<{ success: true; paneId: string }>();

--- a/src/multiplexer/cmux/session-lifecycle.ts
+++ b/src/multiplexer/cmux/session-lifecycle.ts
@@ -397,7 +397,8 @@ export class CmuxSessionLifecycle {
       this.disposed ||
       this.store.get(record.session) !== record ||
       record.owner !== this.owner ||
-      record.lifecycle !== 'orphaned'
+      record.lifecycle !== 'orphaned' ||
+      record.closePromise
     )
       return;
     record.closeTimer?.cancel();
@@ -412,6 +413,11 @@ export class CmuxSessionLifecycle {
   private activity(session: string): void {
     const record = this.store.get(session);
     if (!record || record.owner !== this.owner || this.disposed) return;
+    if (record.closePromise) {
+      this.store.markActivity(session, this.now());
+      record.terminalConfirmed = false;
+      return;
+    }
     this.store.markActivity(session, this.now());
     record.terminalConfirmed = false;
     const next = this.policy.activity(record.closeIntent);
@@ -435,6 +441,10 @@ export class CmuxSessionLifecycle {
       !(this.backgroundJobs?.deferIfRunning(record.session) ?? true)
     )
       return;
+    if (record.closePromise) {
+      await record.closePromise;
+      return;
+    }
     const previous = record.closeIntent;
     record.closeIntent = this.policy.request(
       reason,
@@ -516,16 +526,15 @@ export class CmuxSessionLifecycle {
       record.paneId !== paneId
     )
       return;
-    if (
-      !intentStillCurrent ||
-      !idleStillCurrent ||
-      (this.disposed &&
-        !(record.lifecycle === 'orphaned' && intent.reason === 'cleanup'))
-    ) {
+    if (!intentStillCurrent || !idleStillCurrent) {
       if (closed) await this.settleClosedPane(record, paneId);
       return;
     }
     if (closed) {
+      if (this.disposed) {
+        await this.settleClosedPane(record, paneId);
+        return;
+      }
       record.closeTimer?.cancel();
       record.closeTimer = undefined;
       if (record.lifecycle !== 'active') {
@@ -545,7 +554,19 @@ export class CmuxSessionLifecycle {
       this.updatePolling();
       return;
     }
-    if (!intentStillCurrent || !idleStillCurrent) return;
+    if (this.disposed) {
+      record.closeIntent = this.policy.failed(intent, this.now());
+      if (record.closeIntent.phase === 'cooldown') {
+        this.scheduleCooldown(record);
+      } else {
+        record.closeTimer?.cancel();
+        record.closeTimer = this.timer(
+          () => this.attemptClose(record),
+          this.closeRetryMs,
+        );
+      }
+      return;
+    }
     record.closeIntent = this.policy.failed(intent, this.now());
     if (record.closeIntent.phase === 'cooldown') {
       if (!Number.isFinite(record.closeIntent.nextAttemptAt))
@@ -719,31 +740,42 @@ export class CmuxSessionLifecycle {
     }
   }
 
-  private async waitForSpawnSettlement(
+  private async waitForSettlements(
     pending: Promise<unknown>[],
-  ): Promise<void> {
-    if (pending.length === 0) return;
-    await new Promise<void>((resolve) => {
+    deadlineAt: number,
+  ): Promise<boolean> {
+    if (pending.length === 0) return true;
+    const settled = Promise.allSettled(pending).then(() => true);
+    const remaining = deadlineAt - Date.now();
+    if (remaining <= 0) {
+      void settled;
+      return false;
+    }
+    return new Promise<boolean>((resolve) => {
       let finished = false;
       let nativeTimer: ReturnType<typeof setTimeout> | undefined;
       let injectedTimer: { cancel(): void } | undefined;
-      const finish = () => {
+      const finish = (completed: boolean) => {
         if (finished) return;
         finished = true;
         if (nativeTimer) clearTimeout(nativeTimer);
         injectedTimer?.cancel();
-        resolve();
+        resolve(completed);
       };
 
-      nativeTimer = setTimeout(finish, this.shutdownTimeoutMs);
+      nativeTimer = setTimeout(() => finish(false), remaining);
       nativeTimer.unref?.();
       if (this.injectedDelay)
-        injectedTimer = this.timer(finish, this.shutdownTimeoutMs);
-      void Promise.allSettled(pending).then(finish, finish);
+        injectedTimer = this.timer(() => finish(false), Math.max(0, remaining));
+      void settled.then(
+        () => finish(true),
+        () => finish(true),
+      );
     });
   }
 
   private async runCleanup(): Promise<void> {
+    const deadlineAt = Date.now() + Math.max(0, this.shutdownTimeoutMs);
     this.disposed = true;
     this.removeLatePaneObserver();
     this.spawnGeneration += 1;
@@ -754,33 +786,51 @@ export class CmuxSessionLifecycle {
     const pending = records.flatMap((record) =>
       record.spawnPromise ? [record.spawnPromise] : [],
     );
-    await this.waitForSpawnSettlement(pending);
-    const pendingCloses = this.store
+    await this.waitForSettlements(pending, deadlineAt);
+    const closeWork = this.store
       .ownedBy(this.owner)
-      .flatMap((record) => (record.closePromise ? [record.closePromise] : []));
-    if (pendingCloses.length) await Promise.all(pendingCloses);
-    for (const record of this.store.ownedBy(this.owner)) {
+      .map((record) => this.cleanupRecordUntil(record, deadlineAt));
+    await Promise.allSettled(closeWork);
+  }
+
+  private async cleanupRecordUntil(
+    record: CmuxSessionRecord,
+    deadlineAt: number,
+  ): Promise<void> {
+    try {
       if (!record.paneId) {
         if (!record.spawnPromise) this.store.removeWithoutPane(record.session);
-        continue;
+        return;
       }
-      if (this.applyCloseSettlement(record)) continue;
+      if (this.applyCloseSettlement(record)) return;
       record.closeTimer?.cancel();
       record.closeTimer = undefined;
-      record.closeIntent = this.policy.request(
-        'cleanup',
-        record.activityVersion,
-        this.now(),
-      );
+      if (!record.closePromise || !record.closeIntent)
+        record.closeIntent = this.policy.request(
+          'cleanup',
+          record.activityVersion,
+          this.now(),
+        );
       while (
         record.closeIntent?.phase === 'pending' &&
         this.store.get(record.session) === record &&
         record.owner === this.owner
       ) {
-        await this.attemptCloseWithoutTimer(record);
-        if (record.closeIntent?.phase === 'pending')
-          await this.delay(this.closeRetryMs);
+        const attempt = this.attemptCloseWithoutTimer(record);
+        if (!(await this.waitForSettlements([attempt], deadlineAt))) {
+          void attempt.then(
+            () => this.scheduleRetryAfterCleanupTimeout(record),
+            () => this.scheduleRetryAfterCleanupTimeout(record),
+          );
+          return;
+        }
+        if (record.closeIntent?.phase !== 'pending') return;
+        const remaining = deadlineAt - Date.now();
+        if (remaining <= 0) return;
+        const retryDelay = this.delay(Math.min(this.closeRetryMs, remaining));
+        if (!(await this.waitForSettlements([retryDelay], deadlineAt))) return;
       }
+    } finally {
       if (
         record.closeIntent &&
         this.store.get(record.session) === record &&
@@ -788,6 +838,22 @@ export class CmuxSessionLifecycle {
       )
         this.store.markOrphaned(record.session);
     }
+  }
+
+  private scheduleRetryAfterCleanupTimeout(record: CmuxSessionRecord): void {
+    const intent = record.closeIntent;
+    if (
+      intent?.phase !== 'pending' ||
+      !record.paneId ||
+      record.owner !== this.owner ||
+      this.store.get(record.session) !== record
+    )
+      return;
+    record.closeTimer?.cancel();
+    record.closeTimer = this.timer(
+      () => this.attemptClose(record),
+      this.closeRetryMs,
+    );
   }
 
   private async attemptCloseWithoutTimer(

--- a/src/multiplexer/cmux/session-lifecycle.ts
+++ b/src/multiplexer/cmux/session-lifecycle.ts
@@ -53,6 +53,15 @@ const ACTIVITY_EVENTS = new Set([
 const MIN_LIFETIME_MS = 10_000;
 const IDLE_CONFIRMATIONS = 3;
 
+function normalizeServerUrl(value: string | null): string | undefined {
+  if (!value) return undefined;
+  try {
+    return new URL(value).toString();
+  } catch {
+    return value;
+  }
+}
+
 class ServerUrlUnavailableError extends Error {
   constructor() {
     super('OpenCode server URL is unavailable');
@@ -80,6 +89,7 @@ export class CmuxSessionLifecycle {
   private disposed = false;
   private spawnGeneration = 0;
   private readonly permanentlyClosedSessions?: Set<string>;
+  private readonly removeLatePaneObserver: () => void;
 
   constructor(
     private readonly owner: string,
@@ -106,22 +116,20 @@ export class CmuxSessionLifecycle {
     );
     this.serverCheck = options.isServerRunning ?? isServerRunning;
     this.fetchStatuses = options.fetchStatuses ?? (() => this.loadStatuses());
-    for (const orphan of this.store.claimOrphans(owner, defaultDirectory)) {
-      if (orphan.closePromise) continue;
-      if (
-        orphan.closeIntent?.phase === 'cooldown' &&
-        Number.isFinite(orphan.closeIntent.nextAttemptAt)
-      ) {
-        this.scheduleCooldown(orphan);
-      } else {
-        orphan.closeIntent = undefined;
-        void this.requestClose(orphan, 'cleanup');
-      }
-    }
+    const serverScope = () => normalizeServerUrl(this.resolveServerUrl());
+    this.removeLatePaneObserver = this.store.observeLatePaneOrphans(
+      defaultDirectory,
+      serverScope,
+      () => this.claimLatePaneOrphans(),
+    );
+    this.recoverOrphans(
+      this.store.claimOrphans(owner, defaultDirectory, serverScope),
+    );
   }
 
   async onSessionCreated(event: CmuxSessionEvent): Promise<void> {
     if (this.disposed) return;
+    this.claimLatePaneOrphans();
     if (event.type !== 'session.created') return;
     const info = event.properties?.info;
     if (!info?.id || !info.parentID) return;
@@ -139,7 +147,16 @@ export class CmuxSessionLifecycle {
       activityVersion: 0,
       idleConsecutive: 0,
     };
-    if (!this.store.claimCreated(record)) return;
+    if (!this.store.claimCreated(record)) {
+      const current = this.store.get(record.session);
+      if (
+        current?.owner === this.owner &&
+        current.paneId &&
+        (current.lifecycle === 'orphaned' || current.lifecycle === 'deleted')
+      )
+        this.recoverOrphans([current]);
+      return;
+    }
     if (record.paneId && record.lifecycle !== 'active') {
       record.closeIntent = undefined;
       await this.requestClose(record, 'cleanup');
@@ -150,6 +167,7 @@ export class CmuxSessionLifecycle {
 
   async onSessionStatus(event: CmuxSessionEvent): Promise<void> {
     if (this.disposed) return;
+    this.claimLatePaneOrphans();
     const session = this.eventSession(event);
     if (!session) return;
     const owned = this.store.get(session);
@@ -182,6 +200,8 @@ export class CmuxSessionLifecycle {
 
   async onSessionDeleted(event: CmuxSessionEvent): Promise<void> {
     if (event.type !== 'session.deleted') return;
+    if (this.disposed) return;
+    this.claimLatePaneOrphans();
     const session = this.eventSession(event);
     if (!session) return;
     const record = this.store.get(session);
@@ -199,6 +219,7 @@ export class CmuxSessionLifecycle {
 
   async closeSessionFromCoordinator(session: string): Promise<void> {
     if (this.disposed) return;
+    this.claimLatePaneOrphans();
     const record = this.store.get(session);
     if (record?.paneId && record.owner === this.owner) {
       // This is independent terminal evidence. It may permit an absent map
@@ -210,6 +231,7 @@ export class CmuxSessionLifecycle {
 
   async closeSessionPermanentlyFromCoordinator(session: string): Promise<void> {
     if (this.disposed) return;
+    this.claimLatePaneOrphans();
     this.permanentlyClosedSessions?.add(session);
     const record = this.store.get(session);
     if (!record || record.owner !== this.owner) return;
@@ -253,14 +275,16 @@ export class CmuxSessionLifecycle {
     const result = await operation;
     if (record.spawnPromise === operation) record.spawnPromise = undefined;
     const current = this.store.get(record.session);
+    const ownerChanged = current && current.owner !== this.owner;
     if (
       this.disposed ||
       generation !== this.spawnGeneration ||
-      this.permanentlyClosedSessions?.has(record.session)
+      this.permanentlyClosedSessions?.has(record.session) ||
+      ownerChanged
     ) {
       const latePane = result.paneId ?? result.orphanPaneId;
       if (latePane) await this.closeLatePane(record, latePane);
-      else if (current && !current.paneId)
+      if (current && current.owner === this.owner && !current.paneId)
         this.store.removeWithoutPane(record.session);
       return;
     }
@@ -310,6 +334,7 @@ export class CmuxSessionLifecycle {
       log('[cmux-session-lifecycle] no valid server URL; skipping spawn');
       return { success: false, error: 'unavailable' as const };
     }
+    record.serverUrl = normalizeServerUrl(serverUrl);
     if (!(await this.serverCheck(serverUrl)))
       return { success: false, error: 'unavailable' as const };
     if (this.permanentlyClosedSessions?.has(record.session))
@@ -399,8 +424,10 @@ export class CmuxSessionLifecycle {
     }
     const operation = this.performClose(record);
     const trackedOperation = operation.finally(() => {
-      if (record.closePromise === trackedOperation)
+      if (record.closePromise === trackedOperation) {
         record.closePromise = undefined;
+        this.store.notifyLatePaneOrphan(record);
+      }
     });
     record.closePromise = trackedOperation;
     await trackedOperation;
@@ -428,24 +455,34 @@ export class CmuxSessionLifecycle {
       record.closeIntent = this.policy.activity(intent);
       return;
     }
+    const paneId = record.paneId;
     let closed = false;
     try {
       // Await completion before any retry so the pane ID is never reused while
       // an older adapter kill may still be running.
-      closed = await this.multiplexer.closePane(record.paneId);
+      closed = await this.multiplexer.closePane(paneId);
     } catch (error) {
       log('[cmux-session-lifecycle] closePane failed; retaining pane', {
         owner: this.owner,
         session: record.session,
-        paneId: record.paneId,
+        paneId,
         error: String(error),
       });
     }
+    const current = this.store.get(record.session);
+    const ownerChanged =
+      current === record &&
+      record.owner !== this.owner &&
+      record.paneId === paneId;
+    if (ownerChanged) record.closeSettlement = { paneId, closed };
+    else record.closeSettlement = undefined;
     if (
-      this.disposed ||
-      this.store.get(record.session) !== record ||
+      (this.disposed &&
+        !(record.lifecycle === 'orphaned' && intent.reason === 'cleanup')) ||
+      current !== record ||
       record.owner !== this.owner ||
-      record.closeIntent !== intent
+      record.closeIntent !== intent ||
+      record.paneId !== paneId
     )
       return;
     const intentStillCurrent = record.closeIntent === intent;
@@ -500,7 +537,9 @@ export class CmuxSessionLifecycle {
   }
 
   private async poll(): Promise<void> {
-    if (this.polling || this.disposed) return;
+    if (this.disposed) return;
+    this.claimLatePaneOrphans();
+    if (this.polling) return;
     this.polling = true;
     try {
       const statuses = await this.fetchStatuses();
@@ -560,6 +599,31 @@ export class CmuxSessionLifecycle {
     }
   }
 
+  private resumeTransferredClose(record: CmuxSessionRecord): void {
+    const closePromise = record.closePromise;
+    if (!closePromise) return;
+    void closePromise.then(() => {
+      if (
+        this.disposed ||
+        this.store.get(record.session) !== record ||
+        record.owner !== this.owner ||
+        !record.paneId
+      )
+        return;
+      if (this.applyCloseSettlement(record)) return;
+      void this.requestClose(record, 'cleanup');
+    });
+  }
+
+  private applyCloseSettlement(record: CmuxSessionRecord): boolean {
+    const settlement = this.store.consumeCloseSettlement(record);
+    if (!settlement) return false;
+    if (!settlement.closed) return false;
+    this.store.removeAfterConfirmedClose(record.session);
+    this.updatePolling();
+    return true;
+  }
+
   private startPolling(): void {
     if (this.pollTimer || this.disposed) return;
     this.pollTimer = setInterval(
@@ -570,7 +634,11 @@ export class CmuxSessionLifecycle {
   }
 
   private updatePolling(): void {
-    if (this.store.ownedBy(this.owner).some((record) => record.paneId))
+    if (
+      this.store
+        .ownedBy(this.owner)
+        .some((record) => record.paneId && record.lifecycle === 'active')
+    )
       this.startPolling();
     else if (this.pollTimer) {
       clearInterval(this.pollTimer);
@@ -578,8 +646,33 @@ export class CmuxSessionLifecycle {
     }
   }
 
+  private async waitForSpawnSettlement(
+    pending: Promise<unknown>[],
+  ): Promise<void> {
+    if (pending.length === 0) return;
+    await new Promise<void>((resolve) => {
+      let finished = false;
+      let nativeTimer: ReturnType<typeof setTimeout> | undefined;
+      let injectedTimer: { cancel(): void } | undefined;
+      const finish = () => {
+        if (finished) return;
+        finished = true;
+        if (nativeTimer) clearTimeout(nativeTimer);
+        injectedTimer?.cancel();
+        resolve();
+      };
+
+      nativeTimer = setTimeout(finish, this.shutdownTimeoutMs);
+      nativeTimer.unref?.();
+      if (this.injectedDelay)
+        injectedTimer = this.timer(finish, this.shutdownTimeoutMs);
+      void Promise.allSettled(pending).then(finish, finish);
+    });
+  }
+
   private async runCleanup(): Promise<void> {
     this.disposed = true;
+    this.removeLatePaneObserver();
     this.spawnGeneration += 1;
     if (this.pollTimer) clearInterval(this.pollTimer);
     this.pollTimer = undefined;
@@ -588,12 +681,7 @@ export class CmuxSessionLifecycle {
     const pending = records.flatMap((record) =>
       record.spawnPromise ? [record.spawnPromise] : [],
     );
-    if (pending.length) {
-      await Promise.race([
-        Promise.allSettled(pending),
-        this.delay(this.shutdownTimeoutMs),
-      ]);
-    }
+    await this.waitForSpawnSettlement(pending);
     const pendingCloses = this.store
       .ownedBy(this.owner)
       .flatMap((record) => (record.closePromise ? [record.closePromise] : []));
@@ -603,6 +691,7 @@ export class CmuxSessionLifecycle {
         if (!record.spawnPromise) this.store.removeWithoutPane(record.session);
         continue;
       }
+      if (this.applyCloseSettlement(record)) continue;
       record.closeTimer?.cancel();
       record.closeTimer = undefined;
       record.closeIntent = this.policy.request(
@@ -637,8 +726,10 @@ export class CmuxSessionLifecycle {
     }
     const operation = this.performCloseWithoutTimer(record);
     const trackedOperation = operation.finally(() => {
-      if (record.closePromise === trackedOperation)
+      if (record.closePromise === trackedOperation) {
         record.closePromise = undefined;
+        this.store.notifyLatePaneOrphan(record);
+      }
     });
     record.closePromise = trackedOperation;
     await trackedOperation;
@@ -661,8 +752,15 @@ export class CmuxSessionLifecycle {
         error: String(error),
       });
     }
+    const current = this.store.get(record.session);
+    const ownerChanged =
+      current === record &&
+      record.owner !== this.owner &&
+      record.paneId === paneId;
+    if (ownerChanged) record.closeSettlement = { paneId, closed };
+    else record.closeSettlement = undefined;
     if (
-      this.store.get(record.session) !== record ||
+      current !== record ||
       record.owner !== this.owner ||
       record.closeIntent !== intent ||
       record.paneId !== paneId
@@ -688,38 +786,67 @@ export class CmuxSessionLifecycle {
     source: CmuxSessionRecord,
     paneId: string,
   ): Promise<void> {
-    const existing = this.store.get(source.session);
-    if (existing && existing.owner !== this.owner) {
-      this.store.claimCreated({
-        session: `${source.session}\0late\0${paneId}`,
-        owner: this.owner,
-        parent: source.parent,
-        title: source.title,
-        directory: source.directory,
-        paneId,
-        spawnState: 'attached',
-        lifecycle: 'orphaned',
-        attachedAt: this.now(),
-        lastActivityAt: source.lastActivityAt,
-        activityVersion: source.activityVersion,
-        idleConsecutive: 0,
-      });
+    const session = `${source.session}\0late\0${paneId}`;
+    const existing = this.store.get(session);
+    if (existing) {
+      if (existing.owner !== this.owner || existing.paneId !== paneId) return;
+      await this.requestClose(existing, 'cleanup');
       return;
     }
-    const record = existing ?? source;
-    if (!existing) this.store.claimCreated(record);
-    record.paneId = paneId;
-    record.spawnState = 'attached';
-    record.lifecycle = 'orphaned';
-    record.closeIntent = this.policy.request(
-      'cleanup',
-      record.activityVersion,
-      this.now(),
+
+    const late: CmuxSessionRecord = {
+      session,
+      owner: this.owner,
+      parent: source.parent,
+      title: source.title,
+      directory: source.directory,
+      paneId,
+      spawnState: 'attached',
+      lifecycle: 'orphaned',
+      serverUrl: source.serverUrl,
+      attachedAt: this.now(),
+      lastActivityAt: source.lastActivityAt,
+      activityVersion: source.activityVersion,
+      idleConsecutive: 0,
+      latePaneCleanup: true,
+    };
+    if (!this.store.claimCreated(late)) return;
+    const current = this.store.get(session);
+    if (current !== late || current.owner !== this.owner) return;
+
+    // Keep this as a normal owner-scoped close intent. It may run after this
+    // lifecycle is disposed, and a later lifecycle can claim the record if a
+    // retry enters cooldown.
+    await this.requestClose(current, 'cleanup');
+  }
+
+  private claimLatePaneOrphans(): void {
+    const serverUrl = normalizeServerUrl(this.resolveServerUrl());
+    if (!serverUrl) return;
+    const claimed = this.store.claimLatePaneOrphans(
+      this.owner,
+      this.defaultDirectory,
+      serverUrl,
     );
-    while (record.closeIntent?.phase === 'pending') {
-      await this.attemptCloseWithoutTimer(record);
-      if (record.closeIntent?.phase === 'pending')
-        await this.delay(this.closeRetryMs);
+    this.recoverOrphans(claimed);
+  }
+
+  private recoverOrphans(orphaned: CmuxSessionRecord[]): void {
+    for (const orphan of orphaned) {
+      if (orphan.closePromise) {
+        this.resumeTransferredClose(orphan);
+        continue;
+      }
+      if (this.applyCloseSettlement(orphan)) continue;
+      if (
+        orphan.closeIntent?.phase === 'cooldown' &&
+        Number.isFinite(orphan.closeIntent.nextAttemptAt)
+      ) {
+        this.scheduleCooldown(orphan);
+      } else {
+        orphan.closeIntent = undefined;
+        void this.requestClose(orphan, 'cleanup');
+      }
     }
   }
 

--- a/src/multiplexer/cmux/session-lifecycle.ts
+++ b/src/multiplexer/cmux/session-lifecycle.ts
@@ -31,6 +31,7 @@ export interface CmuxSessionLifecycleOptions {
   delay?: (milliseconds: number) => Promise<void>;
   deferredRetryMs?: number;
   deferredTtlMs?: number;
+  /** @deprecated Missing status never establishes deletion. */
   missingGraceMs?: number;
   closeRetryMs?: number;
   closeRetryTtlMs?: number;
@@ -67,7 +68,6 @@ export class CmuxSessionLifecycle {
   private readonly injectedDelay: boolean;
   private readonly deferredRetryMs: number;
   private readonly deferredTtlMs: number;
-  private readonly missingGraceMs: number;
   private readonly closeRetryMs: number;
   private readonly shutdownTimeoutMs: number;
   private readonly serverCheck: (url: string) => Promise<boolean>;
@@ -98,7 +98,6 @@ export class CmuxSessionLifecycle {
         new Promise((resolve) => setTimeout(resolve, milliseconds)));
     this.deferredRetryMs = options.deferredRetryMs ?? 2_000;
     this.deferredTtlMs = options.deferredTtlMs ?? 300_000;
-    this.missingGraceMs = options.missingGraceMs ?? 30_000;
     this.closeRetryMs = options.closeRetryMs ?? 1_000;
     this.shutdownTimeoutMs = options.shutdownTimeoutMs ?? 5_000;
     this.policy = new CmuxClosePolicy(
@@ -108,6 +107,7 @@ export class CmuxSessionLifecycle {
     this.serverCheck = options.isServerRunning ?? isServerRunning;
     this.fetchStatuses = options.fetchStatuses ?? (() => this.loadStatuses());
     for (const orphan of this.store.claimOrphans(owner, defaultDirectory)) {
+      if (orphan.closePromise) continue;
       if (
         orphan.closeIntent?.phase === 'cooldown' &&
         Number.isFinite(orphan.closeIntent.nextAttemptAt)
@@ -200,7 +200,12 @@ export class CmuxSessionLifecycle {
   async closeSessionFromCoordinator(session: string): Promise<void> {
     if (this.disposed) return;
     const record = this.store.get(session);
-    if (record?.paneId && record.owner === this.owner) this.startPolling();
+    if (record?.paneId && record.owner === this.owner) {
+      // This is independent terminal evidence. It may permit an absent map
+      // entry, while a bare absent status remains non-terminal.
+      record.terminalConfirmed = true;
+      this.startPolling();
+    }
   }
 
   async closeSessionPermanentlyFromCoordinator(session: string): Promise<void> {
@@ -305,12 +310,10 @@ export class CmuxSessionLifecycle {
       log('[cmux-session-lifecycle] no valid server URL; skipping spawn');
       return { success: false, error: 'unavailable' as const };
     }
-    if (!(await this.serverCheck(serverUrl))) {
+    if (!(await this.serverCheck(serverUrl)))
       return { success: false, error: 'unavailable' as const };
-    }
-    if (this.permanentlyClosedSessions?.has(record.session)) {
+    if (this.permanentlyClosedSessions?.has(record.session))
       return { success: false, error: 'unavailable' as const };
-    }
     try {
       return await this.multiplexer.spawnPane(
         record.session,
@@ -360,6 +363,7 @@ export class CmuxSessionLifecycle {
     const record = this.store.get(session);
     if (!record || record.owner !== this.owner || this.disposed) return;
     this.store.markActivity(session, this.now());
+    record.terminalConfirmed = false;
     const next = this.policy.activity(record.closeIntent);
     if (!next && record.closeIntent) record.closeTimer?.cancel();
     record.closeIntent = next;
@@ -388,6 +392,21 @@ export class CmuxSessionLifecycle {
   }
 
   private async attemptClose(record: CmuxSessionRecord): Promise<void> {
+    if (record.closePromise) {
+      await record.closePromise;
+      if (record.paneId && record.closeIntent) await this.attemptClose(record);
+      return;
+    }
+    const operation = this.performClose(record);
+    const trackedOperation = operation.finally(() => {
+      if (record.closePromise === trackedOperation)
+        record.closePromise = undefined;
+    });
+    record.closePromise = trackedOperation;
+    await trackedOperation;
+  }
+
+  private async performClose(record: CmuxSessionRecord): Promise<void> {
     const intent = record.closeIntent;
     if (
       !intent ||
@@ -401,7 +420,7 @@ export class CmuxSessionLifecycle {
       return;
     }
     record.closeIntent = this.policy.resume(intent, this.now());
-    if (record.closeIntent !== intent) return this.attemptClose(record);
+    if (record.closeIntent !== intent) return this.performClose(record);
     if (
       intent.reason === 'idle' &&
       intent.expectedActivityVersion !== record.activityVersion
@@ -411,8 +430,17 @@ export class CmuxSessionLifecycle {
     }
     let closed = false;
     try {
+      // Await completion before any retry so the pane ID is never reused while
+      // an older adapter kill may still be running.
       closed = await this.multiplexer.closePane(record.paneId);
-    } catch {}
+    } catch (error) {
+      log('[cmux-session-lifecycle] closePane failed; retaining pane', {
+        owner: this.owner,
+        session: record.session,
+        paneId: record.paneId,
+        error: String(error),
+      });
+    }
     if (
       this.disposed ||
       this.store.get(record.session) !== record ||
@@ -438,9 +466,8 @@ export class CmuxSessionLifecycle {
           record.owner === this.owner &&
           !this.disposed &&
           record.activityVersion !== intent.expectedActivityVersion
-        ) {
+        )
           await this.spawn(record);
-        }
       }
       this.updatePolling();
       return;
@@ -482,13 +509,21 @@ export class CmuxSessionLifecycle {
         const status = statuses[record.session];
         if (!status) {
           record.statusMissingSince ??= this.now();
-          if (this.now() - record.statusMissingSince < this.missingGraceMs) {
-            record.idleConsecutive = 0;
-            continue;
-          }
+          record.idleConsecutive = 0;
+          if (record.terminalConfirmed) await this.requestClose(record, 'idle');
+          else
+            log('[cmux-session-lifecycle] status absent; retaining pane', {
+              owner: this.owner,
+              session: record.session,
+              paneId: record.paneId,
+              missingForMs: this.now() - record.statusMissingSince,
+              recovery:
+                'requires-session.deleted-or-reliable-existence-evidence',
+            });
+          continue;
         }
-        if (status) record.statusMissingSince = undefined;
-        if (status && status.type !== 'idle') {
+        record.statusMissingSince = undefined;
+        if (status.type !== 'idle') {
           this.activity(record.session);
           continue;
         }
@@ -504,13 +539,18 @@ export class CmuxSessionLifecycle {
         const version = record.activityVersion;
         const final = await this.fetchStatuses();
         if (
-          (final[record.session]?.type === 'idle' ||
-            (!final[record.session] &&
-              record.statusMissingSince !== undefined &&
-              this.now() - record.statusMissingSince >= this.missingGraceMs)) &&
+          final[record.session]?.type === 'idle' &&
           version === record.activityVersion
         )
           await this.requestClose(record, 'idle');
+        else if (!final[record.session] && record.terminalConfirmed)
+          await this.requestClose(record, 'idle');
+        else if (!final[record.session])
+          log('[cmux-session-lifecycle] final status absent; retaining pane', {
+            owner: this.owner,
+            session: record.session,
+            paneId: record.paneId,
+          });
         else this.activity(record.session);
       }
     } catch {
@@ -528,6 +568,7 @@ export class CmuxSessionLifecycle {
     );
     this.pollTimer.unref?.();
   }
+
   private updatePolling(): void {
     if (this.store.ownedBy(this.owner).some((record) => record.paneId))
       this.startPolling();
@@ -553,6 +594,10 @@ export class CmuxSessionLifecycle {
         this.delay(this.shutdownTimeoutMs),
       ]);
     }
+    const pendingCloses = this.store
+      .ownedBy(this.owner)
+      .flatMap((record) => (record.closePromise ? [record.closePromise] : []));
+    if (pendingCloses.length) await Promise.all(pendingCloses);
     for (const record of this.store.ownedBy(this.owner)) {
       if (!record.paneId) {
         if (!record.spawnPromise) this.store.removeWithoutPane(record.session);
@@ -586,13 +631,36 @@ export class CmuxSessionLifecycle {
   private async attemptCloseWithoutTimer(
     record: CmuxSessionRecord,
   ): Promise<void> {
+    if (record.closePromise) {
+      await record.closePromise;
+      return;
+    }
+    const operation = this.performCloseWithoutTimer(record);
+    const trackedOperation = operation.finally(() => {
+      if (record.closePromise === trackedOperation)
+        record.closePromise = undefined;
+    });
+    record.closePromise = trackedOperation;
+    await trackedOperation;
+  }
+
+  private async performCloseWithoutTimer(
+    record: CmuxSessionRecord,
+  ): Promise<void> {
     const intent = record.closeIntent;
     if (!intent || !record.paneId) return;
     const paneId = record.paneId;
     let closed = false;
     try {
       closed = await this.multiplexer.closePane(paneId);
-    } catch {}
+    } catch (error) {
+      log('[cmux-session-lifecycle] cleanup closePane failed; retaining pane', {
+        owner: this.owner,
+        session: record.session,
+        paneId,
+        error: String(error),
+      });
+    }
     if (
       this.store.get(record.session) !== record ||
       record.owner !== this.owner ||
@@ -622,11 +690,20 @@ export class CmuxSessionLifecycle {
   ): Promise<void> {
     const existing = this.store.get(source.session);
     if (existing && existing.owner !== this.owner) {
-      let closed = false;
-      try {
-        closed = await this.multiplexer.closePane(paneId);
-      } catch {}
-      if (!closed) this.trackStalePane(source, paneId);
+      this.store.claimCreated({
+        session: `${source.session}\0late\0${paneId}`,
+        owner: this.owner,
+        parent: source.parent,
+        title: source.title,
+        directory: source.directory,
+        paneId,
+        spawnState: 'attached',
+        lifecycle: 'orphaned',
+        attachedAt: this.now(),
+        lastActivityAt: source.lastActivityAt,
+        activityVersion: source.activityVersion,
+        idleConsecutive: 0,
+      });
       return;
     }
     const record = existing ?? source;
@@ -644,24 +721,6 @@ export class CmuxSessionLifecycle {
       if (record.closeIntent?.phase === 'pending')
         await this.delay(this.closeRetryMs);
     }
-  }
-
-  private trackStalePane(source: CmuxSessionRecord, paneId: string): void {
-    const session = `${source.session}\0late\0${paneId}`;
-    this.store.claimCreated({
-      session,
-      owner: this.owner,
-      parent: source.parent,
-      title: source.title,
-      directory: source.directory,
-      paneId,
-      spawnState: 'attached',
-      lifecycle: 'orphaned',
-      attachedAt: this.now(),
-      lastActivityAt: source.lastActivityAt,
-      activityVersion: source.activityVersion,
-      idleConsecutive: 0,
-    });
   }
 
   private eventSession(event: CmuxSessionEvent): string | undefined {

--- a/src/multiplexer/cmux/session-lifecycle.ts
+++ b/src/multiplexer/cmux/session-lifecycle.ts
@@ -88,8 +88,11 @@ export class CmuxSessionLifecycle {
   private cleanupPromise?: Promise<void>;
   private disposed = false;
   private spawnGeneration = 0;
+  private readonly ownerGeneration: number;
   private readonly permanentlyClosedSessions?: Set<string>;
+  private readonly serverScope: () => string | undefined;
   private readonly removeLatePaneObserver: () => void;
+  private initialOrphansRecovered = false;
 
   constructor(
     private readonly owner: string,
@@ -116,14 +119,13 @@ export class CmuxSessionLifecycle {
     );
     this.serverCheck = options.isServerRunning ?? isServerRunning;
     this.fetchStatuses = options.fetchStatuses ?? (() => this.loadStatuses());
-    const serverScope = () => normalizeServerUrl(this.resolveServerUrl());
+    this.ownerGeneration = this.store.registerOwner();
+    this.serverScope = () => normalizeServerUrl(this.resolveServerUrl());
     this.removeLatePaneObserver = this.store.observeLatePaneOrphans(
       defaultDirectory,
-      serverScope,
-      () => this.claimLatePaneOrphans(),
-    );
-    this.recoverOrphans(
-      this.store.claimOrphans(owner, defaultDirectory, serverScope),
+      this.serverScope,
+      (record) => this.claimLatePaneOrphans(record),
+      this.ownerGeneration,
     );
   }
 
@@ -138,9 +140,11 @@ export class CmuxSessionLifecycle {
     const record: CmuxSessionRecord = {
       session: info.id,
       owner: this.owner,
+      ownerGeneration: this.ownerGeneration,
       parent: info.parentID,
       title: info.title ?? 'Subagent',
       directory: info.directory ?? this.defaultDirectory,
+      serverUrl: normalizeServerUrl(this.resolveServerUrl()),
       spawnState: 'known',
       lifecycle: 'active',
       lastActivityAt: now,
@@ -184,16 +188,18 @@ export class CmuxSessionLifecycle {
           : undefined;
     if (!status) return;
     if (status !== 'idle') {
+      const record = this.store.get(session);
+      if (status === 'busy' && record) this.reactivateOrphan(record);
       this.activity(session);
       this.backgroundJobs?.clearDeferredClose(session);
-      const record = this.store.get(session);
+      const current = this.store.get(session);
       if (
         status === 'busy' &&
-        record &&
-        record.lifecycle === 'active' &&
-        !record.paneId
+        current &&
+        current.lifecycle === 'active' &&
+        !current.paneId
       )
-        await this.spawn(record);
+        await this.spawn(current);
     }
     if (owned.paneId) this.startPolling();
   }
@@ -275,16 +281,18 @@ export class CmuxSessionLifecycle {
     const result = await operation;
     if (record.spawnPromise === operation) record.spawnPromise = undefined;
     const current = this.store.get(record.session);
+    const recordChanged = current && current !== record;
     const ownerChanged = current && current.owner !== this.owner;
     if (
       this.disposed ||
       generation !== this.spawnGeneration ||
       this.permanentlyClosedSessions?.has(record.session) ||
+      recordChanged ||
       ownerChanged
     ) {
       const latePane = result.paneId ?? result.orphanPaneId;
       if (latePane) await this.closeLatePane(record, latePane);
-      if (current && current.owner === this.owner && !current.paneId)
+      if (current === record && current.owner === this.owner && !current.paneId)
         this.store.removeWithoutPane(record.session);
       return;
     }
@@ -384,6 +392,23 @@ export class CmuxSessionLifecycle {
     record.deferredSpawn = undefined;
   }
 
+  private reactivateOrphan(record: CmuxSessionRecord): void {
+    if (
+      this.disposed ||
+      this.store.get(record.session) !== record ||
+      record.owner !== this.owner ||
+      record.lifecycle !== 'orphaned'
+    )
+      return;
+    record.closeTimer?.cancel();
+    record.closeTimer = undefined;
+    record.closeIntent = undefined;
+    record.lifecycle = 'active';
+    record.idleConsecutive = 0;
+    record.statusMissingSince = undefined;
+    record.terminalConfirmed = false;
+  }
+
   private activity(session: string): void {
     const record = this.store.get(session);
     if (!record || record.owner !== this.owner || this.disposed) return;
@@ -399,7 +424,12 @@ export class CmuxSessionLifecycle {
     record: CmuxSessionRecord,
     reason: CmuxCloseReason,
   ): Promise<void> {
-    if (!record.paneId || record.owner !== this.owner) return;
+    if (
+      !record.paneId ||
+      record.owner !== this.owner ||
+      this.store.get(record.session) !== record
+    )
+      return;
     if (
       reason === 'idle' &&
       !(this.backgroundJobs?.deferIfRunning(record.session) ?? true)
@@ -476,19 +506,25 @@ export class CmuxSessionLifecycle {
       record.paneId === paneId;
     if (ownerChanged) record.closeSettlement = { paneId, closed };
     else record.closeSettlement = undefined;
-    if (
-      (this.disposed &&
-        !(record.lifecycle === 'orphaned' && intent.reason === 'cleanup')) ||
-      current !== record ||
-      record.owner !== this.owner ||
-      record.closeIntent !== intent ||
-      record.paneId !== paneId
-    )
-      return;
     const intentStillCurrent = record.closeIntent === intent;
     const idleStillCurrent =
       intent.reason !== 'idle' ||
       intent.expectedActivityVersion === record.activityVersion;
+    if (
+      current !== record ||
+      record.owner !== this.owner ||
+      record.paneId !== paneId
+    )
+      return;
+    if (
+      !intentStillCurrent ||
+      !idleStillCurrent ||
+      (this.disposed &&
+        !(record.lifecycle === 'orphaned' && intent.reason === 'cleanup'))
+    ) {
+      if (closed) await this.settleClosedPane(record, paneId);
+      return;
+    }
     if (closed) {
       record.closeTimer?.cancel();
       record.closeTimer = undefined;
@@ -522,6 +558,30 @@ export class CmuxSessionLifecycle {
       () => this.attemptClose(record),
       this.closeRetryMs,
     );
+  }
+
+  private async settleClosedPane(
+    record: CmuxSessionRecord,
+    paneId: string,
+  ): Promise<void> {
+    if (
+      this.store.get(record.session) !== record ||
+      record.owner !== this.owner ||
+      record.paneId !== paneId
+    )
+      return;
+    record.closeTimer?.cancel();
+    record.closeTimer = undefined;
+    record.closeIntent = undefined;
+    if (record.lifecycle !== 'active' || this.disposed) {
+      this.store.removeAfterConfirmedClose(record.session);
+      this.updatePolling();
+      return;
+    }
+    record.paneId = undefined;
+    record.spawnState = 'known';
+    this.updatePolling();
+    await this.spawn(record);
   }
 
   private scheduleCooldown(record: CmuxSessionRecord): void {
@@ -619,6 +679,19 @@ export class CmuxSessionLifecycle {
     const settlement = this.store.consumeCloseSettlement(record);
     if (!settlement) return false;
     if (!settlement.closed) return false;
+    if (
+      record.lifecycle === 'active' &&
+      !record.closeIntent &&
+      !this.disposed
+    ) {
+      record.closeTimer?.cancel();
+      record.closeTimer = undefined;
+      record.paneId = undefined;
+      record.spawnState = 'known';
+      this.updatePolling();
+      void this.spawn(record);
+      return true;
+    }
     this.store.removeAfterConfirmedClose(record.session);
     this.updatePolling();
     return true;
@@ -739,7 +812,13 @@ export class CmuxSessionLifecycle {
     record: CmuxSessionRecord,
   ): Promise<void> {
     const intent = record.closeIntent;
-    if (!intent || !record.paneId) return;
+    if (
+      !intent ||
+      !record.paneId ||
+      record.owner !== this.owner ||
+      this.store.get(record.session) !== record
+    )
+      return;
     const paneId = record.paneId;
     let closed = false;
     try {
@@ -777,6 +856,8 @@ export class CmuxSessionLifecycle {
     paneId: string,
   ): Promise<void> {
     if (!this.store.get(record.session)) this.store.claimCreated(record);
+    const current = this.store.get(record.session);
+    if (current !== record || current.owner !== this.owner) return;
     this.store.markAttached(record.session, paneId, this.now());
     this.store.markOrphaned(record.session);
     await this.requestClose(record, 'cleanup');
@@ -797,6 +878,7 @@ export class CmuxSessionLifecycle {
     const late: CmuxSessionRecord = {
       session,
       owner: this.owner,
+      ownerGeneration: this.ownerGeneration,
       parent: source.parent,
       title: source.title,
       directory: source.directory,
@@ -820,15 +902,33 @@ export class CmuxSessionLifecycle {
     await this.requestClose(current, 'cleanup');
   }
 
-  private claimLatePaneOrphans(): void {
-    const serverUrl = normalizeServerUrl(this.resolveServerUrl());
+  private claimLatePaneOrphans(expectedRecord?: CmuxSessionRecord): void {
+    this.recoverInitialOrphans();
+    const serverUrl = this.serverScope();
     if (!serverUrl) return;
     const claimed = this.store.claimLatePaneOrphans(
       this.owner,
       this.defaultDirectory,
       serverUrl,
+      this.ownerGeneration,
+      expectedRecord,
     );
     this.recoverOrphans(claimed);
+  }
+
+  private recoverInitialOrphans(): void {
+    if (this.initialOrphansRecovered) return;
+    this.initialOrphansRecovered = true;
+    const serverUrl = this.serverScope();
+    if (!serverUrl) return;
+    this.recoverOrphans(
+      this.store.claimOrphans(
+        this.owner,
+        this.defaultDirectory,
+        serverUrl,
+        this.ownerGeneration,
+      ),
+    );
   }
 
   private recoverOrphans(orphaned: CmuxSessionRecord[]): void {

--- a/src/multiplexer/cmux/session-state.test.ts
+++ b/src/multiplexer/cmux/session-state.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { CmuxSessionStore } from './session-state';
+
+describe('CmuxSessionStore orphan scope', () => {
+  const store = new CmuxSessionStore();
+
+  beforeEach(() => store.resetForTests());
+
+  test('does not claim ordinary orphans without the current server scope', () => {
+    for (const [session, serverUrl] of [
+      ['unscoped-orphan', undefined],
+      ['wrong-scope-orphan', 'http://other/'],
+    ] as const) {
+      store.claimCreated({
+        session,
+        owner: 'old',
+        parent: 'p',
+        title: 'agent',
+        directory: '/repo',
+        serverUrl,
+        paneId: `${session}-pane`,
+        spawnState: 'attached',
+        lifecycle: 'orphaned',
+        lastActivityAt: 0,
+        activityVersion: 0,
+        idleConsecutive: 0,
+      });
+    }
+
+    expect(store.claimOrphans('new', '/repo', 'http://server/')).toEqual([]);
+    expect(store.get('unscoped-orphan')?.owner).toBe('old');
+    expect(store.get('wrong-scope-orphan')?.owner).toBe('old');
+  });
+});

--- a/src/multiplexer/cmux/session-state.ts
+++ b/src/multiplexer/cmux/session-state.ts
@@ -13,6 +13,8 @@ export interface CmuxDeferredSpawn {
 export interface CmuxSessionRecord {
   session: string;
   owner: string;
+  /** Monotonic lifecycle owner fence used for late-pane takeover. */
+  ownerGeneration?: number;
   parent: string;
   title: string;
   directory: string;
@@ -45,14 +47,18 @@ export interface CmuxCloseSettlement {
 }
 
 const STORE_KEY = Symbol.for('oh-my-opencode-slim.cmux-session-store');
+const OWNER_GENERATION_KEY = Symbol.for(
+  'oh-my-opencode-slim.cmux-owner-generation',
+);
 const ORPHAN_OBSERVERS_KEY = Symbol.for(
   'oh-my-opencode-slim.cmux-orphan-observers',
 );
 
 interface LatePaneOrphanObserver {
+  ownerGeneration: number;
   directory: string;
   serverUrl: string | (() => string | undefined);
-  callback: () => void;
+  callback: (record: CmuxSessionRecord) => void;
 }
 
 function records(): Map<string, CmuxSessionRecord> {
@@ -71,7 +77,20 @@ function orphanObservers(): Set<LatePaneOrphanObserver> {
   return globalStore[ORPHAN_OBSERVERS_KEY];
 }
 
+function nextOwnerGeneration(): number {
+  const globalStore = globalThis as typeof globalThis & {
+    [OWNER_GENERATION_KEY]?: number;
+  };
+  const generation = (globalStore[OWNER_GENERATION_KEY] ?? 0) + 1;
+  globalStore[OWNER_GENERATION_KEY] = generation;
+  return generation;
+}
+
 export class CmuxSessionStore {
+  registerOwner(): number {
+    return nextOwnerGeneration();
+  }
+
   consumeCloseSettlement(
     record: CmuxSessionRecord,
   ): CmuxCloseSettlement | undefined {
@@ -93,10 +112,16 @@ export class CmuxSessionStore {
         (existing.lifecycle !== 'orphaned' && existing.lifecycle !== 'deleted')
       )
         return false;
+      if (!existing.serverUrl || existing.serverUrl !== record.serverUrl)
+        return false;
       // Transfer ownership without replacing the record while an adapter
       // close is in flight. The old operation must settle before any retry.
       if (existing.closePromise) {
-        if (!existing.latePaneCleanup) existing.owner = record.owner;
+        if (!existing.latePaneCleanup) {
+          existing.owner = record.owner;
+          if (record.ownerGeneration !== undefined)
+            existing.ownerGeneration = record.ownerGeneration;
+        }
         return false;
       }
       const settlement = this.consumeCloseSettlement(existing);
@@ -107,8 +132,12 @@ export class CmuxSessionStore {
         return false;
       }
       existing.closeTimer?.cancel();
+      const nextOwner = record.owner;
+      const nextOwnerGeneration =
+        record.ownerGeneration ?? existing.ownerGeneration;
       Object.assign(record, existing, {
-        owner: record.owner,
+        owner: nextOwner,
+        ownerGeneration: nextOwnerGeneration,
         closeTimer: undefined,
       });
     }
@@ -125,9 +154,10 @@ export class CmuxSessionStore {
   observeLatePaneOrphans(
     directory: string,
     serverUrl: string | (() => string | undefined),
-    callback: () => void,
+    callback: (record: CmuxSessionRecord) => void,
+    ownerGeneration = 0,
   ): () => void {
-    const observer = { directory, serverUrl, callback };
+    const observer = { directory, serverUrl, callback, ownerGeneration };
     orphanObservers().add(observer);
     return () => orphanObservers().delete(observer);
   }
@@ -141,7 +171,7 @@ export class CmuxSessionStore {
           : observer.serverUrl;
       if (serverUrl !== record.serverUrl) continue;
       queueMicrotask(() => {
-        if (orphanObservers().has(observer)) observer.callback();
+        if (orphanObservers().has(observer)) observer.callback(record);
       });
     }
   }
@@ -149,22 +179,29 @@ export class CmuxSessionStore {
     owner: string,
     directory: string,
     serverUrl?: string | (() => string | undefined),
+    ownerGeneration?: number,
   ): CmuxSessionRecord[] {
+    const currentServerUrl =
+      serverUrl === undefined
+        ? undefined
+        : typeof serverUrl === 'function'
+          ? serverUrl()
+          : serverUrl;
+    if (!currentServerUrl) return [];
     const claimed = [...records().values()].filter(
       (record) =>
         record.directory === directory &&
+        record.serverUrl === currentServerUrl &&
         Boolean(record.paneId) &&
-        (!record.latePaneCleanup ||
-          (serverUrl !== undefined &&
-            (typeof serverUrl === 'function' ? serverUrl() : serverUrl) ===
-              record.serverUrl &&
-            !record.closePromise)) &&
+        (!record.latePaneCleanup || !record.closePromise) &&
         (record.lifecycle === 'orphaned' || record.lifecycle === 'deleted'),
     );
     for (const record of claimed) {
       record.closeTimer?.cancel();
       record.closeTimer = undefined;
       record.owner = owner;
+      if (ownerGeneration !== undefined)
+        record.ownerGeneration = ownerGeneration;
     }
     return claimed;
   }
@@ -172,21 +209,29 @@ export class CmuxSessionStore {
     owner: string,
     directory: string,
     serverUrl: string,
+    ownerGeneration?: number,
+    expectedRecord?: CmuxSessionRecord,
   ): CmuxSessionRecord[] {
     const claimed = [...records().values()].filter(
       (record) =>
+        (!expectedRecord || record === expectedRecord) &&
         record.owner !== owner &&
         record.latePaneCleanup === true &&
         record.directory === directory &&
         record.serverUrl === serverUrl &&
         Boolean(record.paneId) &&
         !record.closePromise &&
+        (ownerGeneration === undefined ||
+          record.ownerGeneration === undefined ||
+          record.ownerGeneration < ownerGeneration) &&
         (record.lifecycle === 'orphaned' || record.lifecycle === 'deleted'),
     );
     for (const record of claimed) {
       record.closeTimer?.cancel();
       record.closeTimer = undefined;
       record.owner = owner;
+      if (ownerGeneration !== undefined)
+        record.ownerGeneration = ownerGeneration;
     }
     return claimed;
   }
@@ -232,5 +277,9 @@ export class CmuxSessionStore {
     }
     records().clear();
     orphanObservers().clear();
+    const globalStore = globalThis as typeof globalThis & {
+      [OWNER_GENERATION_KEY]?: number;
+    };
+    globalStore[OWNER_GENERATION_KEY] = 0;
   }
 }

--- a/src/multiplexer/cmux/session-state.ts
+++ b/src/multiplexer/cmux/session-state.ts
@@ -24,9 +24,12 @@ export interface CmuxSessionRecord {
   activityVersion: number;
   idleConsecutive: number;
   statusMissingSince?: number;
+  /** Set only by a coordinator terminal outcome, not by status absence. */
+  terminalConfirmed?: boolean;
   deferredSpawn?: CmuxDeferredSpawn;
   closeIntent?: CmuxCloseIntent;
   closeTimer?: { cancel(): void };
+  closePromise?: Promise<void>;
   spawnPromise?: Promise<PaneResult>;
 }
 
@@ -49,6 +52,12 @@ export class CmuxSessionStore {
         (existing.lifecycle !== 'orphaned' && existing.lifecycle !== 'deleted')
       )
         return false;
+      // Transfer ownership without replacing the record while an adapter
+      // close is in flight. The old operation must settle before any retry.
+      if (existing.closePromise) {
+        existing.owner = record.owner;
+        return false;
+      }
       existing.closeTimer?.cancel();
       Object.assign(record, existing, {
         owner: record.owner,

--- a/src/multiplexer/cmux/session-state.ts
+++ b/src/multiplexer/cmux/session-state.ts
@@ -16,6 +16,8 @@ export interface CmuxSessionRecord {
   parent: string;
   title: string;
   directory: string;
+  /** Server scope that created the pane. */
+  serverUrl?: string;
   paneId?: string;
   spawnState: CmuxSpawnState;
   lifecycle: CmuxLifecycleState;
@@ -30,10 +32,28 @@ export interface CmuxSessionRecord {
   closeIntent?: CmuxCloseIntent;
   closeTimer?: { cancel(): void };
   closePromise?: Promise<void>;
+  /** Result of a close that settled after ownership changed. */
+  closeSettlement?: CmuxCloseSettlement;
   spawnPromise?: Promise<PaneResult>;
+  /** A pane returned by a spawn generation that can no longer be adopted. */
+  latePaneCleanup?: boolean;
+}
+
+export interface CmuxCloseSettlement {
+  paneId: string;
+  closed: boolean;
 }
 
 const STORE_KEY = Symbol.for('oh-my-opencode-slim.cmux-session-store');
+const ORPHAN_OBSERVERS_KEY = Symbol.for(
+  'oh-my-opencode-slim.cmux-orphan-observers',
+);
+
+interface LatePaneOrphanObserver {
+  directory: string;
+  serverUrl: string | (() => string | undefined);
+  callback: () => void;
+}
 
 function records(): Map<string, CmuxSessionRecord> {
   const globalStore = globalThis as typeof globalThis & {
@@ -43,7 +63,28 @@ function records(): Map<string, CmuxSessionRecord> {
   return globalStore[STORE_KEY];
 }
 
+function orphanObservers(): Set<LatePaneOrphanObserver> {
+  const globalStore = globalThis as typeof globalThis & {
+    [ORPHAN_OBSERVERS_KEY]?: Set<LatePaneOrphanObserver>;
+  };
+  globalStore[ORPHAN_OBSERVERS_KEY] ??= new Set();
+  return globalStore[ORPHAN_OBSERVERS_KEY];
+}
+
 export class CmuxSessionStore {
+  consumeCloseSettlement(
+    record: CmuxSessionRecord,
+  ): CmuxCloseSettlement | undefined {
+    if (records().get(record.session) !== record) return undefined;
+    const settlement = record.closeSettlement;
+    if (!settlement) return undefined;
+    if (settlement.paneId !== record.paneId) {
+      record.closeSettlement = undefined;
+      return undefined;
+    }
+    record.closeSettlement = undefined;
+    return settlement;
+  }
   claimCreated(record: CmuxSessionRecord): boolean {
     const existing = records().get(record.session);
     if (existing) {
@@ -55,7 +96,14 @@ export class CmuxSessionStore {
       // Transfer ownership without replacing the record while an adapter
       // close is in flight. The old operation must settle before any retry.
       if (existing.closePromise) {
-        existing.owner = record.owner;
+        if (!existing.latePaneCleanup) existing.owner = record.owner;
+        return false;
+      }
+      const settlement = this.consumeCloseSettlement(existing);
+      if (settlement?.closed) {
+        existing.closeTimer?.cancel();
+        existing.closeTimer = undefined;
+        records().delete(existing.session);
         return false;
       }
       existing.closeTimer?.cancel();
@@ -65,6 +113,7 @@ export class CmuxSessionStore {
       });
     }
     records().set(record.session, record);
+    this.notifyLatePaneOrphan(record);
     return true;
   }
   get(session: string): CmuxSessionRecord | undefined {
@@ -73,11 +122,65 @@ export class CmuxSessionStore {
   ownedBy(owner: string): CmuxSessionRecord[] {
     return [...records().values()].filter((record) => record.owner === owner);
   }
-  claimOrphans(owner: string, directory: string): CmuxSessionRecord[] {
+  observeLatePaneOrphans(
+    directory: string,
+    serverUrl: string | (() => string | undefined),
+    callback: () => void,
+  ): () => void {
+    const observer = { directory, serverUrl, callback };
+    orphanObservers().add(observer);
+    return () => orphanObservers().delete(observer);
+  }
+  notifyLatePaneOrphan(record: CmuxSessionRecord): void {
+    if (!record.latePaneCleanup || !record.paneId || !record.serverUrl) return;
+    for (const observer of orphanObservers()) {
+      if (observer.directory !== record.directory) continue;
+      const serverUrl =
+        typeof observer.serverUrl === 'function'
+          ? observer.serverUrl()
+          : observer.serverUrl;
+      if (serverUrl !== record.serverUrl) continue;
+      queueMicrotask(() => {
+        if (orphanObservers().has(observer)) observer.callback();
+      });
+    }
+  }
+  claimOrphans(
+    owner: string,
+    directory: string,
+    serverUrl?: string | (() => string | undefined),
+  ): CmuxSessionRecord[] {
     const claimed = [...records().values()].filter(
       (record) =>
         record.directory === directory &&
         Boolean(record.paneId) &&
+        (!record.latePaneCleanup ||
+          (serverUrl !== undefined &&
+            (typeof serverUrl === 'function' ? serverUrl() : serverUrl) ===
+              record.serverUrl &&
+            !record.closePromise)) &&
+        (record.lifecycle === 'orphaned' || record.lifecycle === 'deleted'),
+    );
+    for (const record of claimed) {
+      record.closeTimer?.cancel();
+      record.closeTimer = undefined;
+      record.owner = owner;
+    }
+    return claimed;
+  }
+  claimLatePaneOrphans(
+    owner: string,
+    directory: string,
+    serverUrl: string,
+  ): CmuxSessionRecord[] {
+    const claimed = [...records().values()].filter(
+      (record) =>
+        record.owner !== owner &&
+        record.latePaneCleanup === true &&
+        record.directory === directory &&
+        record.serverUrl === serverUrl &&
+        Boolean(record.paneId) &&
+        !record.closePromise &&
         (record.lifecycle === 'orphaned' || record.lifecycle === 'deleted'),
     );
     for (const record of claimed) {
@@ -128,5 +231,6 @@ export class CmuxSessionStore {
       record.closeTimer?.cancel();
     }
     records().clear();
+    orphanObservers().clear();
   }
 }

--- a/src/multiplexer/session-manager.test.ts
+++ b/src/multiplexer/session-manager.test.ts
@@ -620,6 +620,47 @@ describe('MultiplexerSessionManager', () => {
       expect(state.sessions.has('throw-retry')).toBe(false);
     });
 
+    test('stops polling after a generic close retry is exhausted', async () => {
+      mockMultiplexer.spawnPane.mockResolvedValue({
+        success: true,
+        paneId: 'p-exhausted',
+      });
+      mockMultiplexer.closePane.mockResolvedValue(false);
+      const manager = new MultiplexerSessionManager(
+        createMockContext(),
+        defaultMultiplexerConfig,
+        undefined,
+        { closeRetryMaxAttempts: 1 },
+      );
+
+      await manager.onSessionCreated({
+        type: 'session.created',
+        properties: { info: { id: 'exhausted', parentID: 'parent' } },
+      });
+      await manager.onSessionDeleted({
+        type: 'session.deleted',
+        properties: { sessionID: 'exhausted' },
+      });
+
+      const state = manager as unknown as {
+        sessions: Map<
+          string,
+          { paneId: string; closeState?: Record<string, unknown> }
+        >;
+        pollInterval?: unknown;
+      };
+      expect(mockMultiplexer.closePane).toHaveBeenCalledTimes(1);
+      expect(state.sessions.get('exhausted')).toMatchObject({
+        paneId: 'p-exhausted',
+        closeState: { phase: 'exhausted', attempts: 1 },
+      });
+      expect(state.pollInterval).toBeUndefined();
+
+      await (manager as any).pollSessions();
+      expect(mockMultiplexer.closePane).toHaveBeenCalledTimes(1);
+      expect(state.sessions.has('exhausted')).toBe(true);
+    });
+
     test('closes pane immediately on session.idle event', async () => {
       const ctx = createMockContext();
       mockMultiplexer.spawnPane.mockResolvedValue({
@@ -2955,6 +2996,61 @@ describe('MultiplexerSessionManager', () => {
       expect(mockMultiplexer.closePane).toHaveBeenCalledTimes(2);
       expect(mockMultiplexer.closePane).toHaveBeenCalledWith('p1');
       expect(mockMultiplexer.closePane).toHaveBeenCalledWith('p2');
+    });
+
+    test('cleanup keeps polling retries alive after false and thrown closes', async () => {
+      for (const failure of ['false', 'throw'] as const) {
+        resetMultiplexerSessionManagerState();
+        mockSessionStatuses = {};
+        mockMultiplexer.spawnPane.mockReset();
+        mockMultiplexer.spawnPane.mockResolvedValue({
+          success: true,
+          paneId: `p-cleanup-retry-${failure}`,
+        });
+        mockMultiplexer.closePane.mockReset();
+        if (failure === 'false') {
+          mockMultiplexer.closePane
+            .mockResolvedValueOnce(false)
+            .mockResolvedValueOnce(true);
+        } else {
+          mockMultiplexer.closePane
+            .mockRejectedValueOnce(new Error('cleanup socket'))
+            .mockResolvedValueOnce(true);
+        }
+
+        const sessionId = `cleanup-retry-${failure}`;
+        const manager = new MultiplexerSessionManager(
+          createMockContext(),
+          defaultMultiplexerConfig,
+          undefined,
+          { closeRetryMs: 0 },
+        );
+        await manager.onSessionCreated({
+          type: 'session.created',
+          properties: { info: { id: sessionId, parentID: 'parent' } },
+        });
+
+        await manager.cleanup();
+
+        const state = manager as unknown as {
+          sessions: Map<
+            string,
+            { paneId: string; closeState?: Record<string, unknown> }
+          >;
+          pollInterval?: unknown;
+        };
+        expect(state.sessions.get(sessionId)).toMatchObject({
+          paneId: `p-cleanup-retry-${failure}`,
+          closeState: { phase: 'retrying', attempts: 1 },
+        });
+        expect(state.pollInterval).toBeDefined();
+
+        await (manager as any).pollSessions();
+
+        expect(mockMultiplexer.closePane).toHaveBeenCalledTimes(2);
+        expect(state.sessions.has(sessionId)).toBe(false);
+        expect(state.pollInterval).toBeUndefined();
+      }
     });
 
     test('cleanup fences the in-flight spawn and clears spawning for later creates', async () => {

--- a/src/multiplexer/session-manager.test.ts
+++ b/src/multiplexer/session-manager.test.ts
@@ -534,6 +534,92 @@ describe('MultiplexerSessionManager', () => {
       expect(mockMultiplexer.closePane).toHaveBeenCalledWith('p-1');
     });
 
+    test('retains a false close and retries it through polling', async () => {
+      mockMultiplexer.spawnPane.mockResolvedValue({
+        success: true,
+        paneId: 'p-false-retry',
+      });
+      mockMultiplexer.closePane
+        .mockResolvedValueOnce(false)
+        .mockResolvedValueOnce(true);
+      const manager = new MultiplexerSessionManager(
+        createMockContext(),
+        defaultMultiplexerConfig,
+        undefined,
+        { closeRetryMs: 0 },
+      );
+
+      await manager.onSessionCreated({
+        type: 'session.created',
+        properties: { info: { id: 'false-retry', parentID: 'parent' } },
+      });
+      await manager.onSessionDeleted({
+        type: 'session.deleted',
+        properties: { sessionID: 'false-retry' },
+      });
+
+      const state = manager as unknown as {
+        sessions: Map<
+          string,
+          { paneId: string; closeState?: Record<string, unknown> }
+        >;
+      };
+      expect(state.sessions.get('false-retry')).toMatchObject({
+        paneId: 'p-false-retry',
+        closeState: { phase: 'retrying', attempts: 1 },
+      });
+
+      await (manager as any).pollSessions();
+
+      expect(mockMultiplexer.closePane).toHaveBeenCalledTimes(2);
+      expect(state.sessions.has('false-retry')).toBe(false);
+    });
+
+    test('retains a thrown close and retries it through polling', async () => {
+      mockMultiplexer.spawnPane.mockResolvedValue({
+        success: true,
+        paneId: 'p-throw-retry',
+      });
+      mockMultiplexer.closePane
+        .mockRejectedValueOnce(new Error('socket closed'))
+        .mockResolvedValueOnce(true);
+      const manager = new MultiplexerSessionManager(
+        createMockContext(),
+        defaultMultiplexerConfig,
+        undefined,
+        { closeRetryMs: 0 },
+      );
+
+      await manager.onSessionCreated({
+        type: 'session.created',
+        properties: { info: { id: 'throw-retry', parentID: 'parent' } },
+      });
+      await manager.onSessionDeleted({
+        type: 'session.deleted',
+        properties: { sessionID: 'throw-retry' },
+      });
+
+      const state = manager as unknown as {
+        sessions: Map<
+          string,
+          { paneId: string; closeState?: Record<string, unknown> }
+        >;
+      };
+      expect(state.sessions.get('throw-retry')).toMatchObject({
+        paneId: 'p-throw-retry',
+        closeState: {
+          phase: 'retrying',
+          attempts: 1,
+          lastError: 'Error: socket closed',
+        },
+      });
+
+      await (manager as any).pollSessions();
+
+      expect(mockMultiplexer.closePane).toHaveBeenCalledTimes(2);
+      expect(state.sessions.has('throw-retry')).toBe(false);
+    });
+
     test('closes pane immediately on session.idle event', async () => {
       const ctx = createMockContext();
       mockMultiplexer.spawnPane.mockResolvedValue({
@@ -1332,7 +1418,7 @@ describe('MultiplexerSessionManager', () => {
       );
     });
 
-    test('does not close on transient status absence', async () => {
+    test('retains pane when status remains absent', async () => {
       const ctx = createMockContext();
       const manager = new MultiplexerSessionManager(
         ctx,
@@ -1345,9 +1431,11 @@ describe('MultiplexerSessionManager', () => {
       });
 
       setMockSessionStatuses({});
-      await (manager as any).pollSessions();
+      for (let index = 0; index < 5; index++)
+        await (manager as any).pollSessions();
 
       expect(mockMultiplexer.closePane).not.toHaveBeenCalled();
+      expect((manager as any).sessions.has('c1')).toBe(true);
     });
 
     test('keeps background child pane open while status is running until deleted', async () => {
@@ -2541,38 +2629,26 @@ describe('MultiplexerSessionManager', () => {
       await Promise.all([first, second]);
     });
 
-    test('missing resets idle streak and closes after grace expires', async () => {
+    test('missing status never confirms close', async () => {
       mockMultiplexerType = 'cmux';
       let now = 0;
       const manager = new MultiplexerSessionManager(
         createMockContext(),
         cmuxConfig,
         undefined,
-        { now: () => now, missingGraceMs: 30 },
+        { now: () => now },
       );
       await manager.onSessionCreated({
         type: 'session.created',
         properties: { info: { id: 'missing', parentID: 'parent' } },
       });
       now = 10_000;
-      setMockSessionStatuses({ missing: { type: 'idle' } });
-      await (manager as any).pollSessions();
       setMockSessionStatuses({});
-      await (manager as any).pollSessions();
-      now += 29;
-      await (manager as any).pollSessions();
+      for (let index = 0; index < 6; index++) {
+        await (manager as any).pollSessions();
+        now += 30_000;
+      }
       expect(mockMultiplexer.closePane).not.toHaveBeenCalled();
-      setMockSessionStatuses({ missing: { type: 'idle' } });
-      await (manager as any).pollSessions();
-      await (manager as any).pollSessions();
-      expect(mockMultiplexer.closePane).not.toHaveBeenCalled();
-      setMockSessionStatuses({});
-      await (manager as any).pollSessions();
-      now += 30;
-      await (manager as any).pollSessions();
-      await (manager as any).pollSessions();
-      await (manager as any).pollSessions();
-      expect(mockMultiplexer.closePane).toHaveBeenCalledTimes(1);
     });
 
     test('background job policy still gates stable cmux idle close', async () => {
@@ -2915,6 +2991,7 @@ describe('MultiplexerSessionManager', () => {
       await manager.onSessionCreated(event);
 
       expect(mockMultiplexer.spawnPane).toHaveBeenCalledTimes(1);
+      await manager.cleanup();
     });
   });
 });

--- a/src/multiplexer/session-manager.test.ts
+++ b/src/multiplexer/session-manager.test.ts
@@ -2971,6 +2971,140 @@ describe('MultiplexerSessionManager', () => {
       expect(mockMultiplexer.closePane).not.toHaveBeenCalled();
     });
 
+    test('generic cleanup bounds a pending close and retries after false', async () => {
+      const close = createDeferred<boolean>();
+      mockMultiplexer.closePane
+        .mockImplementationOnce(() => close.promise)
+        .mockResolvedValueOnce(true);
+      const manager = new MultiplexerSessionManager(
+        createMockContext(),
+        defaultMultiplexerConfig,
+        undefined,
+        { closeRetryMs: 0, shutdownTimeoutMs: 1 },
+      );
+      const sessionId = 'generic-cleanup-pending';
+
+      await manager.onSessionCreated({
+        type: 'session.created',
+        properties: { info: { id: sessionId, parentID: 'parent' } },
+      });
+      const deleting = manager.onSessionDeleted({
+        type: 'session.deleted',
+        properties: { sessionID: sessionId },
+      });
+      await flushPromises();
+
+      const state = manager as unknown as {
+        sessions: Map<string, { paneId: string; closeState?: unknown }>;
+        closingSessions: Map<string, Promise<void>>;
+      };
+      const tracked = state.sessions.get(sessionId);
+      const closing = state.closingSessions.get(sessionId);
+      expect(tracked).toMatchObject({ paneId: '%mock-pane' });
+      expect(closing).toBeDefined();
+      expect(mockMultiplexer.closePane).toHaveBeenCalledTimes(1);
+
+      await manager.cleanup();
+
+      expect(state.sessions.get(sessionId)).toBe(tracked);
+      expect(state.sessions.get(sessionId)).toMatchObject({
+        paneId: '%mock-pane',
+        closeState: { phase: 'closing', attempts: 1 },
+      });
+      expect(state.closingSessions.get(sessionId)).toBe(closing);
+      expect(mockMultiplexer.closePane).toHaveBeenCalledTimes(1);
+
+      close.resolve(false);
+      await deleting;
+      await flushPromises();
+      expect(state.sessions.get(sessionId)).toMatchObject({
+        paneId: '%mock-pane',
+        closeState: { phase: 'retrying', attempts: 1 },
+      });
+      expect(state.closingSessions.has(sessionId)).toBe(false);
+      expect(mockMultiplexer.closePane).toHaveBeenCalledTimes(1);
+
+      await (manager as any).pollSessions();
+      expect(mockMultiplexer.closePane).toHaveBeenCalledTimes(2);
+      expect(state.sessions.has(sessionId)).toBe(false);
+    });
+
+    for (const result of [true, false]) {
+      test(`generic cleanup ${result ? 'success' : 'failure'} cannot mutate a replacement record`, async () => {
+        const close = createDeferred<boolean>();
+        mockMultiplexer.closePane.mockImplementationOnce(() => close.promise);
+        const manager = new MultiplexerSessionManager(
+          createMockContext(),
+          defaultMultiplexerConfig,
+          undefined,
+          { shutdownTimeoutMs: 1 },
+        );
+        const sessionId = `generic-replacement-${result}`;
+
+        await manager.onSessionCreated({
+          type: 'session.created',
+          properties: { info: { id: sessionId, parentID: 'parent' } },
+        });
+        const deleting = manager.onSessionDeleted({
+          type: 'session.deleted',
+          properties: { sessionID: sessionId },
+        });
+        await flushPromises();
+
+        const state = manager as unknown as {
+          sessions: Map<
+            string,
+            {
+              sessionId: string;
+              paneId: string;
+              parentId: string;
+              title: string;
+              directory: string;
+              ownerInstanceId: string;
+            }
+          >;
+          closingSessions: Map<string, Promise<void>>;
+        };
+        await manager.cleanup();
+        const oldClosing = state.closingSessions.get(sessionId);
+        expect(oldClosing).toBeDefined();
+        expect(mockMultiplexer.closePane).toHaveBeenCalledTimes(1);
+
+        const next = new MultiplexerSessionManager(
+          createMockContext(),
+          defaultMultiplexerConfig,
+        );
+        const replacement = {
+          sessionId,
+          paneId: 'replacement-pane',
+          parentId: 'parent',
+          title: 'Replacement',
+          directory: '/test/directory',
+          ownerInstanceId: (next as any).instanceId as string,
+        };
+        state.sessions.set(sessionId, replacement);
+
+        close.resolve(result);
+        await deleting;
+        await flushPromises();
+
+        expect(state.sessions.get(sessionId)).toBe(replacement);
+        expect(state.closingSessions.has(sessionId)).toBe(false);
+        expect(mockMultiplexer.closePane).toHaveBeenCalledTimes(1);
+
+        await next.onSessionDeleted({
+          type: 'session.deleted',
+          properties: { sessionID: sessionId },
+        });
+        expect(mockMultiplexer.closePane).toHaveBeenCalledTimes(2);
+        expect(mockMultiplexer.closePane).toHaveBeenLastCalledWith(
+          'replacement-pane',
+        );
+        expect(state.sessions.has(sessionId)).toBe(false);
+        await next.cleanup();
+      });
+    }
+
     test('closes all tracked panes concurrently', async () => {
       const ctx = createMockContext();
       mockMultiplexer.spawnPane

--- a/src/multiplexer/session-manager.ts
+++ b/src/multiplexer/session-manager.ts
@@ -29,6 +29,15 @@ interface TrackedSession {
   title: string;
   directory: string;
   ownerInstanceId: string;
+  closeState?: PaneCloseState;
+}
+
+interface PaneCloseState {
+  reason: CloseReason;
+  phase: 'closing' | 'retrying' | 'exhausted';
+  attempts: number;
+  nextAttemptAt: number;
+  lastError?: string;
 }
 
 interface KnownSession {
@@ -165,8 +174,11 @@ export class MultiplexerSessionManager {
   private enabled = false;
   private cmuxLifecycle?: CmuxSessionLifecycle;
   private readonly readiness: SessionReadinessOptions;
-  /** Abort handle for the in-flight readiness wait; cleanup/disposal abort it. */
+  private readonly now: () => number;
+  private readonly closeRetryMs: number;
+  private readonly closeRetryMaxAttempts: number;
   private readinessAbort?: AbortController;
+  private cleanupInProgress = false;
   /**
    * Sessions that signaled `busy` while a spawn/readiness pass was in flight
    * (the busy handler defers to the pending pass). Consumed after the pass:
@@ -188,6 +200,13 @@ export class MultiplexerSessionManager {
     this.closingSessions = sharedState.closingSessions;
     this.permanentlyClosedSessions = sharedState.permanentlyClosedSessions;
     this.readiness = options;
+    this.now = options.now ?? Date.now;
+    this.closeRetryMs = Number.isFinite(options.closeRetryMs)
+      ? Math.max(0, options.closeRetryMs ?? 1_000)
+      : 1_000;
+    this.closeRetryMaxAttempts = Number.isFinite(options.closeRetryMaxAttempts)
+      ? Math.max(1, Math.floor(options.closeRetryMaxAttempts ?? 4))
+      : 4;
 
     this.directory = ctx.directory;
     this.resolveServerUrl = createServerUrlResolver(ctx);
@@ -233,11 +252,7 @@ export class MultiplexerSessionManager {
     return { ...this.readiness, signal: controller.signal };
   }
 
-  /**
-   * Abort any in-flight readiness wait so cleanup/disposal can never be
-   * stalled by a hanging probe. The aborted wait resolves false and the
-   * pending spawn is fenced off.
-   */
+  /** Abort an in-flight readiness wait during cleanup or disposal. */
   private abortInFlightReadiness(): void {
     this.readinessAbort?.abort();
     this.readinessAbort = undefined;
@@ -249,9 +264,7 @@ export class MultiplexerSessionManager {
     if (event.type !== 'session.created') return;
 
     const info = event.properties?.info;
-    if (!info?.id || !info?.parentID) {
-      return;
-    }
+    if (!info?.id || !info?.parentID) return;
 
     const sessionId = info.id;
     const parentId = info.parentID;
@@ -293,10 +306,7 @@ export class MultiplexerSessionManager {
       if (!serverUrl) {
         log(
           '[multiplexer-session-manager] no valid server URL, skipping spawn',
-          {
-            instanceId: this.instanceId,
-            sessionId,
-          },
+          { instanceId: this.instanceId, sessionId },
         );
         return;
       }
@@ -309,9 +319,7 @@ export class MultiplexerSessionManager {
         return;
       }
 
-      // Attach-before-ready race: wait for the child session to appear on the
-      // status endpoint before launching `opencode attach`; otherwise the
-      // attach TUI falls back to the new-session picker.
+      // Attach only after the child session is visible to the server.
       const readinessOptions = this.readinessOptions();
       const sessionReady = await waitForSessionReady(
         serverUrl,
@@ -321,11 +329,7 @@ export class MultiplexerSessionManager {
       if (!sessionReady || readinessOptions.signal?.aborted) {
         log(
           '[multiplexer-session-manager] child session not ready, skipping spawn',
-          {
-            instanceId: this.instanceId,
-            sessionId,
-            parentId,
-          },
+          { instanceId: this.instanceId, sessionId, parentId },
         );
         return;
       }
@@ -334,19 +338,8 @@ export class MultiplexerSessionManager {
         this.permanentlyClosedSessions.has(sessionId) ||
         this.closingSessions.has(sessionId) ||
         this.sessions.has(sessionId)
-      ) {
+      )
         return;
-      }
-
-      log(
-        '[multiplexer-session-manager] child session created, spawning pane',
-        {
-          sessionId,
-          parentId,
-          title,
-          instanceId: this.instanceId,
-        },
-      );
 
       const paneResult = await this.multiplexer
         .spawnPane(sessionId, title, serverUrl, directory)
@@ -365,16 +358,12 @@ export class MultiplexerSessionManager {
         this.closingSessions.has(sessionId) ||
         this.permanentlyClosedSessions.has(sessionId)
       ) {
-        await this.multiplexer.closePane(paneResult.paneId).catch((err) =>
-          log(
-            '[multiplexer-session-manager] closing stale spawned pane failed',
-            {
-              sessionId,
-              paneId: paneResult.paneId,
-              instanceId: this.instanceId,
-              error: String(err),
-            },
-          ),
+        await this.trackAndCloseStalePane(
+          sessionId,
+          paneResult.paneId,
+          parentId,
+          title,
+          directory,
         );
         return;
       }
@@ -410,10 +399,18 @@ export class MultiplexerSessionManager {
     if (this.cmuxLifecycle) return this.cmuxLifecycle.onSessionStatus(event);
     if (!this.enabled) return;
 
-    if (event.type === 'session.idle') {
-      const sessionId = event.properties?.sessionID;
-      if (!sessionId) return;
+    const sessionId = this.getSessionId(event);
+    if (!sessionId) return;
 
+    const statusType =
+      event.type === 'session.idle'
+        ? 'idle'
+        : event.type === 'session.status'
+          ? event.properties?.status?.type
+          : undefined;
+    if (!statusType) return;
+
+    if (statusType === 'idle') {
       log('[multiplexer-session-manager] session idle event received', {
         instanceId: this.instanceId,
         sessionId,
@@ -422,47 +419,25 @@ export class MultiplexerSessionManager {
         ownerInstanceId: this.sessions.get(sessionId)?.ownerInstanceId,
         backgroundJobState: this.backgroundJobState(sessionId),
       });
-
       await this.closeSession(sessionId, 'idle');
       return;
     }
 
-    if (event.type !== 'session.status') return;
-
-    const sessionId = event.properties?.sessionID;
-    if (!sessionId) return;
-
-    const statusType = event.properties?.status?.type;
-
-    if (statusType === 'idle') {
-      log('[multiplexer-session-manager] session status idle received', {
-        instanceId: this.instanceId,
-        sessionId,
-        tracked: this.sessions.has(sessionId),
-        known: this.knownSessions.has(sessionId),
-        ownerInstanceId: this.sessions.get(sessionId)?.ownerInstanceId,
-        backgroundJobState: this.backgroundJobState(sessionId),
-      });
-      await this.closeSession(sessionId, 'idle');
+    if (statusType !== 'busy') {
+      this.backgroundJobBoard?.clearDeferredClose(sessionId);
+      this.cancelFailedIdleClose(sessionId);
       return;
     }
 
-    if (statusType) {
-      if (statusType !== 'busy') {
-        this.backgroundJobBoard?.clearDeferredClose(sessionId);
-        return;
-      }
-
-      log('[multiplexer-session-manager] session busy event received', {
-        instanceId: this.instanceId,
-        sessionId,
-        tracked: this.sessions.has(sessionId),
-        known: this.knownSessions.has(sessionId),
-        ownerInstanceId: this.sessions.get(sessionId)?.ownerInstanceId,
-        backgroundJobState: this.backgroundJobState(sessionId),
-      });
-      await this.respawnIfKnown(sessionId);
-    }
+    log('[multiplexer-session-manager] session busy event received', {
+      instanceId: this.instanceId,
+      sessionId,
+      tracked: this.sessions.has(sessionId),
+      known: this.knownSessions.has(sessionId),
+      ownerInstanceId: this.sessions.get(sessionId)?.ownerInstanceId,
+      backgroundJobState: this.backgroundJobState(sessionId),
+    });
+    await this.respawnIfKnown(sessionId);
   }
 
   async onSessionDeleted(event: SessionEvent): Promise<void> {
@@ -486,8 +461,7 @@ export class MultiplexerSessionManager {
   }
 
   private startPolling(): void {
-    if (this.pollInterval) return;
-
+    if (this.pollInterval || this.cleanupInProgress) return;
     this.pollInterval = setInterval(
       () => this.pollSessions(),
       POLL_INTERVAL_BACKGROUND_MS,
@@ -509,43 +483,100 @@ export class MultiplexerSessionManager {
 
   private async pollSessions(): Promise<void> {
     if (this.cmuxLifecycle) return this.cmuxLifecycle.pollOnce();
-    if (this.sessions.size === 0) {
+
+    const ownedSessions = () =>
+      [...this.sessions.entries()].filter(
+        ([, tracked]) => tracked.ownerInstanceId === this.instanceId,
+      );
+    if (ownedSessions().length === 0) {
       this.stopPolling();
       return;
     }
 
+    let allStatuses: Record<string, { type: string }> | undefined;
     try {
-      const allStatuses = await this.fetchSessionStatuses();
+      allStatuses = await this.fetchSessionStatuses();
+    } catch (err) {
+      log('[multiplexer-session-manager] poll error', { error: String(err) });
+    }
 
-      const sessionsToClose: string[] = [];
+    await this.retryDueCloses(allStatuses);
+    if (ownedSessions().length === 0) {
+      this.stopPolling();
+      return;
+    }
+    if (!allStatuses) return;
 
-      for (const [sessionId, tracked] of this.sessions.entries()) {
+    const sessionsToClose: string[] = [];
+    for (const [sessionId, tracked] of ownedSessions()) {
+      if (tracked.closeState) continue;
+
+      const status = allStatuses[sessionId];
+      if (!status) {
+        // An absent map entry is only diagnostic; it is not deletion evidence.
+        log('[multiplexer-session-manager] status absent; retaining pane', {
+          instanceId: this.instanceId,
+          ownerInstanceId: tracked.ownerInstanceId,
+          sessionId,
+          paneId: tracked.paneId,
+          backgroundJobState: this.backgroundJobState(sessionId),
+        });
+        continue;
+      }
+
+      if (status.type !== 'idle') {
+        this.backgroundJobBoard?.clearDeferredClose(sessionId);
+        continue;
+      }
+
+      sessionsToClose.push(sessionId);
+    }
+
+    for (const sessionId of sessionsToClose)
+      await this.closeSession(sessionId, 'idle');
+  }
+
+  private async retryDueCloses(
+    allStatuses?: Record<string, { type: string }>,
+  ): Promise<void> {
+    const now = this.now();
+    const retryIds = [...this.sessions.entries()]
+      .filter(([sessionId, tracked]) => {
         if (tracked.ownerInstanceId !== this.instanceId) {
-          log('[multiplexer-session-manager] skipping non-owner poll close', {
+          log('[multiplexer-session-manager] skipping non-owner close retry', {
             instanceId: this.instanceId,
             ownerInstanceId: tracked.ownerInstanceId,
             sessionId,
             paneId: tracked.paneId,
           });
-          continue;
+          return false;
         }
-
-        const status = allStatuses[sessionId];
-        if (!status) continue;
-
-        if (status.type !== 'idle') {
-          this.backgroundJobBoard?.clearDeferredClose(sessionId);
-          continue;
+        const close = tracked.closeState;
+        if (close?.phase !== 'retrying') return false;
+        if (close.nextAttemptAt > now) return false;
+        if (
+          close.reason === 'idle' &&
+          allStatuses?.[sessionId] &&
+          allStatuses[sessionId].type !== 'idle'
+        ) {
+          tracked.closeState = undefined;
+          log(
+            '[multiplexer-session-manager] cancelled idle close after busy poll',
+            {
+              instanceId: this.instanceId,
+              sessionId,
+              paneId: tracked.paneId,
+            },
+          );
+          return false;
         }
+        return true;
+      })
+      .map(([sessionId]) => sessionId);
 
-        sessionsToClose.push(sessionId);
-      }
-
-      for (const sessionId of sessionsToClose) {
-        await this.closeSession(sessionId, 'idle');
-      }
-    } catch (err) {
-      log('[multiplexer-session-manager] poll error', { error: String(err) });
+    for (const sessionId of retryIds) {
+      const reason = this.sessions.get(sessionId)?.closeState?.reason;
+      if (reason) await this.closeSession(sessionId, reason, true);
     }
   }
 
@@ -562,22 +593,45 @@ export class MultiplexerSessionManager {
     const url = new URL('/session/status', serverUrl);
     const response = await fetch(url, { signal: AbortSignal.timeout(2_000) });
 
-    if (!response.ok) {
+    if (!response.ok)
       throw new Error(
         `session status request failed: ${response.status} ${response.statusText}`,
       );
-    }
 
     const body = await response.text();
-    if (body.trim() === '') {
+    if (body.trim() === '')
       throw new Error('session status response was empty');
-    }
 
     try {
       return JSON.parse(body) as Record<string, { type: string }>;
     } catch (err) {
       throw new Error(`session status response was not valid JSON: ${err}`);
     }
+  }
+
+  private async trackAndCloseStalePane(
+    sessionId: string,
+    paneId: string,
+    parentId: string,
+    title: string,
+    directory: string,
+  ): Promise<void> {
+    const trackingId = `${sessionId}\0stale\0${paneId}`;
+    this.sessions.set(trackingId, {
+      sessionId: trackingId,
+      paneId,
+      parentId,
+      title,
+      directory,
+      ownerInstanceId: this.instanceId,
+    });
+    log('[multiplexer-session-manager] tracking stale spawned pane', {
+      instanceId: this.instanceId,
+      sessionId,
+      trackingId,
+      paneId,
+    });
+    await this.closeSession(trackingId, 'deleted', true);
   }
 
   private async closeSession(
@@ -589,9 +643,6 @@ export class MultiplexerSessionManager {
       this.knownSessions.delete(sessionId);
       this.backgroundJobBoard?.clearDeferredClose(sessionId);
     }
-
-    const existingClose = this.closingSessions.get(sessionId);
-    if (existingClose) return existingClose;
 
     const tracked = this.sessions.get(sessionId);
     if (!tracked || !this.multiplexer) {
@@ -605,7 +656,10 @@ export class MultiplexerSessionManager {
       return;
     }
 
-    if (reason !== 'deleted' && tracked.ownerInstanceId !== this.instanceId) {
+    // A session.deleted event is global deletion evidence and keeps the
+    // existing behavior of closing the known pane. Idle/retry work is owner
+    // scoped so another manager cannot close a shared record.
+    if (reason === 'idle' && tracked.ownerInstanceId !== this.instanceId) {
       log('[multiplexer-session-manager] close skipped; non-owner instance', {
         instanceId: this.instanceId,
         ownerInstanceId: tracked.ownerInstanceId,
@@ -615,14 +669,12 @@ export class MultiplexerSessionManager {
       });
       return;
     }
-    if (reason === 'deleted' && tracked.ownerInstanceId !== this.instanceId) {
-      log('[multiplexer-session-manager] closing deleted pane as non-owner', {
-        instanceId: this.instanceId,
-        ownerInstanceId: tracked.ownerInstanceId,
-        sessionId,
-        paneId: tracked.paneId,
-        reason,
-      });
+
+    const existingClose = this.closingSessions.get(sessionId);
+    if (existingClose) {
+      if (reason === 'deleted' && tracked.closeState)
+        tracked.closeState.reason = 'deleted';
+      return existingClose;
     }
 
     if (
@@ -643,52 +695,199 @@ export class MultiplexerSessionManager {
       return;
     }
 
-    this.sessions.delete(sessionId);
+    const closeState = this.getOrCreateCloseState(tracked, reason);
+    if (closeState.phase === 'exhausted') {
+      log('[multiplexer-session-manager] close retry budget exhausted', {
+        instanceId: this.instanceId,
+        sessionId,
+        paneId: tracked.paneId,
+        reason: closeState.reason,
+        attempts: closeState.attempts,
+        lastError: closeState.lastError,
+      });
+      return;
+    }
+    if (closeState.nextAttemptAt > this.now()) return;
 
+    closeState.phase = 'closing';
+    closeState.attempts += 1;
+    const paneId = tracked.paneId;
     log('[multiplexer-session-manager] closing session pane', {
       instanceId: this.instanceId,
       sessionId,
-      paneId: tracked.paneId,
-      reason,
+      paneId,
+      reason: closeState.reason,
+      attempt: closeState.attempts,
       backgroundJobState: this.backgroundJobState(sessionId),
       parentId: tracked.parentId,
       title: tracked.title,
     });
 
-    const closePromise: Promise<void> = this.multiplexer
-      .closePane(tracked.paneId)
-      .then(() => undefined)
-      .catch((err) =>
-        log('[multiplexer-session-manager] failed to close session pane', {
-          instanceId: this.instanceId,
-          sessionId,
-          paneId: tracked.paneId,
-          reason,
-          error: String(err),
-        }),
-      )
-      .finally(() => {
-        this.closingSessions.delete(sessionId);
-        this.updatePolling();
-      });
-
+    const closePromise = this.performClose(
+      sessionId,
+      tracked,
+      paneId,
+      closeState,
+      this.multiplexer,
+    ).finally(() => {
+      this.closingSessions.delete(sessionId);
+      this.updatePolling();
+    });
     this.closingSessions.set(sessionId, closePromise);
     await closePromise;
+  }
+
+  private async performClose(
+    sessionId: string,
+    tracked: TrackedSession,
+    paneId: string,
+    closeState: PaneCloseState,
+    multiplexer: Multiplexer,
+  ): Promise<void> {
+    let closed = false;
+    let error: string | undefined;
+    try {
+      // Await the adapter operation. A later retry cannot reuse this pane ID
+      // until this promise has settled.
+      closed = await multiplexer.closePane(paneId);
+    } catch (err) {
+      error = String(err);
+    }
+
+    const current = this.sessions.get(sessionId);
+    const deletionClose = closeState.reason === 'deleted';
+    if (
+      !current ||
+      current !== tracked ||
+      current.paneId !== paneId ||
+      (current.ownerInstanceId !== this.instanceId && !deletionClose)
+    ) {
+      log('[multiplexer-session-manager] ignoring stale pane close result', {
+        instanceId: this.instanceId,
+        sessionId,
+        paneId,
+        closed,
+        error,
+      });
+      return;
+    }
+
+    if (closed) {
+      current.closeState = undefined;
+      this.sessions.delete(sessionId);
+      log('[multiplexer-session-manager] session pane close confirmed', {
+        instanceId: this.instanceId,
+        sessionId,
+        paneId,
+        attempt: closeState.attempts,
+      });
+      return;
+    }
+
+    closeState.lastError = error ?? 'closePane returned false';
+    if (closeState.attempts >= this.closeRetryMaxAttempts) {
+      closeState.phase = 'exhausted';
+      closeState.nextAttemptAt = Number.POSITIVE_INFINITY;
+    } else {
+      closeState.phase = 'retrying';
+      closeState.nextAttemptAt = this.now() + this.closeRetryMs;
+    }
+    log(
+      '[multiplexer-session-manager] failed to close session pane; retained',
+      {
+        instanceId: this.instanceId,
+        sessionId,
+        paneId,
+        reason: closeState.reason,
+        attempt: closeState.attempts,
+        phase: closeState.phase,
+        nextAttemptAt: closeState.nextAttemptAt,
+        error: closeState.lastError,
+      },
+    );
+  }
+
+  private getOrCreateCloseState(
+    tracked: TrackedSession,
+    reason: CloseReason,
+  ): PaneCloseState {
+    const existing = tracked.closeState;
+    if (!existing) {
+      const state: PaneCloseState = {
+        reason,
+        phase: 'retrying',
+        attempts: 0,
+        nextAttemptAt: this.now(),
+      };
+      tracked.closeState = state;
+      return state;
+    }
+
+    if (reason === 'deleted' && existing.reason !== 'deleted') {
+      existing.reason = 'deleted';
+      if (existing.phase !== 'closing') {
+        existing.phase = 'retrying';
+        existing.attempts = 0;
+        existing.nextAttemptAt = this.now();
+        existing.lastError = undefined;
+      }
+    }
+    return existing;
+  }
+
+  private cancelFailedIdleClose(sessionId: string): void {
+    const tracked = this.sessions.get(sessionId);
+    if (
+      tracked?.ownerInstanceId === this.instanceId &&
+      tracked.closeState?.reason === 'idle' &&
+      !this.closingSessions.has(sessionId)
+    ) {
+      tracked.closeState = undefined;
+      this.updatePolling();
+    }
   }
 
   private async respawnIfKnown(sessionId: string): Promise<void> {
     if (!this.enabled || !this.multiplexer) return;
     if (this.permanentlyClosedSessions.has(sessionId)) return;
+
+    const trackedBeforeClose = this.sessions.get(sessionId);
+    if (
+      trackedBeforeClose &&
+      trackedBeforeClose.ownerInstanceId !== this.instanceId
+    ) {
+      log('[multiplexer-session-manager] respawn skipped; non-owner instance', {
+        instanceId: this.instanceId,
+        ownerInstanceId: trackedBeforeClose.ownerInstanceId,
+        sessionId,
+        paneId: trackedBeforeClose.paneId,
+      });
+      return;
+    }
+
     const closing = this.closingSessions.get(sessionId);
     if (closing) await closing;
 
     if (this.permanentlyClosedSessions.has(sessionId)) return;
-    if (this.isTrackedOrSpawning(sessionId)) {
-      // A busy signal while a spawn is in flight: remember it so the pending
-      // pass can recover if it fails to attach a pane.
-      if (this.spawningSessions.has(sessionId)) {
-        this.busyDuringSpawn.add(sessionId);
+    const tracked = this.sessions.get(sessionId);
+    if (tracked) {
+      if (tracked.closeState?.reason === 'idle') {
+        // A failed idle close leaves the pane attached; busy activity can use
+        // it without spawning a second pane.
+        tracked.closeState = undefined;
+        this.updatePolling();
+        log('[multiplexer-session-manager] retained pane after close failure', {
+          instanceId: this.instanceId,
+          sessionId,
+          paneId: tracked.paneId,
+        });
       }
+      return;
+    }
+
+    if (this.isTrackedOrSpawning(sessionId)) {
+      if (this.spawningSessions.has(sessionId))
+        this.busyDuringSpawn.add(sessionId);
       return;
     }
 
@@ -696,16 +895,12 @@ export class MultiplexerSessionManager {
     if (!known) return;
 
     this.spawningSessions.add(sessionId);
-
     try {
       const serverUrl = this.resolveServerUrl();
       if (!serverUrl) {
         log(
           '[multiplexer-session-manager] no valid server URL, skipping respawn',
-          {
-            instanceId: this.instanceId,
-            sessionId,
-          },
+          { instanceId: this.instanceId, sessionId },
         );
         return;
       }
@@ -713,17 +908,11 @@ export class MultiplexerSessionManager {
       if (!serverRunning) {
         log(
           '[multiplexer-session-manager] server not running, skipping busy respawn',
-          {
-            instanceId: this.instanceId,
-            serverUrl,
-            sessionId,
-          },
+          { instanceId: this.instanceId, serverUrl, sessionId },
         );
         return;
       }
 
-      // Same attach-before-ready guard as the initial spawn: only respawn once
-      // the session is visible on the status endpoint.
       const readinessOptions = this.readinessOptions();
       const sessionReady = await waitForSessionReady(
         serverUrl,
@@ -733,11 +922,7 @@ export class MultiplexerSessionManager {
       if (!sessionReady || readinessOptions.signal?.aborted) {
         log(
           '[multiplexer-session-manager] child session not ready, skipping respawn',
-          {
-            instanceId: this.instanceId,
-            sessionId,
-            parentId: known.parentId,
-          },
+          { instanceId: this.instanceId, sessionId, parentId: known.parentId },
         );
         return;
       }
@@ -746,19 +931,8 @@ export class MultiplexerSessionManager {
         this.permanentlyClosedSessions.has(sessionId) ||
         this.sessions.has(sessionId) ||
         this.closingSessions.has(sessionId)
-      ) {
+      )
         return;
-      }
-
-      log(
-        '[multiplexer-session-manager] child session busy again, respawning pane',
-        {
-          instanceId: this.instanceId,
-          sessionId,
-          parentId: known.parentId,
-          title: known.title,
-        },
-      );
 
       const paneResult = await this.multiplexer
         .spawnPane(sessionId, known.title, serverUrl, known.directory)
@@ -777,16 +951,12 @@ export class MultiplexerSessionManager {
         this.closingSessions.has(sessionId) ||
         this.permanentlyClosedSessions.has(sessionId)
       ) {
-        await this.multiplexer.closePane(paneResult.paneId).catch((err) =>
-          log(
-            '[multiplexer-session-manager] closing stale respawned pane failed',
-            {
-              instanceId: this.instanceId,
-              sessionId,
-              paneId: paneResult.paneId,
-              error: String(err),
-            },
-          ),
+        await this.trackAndCloseStalePane(
+          sessionId,
+          paneResult.paneId,
+          known.parentId,
+          known.title,
+          known.directory,
         );
         return;
       }
@@ -813,9 +983,8 @@ export class MultiplexerSessionManager {
       if (
         this.busyDuringSpawn.delete(sessionId) &&
         !this.sessions.has(sessionId)
-      ) {
+      )
         await this.respawnIfKnown(sessionId);
-      }
     }
   }
 
@@ -824,11 +993,13 @@ export class MultiplexerSessionManager {
   }
 
   private updatePolling(): void {
-    if (this.sessions.size > 0 || this.closingSessions.size > 0) {
+    if (
+      [...this.sessions.values()].some(
+        (tracked) => tracked.ownerInstanceId === this.instanceId,
+      )
+    )
       this.startPolling();
-    } else {
-      this.stopPolling();
-    }
+    else this.stopPolling();
   }
 
   private getSessionId(event: SessionEvent): string | undefined {
@@ -849,9 +1020,7 @@ export class MultiplexerSessionManager {
     if (this.cmuxLifecycle)
       return this.cmuxLifecycle.closeSessionFromCoordinator(sessionId);
     if (!this.enabled) return;
-    // Coordinator already vetted lifecycle policy; skip re-check
-    // ponytail: theoretical race if new job starts between coordinator's
-    // retryDeferredClose() and this call, but session IDs are unique per launch
+    // The coordinator already checked lifecycle policy; skip the second check.
     await this.closeSession(sessionId, 'idle', true);
   }
 
@@ -875,38 +1044,33 @@ export class MultiplexerSessionManager {
       this.permanentlyClosedSessions.clear();
       return;
     }
-    // Fence: abort an in-flight readiness wait so cleanup is not stalled by
-    // a hanging probe; the aborted wait resolves false and skips the spawn.
+
+    this.cleanupInProgress = true;
     this.abortInFlightReadiness();
     this.stopPolling();
 
-    if (this.closingSessions.size > 0) {
-      await Promise.all(this.closingSessions.values());
-    }
+    try {
+      const pending = [...this.closingSessions.entries()]
+        .filter(([sessionId]) => {
+          const tracked = this.sessions.get(sessionId);
+          return tracked?.ownerInstanceId === this.instanceId;
+        })
+        .map(([, promise]) => promise);
+      if (pending.length > 0) await Promise.all(pending);
 
-    if (this.sessions.size > 0 && this.multiplexer) {
-      log('[multiplexer-session-manager] closing all panes', {
-        count: this.sessions.size,
-      });
-      const multiplexer = this.multiplexer;
-      const closePromises = Array.from(this.sessions.values()).map((s) =>
-        multiplexer.closePane(s.paneId).catch((err) =>
-          log('[multiplexer-session-manager] cleanup error for pane', {
-            paneId: s.paneId,
-            error: String(err),
-          }),
-        ),
-      );
-      await Promise.all(closePromises);
-      this.sessions.clear();
-    }
+      const ownedSessionIds = [...this.sessions.entries()]
+        .filter(([, tracked]) => tracked.ownerInstanceId === this.instanceId)
+        .map(([sessionId]) => sessionId);
+      for (const sessionId of ownedSessionIds)
+        await this.closeSession(sessionId, 'deleted', true);
 
-    this.knownSessions.clear();
-    this.spawningSessions.clear();
-    this.closingSessions.clear();
-    this.permanentlyClosedSessions.clear();
-    // ponytail: deferred state lives in coordinator, not here
-    // Note: coordinator has same lifetime as plugin, so no explicit cleanup needed
+      this.knownSessions.clear();
+      this.spawningSessions.clear();
+      this.permanentlyClosedSessions.clear();
+      this.busyDuringSpawn.clear();
+    } finally {
+      this.cleanupInProgress = false;
+    }
 
     log('[multiplexer-session-manager] cleanup complete');
   }

--- a/src/multiplexer/session-manager.ts
+++ b/src/multiplexer/session-manager.ts
@@ -485,8 +485,8 @@ export class MultiplexerSessionManager {
     if (this.cmuxLifecycle) return this.cmuxLifecycle.pollOnce();
 
     const ownedSessions = () =>
-      [...this.sessions.entries()].filter(
-        ([, tracked]) => tracked.ownerInstanceId === this.instanceId,
+      [...this.sessions.entries()].filter(([, tracked]) =>
+        this.isPollableSession(tracked),
       );
     if (ownedSessions().length === 0) {
       this.stopPolling();
@@ -994,12 +994,19 @@ export class MultiplexerSessionManager {
 
   private updatePolling(): void {
     if (
-      [...this.sessions.values()].some(
-        (tracked) => tracked.ownerInstanceId === this.instanceId,
+      [...this.sessions.values()].some((tracked) =>
+        this.isPollableSession(tracked),
       )
     )
       this.startPolling();
     else this.stopPolling();
+  }
+
+  private isPollableSession(tracked: TrackedSession): boolean {
+    return (
+      tracked.ownerInstanceId === this.instanceId &&
+      tracked.closeState?.phase !== 'exhausted'
+    );
   }
 
   private getSessionId(event: SessionEvent): string | undefined {
@@ -1070,6 +1077,9 @@ export class MultiplexerSessionManager {
       this.busyDuringSpawn.clear();
     } finally {
       this.cleanupInProgress = false;
+      // A failed close remains in `sessions` with a retry record. Re-enable
+      // the shared polling executor after cleanup has stopped blocking it.
+      this.updatePolling();
     }
 
     log('[multiplexer-session-manager] cleanup complete');

--- a/src/multiplexer/session-manager.ts
+++ b/src/multiplexer/session-manager.ts
@@ -177,6 +177,7 @@ export class MultiplexerSessionManager {
   private readonly now: () => number;
   private readonly closeRetryMs: number;
   private readonly closeRetryMaxAttempts: number;
+  private readonly shutdownTimeoutMs: number;
   private readinessAbort?: AbortController;
   private cleanupInProgress = false;
   /**
@@ -207,6 +208,9 @@ export class MultiplexerSessionManager {
     this.closeRetryMaxAttempts = Number.isFinite(options.closeRetryMaxAttempts)
       ? Math.max(1, Math.floor(options.closeRetryMaxAttempts ?? 4))
       : 4;
+    this.shutdownTimeoutMs = Number.isFinite(options.shutdownTimeoutMs)
+      ? Math.max(0, options.shutdownTimeoutMs ?? 5_000)
+      : 5_000;
 
     this.directory = ctx.directory;
     this.resolveServerUrl = createServerUrlResolver(ctx);
@@ -730,6 +734,7 @@ export class MultiplexerSessionManager {
       closeState,
       this.multiplexer,
     ).finally(() => {
+      if (this.closingSessions.get(sessionId) !== closePromise) return;
       this.closingSessions.delete(sessionId);
       this.updatePolling();
     });
@@ -1005,6 +1010,7 @@ export class MultiplexerSessionManager {
   private isPollableSession(tracked: TrackedSession): boolean {
     return (
       tracked.ownerInstanceId === this.instanceId &&
+      !this.closingSessions.has(tracked.sessionId) &&
       tracked.closeState?.phase !== 'exhausted'
     );
   }
@@ -1055,21 +1061,17 @@ export class MultiplexerSessionManager {
     this.cleanupInProgress = true;
     this.abortInFlightReadiness();
     this.stopPolling();
+    const deadlineAt = Date.now() + this.shutdownTimeoutMs;
 
     try {
-      const pending = [...this.closingSessions.entries()]
-        .filter(([sessionId]) => {
-          const tracked = this.sessions.get(sessionId);
-          return tracked?.ownerInstanceId === this.instanceId;
-        })
-        .map(([, promise]) => promise);
-      if (pending.length > 0) await Promise.all(pending);
-
       const ownedSessionIds = [...this.sessions.entries()]
         .filter(([, tracked]) => tracked.ownerInstanceId === this.instanceId)
         .map(([sessionId]) => sessionId);
-      for (const sessionId of ownedSessionIds)
-        await this.closeSession(sessionId, 'deleted', true);
+      const closeWork = ownedSessionIds.map((sessionId) => {
+        const existing = this.closingSessions.get(sessionId);
+        return existing ?? this.closeSession(sessionId, 'deleted', true);
+      });
+      await this.waitForSettlements(closeWork, deadlineAt);
 
       this.knownSessions.clear();
       this.spawningSessions.clear();
@@ -1083,6 +1085,35 @@ export class MultiplexerSessionManager {
     }
 
     log('[multiplexer-session-manager] cleanup complete');
+  }
+
+  private async waitForSettlements(
+    pending: Promise<unknown>[],
+    deadlineAt: number,
+  ): Promise<boolean> {
+    if (pending.length === 0) return true;
+    const settled = Promise.allSettled(pending).then(() => true);
+    const remaining = deadlineAt - Date.now();
+    if (remaining <= 0) {
+      void settled;
+      return false;
+    }
+    return new Promise<boolean>((resolve) => {
+      let finished = false;
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const finish = (completed: boolean) => {
+        if (finished) return;
+        finished = true;
+        if (timer) clearTimeout(timer);
+        resolve(completed);
+      };
+      timer = setTimeout(() => finish(false), remaining);
+      timer.unref?.();
+      void settled.then(
+        () => finish(true),
+        () => finish(true),
+      );
+    });
   }
 
   async cleanupOnInstanceDisposed(): Promise<void> {

--- a/src/tools/cancel-task.test.ts
+++ b/src/tools/cancel-task.test.ts
@@ -119,7 +119,7 @@ describe('cancel_task tool', () => {
     expect(String(output)).toContain('state: unknown');
   });
 
-  test('aborts tracked jobs regardless of current board state', async () => {
+  test('refuses tracked jobs that are no longer running', async () => {
     const { board, abort, cancelTask } = createTool();
     board.registerLaunch({
       taskID: 'ses_1',
@@ -130,22 +130,23 @@ describe('cancel_task tool', () => {
 
     const output = await cancelTask.execute({ task_id: 'ses_1' }, context);
 
-    expect(abort).toHaveBeenCalledWith({ path: { id: 'ses_1' } });
-    expect(String(output)).toContain('state: cancelled');
-    expect(board.get('ses_1')).toMatchObject({ state: 'cancelled' });
+    expect(abort).not.toHaveBeenCalled();
+    expect(String(output)).toContain('stale/uncertain cancellation');
+    expect(board.get('ses_1')).toMatchObject({ state: 'completed' });
   });
 
-  test('aborts owned raw session IDs when job board lost the task', async () => {
-    const { abort, cancelTask } = createTool();
+  test('does not destructively cancel an owned raw session without a generation', async () => {
+    const { abort, deleteSession, cancelTask } = createTool();
 
     const output = await cancelTask.execute(
       { task_id: 'ses_lost', reason: 'stop ghost worker' },
       context,
     );
 
-    expect(abort).toHaveBeenCalledWith({ path: { id: 'ses_lost' } });
-    expect(String(output)).toContain('state: cancelled');
-    expect(String(output)).toContain('cancelled: stop ghost worker');
+    expect(abort).not.toHaveBeenCalled();
+    expect(deleteSession).not.toHaveBeenCalled();
+    expect(String(output)).toContain('state: unknown');
+    expect(String(output)).toContain('best-effort/uncertain');
   });
 
   test('does not abort raw session ID without metadata ownership', async () => {
@@ -171,7 +172,7 @@ describe('cancel_task tool', () => {
     expect(String(output)).toContain('state: unknown');
   });
 
-  test('still aborts stale cancelled jobs', async () => {
+  test('refuses stale cancelled jobs without a running generation', async () => {
     const { board, abort, cancelTask } = createTool();
     board.registerLaunch({
       taskID: 'ses_1',
@@ -185,11 +186,11 @@ describe('cancel_task tool', () => {
       context,
     );
 
-    expect(abort).toHaveBeenCalledWith({ path: { id: 'ses_1' } });
-    expect(String(output)).toContain('state: cancelled');
+    expect(abort).not.toHaveBeenCalled();
+    expect(String(output)).toContain('stale/uncertain cancellation');
   });
 
-  test('still aborts reconciled stale cancellations', async () => {
+  test('refuses reconciled stale cancellations without a running generation', async () => {
     const { board, abort, cancelTask } = createTool();
     board.registerLaunch({
       taskID: 'ses_1',
@@ -204,8 +205,8 @@ describe('cancel_task tool', () => {
       context,
     );
 
-    expect(abort).toHaveBeenCalledWith({ path: { id: 'ses_1' } });
-    expect(String(output)).toContain('state: cancelled');
+    expect(abort).not.toHaveBeenCalled();
+    expect(String(output)).toContain('stale/uncertain cancellation');
   });
 
   test('does not terminalize board when abort fails without delete', async () => {
@@ -308,6 +309,97 @@ describe('cancel_task tool', () => {
     });
   });
 
+  test('does not confirm cancellation when abort/delete fail and status is absent', async () => {
+    const { board, abort, deleteSession, cancelTask } = createTool({
+      abort: async () => {
+        throw new Error('abort transport failed');
+      },
+      delete: async () => {
+        throw new Error('delete network failed');
+      },
+      status: async () => ({ data: {} }),
+    });
+    const terminalNotifications: string[] = [];
+    board.addTerminalStateListener((taskID) => {
+      terminalNotifications.push(taskID);
+    });
+    board.registerLaunch({
+      taskID: 'ses_1',
+      parentSessionID: 'parent-1',
+      agent: 'fixer',
+    });
+
+    const output = await cancelTask.execute({ task_id: 'ses_1' }, context);
+
+    expect(abort).toHaveBeenCalled();
+    expect(deleteSession).toHaveBeenCalled();
+    expect(String(output)).toContain('state: running');
+    expect(String(output)).toContain('delete network failed');
+    expect(board.get('ses_1')).toMatchObject({
+      state: 'running',
+      statusUncertain: true,
+      terminalUnreconciled: false,
+    });
+    expect(terminalNotifications).toEqual([]);
+  });
+
+  test('does not cancel a relaunched generation after status verification awaits', async () => {
+    let releaseStatus!: () => void;
+    let signalStatusStarted!: () => void;
+    const statusStarted = new Promise<void>((resolve) => {
+      signalStatusStarted = resolve;
+    });
+    const statusGate = new Promise<void>((resolve) => {
+      releaseStatus = resolve;
+    });
+    const { board, status, deleteSession, cancelTask } = createTool({
+      status: async () => {
+        signalStatusStarted();
+        await statusGate;
+        return { data: {} };
+      },
+    });
+    const terminalNotifications: string[] = [];
+    board.addTerminalStateListener((taskID) => {
+      terminalNotifications.push(taskID);
+    });
+    board.registerLaunch({
+      taskID: 'ses_1',
+      parentSessionID: 'parent-1',
+      agent: 'fixer',
+      now: 100,
+    });
+
+    const cancellation = cancelTask.execute({ task_id: 'ses_1' }, context);
+    await statusStarted;
+
+    expect(() =>
+      board.registerLaunch({
+        taskID: 'ses_1',
+        parentSessionID: 'parent-1',
+        agent: 'fixer',
+        now: 200,
+      }),
+    ).toThrow('cancellation lease');
+    releaseStatus();
+
+    const output = await cancellation;
+
+    expect(status).toHaveBeenCalled();
+    expect(deleteSession).toHaveBeenCalledTimes(1);
+    expect(String(output)).toContain('state: cancelled');
+    expect(parseTaskStatusOutput(String(output))).toMatchObject({
+      taskID: 'ses_1',
+      state: 'cancelled',
+    });
+    expect(board.get('ses_1')).toMatchObject({
+      generation: 1,
+      state: 'cancelled',
+      cancellationRequested: true,
+    });
+    expect(terminalNotifications).toEqual(['ses_1']);
+  });
+
   test('keeps running/status uncertain when abort times out without delete', async () => {
     const { board, cancelTask } = createTool({
       abort: () => new Promise(() => {}),
@@ -335,6 +427,121 @@ describe('cancel_task tool', () => {
       terminalUnreconciled: false,
       statusUncertain: true,
     });
+  });
+
+  test('keeps the cancellation quarantine while the abort promise is pending', async () => {
+    let releaseAbort!: (value: unknown) => void;
+    const abortPending = new Promise<unknown>((resolve) => {
+      releaseAbort = resolve;
+    });
+    const { board, abort, deleteSession, cancelTask } = createTool({
+      abort: () => abortPending,
+      abortTimeoutMs: 1,
+    });
+    board.registerLaunch({
+      taskID: 'ses_1',
+      parentSessionID: 'parent-1',
+      agent: 'fixer',
+    });
+
+    const cancellation = cancelTask.execute({ task_id: 'ses_1' }, context);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(abort).toHaveBeenCalledTimes(1);
+    expect(deleteSession).not.toHaveBeenCalled();
+    expect(board.acquireRelaunchLease('ses_1', 1)).toBeUndefined();
+    expect(() =>
+      board.registerLaunch({
+        taskID: 'ses_1',
+        parentSessionID: 'parent-1',
+        agent: 'fixer',
+      }),
+    ).toThrow('cancellation lease');
+    releaseAbort({});
+    await cancellation;
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const relaunchLease = board.acquireRelaunchLease('ses_1', 1);
+    expect(relaunchLease).toBeDefined();
+    if (!relaunchLease) throw new Error('relaunch lease was not released');
+    board.releaseLease(relaunchLease);
+  });
+
+  test('keeps the cancellation quarantine while the delete promise is pending', async () => {
+    let releaseDelete!: (value: unknown) => void;
+    const deletePending = new Promise<unknown>((resolve) => {
+      releaseDelete = resolve;
+    });
+    const { board, deleteSession, cancelTask } = createTool({
+      delete: () => deletePending,
+      deleteTimeoutMs: 1,
+    });
+    board.registerLaunch({
+      taskID: 'ses_1',
+      parentSessionID: 'parent-1',
+      agent: 'fixer',
+    });
+
+    const cancellation = cancelTask.execute({ task_id: 'ses_1' }, context);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(deleteSession).toHaveBeenCalledTimes(1);
+    expect(board.acquireRelaunchLease('ses_1', 1)).toBeUndefined();
+    expect(() =>
+      board.registerLaunch({
+        taskID: 'ses_1',
+        parentSessionID: 'parent-1',
+        agent: 'fixer',
+      }),
+    ).toThrow('cancellation lease');
+    releaseDelete({});
+    await cancellation;
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const relaunchLease = board.acquireRelaunchLease('ses_1', 1);
+    expect(relaunchLease).toBeDefined();
+    if (!relaunchLease) throw new Error('relaunch lease was not released');
+    board.releaseLease(relaunchLease);
+  });
+
+  test('keeps the cancellation quarantine while status verification is pending', async () => {
+    let releaseStatus!: (value: unknown) => void;
+    const statusPending = new Promise<unknown>((resolve) => {
+      releaseStatus = resolve;
+    });
+    const { board, deleteSession, cancelTask } = createTool({
+      status: () => statusPending,
+      deleteVerifyMs: 1,
+    });
+    board.registerLaunch({
+      taskID: 'ses_1',
+      parentSessionID: 'parent-1',
+      agent: 'fixer',
+    });
+
+    const cancellation = cancelTask.execute({ task_id: 'ses_1' }, context);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(deleteSession).toHaveBeenCalledTimes(1);
+    expect(board.acquireRelaunchLease('ses_1', 1)).toBeUndefined();
+    expect(() =>
+      board.registerLaunch({
+        taskID: 'ses_1',
+        parentSessionID: 'parent-1',
+        agent: 'fixer',
+      }),
+    ).toThrow('cancellation lease');
+    releaseStatus({ data: {} });
+    await cancellation;
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const relaunchLease = board.acquireRelaunchLease('ses_1', 1);
+    expect(relaunchLease).toBeDefined();
+    if (!relaunchLease) throw new Error('relaunch lease was not released');
+    board.releaseLease(relaunchLease);
   });
 
   test('deletes session when abort returns but session stays busy', async () => {
@@ -458,8 +665,8 @@ describe('cancel_task tool', () => {
     });
   });
 
-  test('cancelSessionByID returns state: error when abort throws non-SessionStillRunningError, even if board shows running', async () => {
-    const { board, abort, cancelTask } = createTool({
+  test('does not destructively cancel a raw session when the board lookup is unavailable', async () => {
+    const { board, abort, deleteSession, cancelTask } = createTool({
       abort: async () => {
         throw new Error('network timeout');
       },
@@ -475,8 +682,8 @@ describe('cancel_task tool', () => {
       parentSessionID: 'parent-1',
       agent: 'fixer',
     });
-    // Override resolve to return undefined, forcing the cancelSessionByID
-    // raw session path instead of the tracked task path.
+    // Override resolve to return undefined, forcing the untracked raw-session
+    // path instead of the tracked task path.
     board.resolve = mock(() => undefined);
 
     const output = await cancelTask.execute(
@@ -484,11 +691,10 @@ describe('cancel_task tool', () => {
       context,
     );
 
-    expect(abort).toHaveBeenCalledWith({ path: { id: 'ses_running' } });
-    // cancelSessionByID must return state: error for non-SessionStillRunningError,
-    // NOT state: running (which would happen if || isRunning() were present).
-    expect(String(output)).toContain('state: error');
-    expect(String(output)).not.toContain('state: running');
+    expect(abort).not.toHaveBeenCalled();
+    expect(deleteSession).not.toHaveBeenCalled();
+    expect(String(output)).toContain('state: unknown');
+    expect(String(output)).toContain('best-effort/uncertain');
   });
 
   test('denies non-orchestrator agents', async () => {

--- a/src/tools/cancel-task.ts
+++ b/src/tools/cancel-task.ts
@@ -3,19 +3,16 @@ import {
   type ToolDefinition,
   tool,
 } from '@opencode-ai/plugin';
+import type { BackgroundJobLease } from '../utils/background-job-board';
 import type { BackgroundJobStore } from '../utils/background-job-store';
 import { log } from '../utils/logger';
 import { getClient } from '../utils/opencode-client';
 import { delay } from '../utils/polling';
 import {
-  abortSessionWithTimeout,
+  OperationTimeoutError,
   SESSION_ID_PATTERN,
   withTimeout,
 } from '../utils/session';
-import {
-  getRuntimeSessionStatusSnapshot,
-  runtimeSessionStatus,
-} from '../utils/session-runtime-status';
 
 const z = tool.schema;
 
@@ -33,6 +30,18 @@ interface CancelTaskToolOptions {
 }
 
 class SessionStillRunningError extends Error {}
+
+class LeaseOwnershipLostError extends Error {}
+
+class LeaseOperationTimeoutError extends Error {
+  constructor(
+    message: string,
+    readonly pending: boolean,
+  ) {
+    super(message);
+    this.name = 'LeaseOperationTimeoutError';
+  }
+}
 
 export function createCancelTaskTool(
   options: CancelTaskToolOptions,
@@ -119,11 +128,17 @@ Use only for obsolete, wrong, conflicting, or user-requested cancellation. Accep
             );
           }
 
-          log('[cancel-task] falling back to owned raw session abort', {
-            parentSessionID,
-            taskID: requested,
-          });
-          return cancelSessionByID(options, requested, args.reason);
+          log(
+            '[cancel-task] refusing destructive action for untracked raw session',
+            {
+              parentSessionID,
+              taskID: requested,
+            },
+          );
+          return unknownTaskOutput(
+            requested,
+            'best-effort/uncertain cancellation: session ownership was observed, but no tracked generation exists; no remote abort or delete was attempted',
+          );
         }
 
         return unknownTaskOutput(
@@ -132,26 +147,64 @@ Use only for obsolete, wrong, conflicting, or user-requested cancellation. Accep
         );
       }
 
-      const generation = job.generation;
+      const capturedExecution = {
+        taskID: job.taskID,
+        generation: job.generation,
+      };
+      const cancellationLease =
+        options.backgroundJobBoard.acquireCancellationLease(
+          capturedExecution.taskID,
+          capturedExecution.generation,
+        );
+      if (!cancellationLease) {
+        return staleCancellationOutput(
+          options,
+          capturedExecution,
+          'cancellation lease unavailable; no remote operation was attempted',
+        );
+      }
       try {
-        await abortAndVerifySession(options, job.taskID);
+        await abortAndVerifySession(
+          options,
+          capturedExecution,
+          cancellationLease,
+        );
+        if (!options.backgroundJobBoard.validateLease(cancellationLease)) {
+          return staleCancellationOutput(options, capturedExecution);
+        }
       } catch (error) {
         const stillRunning = error instanceof SessionStillRunningError;
-        const boardRunning = options.backgroundJobBoard.isRunning(job.taskID);
+        const boardRunning = options.backgroundJobBoard.isRunning(
+          capturedExecution.taskID,
+        );
         log('[cancel-task] abort failed', {
-          taskID: job.taskID,
+          taskID: capturedExecution.taskID,
           stillRunning,
           boardRunning,
           error: error instanceof Error ? error.message : String(error),
         });
+        if (!options.backgroundJobBoard.validateLease(cancellationLease)) {
+          return staleCancellationOutput(options, capturedExecution);
+        }
         const message = error instanceof Error ? error.message : String(error);
         const updated = options.backgroundJobBoard.markStatusUncertain(
-          job.taskID,
+          capturedExecution.taskID,
           message,
-          generation,
+          capturedExecution.generation,
         );
+        const quarantined =
+          error instanceof LeaseOperationTimeoutError && error.pending;
+        if (!isCapturedExecution(updated, capturedExecution)) {
+          if (!quarantined) {
+            options.backgroundJobBoard.releaseLease(cancellationLease);
+          }
+          return staleCancellationOutput(options, capturedExecution);
+        }
+        if (!quarantined) {
+          options.backgroundJobBoard.releaseLease(cancellationLease);
+        }
         return [
-          `task_id: ${job.taskID}`,
+          `task_id: ${capturedExecution.taskID}`,
           `state: ${updated?.state ?? 'unknown'}`,
           '',
           '<task_error>',
@@ -160,29 +213,48 @@ Use only for obsolete, wrong, conflicting, or user-requested cancellation. Accep
         ].join('\n');
       }
 
-      options.backgroundJobBoard.markCancelled(
-        job.taskID,
+      const cancellationOptions = {
+        force: true,
+        expectedGeneration: capturedExecution.generation,
+        cancellationLease,
+      };
+      const marked = options.backgroundJobBoard.markCancelled(
+        capturedExecution.taskID,
         args.reason,
         Date.now(),
-        { force: true },
+        cancellationOptions,
       );
-      const state = options.backgroundJobBoard.getState(job.taskID);
+      if (!isCapturedExecution(marked, capturedExecution)) {
+        options.backgroundJobBoard.releaseLease(cancellationLease);
+        return staleCancellationOutput(options, capturedExecution);
+      }
+      if (!options.backgroundJobBoard.validateLease(cancellationLease)) {
+        return staleCancellationOutput(options, capturedExecution);
+      }
+      const state = options.backgroundJobBoard.getState(
+        capturedExecution.taskID,
+      );
       log('[cancel-task] marked job cancelled after verified abort', {
-        taskID: job.taskID,
-        alias: options.backgroundJobBoard.field(job.taskID, 'alias'),
+        taskID: capturedExecution.taskID,
+        alias: options.backgroundJobBoard.field(
+          capturedExecution.taskID,
+          'alias',
+        ),
         state,
         cancellationRequested: options.backgroundJobBoard.field(
-          job.taskID,
+          capturedExecution.taskID,
           'cancellationRequested',
         ),
       });
+      options.backgroundJobBoard.releaseLease(cancellationLease);
 
       return [
-        `task_id: ${job.taskID}`,
+        `task_id: ${capturedExecution.taskID}`,
         `state: ${state ?? 'cancelled'}`,
         '',
         '<task_error>',
-        options.backgroundJobBoard.getResultSummary(job.taskID) ?? 'cancelled',
+        options.backgroundJobBoard.getResultSummary(capturedExecution.taskID) ??
+          'cancelled',
         '</task_error>',
       ].join('\n');
     },
@@ -191,54 +263,36 @@ Use only for obsolete, wrong, conflicting, or user-requested cancellation. Accep
   return { cancel_task };
 }
 
-async function cancelSessionByID(
-  options: CancelTaskToolOptions,
-  taskID: string,
-  reason?: string,
-): Promise<string> {
-  try {
-    await abortAndVerifySession(options, taskID);
-  } catch (error) {
-    const stillRunning = error instanceof SessionStillRunningError;
-    log('[cancel-task] raw session abort failed', {
-      taskID,
-      stillRunning,
-      error: error instanceof Error ? error.message : String(error),
-    });
-    return [
-      `task_id: ${taskID}`,
-      `state: ${stillRunning ? 'running' : 'error'}`,
-      '',
-      '<task_error>',
-      error instanceof Error ? error.message : String(error),
-      '</task_error>',
-    ].join('\n');
-  }
-
-  return [
-    `task_id: ${taskID}`,
-    'state: cancelled',
-    '',
-    '<task_error>',
-    normalizeCancelReason(reason),
-    '</task_error>',
-  ].join('\n');
-}
-
 async function abortAndVerifySession(
   options: CancelTaskToolOptions,
-  taskID: string,
+  execution: { taskID: string; generation: number },
+  lease: BackgroundJobLease,
 ): Promise<void> {
+  const taskID = execution.taskID;
+  let abortConfirmed = false;
   log('[cancel-task] abort attempt starting', { taskID });
+  assertLease(options.backgroundJobBoard, lease, execution);
   try {
-    // abortSessionWithTimeout uses the in-process runtime client
-    await abortSessionWithTimeout(
-      getClient(options.input),
-      taskID,
+    const response = await awaitLeaseOperation(
+      options.backgroundJobBoard,
+      lease,
+      () => getClient(options.input).session.abort({ path: { id: taskID } }),
       options.abortTimeoutMs ?? 10_000,
+      `Session abort timed out after ${options.abortTimeoutMs ?? 10_000}ms`,
     );
+    assertLease(options.backgroundJobBoard, lease, execution);
+    const responseError = operationError(response);
+    if (responseError !== undefined) throw responseError;
+    const responseData = operationBoolean(response);
+    if (responseData === false) {
+      throw new Error(`Session abort was not confirmed: ${taskID}`);
+    }
+    abortConfirmed = responseData === true;
     log('[cancel-task] abort call returned', { taskID });
   } catch (error) {
+    if (error instanceof LeaseOperationTimeoutError) throw error;
+    assertLease(options.backgroundJobBoard, lease, execution);
+    abortConfirmed = isExplicitSessionAbsence(error);
     log('[cancel-task] abort call failed', {
       taskID,
       error: error instanceof Error ? error.message : String(error),
@@ -248,31 +302,69 @@ async function abortAndVerifySession(
   // ponytail: v1 had a polling loop here that verified abort succeeded before
   // proceeding to delete. v2 abort is server-side and synchronous — the delete
   // verification loop below catches any remaining running state.
-  await deleteAndVerifySession(options, taskID, 'cancel-task-after-abort');
+  assertLease(options.backgroundJobBoard, lease, execution);
+  try {
+    await deleteAndVerifySession(
+      options,
+      execution,
+      lease,
+      'cancel-task-after-abort',
+    );
+  } catch (error) {
+    if (error instanceof LeaseOperationTimeoutError) throw error;
+    // A confirmed native abort or an explicit not-found response is already
+    // terminal evidence. A transport/unknown abort failure is not evidence;
+    // in that case a failed delete must remain uncertain as well.
+    if (abortConfirmed) return;
+    throw error;
+  }
 }
 
 async function deleteAndVerifySession(
   options: CancelTaskToolOptions,
-  taskID: string,
+  execution: { taskID: string; generation: number },
+  lease: BackgroundJobLease,
   reason: string,
 ): Promise<void> {
+  const taskID = execution.taskID;
   const client = getClient(options.input);
 
+  assertLease(options.backgroundJobBoard, lease, execution);
   log('[cancel-task] deleting session after abort attempt', {
     taskID,
     reason,
   });
   try {
-    await withTimeout(
-      client.session.delete({
-        path: { id: taskID },
-        query: { directory: options.input.directory },
-      }),
+    const response = await awaitLeaseOperation(
+      options.backgroundJobBoard,
+      lease,
+      () =>
+        client.session.delete({
+          path: { id: taskID },
+          query: { directory: options.input.directory },
+        }),
       options.deleteTimeoutMs ?? 10_000,
       `Session delete timed out after ${options.deleteTimeoutMs ?? 10_000}ms`,
     );
+    assertLease(options.backgroundJobBoard, lease, execution);
+    const responseError = operationError(response);
+    if (responseError !== undefined) throw responseError;
+    const responseData = operationBoolean(response);
+    if (responseData === false) {
+      throw new Error(`Session delete was not confirmed: ${taskID}`);
+    }
     log('[cancel-task] session delete returned', { taskID, reason });
   } catch (error) {
+    if (error instanceof LeaseOperationTimeoutError) throw error;
+    assertLease(options.backgroundJobBoard, lease, execution);
+    if (isExplicitSessionAbsence(error)) {
+      log('[cancel-task] session delete confirmed missing/deleted', {
+        taskID,
+        reason,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return;
+    }
     log('[cancel-task] session delete failed; verifying live state', {
       taskID,
       reason,
@@ -282,7 +374,10 @@ async function deleteAndVerifySession(
       options.input,
       taskID,
       options.deleteVerifyMs ?? 1_500,
+      lease,
+      options.backgroundJobBoard,
     );
+    assertLease(options.backgroundJobBoard, lease, execution);
     log('[cancel-task] delete failure verification status', {
       taskID,
       reason,
@@ -295,13 +390,10 @@ async function deleteAndVerifySession(
         `Session delete failed and task is still busy: ${taskID}`,
       );
     }
-    // A successful/not-found delete may legitimately remove the session from
-    // the active status map. Treat that as quiescent only in the context of
-    // the explicit delete verification; it never becomes a generic terminal
-    // board transition.
-    if (status.status !== 'idle' && status.source !== 'missing-from-map') {
-      throw error;
-    }
+    // An idle or missing status entry is only a liveness observation. It does
+    // not prove that a failed delete or abort reached the server, so preserve
+    // the operation error and let the caller expose an uncertain/error state.
+    throw error;
   }
 
   const deadline = Date.now() + (options.deleteVerifyMs ?? 1_500);
@@ -312,11 +404,15 @@ async function deleteAndVerifySession(
   let lastStatus: string | undefined;
   while (Date.now() <= deadline) {
     attempts += 1;
+    assertLease(options.backgroundJobBoard, lease, execution);
     const status = await getSessionStatus(
       options.input,
       taskID,
       Math.max(1, deadline - Date.now()),
+      lease,
+      options.backgroundJobBoard,
     );
+    assertLease(options.backgroundJobBoard, lease, execution);
     lastStatus = status.status;
     log('[cancel-task] delete verification status', {
       taskID,
@@ -332,11 +428,13 @@ async function deleteAndVerifySession(
     if (!quiescent) {
       stableStoppedSince = undefined;
       await delay(retryIntervalMs);
+      assertLease(options.backgroundJobBoard, lease, execution);
       continue;
     }
     stableStoppedSince ??= Date.now();
     if (Date.now() - stableStoppedSince >= stableStoppedMs) return;
     await delay(retryIntervalMs);
+    assertLease(options.backgroundJobBoard, lease, execution);
   }
 
   throw new SessionStillRunningError(
@@ -348,28 +446,181 @@ async function getSessionStatus(
   input: PluginInput,
   taskID: string,
   timeoutMs?: number,
+  lease?: BackgroundJobLease,
+  backgroundJobBoard?: BackgroundJobStore,
 ): Promise<{
   status: string | undefined;
   source: string;
   keys: string[];
 }> {
-  const snapshot = await getRuntimeSessionStatusSnapshot(input, { timeoutMs });
+  if (!lease || !backgroundJobBoard) {
+    throw new LeaseOwnershipLostError(
+      `Session status lookup requires a live cancellation lease: ${taskID}`,
+    );
+  }
+  assertLease(backgroundJobBoard, lease, {
+    taskID: lease.taskID,
+    generation: lease.generation,
+  });
+
+  let response: unknown;
+  try {
+    response = await awaitLeaseOperation(
+      backgroundJobBoard,
+      lease,
+      () =>
+        getClient(input).session.status({
+          query: { directory: input.directory },
+        }),
+      Math.max(1, timeoutMs ?? 5_000),
+      `Session status lookup timed out after ${Math.max(1, timeoutMs ?? 5_000)}ms`,
+    );
+  } catch (error) {
+    if (error instanceof LeaseOperationTimeoutError) throw error;
+    if (error instanceof LeaseOwnershipLostError) throw error;
+    return {
+      status: undefined,
+      source: 'lookup-error',
+      keys: [],
+    };
+  }
+  assertLease(backgroundJobBoard, lease, {
+    taskID: lease.taskID,
+    generation: lease.generation,
+  });
+
+  const data = isRecord(response) ? response.data : undefined;
+  if (
+    !isRecord(data) ||
+    Object.hasOwn(data, 'type') ||
+    Object.hasOwn(data, 'status')
+  ) {
+    return { status: undefined, source: 'lookup-error', keys: [] };
+  }
+
+  const statuses = new Map<string, 'busy' | 'retry' | 'idle'>();
+  const malformedSessionIDs = new Set<string>();
+  for (const [sessionID, value] of Object.entries(data)) {
+    if (
+      isRecord(value) &&
+      (value.type === 'busy' || value.type === 'retry' || value.type === 'idle')
+    ) {
+      statuses.set(sessionID, value.type);
+    } else {
+      malformedSessionIDs.add(sessionID);
+    }
+  }
   return {
-    status: runtimeSessionStatus(snapshot, taskID),
-    source: snapshot.error
-      ? 'lookup-error'
-      : snapshot.malformedSessionIDs.has(taskID)
-        ? 'malformed-entry'
-        : snapshot.statuses.has(taskID)
-          ? 'task-map-entry'
-          : 'missing-from-map',
-    keys: [...snapshot.statuses.keys()].slice(0, 20),
+    status: malformedSessionIDs.has(taskID) ? undefined : statuses.get(taskID),
+    source: malformedSessionIDs.has(taskID)
+      ? 'malformed-entry'
+      : statuses.has(taskID)
+        ? 'task-map-entry'
+        : 'missing-from-map',
+    keys: [...statuses.keys()].slice(0, 20),
   };
 }
 
-function normalizeCancelReason(reason?: string): string {
-  const normalized = reason?.replace(/\s+/g, ' ').trim();
-  return normalized ? `cancelled: ${normalized}` : 'cancelled';
+function assertLease(
+  backgroundJobBoard: BackgroundJobStore,
+  lease: BackgroundJobLease,
+  execution: { taskID: string; generation: number },
+): void {
+  if (
+    lease.taskID !== execution.taskID ||
+    lease.generation !== execution.generation ||
+    lease.kind !== 'cancellation' ||
+    !backgroundJobBoard.validateLease(lease)
+  ) {
+    throw new LeaseOwnershipLostError(
+      `Cancellation lease is no longer valid for ${execution.taskID} generation ${execution.generation}`,
+    );
+  }
+}
+
+async function awaitLeaseOperation<T>(
+  backgroundJobBoard: BackgroundJobStore,
+  lease: BackgroundJobLease,
+  operation: () => Promise<T>,
+  timeoutMs: number,
+  message: string,
+): Promise<T> {
+  let timedOut = false;
+  let settled = false;
+  const underlying = Promise.resolve().then(operation);
+  const tracked = underlying.then(
+    (value) => {
+      settled = true;
+      if (timedOut) backgroundJobBoard.releaseLease(lease);
+      return value;
+    },
+    (error: unknown) => {
+      settled = true;
+      if (timedOut) backgroundJobBoard.releaseLease(lease);
+      throw error;
+    },
+  );
+
+  try {
+    return await withTimeout(tracked, timeoutMs, message);
+  } catch (error) {
+    if (!(error instanceof OperationTimeoutError)) throw error;
+    timedOut = true;
+    const pending = !settled;
+    if (!pending) backgroundJobBoard.releaseLease(lease);
+    throw new LeaseOperationTimeoutError(error.message, pending);
+  }
+}
+
+function operationError(response: unknown): unknown {
+  if (!isRecord(response)) return undefined;
+  const error = response.error;
+  return error === undefined || error === null ? undefined : error;
+}
+
+function operationBoolean(response: unknown): boolean | undefined {
+  if (response === true || response === false) return response;
+  if (!isRecord(response)) return undefined;
+  return typeof response.data === 'boolean' ? response.data : undefined;
+}
+
+function isExplicitSessionAbsence(error: unknown): boolean {
+  const statusCode = findStatusCode(error);
+  if (statusCode === 404) return true;
+
+  const text = errorText(error);
+  return /\b(?:not[\s_-]?found(?:error)?|no such (?:session|resource)|does not exist|already[\s_-]?deleted|session[\s_-]?deleted)\b/i.test(
+    text,
+  );
+}
+
+function findStatusCode(value: unknown, depth = 0): number | undefined {
+  if (depth > 3 || !isRecord(value)) return undefined;
+  for (const key of ['statusCode', 'status']) {
+    const candidate = value[key];
+    if (typeof candidate === 'number') return candidate;
+    if (typeof candidate === 'string' && /^\d+$/.test(candidate)) {
+      return Number(candidate);
+    }
+  }
+  return (
+    findStatusCode(value.data, depth + 1) ??
+    findStatusCode(value.cause, depth + 1)
+  );
+}
+
+function errorText(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'string') return error;
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
 }
 
 async function getSessionParentID(
@@ -397,6 +648,43 @@ function unknownTaskOutput(taskID: string, message: string): string {
   return [
     `task_id: ${taskID}`,
     'state: unknown',
+    '',
+    '<task_error>',
+    message,
+    '</task_error>',
+  ].join('\n');
+}
+
+function isCapturedExecution(
+  record: ReturnType<BackgroundJobStore['get']>,
+  capturedExecution: { taskID: string; generation: number },
+): boolean {
+  return (
+    record?.taskID === capturedExecution.taskID &&
+    record.generation === capturedExecution.generation
+  );
+}
+
+function staleCancellationOutput(
+  options: CancelTaskToolOptions,
+  capturedExecution: { taskID: string; generation: number },
+  detail?: string,
+): string {
+  const current = options.backgroundJobBoard.get(capturedExecution.taskID);
+  const message = detail
+    ? `stale/uncertain cancellation: ${detail}`
+    : current
+      ? `stale/uncertain cancellation: ${capturedExecution.taskID} changed from generation ${capturedExecution.generation} to generation ${current.generation}; the newer execution was not cancelled`
+      : `stale/uncertain cancellation: ${capturedExecution.taskID} is no longer tracked; generation ${capturedExecution.generation} was not cancelled`;
+  log('[cancel-task] refusing stale cancellation terminal transition', {
+    taskID: capturedExecution.taskID,
+    capturedGeneration: capturedExecution.generation,
+    currentGeneration: current?.generation,
+    currentState: current?.state,
+  });
+  return [
+    `task_id: ${capturedExecution.taskID}`,
+    `state: ${current?.state ?? 'unknown'}`,
     '',
     '<task_error>',
     message,

--- a/src/tools/cancel-task.ts
+++ b/src/tools/cancel-task.ts
@@ -295,7 +295,13 @@ async function deleteAndVerifySession(
         `Session delete failed and task is still busy: ${taskID}`,
       );
     }
-    if (status.status !== 'idle') throw error;
+    // A successful/not-found delete may legitimately remove the session from
+    // the active status map. Treat that as quiescent only in the context of
+    // the explicit delete verification; it never becomes a generic terminal
+    // board transition.
+    if (status.status !== 'idle' && status.source !== 'missing-from-map') {
+      throw error;
+    }
   }
 
   const deadline = Date.now() + (options.deleteVerifyMs ?? 1_500);
@@ -321,7 +327,9 @@ async function deleteAndVerifySession(
       statusKeys: status.keys,
       stableStoppedSince,
     });
-    if (status.status !== 'idle') {
+    const quiescent =
+      status.status === 'idle' || status.source === 'missing-from-map';
+    if (!quiescent) {
       stableStoppedSince = undefined;
       await delay(retryIntervalMs);
       continue;
@@ -350,9 +358,11 @@ async function getSessionStatus(
     status: runtimeSessionStatus(snapshot, taskID),
     source: snapshot.error
       ? 'lookup-error'
-      : snapshot.statuses.has(taskID)
-        ? 'task-map-entry'
-        : 'missing-from-map',
+      : snapshot.malformedSessionIDs.has(taskID)
+        ? 'malformed-entry'
+        : snapshot.statuses.has(taskID)
+          ? 'task-map-entry'
+          : 'missing-from-map',
     keys: [...snapshot.statuses.keys()].slice(0, 20),
   };
 }

--- a/src/tools/task-nudge.test.ts
+++ b/src/tools/task-nudge.test.ts
@@ -34,6 +34,17 @@ function busyClient(promptCalls: Array<() => Promise<unknown>> = []): void {
   };
 }
 
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
 describe('task_nudge', () => {
   test('admits a parent-owned live, possibly-stuck child via noReply without resuming it', async () => {
     const board = new BackgroundJobBoard();
@@ -257,6 +268,93 @@ describe('task_nudge', () => {
         sessionID: 'parent-1',
       } as any),
     ).rejects.toThrow('board state is completed, not running');
+    expect(prompt).not.toHaveBeenCalled();
+  });
+
+  test('does not prompt after the task completes during live status lookup', async () => {
+    const board = new BackgroundJobBoard();
+    registerStuckChild(board);
+    const prompt = mock(async () => ({}));
+    const statusResult = deferred<{ data: Record<string, unknown> }>();
+    const status = mock(async () => statusResult.promise);
+    client = { session: { status, prompt } };
+    const { task_nudge } = createTaskNudgeTool({
+      input: { directory: '/test' } as any,
+      backgroundJobBoard: board,
+      now: () => 120_000,
+    });
+
+    const pending = task_nudge.execute(
+      { task_id: 'ses_child1', message: 'Nudge' },
+      { sessionID: 'parent-1' } as any,
+    );
+    await Promise.resolve();
+    board.updateStatus({
+      taskID: 'ses_child1',
+      state: 'completed',
+      resultSummary: 'done',
+    });
+    statusResult.resolve({ data: { ses_child1: { type: 'busy' } } });
+
+    await expect(pending).rejects.toThrow(
+      'board state is completed, not running',
+    );
+    expect(status).toHaveBeenCalledTimes(1);
+    expect(prompt).not.toHaveBeenCalled();
+  });
+
+  test('does not prompt after the task is deleted during live status lookup', async () => {
+    const board = new BackgroundJobBoard();
+    registerStuckChild(board);
+    const prompt = mock(async () => ({}));
+    const statusResult = deferred<{ data: Record<string, unknown> }>();
+    const status = mock(async () => statusResult.promise);
+    client = { session: { status, prompt } };
+    const { task_nudge } = createTaskNudgeTool({
+      input: { directory: '/test' } as any,
+      backgroundJobBoard: board,
+      now: () => 120_000,
+    });
+
+    const pending = task_nudge.execute(
+      { task_id: 'ses_child1', message: 'Nudge' },
+      { sessionID: 'parent-1' } as any,
+    );
+    await Promise.resolve();
+    board.drop('ses_child1');
+    statusResult.resolve({ data: { ses_child1: { type: 'busy' } } });
+
+    await expect(pending).rejects.toThrow('no longer tracked');
+    expect(prompt).not.toHaveBeenCalled();
+  });
+
+  test('does not prompt an old generation after relaunch during live status lookup', async () => {
+    const board = new BackgroundJobBoard();
+    registerStuckChild(board);
+    const prompt = mock(async () => ({}));
+    const statusResult = deferred<{ data: Record<string, unknown> }>();
+    const status = mock(async () => statusResult.promise);
+    client = { session: { status, prompt } };
+    const { task_nudge } = createTaskNudgeTool({
+      input: { directory: '/test' } as any,
+      backgroundJobBoard: board,
+      now: () => 120_000,
+    });
+
+    const pending = task_nudge.execute(
+      { task_id: 'ses_child1', message: 'Nudge' },
+      { sessionID: 'parent-1' } as any,
+    );
+    await Promise.resolve();
+    board.registerLaunch({
+      taskID: 'ses_child1',
+      parentSessionID: 'parent-1',
+      agent: 'fixer',
+      now: 121_000,
+    });
+    statusResult.resolve({ data: { ses_child1: { type: 'busy' } } });
+
+    await expect(pending).rejects.toThrow('run generation changed');
     expect(prompt).not.toHaveBeenCalled();
   });
 

--- a/src/tools/task-nudge.test.ts
+++ b/src/tools/task-nudge.test.ts
@@ -186,7 +186,7 @@ describe('task_nudge', () => {
     expect(prompt).not.toHaveBeenCalled();
   });
 
-  test('refuses to nudge an idle or absent child session', async () => {
+  test('refuses to nudge an absent child session as unknown', async () => {
     const board = new BackgroundJobBoard();
     registerStuckChild(board);
     const prompt = mock(async () => ({}));
@@ -200,7 +200,33 @@ describe('task_nudge', () => {
       task_nudge.execute({ task_id: 'ses_child1', message: 'Nudge' }, {
         sessionID: 'parent-1',
       } as any),
-    ).rejects.toThrow('child session is idle');
+    ).rejects.toThrow('child session status unknown');
+    expect(prompt).not.toHaveBeenCalled();
+  });
+
+  test('keeps malformed live status distinct from an absent session', async () => {
+    const board = new BackgroundJobBoard();
+    registerStuckChild(board);
+    const prompt = mock(async () => ({}));
+    client = {
+      session: {
+        status: mock(async () => ({
+          data: { ses_child1: { type: 'suspended' } },
+        })),
+        prompt,
+      },
+    };
+    const { task_nudge } = createTaskNudgeTool({
+      input: { directory: '/test' } as any,
+      backgroundJobBoard: board,
+      now: () => 120_000,
+    });
+
+    await expect(
+      task_nudge.execute({ task_id: 'ses_child1', message: 'Nudge' }, {
+        sessionID: 'parent-1',
+      } as any),
+    ).rejects.toThrow('child session status malformed');
     expect(prompt).not.toHaveBeenCalled();
   });
 

--- a/src/tools/task-nudge.test.ts
+++ b/src/tools/task-nudge.test.ts
@@ -358,6 +358,43 @@ describe('task_nudge', () => {
     expect(prompt).not.toHaveBeenCalled();
   });
 
+  test('does not prompt when relaunch happens while acquiring the prompt boundary', async () => {
+    const board = new BackgroundJobBoard();
+    registerStuckChild(board);
+    const prompt = mock(async () => ({}));
+    let promptPropertyRead = false;
+    const session = {
+      status: mock(async () => ({
+        data: { ses_child1: { type: 'busy' } },
+      })),
+      get prompt() {
+        if (!promptPropertyRead) {
+          promptPropertyRead = true;
+          board.registerLaunch({
+            taskID: 'ses_child1',
+            parentSessionID: 'parent-1',
+            agent: 'fixer',
+            now: 121_000,
+          });
+        }
+        return prompt;
+      },
+    };
+    client = { session };
+    const { task_nudge } = createTaskNudgeTool({
+      input: { directory: '/test' } as any,
+      backgroundJobBoard: board,
+      now: () => 120_000,
+    });
+
+    await expect(
+      task_nudge.execute({ task_id: 'ses_child1', message: 'Nudge' }, {
+        sessionID: 'parent-1',
+      } as any),
+    ).rejects.toThrow('run generation changed');
+    expect(prompt).not.toHaveBeenCalled();
+  });
+
   test('rejects a task id owned by a different parent', async () => {
     const board = new BackgroundJobBoard();
     registerStuckChild(board);

--- a/src/tools/task-nudge.ts
+++ b/src/tools/task-nudge.ts
@@ -90,6 +90,13 @@ export function createTaskNudgeTool(options: {
           );
         }
 
+        // Resolve the transport before the final fence so no property access
+        // or client lookup remains between that fence and prompt invocation.
+        // OpenCode's prompt API has no expected-generation/CAS argument: a
+        // relaunch that races after this synchronous boundary is outside what
+        // this lane can prove, and is intentionally not described as atomic.
+        const session = getClient(options.input).session;
+        const prompt = session.prompt.bind(session);
         const promptJob = getCurrentNudgeJob(
           options.backgroundJobBoard,
           parentSessionID,
@@ -97,7 +104,7 @@ export function createTaskNudgeTool(options: {
           job.taskID,
           job.generation,
         );
-        await getClient(options.input).session.prompt({
+        await prompt({
           path: { id: promptJob.taskID },
           body: {
             noReply: true,

--- a/src/tools/task-nudge.ts
+++ b/src/tools/task-nudge.ts
@@ -66,13 +66,20 @@ export function createTaskNudgeTool(options: {
         const snapshot = await getRuntimeSessionStatusSnapshot(options.input, {
           timeoutMs: options.statusTimeoutMs,
         });
+        const currentJob = getCurrentNudgeJob(
+          options.backgroundJobBoard,
+          parentSessionID,
+          args.task_id.trim(),
+          job.taskID,
+          job.generation,
+        );
         const observation = observationFromSnapshot(snapshot, job.taskID);
         const lastActivityAt =
           options.activityTracker?.lastActivityAt(job.taskID) ??
-          job.lastLiveBusyAt ??
-          job.runStartedAt;
+          currentJob.lastLiveBusyAt ??
+          currentJob.runStartedAt;
         const eligibility = evaluateNudgeEligibility(
-          job,
+          currentJob,
           observation,
           lastActivityAt,
           at,
@@ -83,8 +90,15 @@ export function createTaskNudgeTool(options: {
           );
         }
 
+        const promptJob = getCurrentNudgeJob(
+          options.backgroundJobBoard,
+          parentSessionID,
+          args.task_id.trim(),
+          job.taskID,
+          job.generation,
+        );
         await getClient(options.input).session.prompt({
-          path: { id: job.taskID },
+          path: { id: promptJob.taskID },
           body: {
             noReply: true,
             parts: [{ type: 'text', text: args.message.trim() }],
@@ -100,4 +114,40 @@ export function createTaskNudgeTool(options: {
     },
   });
   return { task_nudge };
+}
+
+function getCurrentNudgeJob(
+  backgroundJobBoard: BackgroundJobStore,
+  parentSessionID: string,
+  requested: string,
+  expectedTaskID: string,
+  expectedGeneration: number,
+): NonNullable<ReturnType<BackgroundJobStore['get']>> {
+  const current = backgroundJobBoard.get(expectedTaskID);
+  const resolved = backgroundJobBoard.resolve(parentSessionID, requested);
+  if (!current || !resolved || resolved.taskID !== expectedTaskID) {
+    throw new Error(
+      `Task ${requested} is no longer tracked; refusing to nudge stale execution`,
+    );
+  }
+  if (
+    current.taskID !== expectedTaskID ||
+    current.generation !== expectedGeneration ||
+    resolved.generation !== expectedGeneration
+  ) {
+    throw new Error(
+      `Task ${requested} run generation changed; refusing to nudge stale execution`,
+    );
+  }
+  if (current.state !== 'running') {
+    throw new Error(
+      `Task ${requested} cannot be nudged: board state is ${current.state}, not running`,
+    );
+  }
+  if (current.cancellationRequested) {
+    throw new Error(
+      `Task ${requested} cannot be nudged: cancellation was requested`,
+    );
+  }
+  return current;
 }

--- a/src/tools/task-policy.ts
+++ b/src/tools/task-policy.ts
@@ -12,9 +12,9 @@ export const STUCK_IDLE_THRESHOLD_MS = 120_000;
  * Bounded, explicit observation of a tracked child's live session status.
  *
  * `ok` is true only when the host status map was read successfully (within
- * the bounded timeout). An absent session in a valid map is `status: 'idle'`;
- * a malformed entry is `status: undefined` with `error`; a failed or
- * timed-out read is `ok: false` with `error`.
+ * the bounded timeout). An absent session in a valid map is unknown;
+ * a malformed entry is also `status: undefined` but carries `error`; a
+ * failed or timed-out read is `ok: false` with `error`.
  */
 export interface LiveStatusObservation {
   ok: boolean;
@@ -42,8 +42,9 @@ export interface NudgeEligibility {
 /**
  * Converts a bounded snapshot into a single-session observation. A failed
  * read becomes `ok: false`; a malformed entry becomes `ok: true` with
- * `status: undefined` and an error; a valid map reports the entry's status
- * (absent means 'idle').
+ * `status: undefined` and an error; a valid map reports the entry's status.
+ * A valid map without the requested session is an unknown/quiescent
+ * observation, not an idle or terminal observation.
  */
 export function observationFromSnapshot(
   snapshot: RuntimeSessionStatusSnapshot,
@@ -140,7 +141,9 @@ export function evaluateNudgeEligibility(
   if (observation.status === undefined) {
     return {
       eligible: false,
-      reason: 'child session status malformed; refusing to nudge',
+      reason: observation.error
+        ? 'child session status malformed; refusing to nudge'
+        : 'child session status unknown; refusing to nudge without confirmed live activity',
     };
   }
   if (observation.status === 'idle') {

--- a/src/tools/task-result.test.ts
+++ b/src/tools/task-result.test.ts
@@ -197,6 +197,94 @@ describe('task_result', () => {
     expect(output).toBe('complete findings');
   });
 
+  test('does not return G2 partial output after G1 completion races a relaunch', async () => {
+    const { board, tool, messages } = createTool();
+    board.registerLaunch({
+      taskID: 'ses_child1',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+      description: 'trace bug',
+    });
+    const first = board.updateStatus({
+      taskID: 'ses_child1',
+      state: 'completed',
+      resultSummary: 'G1 complete',
+    });
+    if (!first) throw new Error('G1 was not registered');
+
+    mockClient.session.status.mockImplementation(async () => {
+      board.registerLaunch({
+        taskID: 'ses_child1',
+        parentSessionID: 'parent-1',
+        agent: 'explorer',
+        description: 'G2 relaunch',
+      });
+      return { data: { ses_child1: { type: 'busy' } } };
+    });
+    mockClient.session.messages.mockResolvedValue({
+      data: [
+        {
+          info: { role: 'assistant' },
+          parts: [{ type: 'text', text: 'G2 partial output' }],
+        },
+      ],
+    });
+
+    await expect(
+      tool.execute({ task_id: 'exp-1' }, {
+        sessionID: 'parent-1',
+        agent: 'orchestrator',
+      } as any),
+    ).rejects.toThrow('still running');
+
+    expect(board.get('ses_child1')).toMatchObject({
+      generation: first.generation + 1,
+      state: 'running',
+    });
+    expect(messages).not.toHaveBeenCalled();
+  });
+
+  test('does not return a result when G2 relaunches during result extraction', async () => {
+    const { board, tool } = createTool();
+    board.registerLaunch({
+      taskID: 'ses_child1',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+      description: 'trace bug',
+    });
+    board.updateStatus({
+      taskID: 'ses_child1',
+      state: 'completed',
+      resultSummary: 'G1 complete',
+    });
+
+    mockClient.session.messages.mockImplementation(async () => {
+      board.registerLaunch({
+        taskID: 'ses_child1',
+        parentSessionID: 'parent-1',
+        agent: 'explorer',
+        description: 'G2 relaunch',
+      });
+      return {
+        data: [
+          {
+            info: { role: 'assistant' },
+            parts: [{ type: 'text', text: 'G2 partial output' }],
+          },
+        ],
+      };
+    });
+
+    await expect(
+      tool.execute({ task_id: 'exp-1' }, {
+        sessionID: 'parent-1',
+        agent: 'orchestrator',
+      } as any),
+    ).rejects.toThrow('still running');
+
+    expect(board.get('ses_child1')?.state).toBe('running');
+  });
+
   test('rejects a reconciled task whose terminal outcome was error', async () => {
     const { board, tool, messages } = createTool();
     board.registerLaunch({

--- a/src/tools/task-result.test.ts
+++ b/src/tools/task-result.test.ts
@@ -103,6 +103,39 @@ describe('task_result', () => {
     expect(messages).not.toHaveBeenCalled();
   });
 
+  test('self-heals a stopped board record when the live child is busy', async () => {
+    const { board, tool, messages } = createTool();
+    board.registerLaunch({
+      taskID: 'ses_child1',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+      description: 'trace bug',
+    });
+    const generation = board.get('ses_child1')?.generation;
+    board.markStopped(
+      'ses_child1',
+      'provisional idle observation',
+      1,
+      generation,
+    );
+    mockClient.session.status.mockResolvedValue({
+      data: { ses_child1: { type: 'busy' } },
+    });
+
+    await expect(
+      tool.execute({ task_id: 'exp-1' }, {
+        sessionID: 'parent-1',
+        agent: 'orchestrator',
+      } as any),
+    ).rejects.toThrow('still running');
+
+    expect(board.get('ses_child1')).toMatchObject({
+      state: 'running',
+      statusUncertain: false,
+    });
+    expect(messages).not.toHaveBeenCalled();
+  });
+
   test('rejects a tracked task that ended in error', async () => {
     const { board, tool, messages } = createTool();
     board.registerLaunch({

--- a/src/tools/task-result.ts
+++ b/src/tools/task-result.ts
@@ -58,6 +58,29 @@ function assertRetrievableState(
   }
 }
 
+function assertStableTrackedGeneration(
+  requested: string,
+  parentSessionID: string,
+  expectedTaskID: string,
+  expectedGeneration: number,
+  backgroundJobBoard: BackgroundJobStore,
+): BackgroundJobRecord {
+  const current = backgroundJobBoard.resolve(parentSessionID, requested);
+  if (
+    !current ||
+    current.taskID !== expectedTaskID ||
+    current.generation !== expectedGeneration
+  ) {
+    if (current) assertRetrievableState(requested, current);
+    throw new Error(
+      `Task ${requested} changed generation while its result was being retrieved; wait for its current terminal result instead of retrieving it.`,
+    );
+  }
+
+  assertRetrievableState(requested, current);
+  return current;
+}
+
 export function createTaskResultTool(
   options: TaskResultToolOptions,
 ): Record<string, ToolDefinition> {
@@ -80,6 +103,21 @@ Use this when the user asks to see a prior task's full result, or before retryin
         parentSessionID,
         requested,
       );
+      const trackedTaskID = tracked?.taskID;
+      const trackedGeneration = tracked?.generation;
+
+      const revalidateTracked = (): void => {
+        if (trackedTaskID === undefined || trackedGeneration === undefined) {
+          return;
+        }
+        tracked = assertStableTrackedGeneration(
+          requested,
+          parentSessionID,
+          trackedTaskID,
+          trackedGeneration,
+          options.backgroundJobBoard,
+        );
+      };
 
       // A stopped board record is only a provisional observation. Re-check the
       // live runner once, with the same bounded status path used elsewhere,
@@ -102,9 +140,7 @@ Use this when the user asks to see a prior task's full result, or before retryin
         }
       }
 
-      if (tracked) {
-        assertRetrievableState(requested, tracked);
-      }
+      revalidateTracked();
 
       const taskID = tracked?.taskID ?? requested;
       if (!SESSION_ID_PATTERN.test(taskID)) {
@@ -130,7 +166,9 @@ Use this when the user asks to see a prior task's full result, or before retryin
         );
       }
 
+      revalidateTracked();
       liveSnapshot ??= await getRuntimeSessionStatusSnapshot(options.input);
+      revalidateTracked();
       const status = runtimeSessionStatus(liveSnapshot, taskID);
       const trackedTerminalState = tracked
         ? tracked.state === 'reconciled'
@@ -155,10 +193,12 @@ Use this when the user asks to see a prior task's full result, or before retryin
         return result;
       }
 
+      revalidateTracked();
       const result = await extractFinalSessionResult(client, taskID, {
         directory: options.input.directory,
         includeReasoning: false,
       });
+      revalidateTracked();
       if (result.empty) {
         throw new Error(`Task ${requested} has no completed text result`);
       }

--- a/src/tools/task-result.ts
+++ b/src/tools/task-result.ts
@@ -5,12 +5,16 @@ import {
 } from '@opencode-ai/plugin';
 import type { BackgroundJobRecord } from '../utils/background-job-board';
 import type { BackgroundJobStore } from '../utils/background-job-store';
-import { isRecord } from '../utils/guards';
 import { getClient } from '../utils/opencode-client';
 import {
   extractFinalSessionResult,
   SESSION_ID_PATTERN,
 } from '../utils/session';
+import {
+  getRuntimeSessionStatusSnapshot,
+  type RuntimeSessionStatusSnapshot,
+  runtimeSessionStatus,
+} from '../utils/session-runtime-status';
 
 const z = tool.schema;
 
@@ -72,10 +76,32 @@ Use this when the user asks to see a prior task's full result, or before retryin
       const requested = args.task_id.trim();
       if (!requested) throw new Error('task_result requires task_id');
 
-      const tracked = options.backgroundJobBoard.resolve(
+      let tracked = options.backgroundJobBoard.resolve(
         parentSessionID,
         requested,
       );
+
+      // A stopped board record is only a provisional observation. Re-check the
+      // live runner once, with the same bounded status path used elsewhere,
+      // before rejecting it. A busy/retry observation self-heals that record
+      // and prevents a stale stopped gate from hiding a still-live task.
+      let liveSnapshot: RuntimeSessionStatusSnapshot | undefined;
+      if (tracked?.state === 'stopped') {
+        liveSnapshot = await getRuntimeSessionStatusSnapshot(options.input);
+        const liveStatus = runtimeSessionStatus(liveSnapshot, tracked.taskID);
+        if (liveStatus === 'busy' || liveStatus === 'retry') {
+          options.backgroundJobBoard.markRunningFromLiveSession(
+            tracked.taskID,
+            Date.now(),
+            tracked.generation,
+          );
+          tracked = options.backgroundJobBoard.resolve(
+            parentSessionID,
+            requested,
+          );
+        }
+      }
+
       if (tracked) {
         assertRetrievableState(requested, tracked);
       }
@@ -104,14 +130,16 @@ Use this when the user asks to see a prior task's full result, or before retryin
         );
       }
 
-      const statuses = await client.session.status({
-        query: { directory: options.input.directory },
-      });
-      const statusMap = statuses.data;
-      const status = isRecord(statusMap) ? statusMap[taskID] : undefined;
+      liveSnapshot ??= await getRuntimeSessionStatusSnapshot(options.input);
+      const status = runtimeSessionStatus(liveSnapshot, taskID);
+      const trackedTerminalState = tracked
+        ? tracked.state === 'reconciled'
+          ? tracked.terminalState
+          : tracked.state
+        : undefined;
       if (
-        isRecord(status) &&
-        (status.type === 'busy' || status.type === 'retry')
+        (status === 'busy' || status === 'retry') &&
+        trackedTerminalState !== 'completed'
       ) {
         throw new Error(
           `Task ${requested} is still running. Wait for its terminal result instead of retrieving or duplicating it.`,

--- a/src/tools/task-status.test.ts
+++ b/src/tools/task-status.test.ts
@@ -154,7 +154,7 @@ describe('task_status', () => {
     expect(output).toContain('possibly_stuck: false');
   });
 
-  test('reports an absent session in a valid map as live idle', async () => {
+  test('reports an absent session in a valid map as uncertain', async () => {
     const board = new BackgroundJobBoard();
     board.registerLaunch({
       taskID: 'ses_child1',
@@ -168,8 +168,11 @@ describe('task_status', () => {
     const output = await task_status.execute({ task_id: 'ses_child1' }, {
       sessionID: 'parent-1',
     } as any);
-    expect(output).toContain('state: idle');
-    expect(output).not.toContain('status_uncertain');
+    expect(output).toContain('state: running (unconfirmed)');
+    expect(output).toContain('status_uncertain: true');
+    expect(output).toContain(
+      'last_status_error: no live status entry for session',
+    );
     expect(output).toContain('possibly_stuck: false');
   });
 

--- a/src/utils/background-job-board.test.ts
+++ b/src/utils/background-job-board.test.ts
@@ -25,6 +25,120 @@ describe('BackgroundJobBoard', () => {
     expect(board.hasRunning('parent-1')).toBe(true);
   });
 
+  test('cancellation lease fences a same-ID relaunch', () => {
+    const board = new BackgroundJobBoard();
+    const first = board.registerLaunch({
+      taskID: 'ses_lease',
+      parentSessionID: 'parent-1',
+      agent: 'fixer',
+    });
+
+    const cancellationLease = board.acquireCancellationLease(
+      first.taskID,
+      first.generation,
+    );
+
+    expect(cancellationLease).toMatchObject({
+      taskID: first.taskID,
+      generation: first.generation,
+      kind: 'cancellation',
+    });
+    expect(
+      board.acquireRelaunchLease(first.taskID, first.generation),
+    ).toBeUndefined();
+    expect(() =>
+      board.registerLaunch({
+        taskID: first.taskID,
+        parentSessionID: 'parent-1',
+        agent: 'fixer',
+      }),
+    ).toThrow('cancellation lease');
+    expect(board.get(first.taskID)?.generation).toBe(first.generation);
+  });
+
+  test('relaunch lease fences cancellation and validates token/generation', () => {
+    const board = new BackgroundJobBoard();
+    const first = board.registerLaunch({
+      taskID: 'ses_lease',
+      parentSessionID: 'parent-1',
+      agent: 'fixer',
+    });
+    const relaunchLease = board.acquireRelaunchLease(
+      first.taskID,
+      first.generation,
+    );
+
+    expect(relaunchLease).toBeDefined();
+    if (!relaunchLease) throw new Error('relaunch lease was not acquired');
+    expect(
+      board.acquireCancellationLease(first.taskID, first.generation),
+    ).toBeUndefined();
+    expect(
+      board.releaseLease({
+        ...relaunchLease,
+        token: 'wrong-token',
+      }),
+    ).toBe(false);
+    expect(
+      board.releaseLease({
+        ...relaunchLease,
+        generation: first.generation + 1,
+      }),
+    ).toBe(false);
+    expect(board.validateLease(relaunchLease)).toBe(true);
+
+    const second = board.registerLaunch({
+      taskID: first.taskID,
+      parentSessionID: 'parent-1',
+      agent: 'fixer',
+      relaunchLease,
+    });
+    expect(second.generation).not.toBe(first.generation);
+    expect(board.releaseLease(relaunchLease)).toBe(true);
+  });
+
+  test('expected generation and cancellation token fence markCancelled', () => {
+    const board = new BackgroundJobBoard();
+    const first = board.registerLaunch({
+      taskID: 'ses_lease',
+      parentSessionID: 'parent-1',
+      agent: 'fixer',
+    });
+    const cancellationLease = board.acquireCancellationLease(
+      first.taskID,
+      first.generation,
+    );
+    expect(cancellationLease).toBeDefined();
+    if (!cancellationLease) {
+      throw new Error('cancellation lease was not acquired');
+    }
+
+    expect(
+      board.markCancelled(first.taskID, 'wrong generation', Date.now(), {
+        force: true,
+        expectedGeneration: first.generation + 1,
+        cancellationLease,
+      })?.state,
+    ).toBe('running');
+    expect(
+      board.markCancelled(first.taskID, 'wrong token', Date.now(), {
+        force: true,
+        expectedGeneration: first.generation,
+        cancellationLease: {
+          ...cancellationLease,
+          token: 'wrong-token',
+        },
+      })?.state,
+    ).toBe('running');
+    expect(
+      board.markCancelled(first.taskID, 'cancelled', Date.now(), {
+        force: true,
+        expectedGeneration: first.generation,
+        cancellationLease,
+      })?.state,
+    ).toBe('cancelled');
+  });
+
   test('updates terminal task results as unreconciled', () => {
     const board = new BackgroundJobBoard();
     board.registerLaunch({
@@ -530,6 +644,43 @@ describe('BackgroundJobBoard', () => {
 
     expect(listener).toHaveBeenCalledWith('ses_1');
     expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not force-cancel a newer generation or notify terminal listeners', () => {
+    const board = new BackgroundJobBoard();
+    const listener = mock(() => {});
+    board.setTerminalStateListener(listener);
+    board.registerLaunch({
+      taskID: 'ses_1',
+      parentSessionID: 'parent-1',
+      agent: 'fixer',
+    });
+    board.updateStatus({ taskID: 'ses_1', state: 'completed' });
+    listener.mockClear();
+    const relaunched = board.registerLaunch({
+      taskID: 'ses_1',
+      parentSessionID: 'parent-1',
+      agent: 'fixer',
+    });
+
+    const result = board.markCancelled(
+      'ses_1',
+      'stale cancellation',
+      Date.now(),
+      { force: true, expectedGeneration: relaunched.generation - 1 },
+    );
+
+    expect(result).toMatchObject({
+      generation: relaunched.generation,
+      state: 'running',
+      cancellationRequested: false,
+    });
+    expect(board.get('ses_1')).toMatchObject({
+      generation: relaunched.generation,
+      state: 'running',
+      terminalUnreconciled: false,
+    });
+    expect(listener).not.toHaveBeenCalled();
   });
 
   test('does not notify terminal listener on forced markCancelled from terminal', () => {

--- a/src/utils/background-job-board.test.ts
+++ b/src/utils/background-job-board.test.ts
@@ -165,6 +165,55 @@ describe('BackgroundJobBoard', () => {
     expect(board.hasTerminalUnreconciled('parent-1')).toBe(true);
   });
 
+  test('expected generation fences a late native terminal status', () => {
+    const board = new BackgroundJobBoard();
+    const listener = mock(() => {});
+    board.setTerminalStateListener(listener);
+    const first = board.registerLaunch({
+      taskID: 'ses_generation',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+    });
+    board.updateStatus({
+      taskID: 'ses_generation',
+      state: 'completed',
+      resultSummary: 'G1 result',
+    });
+    listener.mockClear();
+    const second = board.registerLaunch({
+      taskID: 'ses_generation',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+    });
+
+    board.updateStatus({
+      taskID: 'ses_generation',
+      state: 'completed',
+      expectedGeneration: first.generation,
+      resultSummary: 'late G1 result',
+    });
+
+    expect(board.get('ses_generation')).toMatchObject({
+      generation: second.generation,
+      state: 'running',
+      resultSummary: undefined,
+    });
+    expect(listener).not.toHaveBeenCalled();
+
+    board.updateStatus({
+      taskID: 'ses_generation',
+      state: 'completed',
+      expectedGeneration: second.generation,
+      resultSummary: 'G2 result',
+    });
+    expect(board.get('ses_generation')).toMatchObject({
+      generation: second.generation,
+      state: 'completed',
+      resultSummary: 'G2 result',
+    });
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
   test('keeps timeout status running with timedOut overlay', () => {
     const board = new BackgroundJobBoard();
     board.registerLaunch({

--- a/src/utils/background-job-board.ts
+++ b/src/utils/background-job-board.ts
@@ -104,6 +104,8 @@ export interface BackgroundJobLaunchInput {
 export interface BackgroundJobStatusInput {
   taskID: string;
   state: TaskOutputState;
+  /** Ignore native output from an older run of the same task ID. */
+  expectedGeneration?: number;
   timedOut?: boolean;
   statusUncertain?: boolean;
   resultSummary?: string;
@@ -317,6 +319,12 @@ export class BackgroundJobBoard implements BackgroundJobStore {
   ): BackgroundJobRecord | undefined {
     const existing = this.jobs.get(input.taskID);
     if (!existing) return undefined;
+    if (
+      input.expectedGeneration !== undefined &&
+      existing.generation !== input.expectedGeneration
+    ) {
+      return existing;
+    }
 
     // A wall-clock deadline is a hard, non-recoverable claim. Completion after
     // that claim is late evidence and cannot replace the canonical timeout.

--- a/src/utils/background-job-board.ts
+++ b/src/utils/background-job-board.ts
@@ -6,6 +6,10 @@ import {
   formatSystemReminder,
 } from '../config/constants';
 import type { BackgroundJobStore } from './background-job-store';
+import {
+  clearBackgroundJobSuppression,
+  recordBackgroundJobSuppression,
+} from './background-job-store';
 import { log } from './logger';
 import { parseTaskStatusOutput, type TaskOutputState } from './task';
 
@@ -19,6 +23,16 @@ export interface ContextFile {
 export interface BackgroundJobExecution {
   taskID: string;
   generation: number;
+}
+
+export type BackgroundJobLeaseKind = 'cancellation' | 'relaunch';
+
+/** Process-local ownership of a remote operation or same-ID relaunch. */
+export interface BackgroundJobLease {
+  taskID: string;
+  generation: number;
+  token: string;
+  kind: BackgroundJobLeaseKind;
 }
 
 export interface BackgroundJobPromptMetadata {
@@ -80,6 +94,10 @@ export interface BackgroundJobLaunchInput {
   background?: boolean;
   /** Preserve the current run when this is a duplicate lifecycle observation. */
   preserveRun?: boolean;
+  /** Lease proving that this is an authorized same-ID relaunch observation. */
+  relaunchLease?: BackgroundJobLease;
+  /** Backwards-compatible generic spelling for the relaunch lease. */
+  lease?: BackgroundJobLease;
   now?: number;
 }
 
@@ -110,6 +128,13 @@ export interface WallClockTimeoutFinalizeInput {
 
 type TerminalStateListener = (taskID: string) => void;
 
+export class BackgroundJobLaunchConflictError extends Error {
+  constructor(taskID: string, message: string) {
+    super(`Cannot register launch for ${taskID}: ${message}`);
+    this.name = 'BackgroundJobLaunchConflictError';
+  }
+}
+
 const CANONICAL_TERMINAL_STATES = new Set<TaskOutputState>([
   'completed',
   'error',
@@ -128,8 +153,11 @@ const AGENT_PREFIX: Record<string, string> = {
 
 export class BackgroundJobBoard implements BackgroundJobStore {
   private readonly jobs = new Map<string, BackgroundJobRecord>();
+  /** One live operation/relaunch owner per native session ID. */
+  private readonly liveLeases = new Map<string, BackgroundJobLease>();
   private readonly counters = new Map<string, number>();
   private executionSequence = 0;
+  private leaseSequence = 0;
   private terminalStateListeners: TerminalStateListener[] = [];
 
   private readonly maxReusablePerAgent: number;
@@ -176,8 +204,39 @@ export class BackgroundJobBoard implements BackgroundJobStore {
 
   registerLaunch(input: BackgroundJobLaunchInput): BackgroundJobRecord {
     const now = input.now ?? Date.now();
-    const generation = ++this.executionSequence;
     const existing = this.jobs.get(input.taskID);
+    const requestedLease = input.relaunchLease ?? input.lease;
+    const liveLease = this.liveLeases.get(input.taskID);
+
+    if (requestedLease) {
+      if (
+        requestedLease.kind !== 'relaunch' ||
+        !this.validateLease(requestedLease) ||
+        requestedLease.taskID !== input.taskID ||
+        existing?.generation !== requestedLease.generation
+      ) {
+        throw new BackgroundJobLaunchConflictError(
+          input.taskID,
+          'the relaunch lease is missing, stale, or belongs to another generation',
+        );
+      }
+    }
+
+    if (liveLease) {
+      if (
+        liveLease.kind !== 'relaunch' ||
+        requestedLease === undefined ||
+        !this.validateLease(requestedLease)
+      ) {
+        throw new BackgroundJobLaunchConflictError(
+          input.taskID,
+          `a ${liveLease.kind} lease already owns this session`,
+        );
+      }
+    }
+
+    clearBackgroundJobSuppression(this, input.taskID);
+    const generation = ++this.executionSequence;
 
     if (existing) {
       if (input.preserveRun) {
@@ -506,10 +565,36 @@ export class BackgroundJobBoard implements BackgroundJobStore {
     taskID: string,
     reason?: string,
     now = Date.now(),
-    options: { force?: boolean } = {},
+    options: {
+      force?: boolean;
+      expectedGeneration?: number;
+      cancellationLease?: BackgroundJobLease;
+    } = {},
   ): BackgroundJobRecord | undefined {
     const existing = this.jobs.get(taskID);
     if (!existing) return undefined;
+    if (
+      options.expectedGeneration !== undefined &&
+      existing.generation !== options.expectedGeneration
+    ) {
+      return existing;
+    }
+    const activeLease = this.liveLeases.get(taskID);
+    if (
+      options.cancellationLease !== undefined &&
+      (options.cancellationLease.kind !== 'cancellation' ||
+        !this.validateLease(options.cancellationLease))
+    ) {
+      return existing;
+    }
+    if (
+      activeLease !== undefined &&
+      (activeLease.kind !== 'cancellation' ||
+        options.cancellationLease === undefined ||
+        !this.validateLease(options.cancellationLease))
+    ) {
+      return existing;
+    }
     if (existing.deadlineExceededAt !== undefined) {
       if (existing.state !== 'running') return existing;
       return this.finalizeWallClockTimeout({
@@ -547,6 +632,61 @@ export class BackgroundJobBoard implements BackgroundJobStore {
     this.jobs.set(taskID, updated);
     if (notifyTerminal) this.notifyTerminalStateListeners(taskID);
     return updated;
+  }
+
+  acquireCancellationLease(
+    taskID: string,
+    generation: number,
+  ): BackgroundJobLease | undefined {
+    const existing = this.jobs.get(taskID);
+    if (
+      existing?.generation !== generation ||
+      existing.state !== 'running' ||
+      this.liveLeases.has(taskID)
+    ) {
+      return undefined;
+    }
+    const lease: BackgroundJobLease = {
+      taskID,
+      generation,
+      token: this.nextLeaseToken('cancellation'),
+      kind: 'cancellation',
+    };
+    this.liveLeases.set(taskID, lease);
+    return lease;
+  }
+
+  acquireRelaunchLease(
+    taskID: string,
+    generation: number,
+  ): BackgroundJobLease | undefined {
+    const existing = this.jobs.get(taskID);
+    if (existing?.generation !== generation || this.liveLeases.has(taskID)) {
+      return undefined;
+    }
+    const lease: BackgroundJobLease = {
+      taskID,
+      generation,
+      token: this.nextLeaseToken('relaunch'),
+      kind: 'relaunch',
+    };
+    this.liveLeases.set(taskID, lease);
+    return lease;
+  }
+
+  validateLease(lease: BackgroundJobLease): boolean {
+    const activeLease = this.liveLeases.get(lease.taskID);
+    return (
+      activeLease?.token === lease.token &&
+      activeLease.generation === lease.generation &&
+      activeLease.kind === lease.kind
+    );
+  }
+
+  releaseLease(lease: BackgroundJobLease): boolean {
+    if (!this.validateLease(lease)) return false;
+    this.liveLeases.delete(lease.taskID);
+    return true;
   }
 
   get(taskID: string): BackgroundJobRecord | undefined {
@@ -798,11 +938,13 @@ export class BackgroundJobBoard implements BackgroundJobStore {
 
   clearParent(parentSessionID: string): void {
     for (const job of this.list(parentSessionID)) {
+      recordBackgroundJobSuppression(this, job.taskID);
       this.jobs.delete(job.taskID);
     }
   }
 
   drop(taskID: string): void {
+    recordBackgroundJobSuppression(this, taskID);
     this.jobs.delete(taskID);
   }
 
@@ -835,6 +977,7 @@ export class BackgroundJobBoard implements BackgroundJobStore {
         (entry.terminalState ?? terminalStateOf(entry.state)) !== undefined &&
         sumContextLines(entry) > this.maxContextLines
       ) {
+        recordBackgroundJobSuppression(this, entry.taskID);
         this.jobs.delete(entry.taskID);
       }
     }
@@ -850,6 +993,7 @@ export class BackgroundJobBoard implements BackgroundJobStore {
       )
       .sort((a, b) => b.lastUsedAt - a.lastUsedAt);
     for (const stale of reusable.slice(this.maxReusablePerAgent)) {
+      recordBackgroundJobSuppression(this, stale.taskID);
       this.jobs.delete(stale.taskID);
     }
   }
@@ -878,6 +1022,11 @@ export class BackgroundJobBoard implements BackgroundJobStore {
     this.counters.set(key, next);
 
     return `${prefix}-${next}`;
+  }
+
+  private nextLeaseToken(kind: BackgroundJobLeaseKind): string {
+    this.leaseSequence += 1;
+    return `background-job-${kind}-lease-${this.leaseSequence}`;
   }
 }
 

--- a/src/utils/background-job-coordinator.test.ts
+++ b/src/utils/background-job-coordinator.test.ts
@@ -166,4 +166,39 @@ describe('BackgroundJobCoordinator', () => {
     expect(listener).toHaveBeenCalledWith('full-chain-test');
     expect(listener).toHaveBeenCalledTimes(1);
   });
+
+  test('forwards live lease acquisition, validation, release, and mark generation', () => {
+    const board = new BackgroundJobBoard();
+    const coordinator = new BackgroundJobCoordinator(board);
+    const first = coordinator.registerLaunch({
+      taskID: 'ses_forwarded_lease',
+      parentSessionID: 'parent-1',
+      agent: 'fixer',
+    });
+    const lease = coordinator.acquireCancellationLease(
+      first.taskID,
+      first.generation,
+    );
+
+    expect(lease).toBeDefined();
+    if (!lease) throw new Error('cancellation lease was not acquired');
+    expect(coordinator.validateLease(lease)).toBe(true);
+    expect(
+      coordinator.markCancelled(first.taskID, 'wrong generation', Date.now(), {
+        force: true,
+        expectedGeneration: first.generation + 1,
+        cancellationLease: lease,
+      })?.state,
+    ).toBe('running');
+    expect(coordinator.releaseLease(lease)).toBe(true);
+    expect(coordinator.validateLease(lease)).toBe(false);
+    const relaunchLease = coordinator.acquireRelaunchLease(
+      first.taskID,
+      first.generation,
+    );
+    expect(relaunchLease).toBeDefined();
+    if (!relaunchLease) throw new Error('relaunch lease was not acquired');
+    expect(coordinator.validateLease(relaunchLease)).toBe(true);
+    expect(coordinator.releaseLease(relaunchLease)).toBe(true);
+  });
 });

--- a/src/utils/background-job-coordinator.ts
+++ b/src/utils/background-job-coordinator.ts
@@ -1,6 +1,7 @@
 import type {
   BackgroundJobBoard,
   BackgroundJobLaunchInput,
+  BackgroundJobLease,
   BackgroundJobPromptMetadata,
   BackgroundJobRecord,
   BackgroundJobStatusInput,
@@ -137,6 +138,28 @@ export class BackgroundJobCoordinator implements BackgroundJobStore {
     return this.board.registerLaunch(input);
   }
 
+  acquireCancellationLease(
+    taskID: string,
+    generation: number,
+  ): BackgroundJobLease | undefined {
+    return this.board.acquireCancellationLease(taskID, generation);
+  }
+
+  acquireRelaunchLease(
+    taskID: string,
+    generation: number,
+  ): BackgroundJobLease | undefined {
+    return this.board.acquireRelaunchLease(taskID, generation);
+  }
+
+  validateLease(lease: BackgroundJobLease): boolean {
+    return this.board.validateLease(lease);
+  }
+
+  releaseLease(lease: BackgroundJobLease): boolean {
+    return this.board.releaseLease(lease);
+  }
+
   updateStatus(
     input: BackgroundJobStatusInput,
   ): BackgroundJobRecord | undefined {
@@ -212,7 +235,11 @@ export class BackgroundJobCoordinator implements BackgroundJobStore {
     taskID: string,
     reason?: string,
     now = Date.now(),
-    options: { force?: boolean } = {},
+    options: {
+      force?: boolean;
+      expectedGeneration?: number;
+      cancellationLease?: BackgroundJobLease;
+    } = {},
   ): BackgroundJobRecord | undefined {
     return this.board.markCancelled(taskID, reason, now, options);
   }

--- a/src/utils/background-job-store.ts
+++ b/src/utils/background-job-store.ts
@@ -1,5 +1,6 @@
 import type {
   BackgroundJobLaunchInput,
+  BackgroundJobLease,
   BackgroundJobPromptMetadata,
   BackgroundJobRecord,
   BackgroundJobStatusInput,
@@ -7,6 +8,110 @@ import type {
   WallClockTimeoutClaimInput,
   WallClockTimeoutFinalizeInput,
 } from './background-job-board';
+
+export type BackgroundJobSyntheticTerminalOccurrencePhase =
+  | 'observed'
+  | 'processed'
+  | 'ambiguous';
+
+export interface BackgroundJobSyntheticTerminalOccurrence {
+  taskID: string;
+  occurrenceID: string;
+  generationAtObservation?: number;
+  lifecycleEpochAtObservation: number;
+  phase: BackgroundJobSyntheticTerminalOccurrencePhase;
+}
+
+export interface BackgroundJobInjectedCompletionFence {
+  taskID: string;
+  generation: number;
+  lifecycleEpoch: number;
+}
+
+/**
+ * Process-local lifecycle memory shared by every hook using one job store.
+ *
+ * These sets/maps intentionally have no count cap. Evicting an old identity
+ * would turn a replay of valid history into a false negative for the current
+ * generation. The ledger is process-local by design; it is not persistence.
+ */
+export interface BackgroundJobLifecycleLedger {
+  tombstones: Set<string>;
+  deletionEpochs: Map<string, number>;
+  injectedCompletionFences: Map<string, BackgroundJobInjectedCompletionFence>;
+  syntheticTerminalOccurrences: Map<
+    string,
+    BackgroundJobSyntheticTerminalOccurrence
+  >;
+  syntheticTerminalOccurrenceOrder: string[];
+  processedInjectedCompletions: Set<string>;
+  processedInjectedCompletionOrder: string[];
+  nextEpoch: number;
+}
+
+const lifecycleLedgers = new WeakMap<object, BackgroundJobLifecycleLedger>();
+
+/**
+ * Coordinators wrap a board without exposing it in their public type. Use the
+ * wrapped board as the identity when one is present so both store facades
+ * share the same lifecycle ledger.
+ */
+function backingStore(store: BackgroundJobStore): object {
+  let current: unknown = store;
+  const seen = new Set<object>();
+
+  while (current && typeof current === 'object') {
+    const object = current as object;
+    if (seen.has(object)) return object;
+    seen.add(object);
+
+    const nested = (current as { board?: unknown }).board;
+    if (!nested || typeof nested !== 'object') return object;
+    current = nested;
+  }
+
+  return store as object;
+}
+
+export function getBackgroundJobLifecycleLedger(
+  store: BackgroundJobStore,
+): BackgroundJobLifecycleLedger {
+  const key = backingStore(store);
+  const existing = lifecycleLedgers.get(key);
+  if (existing) return existing;
+
+  const ledger: BackgroundJobLifecycleLedger = {
+    tombstones: new Set<string>(),
+    deletionEpochs: new Map<string, number>(),
+    injectedCompletionFences: new Map(),
+    syntheticTerminalOccurrences: new Map(),
+    syntheticTerminalOccurrenceOrder: [],
+    processedInjectedCompletions: new Set<string>(),
+    processedInjectedCompletionOrder: [],
+    nextEpoch: 0,
+  };
+  lifecycleLedgers.set(key, ledger);
+  return ledger;
+}
+
+/** Record a task drop/eviction as a rehydrate and late-output tombstone. */
+export function recordBackgroundJobSuppression(
+  store: BackgroundJobStore,
+  taskID: string,
+): void {
+  const ledger = getBackgroundJobLifecycleLedger(store);
+  if (ledger.tombstones.has(taskID)) return;
+  ledger.tombstones.add(taskID);
+  ledger.deletionEpochs.set(taskID, ++ledger.nextEpoch);
+}
+
+/** Clear only the active rehydrate tombstone for a proven new launch. */
+export function clearBackgroundJobSuppression(
+  store: BackgroundJobStore,
+  taskID: string,
+): void {
+  getBackgroundJobLifecycleLedger(store).tombstones.delete(taskID);
+}
 
 /**
  * Unified interface for background job operations.
@@ -17,6 +122,16 @@ import type {
 export interface BackgroundJobStore {
   // ── Mutation methods ──────────────────────────────────────────────
   registerLaunch(input: BackgroundJobLaunchInput): BackgroundJobRecord;
+  acquireCancellationLease(
+    taskID: string,
+    generation: number,
+  ): BackgroundJobLease | undefined;
+  acquireRelaunchLease(
+    taskID: string,
+    generation: number,
+  ): BackgroundJobLease | undefined;
+  validateLease(lease: BackgroundJobLease): boolean;
+  releaseLease(lease: BackgroundJobLease): boolean;
   updateStatus(
     input: BackgroundJobStatusInput,
   ): BackgroundJobRecord | undefined;
@@ -50,7 +165,11 @@ export interface BackgroundJobStore {
     taskID: string,
     reason?: string,
     now?: number,
-    options?: { force?: boolean },
+    options?: {
+      force?: boolean;
+      expectedGeneration?: number;
+      cancellationLease?: BackgroundJobLease;
+    },
   ): BackgroundJobRecord | undefined;
   clearParent(parentSessionID: string): void;
   drop(taskID: string): void;

--- a/src/utils/session-runtime-status.ts
+++ b/src/utils/session-runtime-status.ts
@@ -13,15 +13,20 @@ export interface RuntimeSessionStatusSnapshot {
 
 /**
  * Reads OpenCode's single live session-status map. An absent session in a
- * valid response is idle; an invalid response or failed request is unknown.
+ * valid response is unknown: the endpoint only describes currently active
+ * runners and does not prove that a background task has terminated.
  */
 export async function getRuntimeSessionStatusSnapshot(
   input: PluginInput,
   options: { timeoutMs?: number } = {},
 ): Promise<RuntimeSessionStatusSnapshot> {
   try {
+    const client =
+      typeof input.client?.session?.status === 'function'
+        ? input.client
+        : getClient(input);
     const response = await withTimeout(
-      getClient(input).session.status({
+      client.session.status({
         query: { directory: input.directory },
       }),
       options.timeoutMs ?? DEFAULT_RUNTIME_SESSION_STATUS_TIMEOUT_MS,
@@ -74,9 +79,7 @@ export function runtimeSessionStatus(
 ): RuntimeSessionStatus | undefined {
   if (snapshot.error) return undefined;
   if (snapshot.malformedSessionIDs.has(sessionID)) return undefined;
-  const status = snapshot.statuses.get(sessionID);
-  if (status === undefined) return 'idle';
-  return status;
+  return snapshot.statuses.get(sessionID);
 }
 
 async function withTimeout<T>(


### PR DESCRIPTION
# fix(tasks): harden background task lifecycle

## What problem are you solving?

omo-slim can report a still-running background task as `stopped` when OpenCode
briefly reports the child runner as `idle` or omits it from `/session/status`.
That status map describes current runner activity; it is not proof that the
background task has ended or that a terminal task result cannot arrive later.

The same lifecycle boundary can remove a board record while its historical
task part remains `state: running`. A later message transform can then
rehydrate the old task under a new alias. Pane bookkeeping had a separate
failure mode: it could forget a pane before the adapter confirmed that close
succeeded, or lose a failed close during owner transfer.

## Reproduction and evidence

The affected `des-1` trace showed this ordering:

```text
09:14:43.998  last child busy; board state = running
09:14:44.013  child idle; runningJobForSession = true
09:14:44.270  runtime reconciliation records runtime-stopped
09:14:44.578  the same task emits completed with a result
```

The false stop preceded the real terminal result by 308 ms. A separate
`fix-3` trace showed:

```text
session.deleted -> board drop -> historical running part -> rehydrate as fix-4
-> status entry absent -> fix-4 marked stopped
```

This is a lifecycle/event-ordering bug, not evidence that the child process
exited. The changes are based on the task-session-manager, board, task-tool,
and multiplexer code paths and their regression tests.

## Environment

- PR branch: `fix/task-lifecycle-status-race`
- PR head: `8fe23cd` (`fix(multiplexer): bound pane cleanup waits`)
- Commits in this PR: `4ac5447`, `f427ea7`, `99b8437`, `8fe23cd`
- Bun: `1.3.14`
- Host: Linux/WSL
- OpenCode: `1.18.18`

## Why this spans four commits

- `4ac5447` fixes the original idle/absent false-terminal path and adds the
  initial generation, deletion, and pane-close safeguards.
- `f427ea7` hardens synthetic terminal provenance, cancellation/relaunch
  serialization, and pane ownership and close settlement.
- `99b8437` completes generation, event, and `task_result` fencing together
  with the final cmux recovery integration and deterministic regression tests.
- `8fe23cd` bounds cmux and generic cleanup waits without cancelling an
  in-flight adapter close, while preserving pane identity fences and retrying
  late `false`/rejected settlements safely.

## What does this change?

### Task state and terminal evidence

- Treat `idle`, absent, malformed, and failed runtime-status observations as
  quiescent/uncertain rather than terminal.
- Keep native terminal task output as the primary completion/error evidence.
- Record synthetic terminal-part origin at `message.part.updated`; after a
  deletion boundary, missing or ambiguous provenance fails closed and cannot
  be inferred from the current generation.
- Keep an unbounded, process-local suppression/provenance ledger for the
  lifetime of a `BackgroundJobStore`; old occurrence or deletion guards are
  not silently evicted after 500/512 entries.
- Write lifecycle suppression before board `drop`, trim, `clearParent`, and
  direct session-not-found cleanup so historical running parts cannot be
  rehydrated after those removals.
- Preserve deletion epochs and clear an active suppression guard only for a
  legitimate, lease-validated new launch.
- Make `task_result` re-check live status and self-heal stale stopped records
  when the child is busy or retrying; revalidate the tracked generation around
  every awaited status/session/result read so a newer generation cannot return
  partial output through an older completed record.
- Make `task_nudge` and task status reporting distinguish unknown/absent from
  malformed status.
- Fence unproven same-ID `idle`, `error`, `busy`, and `deleted` lifecycle events
  after a relaunch until a current-generation activity boundary is observed;
  explicit stale generation/activity metadata is rejected immediately.

### Cancellation and relaunch safety

- Add an exclusive generation-checked cancellation/relaunch lease to the
  board, store, and coordinator.
- Fence `tool.execute.before`, early `session.created`, and
  `tool.execute.after` registration with the same lease.
- Keep the cancellation lease through abort, delete, and status verification.
  If an underlying request times out without settling, the task remains in
  quarantine and the same task ID cannot relaunch.
- Restrict destructive abort/delete operations to tracked, parent-owned
  tasks. Untracked raw session IDs are reported uncertain instead.
- Preserve the local `expectedGeneration` CAS so an old cancellation cannot
  notify listeners or terminate a later generation.

### Pane lifecycle

- Retain pane records until `closePane()` confirms success.
- Bound cmux and generic cleanup waits by a shared shutdown deadline. A timeout
  stops cleanup from waiting forever but does not cancel or reinterpret the
  underlying adapter operation.
- Keep pending close records and pane IDs until the real adapter promise
  settles; late `true` removes the fenced record and late `false`/reject follows
  the existing retry policy.
- Retry `false`/throwing pane closes without reusing a pane while an older
  adapter operation is still pending.
- Restrict generic and cmux polling/retry actions to the current owner,
  directory, and normalized server scope.
- Keep exhausted records for diagnosis without maintaining an empty polling
  loop.
- Notify active cmux owners when late orphan records appear or close promises
  settle, including records that already entered cooldown before a new owner
  was constructed.
- Transfer close settlements exactly once across owner changes; a confirmed
  close is consumed without a second `closePane()` call, while a failed close
  remains bounded and retryable.
- Do not infer pane deletion from an absent status-map entry.

## Behavioral guarantees

- [x] `idle`, absent, malformed, or failed status alone cannot create a
  terminal task state, terminal listener notification, or stopped recovery.
- [x] Within an unchanged generation, a later native `completed` result
  remains authoritative after a provisional runtime observation.
- [x] Tested same-ID relaunch interleavings fail closed for old or ambiguous
  synthetic completions, delayed native output, and unproven lifecycle events;
  they do not update the new generation or notify its terminal listeners.
- [x] A late native output from a call that began before deletion cannot clear
  the deletion guard or re-register the deleted run.
- [x] A synthetic terminal part with no safe post-deletion provenance is
  fail-closed; multiple ambiguous occurrences cannot be treated as a unique
  current-generation completion, and an ambiguous occurrence cannot later
  upgrade to observed.
- [x] Occurrence and deletion suppression do not lose entries at an arbitrary
  500/512 count within the current process.
- [x] A legitimate subsequent launch can clear its suppression guard and gets
  a new generation when no cancellation lease owns the task.
- [x] A cancellation/relaunch race is serialized by the local lease and keeps
  an unsettled remote operation quarantined; OpenCode's abort/delete API still
  has no server-side generation/CAS token, so this is not a cross-process
  guarantee.
- [x] `task_result` rejects a generation change around status/session/result
  awaits instead of returning partial output from a newer generation.
- [x] Untracked raw sessions are never destructively aborted or deleted.
- [x] A pane record is removed only after the close adapter confirms success.
- [x] Cleanup returns after its shared shutdown deadline even when an adapter
  close never settles; the real operation and pane record remain quarantined.
- [x] A late `false`/reject settlement schedules a fenced retry without
  starting a second close while the original adapter operation is pending.
- [x] Close failures remain observable and retryable; orphan claims are fenced
  by owner generation, record identity, directory, and normalized server scope.
  Initial orphan recovery remains lazy when the server URL is dynamic.
- [x] A transferred successful close is consumed once and cannot close the
  same pane a second time.

## Affected areas

- Background job board, store, coordinator, and lease state transitions
- Runtime status reconciliation and task-session-manager event handling
- Synthetic completion provenance and historical task rehydration
- Pending-call and cancellation/relaunch fencing
- `task_result`, `task_status`, and `task_nudge`
- Generic and cmux multiplexer pane lifecycle management

## Verification

### Passed checks

- [x] `bun test src/multiplexer` - 258 passed, 0 failed
- [x] `bun test src/hooks/task-session-manager` - 184 passed, 0 failed
- [x] Focused task/result/cancel/board/coordinator tests - 130 passed, 0 failed
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] Targeted Biome check for all 31 changed files
- [x] `git diff --check`
- [x] Static review of the changed lifecycle paths found no unresolved
  blocker in the tested scope

### Full-suite result

The final full suite reached `2118 passed / 1 failed` across 124 files. The
single failure was a dashboard integration test outside this diff:

- `src/v2/interview-bridge.test.ts` - shared-dashboard registration timed out
  after a 502 response during concurrent setup

The affected file passes when run in isolation (`3/3`), as does
`src/interview/manager.test.ts` (`22/22`). This is therefore a shared dashboard
resource/election contention baseline, not a lifecycle test failure.

`bun run check:ci` remains blocked by the repository baseline issue in
`src/agents/orchestrator.ts` (formatting), plus the existing
`src/utils/session.ts` non-null assertion warning and Biome configuration
deprecation notice. No unrelated baseline file was modified.

### Real workflow verification

After restarting OpenCode with the modified build, we used it for an extended
normal workflow with multiple real child agents. The agents completed lifecycle,
pane, task-tool, and code-navigation work using real tools and tests. The
original false-stop did not recur: no idle/absent observation produced
`runtime-stopped`, and all workflows completed normally.

The direct verification included `184 pass / 0 fail` for the task-session
manager tests, `249 pass / 0 fail` for multiplexer tests, and `130 pass / 0
fail` for task, cancellation, board, and coordinator tests. Production
`idle`/absent handling only writes `statusUncertain`; there is no production
`idle`/absent -> `markStopped` call.

Manual verification was completed with the modified build. A subsequent
runtime check also confirmed the special-case pane retention behavior
documented below.

## Compatibility and rollback

- OpenCode v1 loads the built plugin through `dist/index.js`; the repository
  CLI installer can register that local path.
- OpenCode v2 should point the plugin entry at the absolute path to
  `dist/server.js`.
- No configuration schema, database, or persisted-state migration is added.
- Suppression/provenance ledgers and cancellation leases are process-local;
  they do not survive a full plugin process restart. The ledgers are not
  bounded by the old fixed count, so a long-lived process should be observed
  for memory growth.
- A permanently unsettled adapter or HTTP request intentionally keeps its
  pane/task quarantined rather than risking a later same-ID generation.
- To roll back the PR, revert commits `8fe23cd`, `99b8437`, `f427ea7`, and
  `4ac5447`, rebuild, and reinstall the selected local entry point.

## Known limitations

- A pane with no reliable pane ID cannot be closed by a later manager.
- Cross-process same-ID pane recreation is intentionally not inferred; the
  safer behavior is to retain the pane rather than risk closing a new pane.
- The suppression ledger and live-operation lease are not cross-process or
  persistent; absolute guarantees across plugin restart require an upstream
  run token or persisted lifecycle record.
- In the special case where a child is already `reconciled`, OpenCode removes
  it from `/session/status`, and no `session.deleted` event arrives, the
  conservative missing-status policy may leave the completed child pane open.
  This behavior comes from `4ac5447` and is disclosed as follow-up cleanup,
  separate from the original false-stop path.
- If a pane close adapter never settles, cleanup returns after its deadline,
  but the pane remains quarantined and is not considered closed until the
  operation settles or a later owner recovery path handles it.
- The full-suite dashboard failure is an independent shared-dashboard
  election/resource race; the affected v2 test passes when run alone.

#1024 