### PR TITLE
fix(task_message): preserve the child agent when queueing messages

### DIFF
--- a/src/tools/task-message.test.ts
+++ b/src/tools/task-message.test.ts
@@ -55,6 +55,7 @@ describe('task_message', () => {
     expect(prompt).toHaveBeenCalledWith({
       path: { id: 'ses_child1' },
       body: {
+        agent: 'fixer',
         noReply: true,
         parts: [{ type: 'text', text: 'Please continue.' }],
       },

--- a/src/tools/task-message.ts
+++ b/src/tools/task-message.ts
@@ -82,7 +82,7 @@ export function createTaskMessageTool(options: {
 
         const session = getClient(options.input).session;
         const prompt = session.prompt.bind(session);
-        getCurrentTaskMessageJob(
+        const transportJob = getCurrentTaskMessageJob(
           options.backgroundJobBoard,
           parentSessionID,
           requested,
@@ -96,6 +96,7 @@ export function createTaskMessageTool(options: {
             prompt({
               path: { id: lease.taskID },
               body: {
+                agent: transportJob.agent,
                 noReply: true,
                 parts: [{ type: 'text', text: args.message.trim() }],
               },


### PR DESCRIPTION
## Summary
- preserve the tracked child agent when `task_message` queues a message
- extend the existing transport test to assert the forwarded agent

## Problem
`task_message` resolves and validates the current `BackgroundJobRecord`, which already contains the authoritative child `agent`. However, the subsequent `session.prompt(...)` call only supplies `noReply` and the text part. Without an explicit agent, the queued child message can inherit the parent orchestrator identity instead of the tracked child identity.

## Change
Use the job returned by the final generation/ownership check and pass its agent to the prompt transport. This keeps the existing lease, generation, cancellation, and no-reply behavior unchanged.

## Scope
This PR preserves only the authoritative child agent already stored by the background job board. It does not change model/variant selection or lifecycle semantics.

## Verification
- `bun test src/tools/task-message.test.ts` — 10 passed
- `bun run typecheck`
- `bunx biome check src/tools/task-message.ts src/tools/task-message.test.ts`
- `git diff --check`
