### PR TITLE
feat(agents): add security reviewer gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   </a>
   <h3>✨ oh-my-opencode-slim ✨</h3>
 
-  <p><i>Seven divine beings emerged from the dawn of code, each an immortal master of their craft,<br>awaiting your command to forge order from chaos and build what was once thought impossible.</i></p>
+  <p><i>Eight divine beings emerged from the dawn of code, each an immortal master of their craft,<br>awaiting your command to forge order from chaos and build what was once thought impossible.</i></p>
 
   <p><b>Opencode Multi Agent Suite</b> · Mix any models · Auto delegate tasks</p>
   <p><sub>by <b>Boring Dystopia Development</b></sub></p>
@@ -30,9 +30,10 @@ The main idea is simple: instead of forcing one model to do everything, the plug
 
 ### ✨ Highlights
 
-- **[Seven specialized agents](#meet-the-pantheon)** - Orchestrator, Explorer,
-  Oracle, Council, Librarian, Designer, and Fixer. Each part of the job goes to
-  the agent best suited for it - mix any models across any providers.
+- **[Eight specialized agents](#meet-the-pantheon)** - Orchestrator, Explorer,
+  Oracle, Council, Librarian, Designer, Fixer, and Security Reviewer. Each part
+  of the job goes to the agent best suited for it - mix any models across any
+  providers.
 - **[Background orchestration](docs/background-orchestration.md)** - the
   Orchestrator dispatches specialists as background tasks, tracks them, and
   reconciles results before continuing - parallel work by default.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -466,6 +466,11 @@ Notes:
 - Custom agents without a `model` are skipped with a warning
 - Disabled custom agents are not registered or injected into the orchestrator prompt
 
+The built-in `security-reviewer` is enabled by default. It is a strictly
+read-only, focused auditor for supplied changed paths and stated behavior. It
+reports only concrete material security findings and is not a replacement for
+the general-purpose `oracle` reviewer.
+
 > **Tip:** Keep `orchestratorPrompt` concise — the orchestrator reads it every turn.
 > Include: when to delegate, when NOT to delegate, and the agent's role in one paragraph.
 
@@ -501,24 +506,6 @@ The field accepts either:
         "task": "deny"
       },
       "prompt": "You are Planner. Create implementation plans only. Do not implement code."
-    }
-  }
-}
-```
-
-**Example: `security-reviewer` agent:**
-
-```jsonc
-{
-  "agents": {
-    "security-reviewer": {
-      "model": "anthropic/claude-sonnet-4-5",
-      "permission": {
-        "edit": "deny",
-        "bash": "deny",
-        "webfetch": "allow"
-      },
-      "prompt": "You are a security reviewer. Inspect code and report findings. Do not patch anything."
     }
   }
 }

--- a/docs/mcps.md
+++ b/docs/mcps.md
@@ -41,6 +41,7 @@ The built-in tool is Exa-backed (optionally Parallel), needs no API key, and is 
 | `oracle` | none |
 | `explorer` | none |
 | `fixer` | none |
+| `security-reviewer` | none |
  | `councillor` | none |
 
 ---

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -123,17 +123,18 @@ Start it directly with:
    based on dependencies and natural delivery boundaries. Do not split work
    merely to make an Oracle review smaller.
 4. Before execution, show a compact overview of phase order, specialist
-   ownership/scope, the Oracle review total, the review after each phase, and a
-   short reason for each gate.
-5. Execute phase by phase: validate, update session state, then get an Oracle
-   review before advancing.
+   ownership/scope, the Oracle gate and security-audit totals, both reviews after
+   each phase, and a short reason for each gate.
+5. Execute phase by phase: validate, update session state, then run one
+   security audit in parallel with one Oracle gate before advancing.
 6. Batch material findings into one bounded remediation pass with focused
-   validation. Re-review only when needed to assess a changed decision/risk or
-   an otherwise unverifiable concern.
+   validation. Oracle follows its existing gate budget; each security audit has
+   at most one re-review, only for a changed security boundary or an original
+   finding that cannot be verified with focused evidence.
 
 **Key features:**
 - Persistent session state in markdown files
-- Predictable Oracle reviews after each planned phase, declared before execution
+- Predictable Oracle gates and security audits after every phase, declared before execution
 - V2 scheduler integration (dispatch specialists, wait for hook-driven completion, reconcile)
 - OpenCode todo lists for progress tracking
 - Flexible structure - orchestrator adapts format to task needs

