### PR TITLE
fix(tasks): reject noncanonical task IDs

### DIFF
--- a/src/agents/orchestrator.ts
+++ b/src/agents/orchestrator.ts
@@ -259,9 +259,9 @@ After spawning all independent background tasks and any remaining non-overlappin
 - If multiple remembered sessions fit, prefer the most recently used matching session.
 - Prefer re-uses over creating new sessions all the time
 - Only sessions listed under Reusable Sessions may be resumed. Active / Unreconciled sessions are not resumable.
-- When reusing a specialist session, you MUST pass the existing session or alias in the task tool's \`task_id\` argument. Saying "reuse" in prose is not enough.
-- If the Background Job Board lists \`fix-1 / ses_abc / fixer\`, call task with \`subagent_type: "fixer"\` and \`task_id: "fix-1"\` or \`task_id: "ses_abc"\`.
-- Do not leave \`task_id\` empty when intending to reuse; omitted or empty \`task_id\` creates a new specialist session.
+- When reusing a specialist session, you MUST pass its full canonical \`ses_...\` taskID in the task tool's \`task_id\` argument. Saying "reuse" in prose is not enough; short board aliases are display-only.
+- If the Background Job Board lists \`fix-1 / ses_abc / fixer\`, call task with \`subagent_type: "fixer"\` and \`task_id: "ses_abc"\`. Never pass \`fix-1\` to task.
+- Omit \`task_id\` only when creating a new specialist session; never pass an empty \`task_id\` when intending to reuse.
 
 ## 5. Verify
 - Reconcile all writer lanes before final validation.

--- a/src/hooks/__snapshots__/cache-payload.snapshot.test.ts.snap
+++ b/src/hooks/__snapshots__/cache-payload.snapshot.test.ts.snap
@@ -188,9 +188,9 @@ After spawning all independent background tasks and any remaining non-overlappin
 - If multiple remembered sessions fit, prefer the most recently used matching session.
 - Prefer re-uses over creating new sessions all the time
 - Only sessions listed under Reusable Sessions may be resumed. Active / Unreconciled sessions are not resumable.
-- When reusing a specialist session, you MUST pass the existing session or alias in the task tool's \`task_id\` argument. Saying "reuse" in prose is not enough.
-- If the Background Job Board lists \`fix-1 / ses_abc / fixer\`, call task with \`subagent_type: "fixer"\` and \`task_id: "fix-1"\` or \`task_id: "ses_abc"\`.
-- Do not leave \`task_id\` empty when intending to reuse; omitted or empty \`task_id\` creates a new specialist session.
+- When reusing a specialist session, you MUST pass its full canonical \`ses_...\` taskID in the task tool's \`task_id\` argument. Saying "reuse" in prose is not enough; short board aliases are display-only.
+- If the Background Job Board lists \`fix-1 / ses_abc / fixer\`, call task with \`subagent_type: "fixer"\` and \`task_id: "ses_abc"\`. Never pass \`fix-1\` to task.
+- Omit \`task_id\` only when creating a new specialist session; never pass an empty \`task_id\` when intending to reuse.
 
 ## 5. Verify
 - Reconcile all writer lanes before final validation.

--- a/src/hooks/task-session-manager/index.test.ts
+++ b/src/hooks/task-session-manager/index.test.ts
@@ -1434,7 +1434,7 @@ describe('task-session-manager hook', () => {
     for (const state of ['cancelled', 'error'] as const) {
       const board = new BackgroundJobBoard();
       const original = board.registerLaunch({
-        taskID: `child-${state}`,
+        taskID: `ses_child_${state}`,
         parentSessionID: 'parent-1',
         agent: 'oracle',
         description: `${state} review`,
@@ -1443,18 +1443,26 @@ describe('task-session-manager hook', () => {
       const { hook } = createHook({ backgroundJobBoard: board });
 
       const beforeAcknowledgement = {
-        args: { subagent_type: 'oracle', task_id: original.alias },
+        args: { subagent_type: 'oracle', task_id: original.taskID },
       };
-      await hook['tool.execute.before'](
-        { tool: 'task', sessionID: 'parent-1', callID: `${state}-before-ack` },
-        beforeAcknowledgement,
+      await expect(
+        hook['tool.execute.before'](
+          {
+            tool: 'task',
+            sessionID: 'parent-1',
+            callID: `${state}-before-ack`,
+          },
+          beforeAcknowledgement,
+        ),
+      ).rejects.toThrow(
+        'cannot be resumed because its session is not reusable',
       );
-      expect(beforeAcknowledgement.args.task_id).toBeUndefined();
+      expect(beforeAcknowledgement.args.task_id).toBe(original.taskID);
 
       board.markReconciled(original.taskID);
 
       const resume = {
-        args: { subagent_type: 'oracle', task_id: original.alias },
+        args: { subagent_type: 'oracle', task_id: original.taskID },
       };
       await hook['tool.execute.before'](
         { tool: 'task', sessionID: 'parent-1', callID: `${state}-resume` },
@@ -1534,7 +1542,7 @@ describe('task-session-manager hook', () => {
     );
   });
 
-  test('reuses timed-out running aliases after live busy recovery', async () => {
+  test('reuses timed-out running sessions after live busy recovery', async () => {
     const board = new BackgroundJobBoard();
     const { hook } = createHook({ backgroundJobBoard: board });
 
@@ -1551,7 +1559,7 @@ describe('task-session-manager hook', () => {
       { tool: 'task', sessionID: 'parent-1', callID: 'call-1' },
       {
         output: [
-          'task_id: child-1',
+          'task_id: ses_child',
           'state: running',
           '',
           '<task_result>',
@@ -1569,7 +1577,7 @@ describe('task-session-manager hook', () => {
       event: {
         type: 'session.status',
         properties: {
-          sessionID: 'child-1',
+          sessionID: 'ses_child',
           status: { type: 'busy' },
         },
       },
@@ -1577,18 +1585,18 @@ describe('task-session-manager hook', () => {
 
     expect(
       board.resolveRecoverable('parent-1', 'exp-1', 'explorer')?.taskID,
-    ).toBe('child-1');
+    ).toBe('ses_child');
 
     const resume = {
-      args: { subagent_type: 'explorer', task_id: 'exp-1' },
+      args: { subagent_type: 'explorer', task_id: 'ses_child' },
     };
     await hook['tool.execute.before'](
       { tool: 'task', sessionID: 'parent-1', callID: 'resume-1' },
       resume,
     );
 
-    expect(resume.args.task_id).toBe('child-1');
-    expect(board.get('child-1')).toMatchObject({
+    expect(resume.args.task_id).toBe('ses_child');
+    expect(board.get('ses_child')).toMatchObject({
       state: 'running',
       timedOut: false,
       recoverableAfterLiveBusy: true,
@@ -1598,13 +1606,13 @@ describe('task-session-manager hook', () => {
   test('holds a relaunch lease through after and releases it after registration', async () => {
     const board = new BackgroundJobBoard();
     setupCompletedJob(board, {
-      taskID: 'child-1',
+      taskID: 'ses_child',
       parentSessionID: 'parent-1',
     });
-    board.markReconciled('child-1');
+    board.markReconciled('ses_child');
     const { hook } = createHook({ backgroundJobBoard: board });
     const resume = {
-      args: { subagent_type: 'oracle', task_id: 'ora-1' },
+      args: { subagent_type: 'oracle', task_id: 'ses_child' },
     };
 
     await hook['tool.execute.before'](
@@ -1613,14 +1621,14 @@ describe('task-session-manager hook', () => {
     );
     await hook['tool.execute.after'](
       { tool: 'task', sessionID: 'parent-1', callID: 'resume-1' },
-      { output: ['task_id: child-1', 'state: running'].join('\n') },
+      { output: ['task_id: ses_child', 'state: running'].join('\n') },
     );
 
-    const relaunched = board.get('child-1');
-    expect(resume.args.task_id).toBe('child-1');
+    const relaunched = board.get('ses_child');
+    expect(resume.args.task_id).toBe('ses_child');
     expect(relaunched).toMatchObject({ generation: 2, state: 'running' });
     const cancellationLease = board.acquireCancellationLease(
-      'child-1',
+      'ses_child',
       relaunched?.generation ?? -1,
     );
     expect(cancellationLease).toBeDefined();
@@ -1677,7 +1685,7 @@ describe('task-session-manager hook', () => {
   test('tool.execute.before refuses a relaunch while cancellation owns the generation', async () => {
     const board = new BackgroundJobBoard();
     const first = board.registerLaunch({
-      taskID: 'child-1',
+      taskID: 'ses_child',
       parentSessionID: 'parent-1',
       agent: 'fixer',
     });
@@ -1697,7 +1705,9 @@ describe('task-session-manager hook', () => {
     );
     expect(cancellationLease).toBeDefined();
     const { hook } = createHook({ backgroundJobBoard: board });
-    const resume = { args: { subagent_type: 'fixer', task_id: 'fix-1' } };
+    const resume = {
+      args: { subagent_type: 'fixer', task_id: 'ses_child' },
+    };
 
     await expect(
       hook['tool.execute.before'](
@@ -1705,7 +1715,7 @@ describe('task-session-manager hook', () => {
         resume,
       ),
     ).rejects.toThrow('cannot be resumed safely');
-    expect(resume.args.task_id).toBe('fix-1');
+    expect(resume.args.task_id).toBe('ses_child');
     expect(board.get(first.taskID)?.generation).toBe(first.generation);
     if (!cancellationLease) {
       throw new Error('cancellation lease was not acquired');
@@ -1716,21 +1726,22 @@ describe('task-session-manager hook', () => {
   test('after output errors still release a pending relaunch lease', async () => {
     const board = new BackgroundJobBoard();
     setupCompletedJob(board, {
-      taskID: 'child-1',
+      taskID: 'ses_child',
       parentSessionID: 'parent-1',
     });
+    board.markReconciled('ses_child');
     const { hook } = createHook({ backgroundJobBoard: board });
 
     await hook['tool.execute.before'](
       { tool: 'task', sessionID: 'parent-1', callID: 'resume-error' },
-      { args: { subagent_type: 'oracle', task_id: 'ora-1' } },
+      { args: { subagent_type: 'oracle', task_id: 'ses_child' } },
     );
     await hook['tool.execute.after'](
       { tool: 'task', sessionID: 'parent-1', callID: 'resume-error' },
       { output: undefined },
     );
 
-    const secondLease = board.acquireRelaunchLease('child-1', 1);
+    const secondLease = board.acquireRelaunchLease('ses_child', 1);
     expect(secondLease).toBeDefined();
     if (!secondLease) throw new Error('relaunch lease was not released');
     board.releaseLease(secondLease);
@@ -1739,10 +1750,10 @@ describe('task-session-manager hook', () => {
   test('after handler exceptions release a pending relaunch lease', async () => {
     const board = new BackgroundJobBoard();
     setupCompletedJob(board, {
-      taskID: 'child-1',
+      taskID: 'ses_child',
       parentSessionID: 'parent-1',
     });
-    board.markReconciled('child-1');
+    board.markReconciled('ses_child');
     board.addContext = () => {
       throw new Error('context tracking failed');
     };
@@ -1750,16 +1761,16 @@ describe('task-session-manager hook', () => {
 
     await hook['tool.execute.before'](
       { tool: 'task', sessionID: 'parent-1', callID: 'resume-throw' },
-      { args: { subagent_type: 'oracle', task_id: 'ora-1' } },
+      { args: { subagent_type: 'oracle', task_id: 'ses_child' } },
     );
     await expect(
       hook['tool.execute.after'](
         { tool: 'task', sessionID: 'parent-1', callID: 'resume-throw' },
-        { output: ['task_id: child-1', 'state: running'].join('\n') },
+        { output: ['task_id: ses_child', 'state: running'].join('\n') },
       ),
     ).rejects.toThrow('context tracking failed');
 
-    const cancellationLease = board.acquireCancellationLease('child-1', 2);
+    const cancellationLease = board.acquireCancellationLease('ses_child', 2);
     expect(cancellationLease).toBeDefined();
     if (!cancellationLease) {
       throw new Error('cancellation lease was not acquired');
@@ -4170,13 +4181,13 @@ describe('task-session-manager hook', () => {
     const { hook } = createHook({ backgroundJobBoard: board });
 
     board.registerLaunch({
-      taskID: 'child-1',
+      taskID: 'ses_child',
       parentSessionID: 'parent-1',
       agent: 'explorer',
       description: 'map config schema',
     });
     board.updateStatus({
-      taskID: 'child-1',
+      taskID: 'ses_child',
       state: 'completed',
       resultSummary: 'schema mapped',
     });
@@ -4197,7 +4208,7 @@ describe('task-session-manager hook', () => {
     await transformMessages(hook, nextMessages);
     expect(boardText(nextMessages)).toContain('#### Reusable Sessions');
     expect(boardText(nextMessages)).toContain(
-      'exp-1 / child-1 / explorer / completed, reconciled',
+      'exp-1 / ses_child / explorer / completed, reconciled',
     );
     expect(nextMessages.messages[0].parts[0].text).not.toContain(
       ['<resumable', '_sessions>'].join(''),
@@ -4210,14 +4221,14 @@ describe('task-session-manager hook', () => {
       args: {
         subagent_type: 'explorer',
         description: 'continue config schema',
-        task_id: 'exp-1',
+        task_id: 'ses_child',
       },
     };
     await hook['tool.execute.before'](
       { tool: 'task', sessionID: 'parent-1', callID: 'resume-1' },
       resume,
     );
-    expect(resume.args.task_id).toBe('child-1');
+    expect(resume.args.task_id).toBe('ses_child');
   });
 
   test('only acknowledged terminal jobs resolve as reusable task sessions', async () => {
@@ -4225,56 +4236,60 @@ describe('task-session-manager hook', () => {
     const { hook } = createHook({ backgroundJobBoard: board });
 
     board.registerLaunch({
-      taskID: 'done-1',
+      taskID: 'ses_done',
       parentSessionID: 'parent-1',
       agent: 'oracle',
       description: 'review plan',
     });
-    board.updateStatus({ taskID: 'done-1', state: 'completed' });
+    board.updateStatus({ taskID: 'ses_done', state: 'completed' });
     board.registerLaunch({
-      taskID: 'err-1',
+      taskID: 'ses_err',
       parentSessionID: 'parent-1',
       agent: 'oracle',
       description: 'bad review',
     });
-    board.updateStatus({ taskID: 'err-1', state: 'error' });
-    board.markReconciled('err-1');
+    board.updateStatus({ taskID: 'ses_err', state: 'error' });
+    board.markReconciled('ses_err');
 
     const unreconciled = {
-      args: { subagent_type: 'oracle', task_id: 'ora-1' },
+      args: { subagent_type: 'oracle', task_id: 'ses_done' },
     };
-    await hook['tool.execute.before'](
-      { tool: 'task', sessionID: 'parent-1', callID: 'call-1' },
-      unreconciled,
-    );
-    expect(unreconciled.args.task_id).toBeUndefined();
+    await expect(
+      hook['tool.execute.before'](
+        { tool: 'task', sessionID: 'parent-1', callID: 'call-1' },
+        unreconciled,
+      ),
+    ).rejects.toThrow('cannot be resumed because its session is not reusable');
+    expect(unreconciled.args.task_id).toBe('ses_done');
 
-    board.markReconciled('done-1');
+    board.markReconciled('ses_done');
 
-    const failed = { args: { subagent_type: 'oracle', task_id: 'ora-2' } };
+    const failed = { args: { subagent_type: 'oracle', task_id: 'ses_err' } };
     await hook['tool.execute.before'](
       { tool: 'task', sessionID: 'parent-1', callID: 'call-2' },
       failed,
     );
-    expect(failed.args.task_id).toBe('err-1');
+    expect(failed.args.task_id).toBe('ses_err');
     await hook['tool.execute.after'](
       { tool: 'task', sessionID: 'parent-1', callID: 'call-2' },
-      { output: ['task_id: err-1', 'state: running'].join('\n') },
+      { output: ['task_id: ses_err', 'state: running'].join('\n') },
     );
 
-    const completed = { args: { subagent_type: 'oracle', task_id: 'ora-1' } };
+    const completed = {
+      args: { subagent_type: 'oracle', task_id: 'ses_done' },
+    };
     await hook['tool.execute.before'](
       { tool: 'task', sessionID: 'parent-1', callID: 'call-3' },
       completed,
     );
-    expect(completed.args.task_id).toBe('done-1');
+    expect(completed.args.task_id).toBe('ses_done');
 
     const messages = createMessages('parent-1', 'continue');
     await transformMessages(hook, messages);
     expect(boardText(messages)).toContain(
-      'ora-1 / done-1 / oracle / completed, reconciled',
+      'ora-1 / ses_done / oracle / completed, reconciled',
     );
-    expect(messages.messages[0].parts[0].text).not.toContain('err-1');
+    expect(messages.messages[0].parts[0].text).not.toContain('ses_err');
   });
 
   test('running aliases fail closed instead of spawning a new task', async () => {
@@ -4351,27 +4366,27 @@ describe('task-session-manager hook', () => {
     expect(resume.args.task_id).toBe('ses_custom123');
   });
 
-  test('custom subagent aliases resolve for the same custom agent', async () => {
+  test('custom subagent canonical sessions resolve for the same custom agent', async () => {
     const board = new BackgroundJobBoard();
     const { hook } = createHook({ backgroundJobBoard: board });
     board.registerLaunch({
-      taskID: 'child-1',
+      taskID: 'ses_custom',
       parentSessionID: 'parent-1',
       agent: 'repro-helper',
       description: 'ask secret letter',
     });
-    board.updateStatus({ taskID: 'child-1', state: 'completed' });
-    board.markReconciled('child-1');
+    board.updateStatus({ taskID: 'ses_custom', state: 'completed' });
+    board.markReconciled('ses_custom');
 
     const resume = {
-      args: { subagent_type: 'repro-helper', task_id: 'rep-1' },
+      args: { subagent_type: 'repro-helper', task_id: 'ses_custom' },
     };
     await hook['tool.execute.before'](
       { tool: 'task', sessionID: 'parent-1', callID: 'resume' },
       resume,
     );
 
-    expect(resume.args.task_id).toBe('child-1');
+    expect(resume.args.task_id).toBe('ses_custom');
   });
 
   test('wrong parent or wrong agent alias does not resolve', async () => {
@@ -4387,39 +4402,43 @@ describe('task-session-manager hook', () => {
     board.markReconciled('child-1');
 
     const wrongAgent = { args: { subagent_type: 'oracle', task_id: 'exp-1' } };
-    await hook['tool.execute.before'](
-      { tool: 'task', sessionID: 'parent-1', callID: 'agent' },
-      wrongAgent,
-    );
-    expect(wrongAgent.args.task_id).toBeUndefined();
+    await expect(
+      hook['tool.execute.before'](
+        { tool: 'task', sessionID: 'parent-1', callID: 'agent' },
+        wrongAgent,
+      ),
+    ).rejects.toThrow('cannot be resumed because its session is not reusable');
+    expect(wrongAgent.args.task_id).toBe('exp-1');
   });
 
   test('resuming reusable job relaunches running and removes reusable entry', async () => {
     const board = new BackgroundJobBoard();
     const { hook } = createHook({ backgroundJobBoard: board });
     board.registerLaunch({
-      taskID: 'child-1',
+      taskID: 'ses_child',
       parentSessionID: 'parent-1',
       agent: 'explorer',
       description: 'map hooks',
     });
-    board.updateStatus({ taskID: 'child-1', state: 'completed' });
-    board.markReconciled('child-1');
+    board.updateStatus({ taskID: 'ses_child', state: 'completed' });
+    board.markReconciled('ses_child');
 
-    const resume = { args: { subagent_type: 'explorer', task_id: 'exp-1' } };
+    const resume = {
+      args: { subagent_type: 'explorer', task_id: 'ses_child' },
+    };
     await hook['tool.execute.before'](
       { tool: 'task', sessionID: 'parent-1', callID: 'resume' },
       resume,
     );
     await hook['tool.execute.after'](
       { tool: 'task', sessionID: 'parent-1', callID: 'resume' },
-      { output: ['task_id: child-1', 'state: running'].join('\n') },
+      { output: ['task_id: ses_child', 'state: running'].join('\n') },
     );
 
     const messages = createMessages('parent-1', 'continue');
     await transformMessages(hook, messages);
     expect(boardText(messages)).toContain(
-      'exp-1 / child-1 / explorer / running',
+      'exp-1 / ses_child / explorer / running',
     );
     expect(boardText(messages)).toContain('#### Reusable Sessions\n- none');
   });
@@ -4481,7 +4500,9 @@ describe('task-session-manager hook', () => {
       'fix-1 / ses_child / fixer / completed, reconciled',
     );
 
-    const resume = { args: { subagent_type: 'fixer', task_id: 'fix-1' } };
+    const resume = {
+      args: { subagent_type: 'fixer', task_id: 'ses_child' },
+    };
     await hook['tool.execute.before'](
       { tool: 'task', sessionID: 'parent-1', callID: 'resume-1' },
       resume,
@@ -4537,16 +4558,17 @@ describe('task-session-manager hook', () => {
     expect(resume.args.task_id).toBe('ses_existing');
   });
 
-  test('still drops unknown reusable aliases', async () => {
+  test('rejects unknown reusable aliases', async () => {
     const { hook } = createHook();
     const resume = { args: { subagent_type: 'fixer', task_id: 'fix-99' } };
 
-    await hook['tool.execute.before'](
-      { tool: 'task', sessionID: 'parent-1', callID: 'resume-1' },
-      resume,
-    );
-
-    expect(resume.args.task_id).toBeUndefined();
+    await expect(
+      hook['tool.execute.before'](
+        { tool: 'task', sessionID: 'parent-1', callID: 'resume-1' },
+        resume,
+      ),
+    ).rejects.toThrow('Unknown task_id fix-99');
+    expect(resume.args.task_id).toBe('fix-99');
   });
 
   test('reads before and after launch attach with unique-line counts and caps', async () => {

--- a/src/hooks/task-session-manager/tool-execute-hooks.test.ts
+++ b/src/hooks/task-session-manager/tool-execute-hooks.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test } from 'bun:test';
+import { BackgroundJobBoard } from '../../utils';
+import type { PendingTaskCall } from './pending-call-tracker';
+import { handleToolExecuteBefore } from './tool-execute-hooks';
+
+function createDependencies(board: BackgroundJobBoard) {
+  const pendingCalls: PendingTaskCall[] = [];
+  const deps = {
+    shouldManageSession: () => true,
+    backgroundJobBoard: board,
+    pendingCallTracker: {
+      add(call: PendingTaskCall) {
+        pendingCalls.push(call);
+      },
+      pendingCallId: () => 'pending-1',
+    },
+    taskContextTracker: { pendingManagedTaskIds: new Set<string>() },
+  } satisfies Parameters<typeof handleToolExecuteBefore>[2];
+
+  return { deps, pendingCalls };
+}
+
+function reusableJob(board: BackgroundJobBoard) {
+  const record = board.registerLaunch({
+    taskID: 'ses_reusable',
+    parentSessionID: 'parent-1',
+    agent: 'explorer',
+    description: 'reusable session',
+  });
+  board.updateStatus({
+    taskID: record.taskID,
+    state: 'completed',
+  });
+  board.markReconciled(record.taskID);
+  return record;
+}
+
+function nonReusableAliasJob(board: BackgroundJobBoard) {
+  const record = board.registerLaunch({
+    taskID: 'ses_unreconciled',
+    parentSessionID: 'parent-1',
+    agent: 'explorer',
+    description: 'unreconciled session',
+  });
+  board.updateStatus({
+    taskID: record.taskID,
+    state: 'completed',
+  });
+  return record;
+}
+
+describe('handleToolExecuteBefore task_id validation', () => {
+  test('rejects a reusable alias with its canonical taskID', async () => {
+    const board = new BackgroundJobBoard();
+    const record = reusableJob(board);
+    const { deps, pendingCalls } = createDependencies(board);
+    const output = {
+      args: { subagent_type: 'explorer', task_id: 'exp-1' },
+    };
+
+    await expect(
+      handleToolExecuteBefore(
+        { tool: 'task', sessionID: 'parent-1', callID: 'call-1' },
+        output,
+        deps,
+      ),
+    ).rejects.toThrow(`resolves to resumable session ${record.taskID}`);
+    expect(output.args.task_id).toBe('exp-1');
+    expect(pendingCalls).toHaveLength(0);
+    expect(
+      board.acquireRelaunchLease(record.taskID, record.generation),
+    ).toBeDefined();
+  });
+
+  test('rejects a known non-reusable alias with a lifecycle error', async () => {
+    const board = new BackgroundJobBoard();
+    nonReusableAliasJob(board);
+    const { deps, pendingCalls } = createDependencies(board);
+    const output = {
+      args: { subagent_type: 'explorer', task_id: 'exp-1' },
+    };
+
+    await expect(
+      handleToolExecuteBefore(
+        { tool: 'task', sessionID: 'parent-1', callID: 'call-1' },
+        output,
+        deps,
+      ),
+    ).rejects.toThrow('cannot be resumed because its session is not reusable');
+    expect(pendingCalls).toHaveLength(0);
+  });
+
+  test('rejects a known non-reusable canonical task ID', async () => {
+    const board = new BackgroundJobBoard();
+    const record = nonReusableAliasJob(board);
+    const { deps, pendingCalls } = createDependencies(board);
+    const output = {
+      args: { subagent_type: 'explorer', task_id: record.taskID },
+    };
+
+    await expect(
+      handleToolExecuteBefore(
+        { tool: 'task', sessionID: 'parent-1', callID: 'call-1' },
+        output,
+        deps,
+      ),
+    ).rejects.toThrow('cannot be resumed because its session is not reusable');
+    expect(output.args.task_id).toBe(record.taskID);
+    expect(pendingCalls).toHaveLength(0);
+    const lease = board.acquireRelaunchLease(record.taskID, record.generation);
+    expect(lease).toBeDefined();
+    if (lease) board.releaseLease(lease);
+  });
+
+  test('rejects an unknown noncanonical task ID', async () => {
+    const board = new BackgroundJobBoard();
+    const { deps, pendingCalls } = createDependencies(board);
+    const output = {
+      args: { subagent_type: 'explorer', task_id: 'exp-99' },
+    };
+
+    await expect(
+      handleToolExecuteBefore(
+        { tool: 'task', sessionID: 'parent-1', callID: 'call-1' },
+        output,
+        deps,
+      ),
+    ).rejects.toThrow(
+      'Omit task_id to create a new session or use a full canonical ses_... ID to resume',
+    );
+    expect(pendingCalls).toHaveLength(0);
+  });
+
+  test('keeps canonical task IDs on the valid resume path', async () => {
+    const board = new BackgroundJobBoard();
+    const record = reusableJob(board);
+    const { deps, pendingCalls } = createDependencies(board);
+    const output = {
+      args: { subagent_type: 'explorer', task_id: record.taskID },
+    };
+
+    await handleToolExecuteBefore(
+      { tool: 'task', sessionID: 'parent-1', callID: 'call-1' },
+      output,
+      deps,
+    );
+
+    expect(output.args.task_id).toBe(record.taskID);
+    expect(pendingCalls).toHaveLength(1);
+    expect(pendingCalls[0]?.resumedTaskId).toBe(record.taskID);
+    expect(
+      board.acquireRelaunchLease(record.taskID, record.generation),
+    ).toBeUndefined();
+  });
+});

--- a/src/hooks/task-session-manager/tool-execute-hooks.ts
+++ b/src/hooks/task-session-manager/tool-execute-hooks.ts
@@ -93,6 +93,14 @@ export async function handleToolExecuteBefore(
 
   const args = output.args as TaskArgs;
   if (
+    args.task_id !== undefined &&
+    (typeof args.task_id !== 'string' || args.task_id.trim() === '')
+  ) {
+    throw new Error(
+      'Invalid task_id. Omit task_id to create a new session or use a full canonical ses_... ID to resume.',
+    );
+  }
+  if (
     typeof args.subagent_type !== 'string' ||
     args.subagent_type.trim() === ''
   ) {
@@ -126,6 +134,8 @@ export async function handleToolExecuteBefore(
   installEarlyRegistrationGenerationFence(pendingCall, deps.backgroundJobBoard);
   if (typeof args.task_id === 'string' && args.task_id.trim() !== '') {
     const requested = args.task_id.trim();
+    const canonical = SESSION_ID_PATTERN.test(requested);
+    if (canonical) args.task_id = requested;
     const remembered =
       deps.backgroundJobBoard.resolveReusable(
         input.sessionID,
@@ -137,6 +147,12 @@ export async function handleToolExecuteBefore(
         requested,
         agentType,
       );
+
+    if (remembered && !canonical) {
+      throw new Error(
+        `Task alias ${requested} is display-only and resolves to resumable session ${remembered.taskID}. Retry with the canonical task_id: ${remembered.taskID}.`,
+      );
+    }
 
     if (!remembered) {
       const knownManagedTask = deps.backgroundJobBoard.resolve(
@@ -150,11 +166,20 @@ export async function handleToolExecuteBefore(
       }
 
       if (knownManagedTask) {
-        delete args.task_id;
-      } else if (SESSION_ID_PATTERN.test(requested)) {
+        if (!canonical) {
+          throw new Error(
+            `Task alias ${requested} cannot be resumed because its session is not reusable (state: ${knownManagedTask.state}). Wait for it to reach Reusable Sessions, or omit task_id to create a new session.`,
+          );
+        }
+        throw new Error(
+          `Task ${requested} is known but cannot be resumed because its session is not reusable (state: ${knownManagedTask.state}). Wait for it to reach Reusable Sessions, or omit task_id to create a new session.`,
+        );
+      } else if (canonical) {
         pendingCall.resumedTaskId = requested;
       } else {
-        delete args.task_id;
+        throw new Error(
+          `Unknown task_id ${requested}. Omit task_id to create a new session or use a full canonical ses_... ID to resume.`,
+        );
       }
     } else {
       const relaunchLease = deps.backgroundJobBoard.acquireRelaunchLease(


### PR DESCRIPTION
Fixes #1038.

Rejects aliases and unknown noncanonical task_id values before native execution, so they cannot reach OpenCode SessionID.make(). Reuse now requires the Board full canonical ses_... ID; known non-reusable sessions also fail before execution.

Tests: bun test; bun run typecheck; bun run check:ci.