### PR TITLE
fix(foreground-fallback): recognize ProviderModelNotFoundError as failover (#1034)

### DIFF
--- a/src/hooks/foreground-fallback/index.test.ts
+++ b/src/hooks/foreground-fallback/index.test.ts
@@ -298,6 +298,36 @@ describe('isFailoverError', () => {
       }),
     ).toBe(false);
   });
+
+  test('returns true for OpenCode ProviderModelNotFoundError "Model not found" errors', () => {
+    // Issue #1034: OpenCode's ProviderModelNotFoundError ("Model not found:
+    // <model>") was not classified as a failover error, so a missing primary
+    // model failed the task outright instead of advancing the fallback chain.
+    // The reporter's error string always carries the message; the bare
+    // camelCase class name "ProviderModelNotFoundError" (no spaces) does not
+    // match /\bmodel not found\b/i and is intentionally not covered here.
+    expect(
+      isFailoverError(
+        'ProviderModelNotFoundError: Model not found: custom/missing-model.',
+      ),
+    ).toBe(true);
+    expect(
+      isFailoverError({ message: 'Model not found: custom/missing-model' }),
+    ).toBe(true);
+  });
+
+  test('returns true for existing model-outage patterns (regression guard)', () => {
+    expect(isFailoverError('model not available')).toBe(true);
+    expect(isFailoverError('unsupported model')).toBe(true);
+    expect(isFailoverError('unknown model')).toBe(true);
+  });
+
+  test('returns false for normal errors and model mentions without outage wording', () => {
+    expect(isFailoverError('Cannot connect to database')).toBe(false);
+    expect(isFailoverError({ message: 'invalid model configuration' })).toBe(
+      false,
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -467,6 +497,42 @@ describe('ForegroundFallbackManager session.error', () => {
         sessionID: 'sess-1',
         error: {
           message: 'stream error: Cannot connect to API',
+        },
+      },
+    });
+
+    expect(mocks.abort).not.toHaveBeenCalled();
+    expect(mocks.promptAsync).toHaveBeenCalledTimes(1);
+
+    const call = mocks.promptAsync.mock.calls[0] as [
+      {
+        model: { providerID: string; modelID: string };
+      },
+    ];
+    expect(call[0].body.model.providerID).toBe('openai');
+    expect(call[0].body.model.modelID).toBe('gpt-4o');
+  });
+
+  test('triggers fallback on ProviderModelNotFoundError session.error', async () => {
+    await mgr.handleEvent({
+      type: 'message.updated',
+      properties: {
+        info: {
+          sessionID: 'sess-1',
+          providerID: 'anthropic',
+          modelID: 'claude-opus-4-5',
+          role: 'assistant',
+        },
+      },
+    });
+
+    await mgr.handleEvent({
+      type: 'session.error',
+      properties: {
+        sessionID: 'sess-1',
+        error: {
+          message:
+            'ProviderModelNotFoundError: Model not found: custom/missing-model.',
         },
       },
     });

--- a/src/hooks/foreground-fallback/index.ts
+++ b/src/hooks/foreground-fallback/index.ts
@@ -103,6 +103,10 @@ const PROVIDER_OUTAGE_PATTERNS = [
   /\bmodel is not available\b/i,
   /\bunsupported model\b/i,
   /\bunknown model\b/i,
+  // OpenCode's ProviderModelNotFoundError uses "Model not found" wording; the
+  // model may exist on a later entry in the configured chain, so treat it as a
+  // provider outage and advance the fallback chain.
+  /\bmodel not found\b/i,
   // Model retired/end-of-life (HTTP 410 Gone) — the model no longer exists,
   // so the next model must be tried instead of retrying the dead one.
   /\bend of life\b/i,


### PR DESCRIPTION
Fixes #1034

## What problem are you solving?

When the first model in an agent's configured model chain is absent from OpenCode's provider registry, OpenCode raises `ProviderModelNotFoundError: Model not found: <model>`. `isFailoverError()` does not classify this wording — `PROVIDER_OUTAGE_PATTERNS` covers `model not available`, `unsupported model`, and `unknown model`, but not `Model not found` — so the fallback chain never advances and the task fails on the missing primary model. Relaunching the task selects the same missing primary and fails identically.

## What does this change?

- `PROVIDER_OUTAGE_PATTERNS` gains `/\bmodel not found\b/i`, so `ProviderModelNotFoundError` advances the fallback chain.
- Tests: classification, regression guard, negative cases, and a gate-level `session.error` fallback-switch test.

## Why this approach?

The model may exist on a later entry in the configured chain, so a missing primary should be treated as a provider outage and advance the chain rather than fail the task. The pattern is deliberately narrow (`model not found`) to avoid matching unrelated wording such as configuration errors.

## Verification

- `bun test src/hooks/foreground-fallback/index.test.ts` — 93 pass (89 pre-existing + 4 new)
- `bun run typecheck` — clean
- `bun x biome check` on both changed files — clean