### PR TITLE
fix(task-result): return status for running background tasks

### DIFF
--- a/src/tools/task-result.test.ts
+++ b/src/tools/task-result.test.ts
@@ -85,7 +85,7 @@ describe('task_result', () => {
     ).resolves.toBe('final findings');
   });
 
-  test('rejects a still-running tracked task', async () => {
+  test('returns a non-error status for a still-running tracked task', async () => {
     const { board, tool, messages } = createTool();
     board.registerLaunch({
       taskID: 'ses_child1',
@@ -94,12 +94,14 @@ describe('task_result', () => {
       description: 'trace bug',
     });
 
-    await expect(
-      tool.execute({ task_id: 'exp-1' }, {
-        sessionID: 'parent-1',
-        agent: 'orchestrator',
-      } as any),
-    ).rejects.toThrow('still running');
+    const output = await tool.execute({ task_id: 'exp-1' }, {
+      sessionID: 'parent-1',
+      agent: 'orchestrator',
+    } as any);
+
+    expect(output).toContain('task_id: ses_child1');
+    expect(output).toContain('state: running');
+    expect(output).toContain('task_status');
     expect(messages).not.toHaveBeenCalled();
   });
 
@@ -122,13 +124,13 @@ describe('task_result', () => {
       data: { ses_child1: { type: 'busy' } },
     });
 
-    await expect(
-      tool.execute({ task_id: 'exp-1' }, {
-        sessionID: 'parent-1',
-        agent: 'orchestrator',
-      } as any),
-    ).rejects.toThrow('still running');
+    const output = await tool.execute({ task_id: 'exp-1' }, {
+      sessionID: 'parent-1',
+      agent: 'orchestrator',
+    } as any);
 
+    expect(output).toContain('state: running');
+    expect(output).toContain('task_status');
     expect(board.get('ses_child1')).toMatchObject({
       state: 'running',
       statusUncertain: false,
@@ -235,8 +237,7 @@ describe('task_result', () => {
         sessionID: 'parent-1',
         agent: 'orchestrator',
       } as any),
-    ).rejects.toThrow('still running');
-
+    ).rejects.toThrow('changed generation');
     expect(board.get('ses_child1')).toMatchObject({
       generation: first.generation + 1,
       state: 'running',
@@ -280,8 +281,7 @@ describe('task_result', () => {
         sessionID: 'parent-1',
         agent: 'orchestrator',
       } as any),
-    ).rejects.toThrow('still running');
-
+    ).rejects.toThrow('changed generation');
     expect(board.get('ses_child1')?.state).toBe('running');
   });
 
@@ -309,33 +309,36 @@ describe('task_result', () => {
     expect(messages).not.toHaveBeenCalled();
   });
 
-  test('rejects an untracked child whose live session is busy', async () => {
+  test('returns a status for an untracked child whose live session is busy', async () => {
     const { tool, messages } = createTool();
     mockClient.session.status.mockImplementation(async () => ({
       data: { ses_child1: { type: 'busy' } },
     }));
 
-    await expect(
-      tool.execute({ task_id: 'ses_child1' }, {
-        sessionID: 'parent-1',
-        agent: 'orchestrator',
-      } as any),
-    ).rejects.toThrow('still running');
+    const output = await tool.execute({ task_id: 'ses_child1' }, {
+      sessionID: 'parent-1',
+      agent: 'orchestrator',
+    } as any);
+
+    expect(output).toContain('task_id: ses_child1');
+    expect(output).toContain('state: running');
+    expect(output).toContain('task_status');
     expect(messages).not.toHaveBeenCalled();
   });
 
-  test('rejects an untracked child whose live session is retrying', async () => {
+  test('returns a status for an untracked child whose live session is retrying', async () => {
     const { tool, messages } = createTool();
     mockClient.session.status.mockImplementation(async () => ({
       data: { ses_child1: { type: 'retry' } },
     }));
 
-    await expect(
-      tool.execute({ task_id: 'ses_child1' }, {
-        sessionID: 'parent-1',
-        agent: 'orchestrator',
-      } as any),
-    ).rejects.toThrow('still running');
+    const output = await tool.execute({ task_id: 'ses_child1' }, {
+      sessionID: 'parent-1',
+      agent: 'orchestrator',
+    } as any);
+
+    expect(output).toContain('state: retry');
+    expect(output).toContain('task_status');
     expect(messages).not.toHaveBeenCalled();
   });
 

--- a/src/tools/task-result.test.ts
+++ b/src/tools/task-result.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, mock, test } from 'bun:test';
 import { BackgroundJobBoard } from '../utils/background-job-board';
 import { buildPluginInput } from '../v2/client-shim';
 import { createTaskResultTool } from './task-result';
+import { createTaskStatusTool } from './task-status';
 
 let mockClient: Record<string, any>;
 
@@ -26,11 +27,22 @@ function createTool() {
   const status = mock(async () => ({ data: {} }));
   mockClient = { session: { get, messages, status } };
 
+  const input = { directory: '/test/project' } as any;
   const tools = createTaskResultTool({
-    input: { directory: '/test/project' } as any,
+    input,
     backgroundJobBoard: board,
   });
-  return { board, get, messages, tool: tools.task_result };
+  const statusTools = createTaskStatusTool({
+    input,
+    backgroundJobBoard: board,
+  });
+  return {
+    board,
+    get,
+    messages,
+    statusTool: statusTools.task_status,
+    tool: tools.task_result,
+  };
 }
 
 describe('task_result', () => {
@@ -86,7 +98,7 @@ describe('task_result', () => {
   });
 
   test('returns a non-error status for a still-running tracked task', async () => {
-    const { board, tool, messages } = createTool();
+    const { board, tool, statusTool, messages } = createTool();
     board.registerLaunch({
       taskID: 'ses_child1',
       parentSessionID: 'parent-1',
@@ -99,9 +111,42 @@ describe('task_result', () => {
       agent: 'orchestrator',
     } as any);
 
-    expect(output).toContain('task_id: ses_child1');
-    expect(output).toContain('state: running');
-    expect(output).toContain('task_status');
+    expect(output).toBe(
+      [
+        'task_id: ses_child1',
+        'state: running',
+        'message: Task is still running. Wait for its terminal result.',
+        'next: use task_status to inspect the task',
+      ].join('\n'),
+    );
+    await expect(
+      statusTool.execute({ task_id: 'exp-1' }, {
+        sessionID: 'parent-1',
+        agent: 'orchestrator',
+      } as any),
+    ).resolves.toContain('state: running');
+    expect(messages).not.toHaveBeenCalled();
+  });
+
+  test('preserves a live retry state for a tracked running task', async () => {
+    const { board, tool, messages } = createTool();
+    board.registerLaunch({
+      taskID: 'ses_child1',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+      description: 'trace bug',
+    });
+    mockClient.session.status.mockResolvedValue({
+      data: { ses_child1: { type: 'retry' } },
+    });
+
+    const output = await tool.execute({ task_id: 'exp-1' }, {
+      sessionID: 'parent-1',
+      agent: 'orchestrator',
+    } as any);
+
+    expect(output).toContain('state: retry');
+    expect(output).toContain('next: use task_status to inspect the task');
     expect(messages).not.toHaveBeenCalled();
   });
 
@@ -320,10 +365,31 @@ describe('task_result', () => {
       agent: 'orchestrator',
     } as any);
 
-    expect(output).toContain('task_id: ses_child1');
-    expect(output).toContain('state: running');
-    expect(output).toContain('task_status');
+    expect(output).toBe(
+      [
+        'task_id: ses_child1',
+        'state: running',
+        'message: Task is still running. Wait for its terminal result.',
+        'next: retry task_result after the task finishes',
+      ].join('\n'),
+    );
     expect(messages).not.toHaveBeenCalled();
+
+    mockClient.session.status.mockResolvedValue({ data: {} });
+    mockClient.session.messages.mockResolvedValue({
+      data: [
+        {
+          info: { role: 'assistant', time: { completed: 100 } },
+          parts: [{ type: 'text', text: 'final findings' }],
+        },
+      ],
+    });
+    await expect(
+      tool.execute({ task_id: 'ses_child1' }, {
+        sessionID: 'parent-1',
+        agent: 'orchestrator',
+      } as any),
+    ).resolves.toBe('final findings');
   });
 
   test('returns a status for an untracked child whose live session is retrying', async () => {
@@ -338,7 +404,8 @@ describe('task_result', () => {
     } as any);
 
     expect(output).toContain('state: retry');
-    expect(output).toContain('task_status');
+    expect(output).toContain('next: retry task_result after the task finishes');
+    expect(output).not.toContain('task_status');
     expect(messages).not.toHaveBeenCalled();
   });
 

--- a/src/tools/task-result.ts
+++ b/src/tools/task-result.ts
@@ -59,12 +59,16 @@ function getTrackedTerminalState(
   return job.state === 'reconciled' ? job.terminalState : job.state;
 }
 
-function formatRunningTaskStatus(taskID: string, state = 'running'): string {
+function formatRunningTaskStatus(
+  taskID: string,
+  state: 'running' | 'retry',
+  tracked: boolean,
+): string {
   return [
     `task_id: ${taskID}`,
     `state: ${state}`,
     'message: Task is still running. Wait for its terminal result.',
-    'next: use task_status to inspect the task',
+    `next: ${tracked ? 'use task_status to inspect the task' : 'retry task_result after the task finishes'}`,
   ].join('\n');
 }
 
@@ -95,13 +99,11 @@ export function createTaskResultTool(
   options: TaskResultToolOptions,
 ): Record<string, ToolDefinition> {
   const task_result = tool({
-    description: `Retrieve the final text already produced by a specialist task without resuming or re-running it.
+    description: `Retrieve the final text already produced by a specialist task, or inspect its active state without resuming or re-running it.
 
-Use this when the user asks to see a prior task's full result, or before retrying work whose completed output may already answer the request. Accepts either the native task_id/session ID or the parent-scoped alias shown in the Background Job Board. This tool is read-only and never sends a new prompt to the specialist.`,
+Use this when the user asks to see a prior task's full result, or before retrying work whose completed output may already answer the request. If the task is still running, this returns a status message; only a completed task returns its final text. Accepts either the native task_id/session ID or the parent-scoped alias shown in the Background Job Board. This tool is read-only and never sends a new prompt to the specialist.`,
     args: {
-      task_id: z
-        .string()
-        .describe('Completed task ID or Background Job Board alias'),
+      task_id: z.string().describe('Task ID or Background Job Board alias'),
     },
     async execute(args, toolContext) {
       const parentSessionID = toolContext?.sessionID;
@@ -151,13 +153,23 @@ Use this when the user asks to see a prior task's full result, or before retryin
       }
 
       revalidateTracked();
-      if (tracked && getTrackedTerminalState(tracked) === 'running') {
-        return formatRunningTaskStatus(tracked.taskID);
-      }
 
       const taskID = tracked?.taskID ?? requested;
       if (!SESSION_ID_PATTERN.test(taskID)) {
         throw new Error(`Unknown task ID or alias: ${requested}`);
+      }
+
+      if (tracked && getTrackedTerminalState(tracked) === 'running') {
+        liveSnapshot ??= await getRuntimeSessionStatusSnapshot(options.input);
+        revalidateTracked();
+        if (tracked && getTrackedTerminalState(tracked) === 'running') {
+          const status = runtimeSessionStatus(liveSnapshot, taskID);
+          return formatRunningTaskStatus(
+            taskID,
+            status === 'retry' ? 'retry' : 'running',
+            true,
+          );
+        }
       }
 
       const client = getClient(options.input);
@@ -180,27 +192,23 @@ Use this when the user asks to see a prior task's full result, or before retryin
       }
 
       revalidateTracked();
-      if (tracked && getTrackedTerminalState(tracked) === 'running') {
-        return formatRunningTaskStatus(tracked.taskID);
-      }
       liveSnapshot ??= await getRuntimeSessionStatusSnapshot(options.input);
       revalidateTracked();
-      if (tracked && getTrackedTerminalState(tracked) === 'running') {
-        return formatRunningTaskStatus(tracked.taskID);
-      }
       const status = runtimeSessionStatus(liveSnapshot, taskID);
       const trackedTerminalState = tracked
-        ? tracked.state === 'reconciled'
-          ? tracked.terminalState
-          : tracked.state
+        ? getTrackedTerminalState(tracked)
         : undefined;
-      if (
-        (status === 'busy' || status === 'retry') &&
-        trackedTerminalState !== 'completed'
-      ) {
+      const activeState =
+        status === 'retry'
+          ? 'retry'
+          : status === 'busy' || trackedTerminalState === 'running'
+            ? 'running'
+            : undefined;
+      if (activeState !== undefined && trackedTerminalState !== 'completed') {
         return formatRunningTaskStatus(
           taskID,
-          status === 'retry' ? 'retry' : 'running',
+          activeState,
+          tracked !== undefined,
         );
       }
 

--- a/src/tools/task-result.ts
+++ b/src/tools/task-result.ts
@@ -26,22 +26,17 @@ interface TaskResultToolOptions {
 /**
  * Gate tracked task retrieval on the tracked terminal outcome. Only a
  * `completed` state (or a reconciled job whose terminal outcome was
- * `completed`) may yield a successful result; running, errored and cancelled
- * jobs are rejected explicitly and accurately instead of leaking partial
- * output as a final result.
+ * `completed`) may yield a successful result. Errored, cancelled and otherwise
+ * unconfirmed jobs are rejected instead of leaking partial output as a final
+ * result.
  */
 function assertRetrievableState(
   requested: string,
   job: BackgroundJobRecord,
 ): void {
-  const terminalState =
-    job.state === 'reconciled' ? job.terminalState : job.state;
+  const terminalState = getTrackedTerminalState(job);
 
-  if (terminalState === 'running') {
-    throw new Error(
-      `Task ${requested} is still running. Wait for its terminal result instead of retrieving or duplicating it.`,
-    );
-  }
+  if (terminalState === 'running') return;
   if (terminalState === 'error') {
     throw new Error(
       `Task ${requested} ended in error: ${job.lastStatusError ?? job.resultSummary ?? 'no error details available'}`,
@@ -56,6 +51,21 @@ function assertRetrievableState(
   if (terminalState !== 'completed') {
     throw new Error(`Task ${requested} has no confirmed completed result`);
   }
+}
+
+function getTrackedTerminalState(
+  job: BackgroundJobRecord,
+): BackgroundJobRecord['state'] | BackgroundJobRecord['terminalState'] {
+  return job.state === 'reconciled' ? job.terminalState : job.state;
+}
+
+function formatRunningTaskStatus(taskID: string, state = 'running'): string {
+  return [
+    `task_id: ${taskID}`,
+    `state: ${state}`,
+    'message: Task is still running. Wait for its terminal result.',
+    'next: use task_status to inspect the task',
+  ].join('\n');
 }
 
 function assertStableTrackedGeneration(
@@ -141,6 +151,9 @@ Use this when the user asks to see a prior task's full result, or before retryin
       }
 
       revalidateTracked();
+      if (tracked && getTrackedTerminalState(tracked) === 'running') {
+        return formatRunningTaskStatus(tracked.taskID);
+      }
 
       const taskID = tracked?.taskID ?? requested;
       if (!SESSION_ID_PATTERN.test(taskID)) {
@@ -167,8 +180,14 @@ Use this when the user asks to see a prior task's full result, or before retryin
       }
 
       revalidateTracked();
+      if (tracked && getTrackedTerminalState(tracked) === 'running') {
+        return formatRunningTaskStatus(tracked.taskID);
+      }
       liveSnapshot ??= await getRuntimeSessionStatusSnapshot(options.input);
       revalidateTracked();
+      if (tracked && getTrackedTerminalState(tracked) === 'running') {
+        return formatRunningTaskStatus(tracked.taskID);
+      }
       const status = runtimeSessionStatus(liveSnapshot, taskID);
       const trackedTerminalState = tracked
         ? tracked.state === 'reconciled'
@@ -179,8 +198,9 @@ Use this when the user asks to see a prior task's full result, or before retryin
         (status === 'busy' || status === 'retry') &&
         trackedTerminalState !== 'completed'
       ) {
-        throw new Error(
-          `Task ${requested} is still running. Wait for its terminal result instead of retrieving or duplicating it.`,
+        return formatRunningTaskStatus(
+          taskID,
+          status === 'retry' ? 'retry' : 'running',
         );
       }
 


### PR DESCRIPTION
Fixes #1039

## What problem are you solving?

When the Orchestrator calls `task_result` for a background task that is still running, the tool throws an exception. OpenCode renders that exception as a red TUI error block even though the child task continues running successfully.

## What does this change?

- Return a clean status message for tracked `running` and `retry` tasks before reading child messages.
- Recommend `task_status` only for tasks registered in the Background Job Board.
- Tell untracked live sessions to retry `task_result` after the task finishes.
- Keep completed tasks returning their final text.
- Preserve error, cancelled, partial-result, and generation-integrity protections.
- Document the active-state response in the tool description.
- Add regression coverage for actionable tracked and untracked guidance, including tracked retry state.

## Why this approach?

The Job Board and runtime status endpoint already distinguish active tasks from terminal results. Returning that existing state removes the misleading UI error without weakening the checks that prevent partial output from being presented as a completed result. The change stays scoped to `task-result` and does not alter Orchestrator prompts or generated files.

## Verification

- [x] `bun test src/tools` — 130 passed
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `bunx biome check src/tools/task-result.ts src/tools/task-result.test.ts` — clean
- [x] `git diff --check` — clean
- `bun test` — 2133 passed; 4 unrelated interview dashboard integration tests currently fail