### PR TITLE
fix(smartfetch): set parentID on secondary sessions to suppress TUI notifications (#1046)

### DIFF
--- a/src/tools/smartfetch/secondary-model.test.ts
+++ b/src/tools/smartfetch/secondary-model.test.ts
@@ -362,4 +362,44 @@ describe('smartfetch/secondary-model', () => {
       _testConfig.secondaryModelTimeoutMs = originalTimeout;
     }
   });
+
+  test('passes parentID to session.create when parentSessionID is provided', async () => {
+    mockV2Client = createV2ClientMock([{ text: 'Answer' }]);
+
+    const result = await runSecondaryModelWithFallback(
+      testInput,
+      [models[0]],
+      'Summarize',
+      'This is enough fetched content to clear the short-content guard.',
+      'parent-session-id',
+    );
+
+    expect(result.text).toBe('Answer');
+    expect(mockV2Session.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          title: 'smartfetch-secondary',
+          parentID: 'parent-session-id',
+        }),
+      }),
+    );
+  });
+
+  test('omits parentID from session.create when parentSessionID is undefined', async () => {
+    mockV2Client = createV2ClientMock([{ text: 'Answer' }]);
+
+    const result = await runSecondaryModelWithFallback(
+      testInput,
+      [models[0]],
+      'Summarize',
+      'This is enough fetched content to clear the short-content guard.',
+    );
+
+    expect(result.text).toBe('Answer');
+    expect(mockV2Session.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: { title: 'smartfetch-secondary' },
+      }),
+    );
+  });
 });

--- a/src/tools/smartfetch/secondary-model.ts
+++ b/src/tools/smartfetch/secondary-model.ts
@@ -204,6 +204,7 @@ async function runSecondaryModel(
   model: SecondaryModel,
   prompt: string,
   content: string,
+  parentSessionID?: string,
 ) {
   const client = getClient(input);
   const directory = input.directory;
@@ -215,7 +216,10 @@ async function runSecondaryModel(
   try {
     const sessionResponse = await client.session.create({
       query: { directory },
-      body: { title: 'smartfetch-secondary' },
+      body: {
+        title: 'smartfetch-secondary',
+        ...(parentSessionID ? { parentID: parentSessionID } : {}),
+      },
       throwOnError: true,
     });
 
@@ -326,11 +330,18 @@ export async function runSecondaryModelWithFallback(
   models: SecondaryModel[],
   prompt: string,
   content: string,
+  parentSessionID?: string,
 ) {
   let lastError: unknown;
   for (const model of models) {
     try {
-      const result = await runSecondaryModel(input, model, prompt, content);
+      const result = await runSecondaryModel(
+        input,
+        model,
+        prompt,
+        content,
+        parentSessionID,
+      );
       if (!isUsableSecondaryText(result.text)) {
         lastError = new Error('Secondary model returned no usable text');
         continue;

--- a/src/tools/smartfetch/tool.test.ts
+++ b/src/tools/smartfetch/tool.test.ts
@@ -2,6 +2,12 @@ import { afterEach, describe, expect, mock, test } from 'bun:test';
 import { CACHE } from './cache';
 import { createWebfetchTool } from './tool';
 
+let mockV2Client: Record<string, unknown>;
+
+mock.module('../../utils/opencode-client', () => ({
+  getClient: () => mockV2Client,
+}));
+
 function createExecutionContext() {
   return {
     ask: mock(async () => undefined),
@@ -119,5 +125,56 @@ describe('smartfetch/tool', () => {
     expect(secondResult).toContain(
       'requested_url: "https://example.com/docs#sec2"',
     );
+  });
+
+  test('passes ctx.sessionID as parentID to the secondary-model session', async () => {
+    const fetchMock = mock(async () => {
+      return new Response(
+        'Article about smartfetch: it fetches pages, extracts the main ' +
+          'content, caches results, and summarizes them with a secondary ' +
+          'model whenever a prompt is provided by the tool caller.',
+        { status: 200, headers: { 'content-type': 'text/plain' } },
+      );
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const session = {
+      create: mock(async () => ({ data: { id: 'secondary-session' } })),
+      prompt: mock(async () => ({
+        data: { parts: [{ type: 'text', text: 'Extracted answer' }] },
+      })),
+      delete: mock(async () => ({ data: true })),
+      abort: mock(async () => ({ data: true })),
+    };
+    const toolIds = { ids: mock(async () => ({ data: ['read'] })) };
+    mockV2Client = { session, tool: toolIds };
+
+    const webfetch = createWebfetchTool({ client: mockV2Client } as any, {
+      webfetchModels: [{ id: 'provider/small-model' }],
+    });
+    const ctx = createExecutionContext();
+    ctx.sessionID = 'main-session-id';
+    const result = await webfetch.execute(
+      {
+        url: 'https://example.com/article',
+        format: 'markdown',
+        extract_main: true,
+        prefer_llms_txt: 'auto',
+        include_metadata: false,
+        save_binary: false,
+        prompt: 'Extract the answer',
+      },
+      ctx,
+    );
+
+    expect(session.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          title: 'smartfetch-secondary',
+          parentID: 'main-session-id',
+        }),
+      }),
+    );
+    expect(result).toContain('Extracted answer');
   });
 });

--- a/src/tools/smartfetch/tool.ts
+++ b/src/tools/smartfetch/tool.ts
@@ -722,6 +722,7 @@ export function createWebfetchTool(
             secondaryModels,
             args.prompt || '',
             fetchResult.markdown,
+            ctx.sessionID,
           );
         } catch (error: unknown) {
           secondaryModelError =


### PR DESCRIPTION
Fixes #1046

## What problem are you solving?

Every `webfetch` call that uses secondary-model summarization pops a macOS notification "Session done — smartfetch-secondary" from the opencode TUI whenever the terminal is blurred. The secondary session is an ephemeral helper session the user never sees, but because it is created without a `parentID`, the TUI's `internal:notifications` plugin treats it like a first-class session and raises a "Session done" notification (it only suppresses notifications for sessions that have a `parentID`).

## What does this change?

- `runSecondaryModel` and `runSecondaryModelWithFallback` accept an optional `parentSessionID`.
- The smartfetch tool passes `ctx.sessionID` (the calling session) as `parentSessionID`.
- The secondary session is created with `parentID: parentSessionID`, so the TUI classifies it as a subagent session and suppresses the "Session done" notification — the same path used by `task`-spawned subagents.
- When `parentSessionID` is absent, the create body is byte-identical to before (safe degradation).
- Tests: `parentID` present in the create body when passed, absent when not; execute-level test asserting `ctx.sessionID` flows into the create body.

## Why this approach?

The secondary session is child work of the real session, so tagging it with the caller's `parentID` is semantically correct and matches how subagent sessions are already tracked. The TUI's notification suppression is keyed on `parentID`, so this is the minimal change that stops the noise without touching the TUI.

## Verification

- [x] `bun test src/tools/smartfetch/` — 50 pass (3 new, no regression)
- [x] `bun run typecheck` — clean
- [x] `bun x biome check` on all 4 changed files — clean