### PR TITLE
fix(tasks): Guard recent live-busy cancellations

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -51,6 +51,8 @@ Fast, structural code search and refactoring - more powerful than plain text gre
 the current orchestrator session, and it does not roll back partial edits. After
 cancelling a write-capable task, inspect and reconcile file changes before
 launching replacement work.
+Recent live-busy tasks are protected for 10 seconds; use `force: true` only for
+user-requested or otherwise confirmed cancellation.
 
 `wait_for_user` is also orchestrator-only. The orchestrator uses it as the final
 tool action after providing concrete instructions for external manual work. Its

--- a/src/tools/cancel-task.test.ts
+++ b/src/tools/cancel-task.test.ts
@@ -19,6 +19,7 @@ function createTool(overrides?: {
   verifyAbortMs?: number;
   abortRetryIntervalMs?: number;
   stableStoppedMs?: number;
+  liveBusyGraceMs?: number;
   deleteVerifyMs?: number;
   deleteStableStoppedMs?: number;
 }) {
@@ -38,6 +39,7 @@ function createTool(overrides?: {
     verifyAbortMs: overrides?.verifyAbortMs ?? 1,
     abortRetryIntervalMs: overrides?.abortRetryIntervalMs ?? 0,
     stableStoppedMs: overrides?.stableStoppedMs ?? 0,
+    liveBusyGraceMs: overrides?.liveBusyGraceMs ?? 0,
     deleteVerifyMs: overrides?.deleteVerifyMs ?? 1,
     deleteStableStoppedMs: overrides?.deleteStableStoppedMs ?? 0,
   });
@@ -94,6 +96,148 @@ describe('cancel_task tool', () => {
     await cancelTask.execute({ task_id: 'ora-1' }, context);
 
     expect(abort).toHaveBeenCalledWith({ path: { id: 'ses_1' } });
+  });
+
+  test('rejects cancellation after a recent live busy signal without force', async () => {
+    const now = Date.now();
+    const { board, abort, deleteSession, cancelTask } = createTool({
+      liveBusyGraceMs: 10_000,
+    });
+    board.registerLaunch({
+      taskID: 'ses_1',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+      now: now - 20_000,
+    });
+    board.markRunningFromLiveSession('ses_1', now);
+
+    const output = await cancelTask.execute({ task_id: 'ses_1' }, context);
+
+    expect(abort).not.toHaveBeenCalled();
+    expect(deleteSession).not.toHaveBeenCalled();
+    expect(String(output)).toContain('state: running');
+    expect(String(output)).toContain('force: true');
+    expect(board.get('ses_1')).toMatchObject({
+      state: 'running',
+      statusUncertain: false,
+    });
+  });
+
+  test('forces cancellation after a recent live busy signal', async () => {
+    const now = Date.now();
+    const { board, abort, cancelTask } = createTool({
+      liveBusyGraceMs: 10_000,
+    });
+    board.registerLaunch({
+      taskID: 'ses_1',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+      now: now - 20_000,
+    });
+    board.markRunningFromLiveSession('ses_1', now);
+
+    const output = await cancelTask.execute(
+      { task_id: 'ses_1', force: true },
+      context,
+    );
+
+    expect(abort).toHaveBeenCalledWith({ path: { id: 'ses_1' } });
+    expect(String(output)).toContain('state: cancelled');
+  });
+
+  test('cancels a recent live busy job when status is uncertain', async () => {
+    const now = Date.now();
+    const { board, abort, cancelTask } = createTool({
+      liveBusyGraceMs: 10_000,
+    });
+    board.registerLaunch({
+      taskID: 'ses_1',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+      now: now - 20_000,
+    });
+    board.markRunningFromLiveSession('ses_1', now - 1);
+    board.markStatusUncertain('ses_1', 'status uncertain', undefined, now);
+
+    const output = await cancelTask.execute({ task_id: 'ses_1' }, context);
+
+    expect(abort).toHaveBeenCalledWith({ path: { id: 'ses_1' } });
+    expect(String(output)).toContain('state: cancelled');
+  });
+
+  test('rejects fresh live busy cancellation after timeout recovery', async () => {
+    const now = Date.now();
+    const { board, abort, cancelTask } = createTool({
+      liveBusyGraceMs: 10_000,
+    });
+    board.registerLaunch({
+      taskID: 'ses_1',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+      now: now - 20_000,
+    });
+    board.updateStatus({
+      taskID: 'ses_1',
+      state: 'running',
+      timedOut: true,
+      now: now - 1,
+    });
+    board.markRunningFromLiveSession('ses_1', now);
+
+    const output = await cancelTask.execute({ task_id: 'ses_1' }, context);
+
+    expect(board.get('ses_1')?.recoverableAfterLiveBusy).toBe(true);
+    expect(abort).not.toHaveBeenCalled();
+    expect(String(output)).toContain('state: running');
+  });
+
+  test('rejects fresh live busy cancellation with historical errors', async () => {
+    const now = Date.now();
+    const { board, abort, cancelTask } = createTool({
+      liveBusyGraceMs: 10_000,
+    });
+    board.registerLaunch({
+      taskID: 'ses_1',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+      now: now - 30_000,
+    });
+    board.updateStatus({
+      taskID: 'ses_1',
+      state: 'error',
+      now: now - 20_000,
+    });
+    board.registerLaunch({
+      taskID: 'ses_1',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+      now: now - 10_000,
+    });
+    board.markRunningFromLiveSession('ses_1', now);
+
+    const output = await cancelTask.execute({ task_id: 'ses_1' }, context);
+
+    expect(board.get('ses_1')?.totalErrors).toBe(1);
+    expect(abort).not.toHaveBeenCalled();
+    expect(String(output)).toContain('state: running');
+  });
+
+  test('cancels a stale live busy job without force', async () => {
+    const now = Date.now();
+    const { board, abort, cancelTask } = createTool({
+      liveBusyGraceMs: 10_000,
+    });
+    board.registerLaunch({
+      taskID: 'ses_1',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+      now: now - 20_000,
+    });
+
+    const output = await cancelTask.execute({ task_id: 'ses_1' }, context);
+
+    expect(abort).toHaveBeenCalledWith({ path: { id: 'ses_1' } });
+    expect(String(output)).toContain('state: cancelled');
   });
 
   test('does not abort raw session IDs tracked by a different parent', async () => {

--- a/src/tools/cancel-task.ts
+++ b/src/tools/cancel-task.ts
@@ -27,10 +27,14 @@ interface CancelTaskToolOptions {
   verifyAbortMs?: number;
   abortRetryIntervalMs?: number;
   stableStoppedMs?: number;
+  liveBusyGraceMs?: number;
   deleteTimeoutMs?: number;
   deleteVerifyMs?: number;
   deleteStableStoppedMs?: number;
 }
+
+// Covers two runtime status cycles of approximately 5 seconds each.
+const CANCEL_LIVE_BUSY_GRACE_MS = 10_000;
 
 class SessionStillRunningError extends Error {}
 
@@ -46,6 +50,12 @@ Use only for obsolete, wrong, conflicting, or user-requested cancellation. Accep
         .string()
         .describe('Tracked background task ID or Background Job Board alias'),
       reason: z.string().optional().describe('Short cancellation reason'),
+      force: z
+        .boolean()
+        .optional()
+        .describe(
+          'Only use when the user explicitly requests cancellation or confirms it is required',
+        ),
     },
     async execute(args, toolContext) {
       const parentSessionID = toolContext?.sessionID;
@@ -130,6 +140,35 @@ Use only for obsolete, wrong, conflicting, or user-requested cancellation. Accep
           requested,
           'unknown or unowned background task',
         );
+      }
+
+      const lastLiveBusyAt = job.lastLiveBusyAt;
+      const liveBusyGraceMs =
+        options.liveBusyGraceMs ?? CANCEL_LIVE_BUSY_GRACE_MS;
+      if (
+        job.state === 'running' &&
+        lastLiveBusyAt !== undefined &&
+        Date.now() - lastLiveBusyAt < liveBusyGraceMs &&
+        !args.force &&
+        job.deadlineExceededAt === undefined &&
+        !job.timedOut &&
+        !job.statusUncertain
+      ) {
+        const message =
+          'Task has a recent live busy signal; wait until the task is no longer active or pass force: true to cancel.';
+        log('[cancel-task] rejected recent live busy cancellation', {
+          taskID: job.taskID,
+          lastLiveBusyAt,
+          liveBusyGraceMs,
+        });
+        return [
+          `task_id: ${job.taskID}`,
+          'state: running',
+          '',
+          '<task_error>',
+          message,
+          '</task_error>',
+        ].join('\n');
       }
 
       const generation = job.generation;


### PR DESCRIPTION
Prevent `cancel_task` from aborting a tracked job that has reported a live busy status in the prior two reconciliation cycles. Intentional cancellation now requires `force: true`; stale, timed-out, and status-uncertain jobs retain their existing paths.

This addresses the parent-initiated cancellation in #1031. Timing display and child-history archival remain out of scope.

Repository-wide `bun run check:ci` still reports pre-existing violations in `src/utils/session.ts` and `src/agents/orchestrator.ts`; targeted Biome, full tests, typecheck, and build pass.

Refs #1031