--- a/src/agents/index.test.ts
+++ b/src/agents/index.test.ts
@@ -122,7 +122,12 @@ describe('built-in subagent preset fallback', () => {
 
     const agents = createAgents(runtimeFor(config));
 
-    for (const name of ['observer', 'council', 'councillor'] as const) {
+    for (const name of [
+      'observer',
+      'security-reviewer',
+      'council',
+      'councillor',
+    ] as const) {
       expect(agents.find((a) => a.name === name)?.config.model).toBe(
         'opencode-go/glm-5.2',
       );
@@ -380,6 +385,21 @@ describe('tool permissions', () => {
     ).toBe('deny');
   });
 
+  test('security reviewer keeps strict read-only advisory permissions', () => {
+    const agents = createAgents(runtimeFor());
+    const reviewer = agents.find((a) => a.name === 'security-reviewer');
+    const permission = reviewer?.config.permission as Record<string, string>;
+
+    expect(permission['*']).toBe('deny');
+    expect(permission.read).toBe('allow');
+    expect(permission.glob).toBe('allow');
+    expect(permission.grep).toBe('allow');
+    expect(permission.edit).toBe('deny');
+    expect(permission.write).toBe('deny');
+    expect(permission.bash).toBe('deny');
+    expect(permission.task).toBe('deny');
+  });
+
   test('subagents are denied access to wait_for_user', () => {
     const agents = createAgents(runtimeFor());
 
@@ -454,6 +474,18 @@ test('orchestrator prompt excludes Council Mode when no councillors', () => {
   expect(prompt).not.toContain('## Council Mode');
 });
 
+test('orchestrator prompt routes focused security audits to security reviewer', () => {
+  const agents = createAgents(runtimeFor());
+  const orchestrator = agents.find((a) => a.name === 'orchestrator');
+  const prompt = orchestrator?.config.prompt as string;
+
+  expect(prompt).toContain('@security-reviewer');
+  expect(prompt).toContain('Focused, strictly read-only security audit');
+  expect(prompt).not.toContain(
+    'Delegate to @security-reviewer for general architecture',
+  );
+});
+
 describe('isSubagent type guard', () => {
   test('returns true for valid subagent names', () => {
     expect(isSubagent('explorer')).toBe(true);
@@ -461,6 +493,7 @@ describe('isSubagent type guard', () => {
     expect(isSubagent('oracle')).toBe(true);
     expect(isSubagent('designer')).toBe(true);
     expect(isSubagent('fixer')).toBe(true);
+    expect(isSubagent('security-reviewer')).toBe(true);
   });
 
   test('returns false for orchestrator', () => {
@@ -568,11 +601,25 @@ describe('createAgents', () => {
     expect(names).toContain('oracle');
     expect(names).toContain('librarian');
     expect(names).toContain('fixer');
+    expect(names).toContain('security-reviewer');
   });
 
-  test('creates exactly 7 agents by default (observer disabled, council unconfigured)', () => {
+  test('security reviewer prompt stays narrow and evidence-driven', () => {
+    const reviewer = createAgents(runtimeFor()).find(
+      (agent) => agent.name === 'security-reviewer',
+    );
+    const prompt = reviewer?.config.prompt as string;
+
+    expect(prompt).toContain('supplied changed paths and stated behavior');
+    expect(prompt).toContain('at most three material findings');
+    expect(prompt).toContain('No material findings');
+    expect(prompt).toContain('Do not report generic authentication');
+    expect(prompt).toContain('Do not use task or other delegation tools');
+  });
+
+  test('creates exactly 8 agents by default (observer disabled, council unconfigured)', () => {
     const agents = createAgents(runtimeFor());
-    expect(agents.length).toBe(7);
+    expect(agents.length).toBe(8);
   });
 
   test('does not create council when council is not configured', () => {
@@ -1089,13 +1136,13 @@ describe('disabled_agents', () => {
 
   test('agent count decreases when agents are disabled', () => {
     const agents = createAgents(runtimeFor());
-    expect(agents.length).toBe(7); // observer disabled, council unconfigured
+    expect(agents.length).toBe(8); // observer disabled, council unconfigured
 
     const disabledConfig: PluginConfig = {
       disabled_agents: ['observer', 'designer'],
     };
     const disabledAgents = createAgents(runtimeFor(disabledConfig));
-    expect(disabledAgents.length).toBe(6);
+    expect(disabledAgents.length).toBe(7);
   });
 
   test('getDisabledAgents respects protection rules', () => {
@@ -1114,7 +1161,7 @@ describe('disabled_agents', () => {
     };
     const agents = createAgents(runtimeFor(config));
     const names = agents.map((a) => a.name);
-    expect(agents.length).toBe(8);
+    expect(agents.length).toBe(9);
     expect(names).toContain('observer');
     expect(names).not.toContain('council');
   });

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -29,6 +29,7 @@ import {
   createOrchestratorAgent,
   resolvePrompt,
 } from './orchestrator';
+import { createSecurityReviewerAgent } from './security-reviewer';
 import { appendTaskRejectionInstruction } from './task-rejection';
 
 export type { AgentDefinition } from './orchestrator';
@@ -323,6 +324,7 @@ const SUBAGENT_FACTORIES: Record<SubagentName, AgentFactory> = {
   designer: createDesignerAgent,
   fixer: createFixerAgent,
   observer: createObserverAgent,
+  'security-reviewer': createSecurityReviewerAgent,
   council: createCouncilAgent,
   councillor: createCouncillorAgent,
 };

--- a/src/agents/orchestrator.ts
+++ b/src/agents/orchestrator.ts
@@ -65,6 +65,14 @@ const AGENT_DESCRIPTIONS: Record<string, string> = {
 - **Don't delegate when:** Routine decisions you're confident about • First bug fix attempt • Straightforward trade-offs • Tactical "how" vs strategic "should" • Time-sensitive good-enough decisions • Quick research/testing can answer
 - **Rule of thumb:** Need senior architect review? → @oracle. Need code review or simplification? → @oracle. Routine coordination or final synthesis? → handle directly.`,
 
+  'security-reviewer': `@security-reviewer
+- Lane: Focused, strictly read-only security audit
+- Role: Evidence-driven review of supplied changed paths and stated behavior
+- Permissions: read_files
+- **Delegate when:** A focused change needs an independent audit for concrete secret disclosure, unintended external actions, data loss/corruption, invalid durable-state transitions, unsafe untrusted-data handling, or incorrect permission/trust-boundary behavior
+- **Don't delegate when:** Implementing a fix • General architecture or code-quality review • Generic auth, authorization, firewall, rate-limit, accessibility, or checklist advice • No changed paths or stated behavior are supplied
+- **Review contract:** Report at most three material findings, each with severity, exact file reference, failure/exploit precondition, impact, and narrowly scoped remediation. Report no material findings when applicable. Never implement or propose broad refactors.`,
+
   designer: `@designer
 - Lane: UI/UX design, related edits, design polish and review
 - Permissions: read_files, write_files
@@ -232,10 +240,14 @@ Balance: respect dependencies, avoid parallelizing what must be sequential, and 
 - Use \`cancel_task\` only when the user asks, or when a running lane is obsolete, wrong, or conflicts with a safer replacement plan.
 - Cancellation is not rollback: if cancelling a writer, inspect and reconcile partial file changes before launching a replacement lane.
 
-${wakeSchedulerEnabled ? `#### End Turn After Background Tasks
+${
+  wakeSchedulerEnabled
+    ? `#### End Turn After Background Tasks
 After spawning all independent background tasks and any remaining non-overlapping work, end the turn immediately with a brief status message. Do not call \`wait_for_user\` to await background task completion — the system notifies you automatically via the Background Job Board when tasks finish, and the orchestrator wake scheduler resumes you. Do not poll for status with repeated tool calls. The correct flow is: launch tasks → brief status → end turn → completion hook or wake scheduler resumes → reconcile results.
 
-` : ''}### Active Task Amendments
+`
+    : ''
+}### Active Task Amendments
 - A task in the Active / Unreconciled section is still running and cannot receive another \`task\` call, even with its \`task_id\`. Do not try to resume, replace, or cancel it merely because the user adds to its existing scope.
 - For an additive request to a running lane, record the amendment in the parent conversation, tell the user it is queued, and wait for that lane's terminal result. Then resume the same specialist only after its session appears in Reusable Sessions.
 - Cancel a running task only when its current objective is genuinely obsolete or must be replaced. Never create-and-cancel speculative duplicate sessions.

--- a/src/agents/security-reviewer.ts
+++ b/src/agents/security-reviewer.ts
@@ -1,0 +1,67 @@
+import { READONLY_FILE_OPERATIONS_RULES } from '../config';
+import type { AgentDefinition } from './orchestrator';
+import { createReadOnlyAgentPermission } from './permissions';
+
+const SECURITY_REVIEWER_PROMPT = `You are Security Reviewer - a narrow, evidence-driven security auditor.
+
+**Scope**:
+- Review only the supplied changed paths and stated behavior. Inspect only the
+  directly relevant code needed to establish evidence.
+- Look for concrete instances of secret disclosure, unintended external
+  actions, data loss or corruption, invalid durable-state transitions, unsafe
+  handling of untrusted data, or incorrect permission/trust-boundary behavior.
+- This is a private, Tailscale-only productivity service for its sole owner.
+  Do not report generic authentication, authorization, firewall, rate-limit,
+  accessibility, or checklist-only advice.
+
+**Behavior**:
+- Require a concrete failure or exploit path; do not speculate or infer risks
+  from conventions alone.
+- Report at most three material findings. Report no material findings when the
+  supplied evidence does not establish one.
+- Do not implement fixes, propose broad refactors, or review unrelated quality,
+  architecture, or style concerns.
+
+**Finding format**:
+For every material finding, include:
+- Severity
+- Exact file reference (path and line when available)
+- Failure/exploit precondition
+- Impact
+- Narrowly scoped remediation
+
+**Output**:
+Start with 'Material findings': then list zero to three findings in the
+format above, or state 'No material findings'. Keep the report concise.
+
+**Constraints**:
+- READ-ONLY: inspect and report; never modify files or run implementation
+  actions.
+
+${READONLY_FILE_OPERATIONS_RULES}
+
+- Do not use task or other delegation tools.`;
+
+export function createSecurityReviewerAgent(
+  model: string,
+  customPrompt?: string,
+  customAppendPrompt?: string,
+): AgentDefinition {
+  const prompt = customPrompt
+    ? customPrompt
+    : customAppendPrompt
+      ? `${SECURITY_REVIEWER_PROMPT}\n\n${customAppendPrompt}`
+      : SECURITY_REVIEWER_PROMPT;
+
+  return {
+    name: 'security-reviewer',
+    description:
+      'Focused read-only security audit for supplied changes and stated behavior; reports only concrete material findings.',
+    config: {
+      model,
+      temperature: 0.1,
+      prompt,
+      permission: createReadOnlyAgentPermission(),
+    },
+  };
+}

--- a/src/config/agent-mcps.test.ts
+++ b/src/config/agent-mcps.test.ts
@@ -24,6 +24,10 @@ describe('parseList', () => {
     ).toEqual(['gh_grep', 'custom-mcp']);
   });
 
+  test('security reviewer has no default MCP access', () => {
+    expect(DEFAULT_AGENT_MCPS['security-reviewer']).toEqual([]);
+  });
+
   test('wildcard with exclusions', () => {
     expect(parseList(['*', '!mcp2'], ['mcp1', 'mcp2', 'mcp3'])).toEqual([
       'mcp1',

--- a/src/config/agent-mcps.ts
+++ b/src/config/agent-mcps.ts
@@ -11,6 +11,7 @@ export const DEFAULT_AGENT_MCPS: Record<AgentName, string[]> = {
   explorer: [],
   fixer: [],
   observer: [],
+  'security-reviewer': [],
   council: [],
   councillor: [],
 };

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -11,13 +11,14 @@ export const SUBAGENT_NAMES = [
   'designer',
   'fixer',
   'observer',
+  'security-reviewer',
   'council',
   'councillor',
 ] as const;
 
 export const ALL_AGENT_NAMES = ['orchestrator', ...SUBAGENT_NAMES] as const;
 
-// Agent name type (for use in DEFAULT_MODELS)
+// Agent name type (for use in per-agent defaults)
 export type AgentName = (typeof ALL_AGENT_NAMES)[number];
 
 /** Agents that cannot be disabled even if listed in disabled_agents config. */
@@ -36,6 +37,7 @@ export const DEFAULT_MODELS: Record<AgentName, string | undefined> = {
   designer: undefined,
   fixer: undefined,
   observer: undefined,
+  'security-reviewer': undefined,
   council: undefined,
   councillor: undefined,
 };

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { mkdtemp, rm } from 'node:fs/promises';
+import { createReadOnlyAgentPermission } from './agents/permissions';
 import { OhMyOpenCodeLite as plugin } from './index';
 
 function createPluginClient(
@@ -140,6 +141,76 @@ describe('plugin tool registration', () => {
         { sessionID: 'parent-after-reload', agent: 'orchestrator' } as never,
       ),
     ).resolves.toContain('state: waiting_for_user');
+  });
+
+  test('keeps security reviewer read-only after host and MCP config merges', async () => {
+    const originalEnv = { ...process.env };
+    const configDir = await mkdtemp('/tmp/oh-my-opencode-security-config-');
+    let hooks: Awaited<ReturnType<typeof plugin>> | undefined;
+
+    try {
+      await Bun.write(
+        `${configDir}/oh-my-opencode-slim.json`,
+        JSON.stringify({
+          agents: {
+            'security-reviewer': {
+              model: 'test/security-reviewer',
+              permission: 'allow',
+              mcps: ['*'],
+              displayName: 'sec-audit',
+            },
+          },
+        }),
+      );
+      process.env = { ...originalEnv, OPENCODE_CONFIG_DIR: configDir };
+      delete process.env.OH_MY_OPENCODE_SLIM_DISABLE;
+
+      hooks = await plugin({
+        client: createPluginClient(async () => ({})),
+        directory: configDir,
+        worktree: configDir,
+        serverUrl: new URL('http://127.0.0.1:4096'),
+      } as never);
+
+      const opencodeConfig = {
+        agent: {
+          'security-reviewer': {
+            permission: 'allow',
+            mcps: ['*'],
+          },
+          'sec-audit': {
+            permission: 'allow',
+            mcps: ['*'],
+          },
+        },
+      } as Record<string, unknown>;
+      await hooks.config?.(opencodeConfig);
+
+      const configAgents = opencodeConfig.agent as Record<
+        string,
+        Record<string, unknown>
+      >;
+      for (const agentName of ['security-reviewer', 'sec-audit']) {
+        const securityReviewer = configAgents[agentName];
+        const permission = securityReviewer.permission as Record<
+          string,
+          unknown
+        >;
+
+        expect(permission).toEqual(createReadOnlyAgentPermission());
+        expect(permission.edit).toBe('deny');
+        expect(permission.task).toBe('deny');
+        expect(permission['context7_*']).toBeUndefined();
+        expect(permission['gh_grep_*']).toBeUndefined();
+        expect(securityReviewer.mcps).toBeUndefined();
+      }
+    } finally {
+      const dispose = (hooks as unknown as { dispose?: () => Promise<void> })
+        ?.dispose;
+      await dispose?.();
+      process.env = originalEnv;
+      await rm(configDir, { recursive: true, force: true });
+    }
   });
 
   test('exposes an idempotent top-level dispose finalizer', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import type { Plugin, ToolDefinition } from '@opencode-ai/plugin';
 import { createAgents, getAgentConfigs, isSubagent } from './agents';
 import { buildOrchestratorPrompt } from './agents/orchestrator';
+import { createReadOnlyAgentPermission } from './agents/permissions';
 import { CompanionManager } from './companion/manager';
 import { ensureCompanionVersion } from './companion/updater';
 import { deepMerge, loadPluginConfig, type MultiplexerConfig } from './config';
@@ -65,6 +66,7 @@ import {
   createDisplayNameMentionRewriter,
   resolveRuntimeAgentName,
 } from './utils';
+import { normalizeAgentName } from './utils/agent-variant';
 import { isPluginDisabledByEnv } from './utils/env';
 import { initLogger, log } from './utils/logger';
 import { SessionMetadataStore } from './utils/session-metadata';
@@ -137,6 +139,7 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
   let runtime: RuntimeConfig;
   let agentDefs: ReturnType<typeof createAgents>;
   let agents: ReturnType<typeof getAgentConfigs>;
+  const securityReviewerConfigKeys = new Set<string>();
   let mcps: ReturnType<typeof createBuiltinMcps>;
   let multiplexerConfig: MultiplexerConfig;
   let multiplexerEnabled: boolean;
@@ -219,6 +222,15 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
     rewriteDisplayNameMentions = createDisplayNameMentionRewriter(runtime);
     agentDefs = createAgents(runtime, { projectDirectory: ctx.directory });
     agents = getAgentConfigs(runtime, { projectDirectory: ctx.directory });
+    for (const agentDef of agentDefs) {
+      if (agentDef.name !== 'security-reviewer') continue;
+      securityReviewerConfigKeys.add(agentDef.name);
+      if (agentDef.displayName) {
+        securityReviewerConfigKeys.add(
+          normalizeAgentName(agentDef.displayName),
+        );
+      }
+    }
 
     // Parse multiplexer config with defaults
     multiplexerConfig = runtime.multiplexer;
@@ -854,10 +866,9 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
           string,
           unknown
         >;
-        const agentPermission = (agentConfigEntry.permission ?? {}) as Record<
-          string,
-          unknown
-        >;
+        const agentPermission = securityReviewerConfigKeys.has(agentName)
+          ? {}
+          : ((agentConfigEntry.permission ?? {}) as Record<string, unknown>);
 
         // Parse mcps list with wildcard and exclusion support
         const allowedMcps = parseList(agentMcps, allMcpNames);
@@ -877,6 +888,23 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
 
         // Update agent config with permissions
         agentConfigEntry.permission = agentPermission;
+      }
+
+      for (const agentName of securityReviewerConfigKeys) {
+        const securityReviewerConfig = configAgent[agentName];
+        if (
+          securityReviewerConfig &&
+          typeof securityReviewerConfig === 'object' &&
+          !Array.isArray(securityReviewerConfig)
+        ) {
+          const finalSecurityReviewerConfig = securityReviewerConfig as Record<
+            string,
+            unknown
+          >;
+          finalSecurityReviewerConfig.permission =
+            createReadOnlyAgentPermission();
+          delete finalSecurityReviewerConfig.mcps;
+        }
       }
 
       interviewManager.registerCommand(opencodeConfig);

--- a/src/skills/deepwork/SKILL.md
+++ b/src/skills/deepwork/SKILL.md
@@ -19,6 +19,14 @@ features.
 When deepwork is active, the orchestrator must manage the work as a scheduler,
 not as the default implementation worker.
 
+## Required Security Gate
+
+Before planning, creating deepwork state, or dispatching work, verify that the
+`@security-reviewer` agent is enabled and available. Deepwork cannot proceed
+without it. If it is unavailable, stop and ask the user to enable
+`security-reviewer` or explicitly change the workflow; do not silently
+substitute another reviewer.
+
 ## Setup and Deepwork State
 
 - create and maintain a local markdown progress file under `.slim/deepwork/`;
@@ -72,10 +80,10 @@ reference local files by path rather than copying their contents.
 - before dispatch, choose a small number of coherent implementation phases from
   the work's dependencies and natural delivery boundaries; do not split work
   merely to reduce an Oracle review's scope;
-- before execution, define coherent delivery phases and make an `@oracle` review
-  mandatory after each one; record the phase order, specialist ownership, gate
-  order, and one-line gate rationale in the deepwork file; share a compact
-  version with the user;
+- before execution, define coherent delivery phases and make one `@oracle` gate
+  and one `@security-reviewer` audit mandatory after every phase, in parallel;
+  record the phase order, specialist ownership, gate order, and one-line gate
+  rationale in the deepwork file; share a compact version with the user;
 - before starting each phase, replace the OpenCode todo list with actionable
   delivery todos for that phase only;
 
@@ -98,9 +106,12 @@ Use the scheduler model throughout:
 
 ## Phase Gate and Commit
 
-- after each planned phase, run relevant validation, update the deepwork file,
-  then request its planned `@oracle` gate before continuing;
-- before its planned Oracle gate, record relevant accepted research and file
+- after each phase, run relevant validation, update the deepwork file, then
+  dispatch the mandatory `@security-reviewer` audit in parallel with the phase's
+  single mandatory `@oracle` gate. The security audit reviews only
+  supplied changed paths and stated behavior for concrete material findings;
+  it does not add another Oracle gate or change the existing review budget;
+- before the Oracle gate, record relevant accepted research and file
   references so Oracle reviews established context rather than repeating
   discovery;
 - record the phase goal, changed paths, validation evidence, and the specific
@@ -108,18 +119,19 @@ Use the scheduler model throughout:
   Oracle with the accepted research and file references;
 - when the phase changes module boundaries, dependency direction, or file
   placement, run an `@explorer` structure scan in parallel with the Oracle gate;
-- reconcile review findings, perform one bounded remediation pass for material
-  issues, and validate that pass with focused evidence;
+- reconcile Oracle and security-reviewer findings, perform one bounded
+  remediation/revalidation pass for material issues, and validate it with
+  focused evidence;
 - create a focused commit when the phase is an independently valid delivery
   boundary before starting the next phase;
 
 ### Oracle Re-Reviews
 
 Every planned Oracle gate has one initial review and may have at most two
-re-reviews. Request a re-review only when the remediation materially changes
-the reviewed decision or risk, or when the original concern cannot be verified
-with focused evidence. Do not spend a re-review on a mechanical or
-already-verified change.
+re-reviews. Request an Oracle re-review only when the remediation materially
+changes the reviewed decision or risk, or when the original concern cannot be
+verified with focused evidence. Do not spend an Oracle re-review on a mechanical
+or already-verified change.
 
 State the attempt in every Oracle prompt, for example:
 
@@ -133,6 +145,14 @@ reopen accepted, unchanged, or resolved concerns. When the two re-reviews are
 exhausted, record any remaining material risk or blocker in the deepwork file
 and ask the user whether to accept the risk, change scope, or authorize an
 exceptional additional review.
+
+### Security Reviewer Re-Reviews
+
+Each mandatory security audit has one initial review and at most one re-review.
+Request that re-review only when remediation changes a security boundary or the
+original finding cannot be verified with focused evidence. Do not re-review for
+an unrelated architecture decision, a mechanical change, or an already-
+verified finding.
 
 ## Designer Handoff Guardrail
 

--- a/src/skills/oh-my-opencode-slim/SKILL.md
+++ b/src/skills/oh-my-opencode-slim/SKILL.md
@@ -68,6 +68,7 @@ Built-in agent prompt file names are exact agent names:
 - `designer.md` / `designer_append.md`
 - `fixer.md` / `fixer_append.md`
 - `observer.md` / `observer_append.md`
+- `security-reviewer.md` / `security-reviewer_append.md`
 - `council.md` / `council_append.md`
 
 Prefer `{agent}_append.md` for small behavior tuning. Use `{agent}.md` only when
@@ -103,7 +104,7 @@ Common customizations:
 Important schema boundary:
 
 - Built-in agents (`orchestrator`, `oracle`, `librarian`, `explorer`,
-  `designer`, `fixer`, `observer`, `council`) can set models, variants, skills,
+  `designer`, `fixer`, `observer`, `security-reviewer`, `council`) can set models, variants, skills,
   MCPs, options, and display names in config.
 - Built-in agent `prompt` and `orchestratorPrompt` fields are **not** supported
   in `oh-my-opencode-slim.json[c]`; use markdown prompt override files instead.
@@ -257,6 +258,7 @@ Avoid custom agents that duplicate existing specialists:
 - codebase scouting → `explorer`
 - external docs/research → `librarian`
 - architecture/debugging/review → `oracle`
+- focused security audit of supplied changes → `security-reviewer`
 - UI/UX polish → `designer`
 - scoped mechanical implementation → `fixer`
 

--- a/src/utils/background-job-board.test.ts
+++ b/src/utils/background-job-board.test.ts
@@ -25,6 +25,18 @@ describe('BackgroundJobBoard', () => {
     expect(board.hasRunning('parent-1')).toBe(true);
   });
 
+  test('uses the security reviewer alias prefix', () => {
+    const board = new BackgroundJobBoard();
+
+    const job = board.registerLaunch({
+      taskID: 'ses_security',
+      parentSessionID: 'parent-1',
+      agent: 'security-reviewer',
+    });
+
+    expect(job.alias).toBe('sec-1');
+  });
+
   test('updates terminal task results as unreconciled', () => {
     const board = new BackgroundJobBoard();
     board.registerLaunch({

--- a/src/utils/background-job-board.ts
+++ b/src/utils/background-job-board.ts
@@ -124,6 +124,7 @@ const AGENT_PREFIX: Record<string, string> = {
   librarian: 'lib',
   observer: 'obs',
   oracle: 'ora',
+  'security-reviewer': 'sec',
 };
 
 export class BackgroundJobBoard implements BackgroundJobStore {


### PR DESCRIPTION
## Summary
- add a strict read-only security-reviewer built-in agent
- run one security audit in parallel with each Deepwork Oracle gate
- enforce the reviewer policy across host config, MCP, and display-name aliases

## Validation
- `bun run typecheck`
- changed-file `bunx biome check`
- focused tests (176 passing)
- independent Oracle review and two re-reviews

`bun test` has 3 pre-existing failures in smartfetch/codemap snapshots. `bun run check:ci` also has unrelated pre-existing formatting/lint failures outside this PR.