### PR TITLE
fix(agents): remove default temperatures

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -113,7 +113,7 @@ Presets can also be switched at runtime without restarting using the `/preset` c
 | `presets` | object | - | Named preset configurations |
 |-----------|--------|---|-----------------------------|
 | `presets.<name>.<agent>.model` | string | - | Model ID in `provider/model` format |
-| `presets.<name>.<agent>.temperature` | number | - | Temperature (0–2) |
+| `presets.<name>.<agent>.temperature` | number | - | Optional temperature (0–2); when omitted, OpenCode chooses its default |
 | `presets.<name>.<agent>.variant` | string | - | Reasoning effort: `"low"`, `"medium"`, `"high"`, or `"max"` (provider-specific) |
 | `presets.<name>.<agent>.displayName` | string | - | Custom user-facing alias for the agent (e.g. `"advisor"` for `oracle`) |
 | `presets.<name>.<agent>.skills` | string[] | - | Skills the agent can use (`"*"`, `"!item"`, explicit list) |

--- a/src/agents/council.ts
+++ b/src/agents/council.ts
@@ -77,7 +77,6 @@ export function createCouncilAgent(
       'Multi-model consensus agent that synthesizes viewpoints from council members to make informed decisions with higher confidence than single models',
     config: {
       model,
-      temperature: 0.1,
       prompt,
       permission: {
         ...createSynthesisOnlyPermission(),

--- a/src/agents/councillor.test.ts
+++ b/src/agents/councillor.test.ts
@@ -17,9 +17,9 @@ describe('createCouncillorAgent', () => {
     expect(agent.config.model).toBe('custom-model');
   });
 
-  test('sets temperature to 0.2', () => {
+  test('leaves temperature unset', () => {
     const agent = createCouncillorAgent('test-model');
-    expect(agent.config.temperature).toBe(0.2);
+    expect(agent.config.temperature).toBeUndefined();
   });
 
   test('sets default prompt when no custom prompts provided', () => {

--- a/src/agents/councillor.ts
+++ b/src/agents/councillor.ts
@@ -72,7 +72,6 @@ export function createCouncillorAgent(
     config: {
       model,
       variant,
-      temperature: 0.2,
       prompt,
       // Strict read-only allowlist: deny all, then allow inspection tools only.
       permission: createReadOnlyAgentPermission(),

--- a/src/agents/designer.ts
+++ b/src/agents/designer.ts
@@ -84,7 +84,6 @@ export function createDesignerAgent(
       'UI/UX design, review, and implementation. Use for styling, responsive design, component architecture and visual polish.',
     config: {
       model,
-      temperature: 0.7,
       prompt,
     },
   };

--- a/src/agents/explorer.ts
+++ b/src/agents/explorer.ts
@@ -52,7 +52,6 @@ export function createExplorerAgent(
       "Fast codebase search and pattern matching. Use for finding files, locating code patterns, and answering 'where is X?' questions.",
     config: {
       model,
-      temperature: 0.1,
       prompt,
     },
   };

--- a/src/agents/fixer.ts
+++ b/src/agents/fixer.ts
@@ -59,7 +59,6 @@ export function createFixerAgent(
       'Fast implementation specialist. Receives complete context and task spec, executes code changes efficiently.',
     config: {
       model,
-      temperature: 0.2,
       prompt,
     },
   };

--- a/src/agents/index.test.ts
+++ b/src/agents/index.test.ts
@@ -630,6 +630,58 @@ describe('getAgentConfigs', () => {
     expect(configs.orchestrator.description).toBeDefined();
     expect(configs.explorer.description).toBeDefined();
   });
+
+  test('omits temperature from default SDK agent configs', () => {
+    const configs = getAgentConfigs(
+      runtimeFor({
+        disabled_agents: [],
+        council: councilConfig(),
+        agents: {
+          reviewer: { model: 'test/reviewer' },
+        },
+        acpAgents: {
+          bridge: {
+            command: 'bridge-acp',
+            args: [],
+            env: {},
+            timeoutMs: 0,
+            permissionMode: 'ask',
+          },
+        },
+      }),
+    );
+
+    for (const name of [
+      'orchestrator',
+      'explorer',
+      'librarian',
+      'oracle',
+      'designer',
+      'fixer',
+      'observer',
+      'council',
+      'councillor',
+      'councillor-alpha',
+      'reviewer',
+      'bridge',
+    ]) {
+      expect(Object.hasOwn(configs[name], 'temperature')).toBe(false);
+    }
+  });
+
+  test('passes explicit temperature overrides to the SDK config', () => {
+    const configs = getAgentConfigs(
+      runtimeFor({
+        agents: {
+          explorer: { temperature: 0.5 },
+          fixer: { temperature: 0 },
+        },
+      }),
+    );
+
+    expect(configs.explorer.temperature).toBe(0.5);
+    expect(configs.fixer.temperature).toBe(0);
+  });
 });
 
 describe('council agent model resolution', () => {

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -104,7 +104,6 @@ function buildAcpAgentDefinition(
     description,
     config: {
       model: config.wrapperModel ?? fallbackModel ?? DEFAULT_MODELS.oracle,
-      temperature: 0,
       prompt,
       permission: {
         read: 'deny',
@@ -227,7 +226,6 @@ function buildCustomAgentDefinition(
     description,
     config: {
       model: primaryModel ?? DEFAULT_MODELS.oracle,
-      temperature: 0.2,
       prompt: resolvePrompt(
         name,
         override.prompt,

--- a/src/agents/librarian.ts
+++ b/src/agents/librarian.ts
@@ -43,7 +43,6 @@ export function createLibrarianAgent(
       'External documentation and library research. Use for official docs lookup, GitHub examples, and understanding library internals.',
     config: {
       model,
-      temperature: 0.1,
       prompt,
     },
   };

--- a/src/agents/observer.ts
+++ b/src/agents/observer.ts
@@ -41,7 +41,6 @@ export function createObserverAgent(
       'Visual analysis. Use for interpreting images, screenshots, PDFs, and diagrams - extracts structured observations without loading raw files into main context. Requires a vision-capable model.',
     config: {
       model,
-      temperature: 0.1,
       prompt,
     },
   };

--- a/src/agents/oracle.ts
+++ b/src/agents/oracle.ts
@@ -46,7 +46,6 @@ export function createOracleAgent(
       'Strategic technical advisor. Use for architecture decisions, complex debugging, code review, simplification, and engineering guidance.',
     config: {
       model,
-      temperature: 0.1,
       prompt,
     },
   };

--- a/src/agents/orchestrator.ts
+++ b/src/agents/orchestrator.ts
@@ -336,7 +336,6 @@ export function createOrchestratorAgent(
     description:
       'AI coding orchestrator that delegates tasks to specialist agents for optimal quality, speed, and cost',
     config: {
-      temperature: 0.1,
       prompt,
     },
   };

--- a/src/v2/adapters.test.ts
+++ b/src/v2/adapters.test.ts
@@ -167,6 +167,24 @@ describe('applyAgentToDraft', () => {
     });
   });
 
+  test('omits an unspecified temperature from request settings', () => {
+    const { draft, calls } = recorder();
+    applyAgentToDraft(draft, 'a', {});
+
+    const request = calls[0].agent.request as Record<string, unknown>;
+    expect(
+      Object.hasOwn(request.settings as Record<string, unknown>, 'temperature'),
+    ).toBe(false);
+  });
+
+  test('passes an explicit temperature to request settings', () => {
+    const { draft, calls } = recorder();
+    applyAgentToDraft(draft, 'a', { temperature: 0 });
+
+    const request = calls[0].agent.request as Record<string, unknown>;
+    expect((request.settings as Record<string, unknown>).temperature).toBe(0);
+  });
+
   test('permission deny beats tools-list allow (tools first, last-wins)', () => {
     const { draft, calls } = recorder();
     applyAgentToDraft(draft, 'a', {


### PR DESCRIPTION
## Summary
- omit built-in, custom, and ACP agent temperatures unless explicitly configured
- preserve explicit config and v2 request-settings overrides
- document that omitted temperatures use OpenCode defaults

## Verification
- bun test src/agents/index.test.ts src/agents/councillor.test.ts src/v2/adapters.test.ts
- bun run typecheck
- bun run build