### PR TITLE
fix(config): strip UTF-8 BOM before parsing config files (#1028)

### DIFF
--- a/src/cli/config-io.test.ts
+++ b/src/cli/config-io.test.ts
@@ -76,6 +76,14 @@ describe('config-io', () => {
     expect(result.error).toBeUndefined();
   });
 
+  test('parseConfigFile strips a UTF-8 BOM before parsing', () => {
+    const path = join(tmpDir, 'bom.json');
+    writeFileSync(path, `\uFEFF${'{"a": 1}'}`);
+    const result = parseConfigFile(path);
+    expect(result.config).toEqual({ a: 1 } as any);
+    expect(result.error).toBeUndefined();
+  });
+
   test('parseConfigFile returns null for non-existent file', () => {
     const result = parseConfigFile(join(tmpDir, 'nonexistent.json'));
     expect(result.config).toBeNull();

--- a/src/cli/config-io.ts
+++ b/src/cli/config-io.ts
@@ -404,7 +404,8 @@ export function parseConfigFile(path: string): {
     if (!existsSync(path)) return { config: null };
     const stat = statSync(path);
     if (stat.size === 0) return { config: null };
-    const content = readFileSync(path, 'utf-8');
+    // Strip a UTF-8 BOM (RFC 8259 permits one) so JSON.parse does not choke.
+    const content = readFileSync(path, 'utf-8').replace(/^\uFEFF/, '');
     if (content.trim().length === 0) return { config: null };
     return { config: JSON.parse(stripJsonComments(content)) as OpenCodeConfig };
   } catch (err) {

--- a/src/cli/doctor.test.ts
+++ b/src/cli/doctor.test.ts
@@ -162,6 +162,27 @@ describe('runDoctorCheck', () => {
     expect(result.configs[1].config?.disabled_tools).toEqual(['webfetch']);
   });
 
+  test('config with UTF-8 BOM is accepted as valid', () => {
+    const projectDir = path.join(tempDir, 'project');
+    const configDir = path.join(projectDir, '.opencode');
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(configDir, 'oh-my-opencode-slim.json'),
+      `\uFEFF${JSON.stringify({
+        agents: { oracle: { model: 'test/model' } },
+      })}`,
+    );
+
+    const result = runDoctorCheck(projectDir);
+
+    // The BOM is stripped before parsing, so the config is valid rather
+    // than a false invalid-json diagnosis
+    expect(result.ok).toBe(true);
+    expect(result.configs[1].ok).toBe(true);
+    expect(result.configs[1].error).toBeUndefined();
+    expect(result.configs[1].config?.agents?.oracle?.model).toBe('test/model');
+  });
+
   test('invalid JSON returns not ok with invalid-json error', () => {
     const projectDir = path.join(tempDir, 'project');
     const configDir = path.join(projectDir, '.opencode');

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -80,7 +80,9 @@ function checkConfigFile(
       };
     }
 
-    const content = fs.readFileSync(configPath, 'utf-8');
+    // Strip a UTF-8 BOM so a BOM-prefixed config is not misdiagnosed as
+    // invalid JSON (matches the loader's behavior).
+    const content = fs.readFileSync(configPath, 'utf-8').replace(/^\uFEFF/, '');
     const rawConfig = JSON.parse(stripJsonComments(content));
     // Normalize disabled_* keys exactly like the loader does before schema
     // validation, so a string value (e.g. "explorer") is not diagnosed as a

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -66,6 +66,29 @@ describe('loadPluginConfig', () => {
     expect(config.autoUpdate).toBe(false);
   });
 
+  test('loads config with a UTF-8 BOM prefix (same result as no BOM)', () => {
+    const projectDir = path.join(tempDir, 'project');
+    const projectConfigDir = path.join(projectDir, '.opencode');
+    fs.mkdirSync(projectConfigDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(projectConfigDir, 'oh-my-opencode-slim.json'),
+      `\uFEFF${JSON.stringify({
+        preset: 'fast',
+        presets: { fast: { oracle: { model: 'fast-model' } } },
+        agents: { oracle: { temperature: 0.9 } },
+        autoUpdate: false,
+      })}`,
+    );
+
+    const config = loadPluginConfig(projectDir);
+
+    // The BOM is stripped silently (RFC 8259 permits one); every setting
+    // survives, including preset resolution.
+    expect(config.autoUpdate).toBe(false);
+    expect(config.agents?.oracle?.model).toBe('fast-model');
+    expect(config.agents?.oracle?.temperature).toBe(0.9);
+  });
+
   test('deep-merges webfetch settings across user and project configs', () => {
     const userConfigPath = path.join(userConfigDir, 'opencode');
     const projectDir = path.join(tempDir, 'project');

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -165,7 +165,9 @@ function loadConfigFromPath(
   options?: LoadPluginConfigOptions,
 ): PluginConfig | null {
   try {
-    const content = fs.readFileSync(configPath, 'utf-8');
+    // Strip a UTF-8 BOM (RFC 8259 permits one); JSON.parse would otherwise
+    // fail with "Unrecognized token" and silently drop the whole config.
+    const content = fs.readFileSync(configPath, 'utf-8').replace(/^\uFEFF/, '');
     // Use stripJsonComments to support JSONC format (comments and trailing commas)
     let rawConfig: unknown;
     try {

--- a/src/hooks/auto-update-checker/checker.test.ts
+++ b/src/hooks/auto-update-checker/checker.test.ts
@@ -108,6 +108,49 @@ describe('auto-update-checker/checker', () => {
       statSpy.mockRestore();
       readSpy.mockRestore();
     });
+
+    test('returns version from a BOM-prefixed config', async () => {
+      const existsSpy = spyOn(fs, 'existsSync').mockImplementation(
+        (p: string) => {
+          if (p.includes('opencode.json')) return true;
+          if (p.includes('package.json')) return true;
+          return false;
+        },
+      );
+      const statSpy = spyOn(fs, 'statSync').mockImplementation(
+        () =>
+          ({
+            isDirectory: () => true,
+          }) as unknown as fs.Stats,
+      );
+      const readSpy = spyOn(fs, 'readFileSync').mockImplementation(
+        (p: string) => {
+          if (p.includes('opencode.json')) {
+            // A UTF-8 BOM (RFC 8259 permits one) must not break JSON.parse.
+            return `\uFEFF${JSON.stringify({
+              plugin: ['file:///dev/oh-my-opencode-slim'],
+            })}`;
+          }
+          if (p.includes('package.json')) {
+            return JSON.stringify({
+              name: 'oh-my-opencode-slim',
+              version: '1.2.3-dev',
+            });
+          }
+          return '';
+        },
+      );
+
+      const { getLocalDevVersion } = await import(
+        `./checker?test=${importCounter++}`
+      );
+
+      expect(getLocalDevVersion('/test')).toBe('1.2.3-dev');
+
+      existsSpy.mockRestore();
+      statSpy.mockRestore();
+      readSpy.mockRestore();
+    });
   });
 
   describe('findPluginEntry', () => {
@@ -130,6 +173,28 @@ describe('auto-update-checker/checker', () => {
       expect(entry?.entry).toBe('oh-my-opencode-slim');
       expect(entry?.isPinned).toBe(false);
       expect(entry?.pinnedVersion).toBeNull();
+
+      existsSpy.mockRestore();
+      readSpy.mockRestore();
+    });
+
+    test('detects entry in a BOM-prefixed config', async () => {
+      const existsSpy = spyOn(fs, 'existsSync').mockImplementation(
+        (p: string) => p.includes('opencode.json'),
+      );
+      const readSpy = spyOn(fs, 'readFileSync').mockReturnValue(
+        `\uFEFF${JSON.stringify({
+          plugin: ['oh-my-opencode-slim'],
+        })}`,
+      );
+
+      const { findPluginEntry } = await import(
+        `./checker?test=${importCounter++}`
+      );
+
+      const entry = findPluginEntry('/test');
+      expect(entry).not.toBeNull();
+      expect(entry?.entry).toBe('oh-my-opencode-slim');
 
       existsSpy.mockRestore();
       readSpy.mockRestore();

--- a/src/hooks/auto-update-checker/checker.ts
+++ b/src/hooks/auto-update-checker/checker.ts
@@ -346,7 +346,11 @@ function getLocalDevPath(directory: string): string | null {
   for (const configPath of getConfigPaths(directory)) {
     try {
       if (!fs.existsSync(configPath)) continue;
-      const content = fs.readFileSync(configPath, 'utf-8');
+      // Strip a UTF-8 BOM (RFC 8259 permits one); JSON.parse would otherwise
+      // fail with "Unrecognized token" and skip the local dev path.
+      const content = fs
+        .readFileSync(configPath, 'utf-8')
+        .replace(/^\uFEFF/, '');
       const config = JSON.parse(stripJsonComments(content)) as OpencodeConfig;
       const plugins = getPluginEntries(config);
 
@@ -436,7 +440,11 @@ export function findPluginEntry(directory: string): PluginEntryInfo | null {
   for (const configPath of getConfigPaths(directory)) {
     try {
       if (!fs.existsSync(configPath)) continue;
-      const content = fs.readFileSync(configPath, 'utf-8');
+      // Strip a UTF-8 BOM (RFC 8259 permits one); JSON.parse would otherwise
+      // fail with "Unrecognized token" and the plugin entry would be missed.
+      const content = fs
+        .readFileSync(configPath, 'utf-8')
+        .replace(/^\uFEFF/, '');
       const config = JSON.parse(stripJsonComments(content)) as OpencodeConfig;
       const plugins = getPluginEntries(config);
 

--- a/src/tools/preset-switch.test.ts
+++ b/src/tools/preset-switch.test.ts
@@ -150,6 +150,39 @@ describe('switchPresetOnDisk', () => {
     });
   });
 
+  test('persists preset name when the user config has a UTF-8 BOM', () => {
+    const configDir = path.join(tempDir, 'opencode-config');
+    fs.mkdirSync(configDir, { recursive: true });
+    process.env.OPENCODE_CONFIG_DIR = configDir;
+
+    const configPath = path.join(configDir, 'oh-my-opencode-slim.json');
+    fs.writeFileSync(
+      configPath,
+      `\uFEFF${JSON.stringify({
+        preset: 'old',
+        agents: { oracle: { model: 'old-model' } },
+      })}`,
+    );
+
+    const config: PluginConfig = {
+      presets: {
+        cheap: { orchestrator: { model: 'anthropic/claude-3.5-haiku' } },
+      },
+    };
+
+    const result = switchPresetOnDisk(tempDir, 'cheap', config);
+    expect(result.ok).toBe(true);
+
+    // The BOM is stripped on read, so the preset name is persisted; the
+    // rewritten file is plain JSON that parses cleanly.
+    const persisted = JSON.parse(fs.readFileSync(configPath, 'utf-8')) as {
+      preset?: string;
+      agents?: Record<string, unknown>;
+    };
+    expect(persisted.preset).toBe('cheap');
+    expect(persisted.agents).toEqual({ oracle: { model: 'old-model' } });
+  });
+
   test('resolves legacy alias keys (explore → explorer)', () => {
     const config: PluginConfig = {
       presets: {
@@ -285,6 +318,36 @@ describe('writePreset', () => {
     });
     // existing fields preserved
     expect(persisted.preset).toBe('old');
+  });
+
+  test('reads a user config with a UTF-8 BOM before writing', () => {
+    const configDir = path.join(tempDir, 'opencode-config');
+    fs.mkdirSync(configDir, { recursive: true });
+    process.env.OPENCODE_CONFIG_DIR = configDir;
+    const configPath = path.join(configDir, 'oh-my-opencode-slim.json');
+    fs.writeFileSync(
+      configPath,
+      `\uFEFF${JSON.stringify({
+        preset: 'old',
+        presets: { existing: { oracle: { model: 'a' } } },
+      })}`,
+    );
+
+    const ok = writePreset(tempDir, 'scout', {
+      explorer: { model: 'openai/gpt-5.6-luna' },
+    });
+
+    expect(ok).toBe(true);
+    const persisted = JSON.parse(fs.readFileSync(configPath, 'utf-8')) as {
+      preset?: string;
+      presets?: Record<string, unknown>;
+    };
+    // Existing fields survived, proving the BOM-prefixed file was parsed
+    expect(persisted.preset).toBe('old');
+    expect(persisted.presets?.existing).toEqual({ oracle: { model: 'a' } });
+    expect(persisted.presets?.scout).toEqual({
+      explorer: { model: 'openai/gpt-5.6-luna' },
+    });
   });
 
   test('overwrites an existing preset of the same name', () => {

--- a/src/tools/preset-switch.ts
+++ b/src/tools/preset-switch.ts
@@ -165,7 +165,9 @@ function persistPresetName(directory: string, presetName: string): void {
   try {
     const { userConfigPath } = findPluginConfigPaths(directory);
     if (!userConfigPath) return;
-    const raw = fs.readFileSync(userConfigPath, 'utf-8');
+    // Strip a UTF-8 BOM (RFC 8259 permits one); JSON.parse would otherwise
+    // fail with "Unrecognized token" and the preset would not be persisted.
+    const raw = fs.readFileSync(userConfigPath, 'utf-8').replace(/^\uFEFF/, '');
     const persisted = JSON.parse(stripJsonComments(raw)) as Record<
       string,
       unknown
@@ -186,7 +188,9 @@ function readUserConfig(directory: string): Record<string, unknown> | null {
   try {
     const { userConfigPath } = findPluginConfigPaths(directory);
     if (!userConfigPath) return null;
-    const raw = fs.readFileSync(userConfigPath, 'utf-8');
+    // Strip a UTF-8 BOM (RFC 8259 permits one); JSON.parse would otherwise
+    // fail with "Unrecognized token" and the preset name would be lost.
+    const raw = fs.readFileSync(userConfigPath, 'utf-8').replace(/^\uFEFF/, '');
     return JSON.parse(stripJsonComments(raw)) as Record<string, unknown>;
   } catch {
     return null;


### PR DESCRIPTION
Fixes #1028

## What problem are you solving?

Config files saved as UTF-8 with BOM (`EF BB BF`) are silently discarded: `fs.readFileSync(..., "utf-8")` keeps the BOM as a leading `\uFEFF` character, `stripJsonComments` leaves it in place, and `JSON.parse` throws `Unrecognized token`. `loadConfigFromPath` then returns `null` and the plugin falls back to an empty config — no preset, no per-agent models, no skills/MCPs configuration is applied, and subagents run the session/orchestrator model instead of their configured model. The only signal is a single `console.warn` at load time.

## What does this change?

- Strip a leading UTF-8 BOM (`/^\uFEFF/`) from file content right after `readFileSync`, before comment stripping / parsing, in all three config-reading paths:
  - `src/config/loader.ts` (`loadConfigFromPath`) — the main runtime path.
  - `src/cli/doctor.ts` (`checkConfigFile`) — so doctor no longer misdiagnoses a BOM-prefixed config as `invalid-json` (keeps doctor consistent with the runtime loader).
  - `src/cli/config-io.ts` (`parseConfigFile`) — shared by auto-update-checker and other consumers.
- Regression tests for all three paths: a BOM-prefixed config loads identically to the same config without BOM.

## Why this approach?

RFC 8259 permits a BOM and treats it as invisible to JSON consumers, so tolerating it is the correct behavior — no warning needed. Stripping at each read site keeps the change minimal and mirrors the existing normalization-before-validation pattern used for `disabled_*` keys (#1029).

## Verification

- [x] `bun test src/config/loader.test.ts` — 84 pass
- [x] `bun test src/cli/doctor.test.ts` — 30 pass
- [x] `bun test src/cli/config-io.test.ts` — 37 pass
- [x] `bun test src/config/` — 180 pass (10 files, no regression)
- [x] `bun run typecheck` — clean
- [x] `bun x biome check` on all 6 changed files — clean