### PR TITLE
fix(tui): support opencode2 beta-17793 { id, setup } TUI plugin contract

### DIFF
--- a/src/tui.test.ts
+++ b/src/tui.test.ts
@@ -272,13 +272,12 @@ describe('tmux pane registration', () => {
       ownerPid: 100,
       lastRecordedAt: 0,
     };
-    const api = {
-      route: {
-        current: { name: 'session', params: { sessionID: 'root-session-b' } },
-      },
-    };
 
-    syncTmuxPaneRegistration(api as never, registration, 1_000);
+    syncTmuxPaneRegistration(
+      { name: 'session', params: { sessionID: 'root-session-b' } },
+      registration,
+      1_000,
+    );
 
     expect(readTmuxPane('root-session-b', 1_000)).toBe('%42');
   });
@@ -288,18 +287,29 @@ describe('tmux pane registration', () => {
       ownerPid: 100,
       lastRecordedAt: 0,
     };
-    const api = {
-      route: {
-        current: { name: 'session', params: { sessionID: 'root-a' } },
-      },
-    };
+    const route = { name: 'session', params: { sessionID: 'root-a' } };
 
-    syncTmuxPaneRegistration(api as never, registration, 1_000);
-    api.route.current.params.sessionID = 'root-b';
-    syncTmuxPaneRegistration(api as never, registration, 2_000);
+    syncTmuxPaneRegistration(route, registration, 1_000);
+    route.params.sessionID = 'root-b';
+    syncTmuxPaneRegistration(route, registration, 2_000);
 
     expect(readTmuxPane('root-a', 2_000)).toBeUndefined();
     expect(readTmuxPane('root-b', 2_000)).toBe('%42');
+  });
+
+  test('accepts the v2 route shape ({ type, sessionID })', () => {
+    const registration: ActiveTmuxPaneRegistration = {
+      ownerPid: 100,
+      lastRecordedAt: 0,
+    };
+
+    syncTmuxPaneRegistration(
+      { type: 'session', sessionID: 'v2-session' },
+      registration,
+      1_000,
+    );
+
+    expect(readTmuxPane('v2-session', 1_000)).toBe('%42');
   });
 });
 
@@ -345,5 +355,99 @@ describe('getContrastForeground', () => {
   test('parses hex string colors correctly', () => {
     const result = getContrastForeground('#ffffff', '#ffffff', '#1e1e1e');
     expect(result).toBe('#1e1e1e');
+  });
+});
+
+describe('dual-contract plugin module', () => {
+  let originalEnv: typeof process.env;
+
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+    delete process.env.OH_MY_OPENCODE_SLIM_DISABLE;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  function createV2Context(directory: string) {
+    const slotClaims: Array<{
+      append?: string;
+      render: (input: { sessionID: string }) => unknown;
+    }> = [];
+    let disposeCalls = 0;
+    const ctx = {
+      location: { directory },
+      renderer: { requestRender: () => {} },
+      theme: {
+        text: { default: '#f0f0f0', subdued: '#8a8a8a' },
+        background: { default: '#101010' },
+        border: { default: '#3a3a3a' },
+      },
+      ui: {
+        slot: (claim: (typeof slotClaims)[number]) => {
+          slotClaims.push(claim);
+          return () => {
+            disposeCalls += 1;
+          };
+        },
+        router: {
+          current: () => ({ type: 'home' }) as {
+            type?: string;
+            sessionID?: string;
+          },
+        },
+      },
+    };
+    return {
+      ctx,
+      slotClaims,
+      getDisposeCalls: () => disposeCalls,
+    };
+  }
+
+  type V2Context = Parameters<typeof tuiPlugin.setup>[0];
+
+  test('exposes the dual contract shape', () => {
+    expect(typeof tuiPlugin.id).toBe('string');
+    expect(tuiPlugin.id.length).toBeGreaterThan(0);
+    expect(typeof tuiPlugin.tui).toBe('function');
+    expect(typeof tuiPlugin.setup).toBe('function');
+  });
+
+  test('setup registers one sidebar.content slot and cleanup disposes it', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'omos-tui-v2-'));
+    let cleanup: (() => void) | undefined;
+    try {
+      const { ctx, slotClaims, getDisposeCalls } = createV2Context(tempDir);
+      cleanup = (await tuiPlugin.setup(
+        ctx as unknown as V2Context,
+      )) as () => void;
+
+      expect(slotClaims).toHaveLength(1);
+      expect(slotClaims[0]?.append).toBe('sidebar.content');
+      expect(typeof slotClaims[0]?.render).toBe('function');
+      expect(getDisposeCalls()).toBe(0);
+
+      cleanup();
+      expect(getDisposeCalls()).toBe(1);
+    } finally {
+      cleanup?.();
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test('setup returns early without registering a slot when disabled by env', async () => {
+    process.env.OH_MY_OPENCODE_SLIM_DISABLE = '1';
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'omos-tui-v2-'));
+    try {
+      const { ctx, slotClaims } = createV2Context(tempDir);
+      const cleanup = await tuiPlugin.setup(ctx as unknown as V2Context);
+
+      expect(slotClaims).toHaveLength(0);
+      expect(cleanup).toBeUndefined();
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -1,7 +1,7 @@
 import type {
   TuiCommand,
+  TuiPlugin,
   TuiPluginApi,
-  TuiPluginModule,
 } from '@opencode-ai/plugin/tui';
 import { type ColorInput, parseColor, RGBA } from '@opentui/core';
 import type { JSX } from '@opentui/solid';
@@ -87,6 +87,41 @@ export interface ActiveTmuxPaneRegistration {
   lastRecordedAt: number;
 }
 
+/**
+ * Route views accepted by `syncTmuxPaneRegistration`. OpenCode v1 exposes
+ * `{ name, params: { sessionID } }` while opencode2 exposes
+ * `{ type: 'session', sessionID }`; both are normalized internally.
+ *
+ * `params.sessionID` is typed `unknown` because the v1 host type allows
+ * arbitrary `Record<string, unknown>` params; the runtime typeof guard
+ * below keeps normalization safe.
+ */
+export type TuiRouteView =
+  | {
+      name?: string;
+      params?: { sessionID?: unknown };
+    }
+  | {
+      type?: string;
+      sessionID?: string;
+    };
+
+function resolveRouteSessionId(route: TuiRouteView): string | undefined {
+  const view = route as {
+    name?: string;
+    params?: { sessionID?: unknown };
+    type?: string;
+    sessionID?: string;
+  };
+  if (view.name === 'session' && typeof view.params?.sessionID === 'string') {
+    return view.params.sessionID;
+  }
+  if (view.type === 'session' && typeof view.sessionID === 'string') {
+    return view.sessionID;
+  }
+  return undefined;
+}
+
 function clearTmuxPaneRegistration(
   registration: ActiveTmuxPaneRegistration,
 ): void {
@@ -103,19 +138,12 @@ function clearTmuxPaneRegistration(
 }
 
 export function syncTmuxPaneRegistration(
-  api: Pick<TuiPluginApi, 'route'>,
+  route: TuiRouteView,
   registration: ActiveTmuxPaneRegistration,
   now = Date.now(),
 ): void {
   const paneId = process.env.TMUX_PANE;
-  const route = api.route.current;
-  const routeParams = 'params' in route ? route.params : undefined;
-  const sessionId =
-    route.name === 'session' &&
-    routeParams &&
-    typeof routeParams.sessionID === 'string'
-      ? routeParams.sessionID
-      : undefined;
+  const sessionId = resolveRouteSessionId(route);
   const unchanged =
     registration.sessionId === sessionId && registration.paneId === paneId;
 
@@ -384,6 +412,117 @@ export function readCompactSidebar(directory: string): boolean {
 }
 
 /**
+ * Local structural subset of the OpenCode v2 TUI plugin context, mirroring
+ * `@opencode-ai/plugin@0.0.0-beta-17793` `dist/tui/context.d.ts`. These
+ * types are declared locally because the pinned dependency (1.18.13) still
+ * ships the old v1 TUI types.
+ */
+interface V2TuiThemeTokens {
+  text: { default: unknown; subdued: unknown };
+  background: { default: unknown };
+  border: { default: unknown };
+}
+
+interface V2TuiSlotClaim {
+  append?: string;
+  prepend?: string;
+  before?: string;
+  after?: string;
+  replace?: string;
+  render: (input: { sessionID: string }) => JSX.Element;
+}
+
+interface V2TuiContext {
+  location?: { directory: string };
+  renderer: { requestRender: () => void };
+  theme: V2TuiThemeTokens;
+  ui: {
+    slot: (claim: V2TuiSlotClaim) => () => void;
+    router: { current: () => { type?: string; sessionID?: string } };
+  };
+}
+
+/**
+ * Map the v2 resolved theme tokens onto the flat theme shape that
+ * `renderSidebar` consumes. v2 has no `accent` token, so the badge renders
+ * without a chip background (`element()` skips undefined props).
+ */
+function v2ThemeView(theme: V2TuiThemeTokens): {
+  accent: undefined;
+  background: unknown;
+  borderActive: unknown;
+  text: unknown;
+  textMuted: unknown;
+} {
+  return {
+    accent: undefined,
+    background: theme.background.default,
+    borderActive: theme.border.default,
+    text: theme.text.default,
+    textMuted: theme.text.subdued,
+  };
+}
+
+/**
+ * OpenCode v2 TUI plugin entry point (`setup(context)` contract). Mirrors
+ * the v1 `tui` hook behavior for the sidebar and tmux pane registration:
+ * a 1000ms interval refreshes the snapshot, follows config directory
+ * changes, heartbeats the tmux pane registration, and requests a render.
+ *
+ * No command/preset registration happens here: `/preset` relies on the
+ * legacy `api.command` API which does not exist on v2.
+ *
+ * Returns a cleanup function disposing the slot, the interval timer, and
+ * the tmux pane registration.
+ */
+async function setup(ctx: V2TuiContext): Promise<void | (() => void)> {
+  if (isPluginDisabledByEnv()) return;
+
+  const version = (await readPackageVersion()) ?? 'dev';
+  let configDirectory = ctx.location?.directory ?? process.cwd();
+  let { configInvalid, compactSidebar } = readConfigState(configDirectory);
+  let snapshot = readTuiSnapshot(configDirectory);
+  const tmuxRegistration: ActiveTmuxPaneRegistration = {
+    ownerPid: process.pid,
+    lastRecordedAt: 0,
+  };
+  syncTmuxPaneRegistration(ctx.ui.router.current(), tmuxRegistration);
+  const renderTimer = setInterval(async () => {
+    try {
+      const currentDirectory = ctx.location?.directory ?? process.cwd();
+      syncTmuxPaneRegistration(ctx.ui.router.current(), tmuxRegistration);
+      snapshot = await readTuiSnapshotAsync(currentDirectory);
+      if (currentDirectory !== configDirectory) {
+        configDirectory = currentDirectory;
+        ({ configInvalid, compactSidebar } =
+          readConfigState(configDirectory));
+      }
+      ctx.renderer.requestRender();
+    } catch {
+      // Ignore render errors; this is best-effort live status.
+    }
+  }, 1000);
+
+  const disposeSlot = ctx.ui.slot({
+    append: 'sidebar.content',
+    render: () =>
+      renderSidebar(
+        snapshot,
+        version,
+        v2ThemeView(ctx.theme),
+        configInvalid,
+        compactSidebar,
+      ),
+  });
+
+  return () => {
+    disposeSlot();
+    clearInterval(renderTimer);
+    clearTmuxPaneRegistration(tmuxRegistration);
+  };
+}
+
+/**
  * Build the TUI slash command for `/preset`. Registered via the legacy
  * `api.command` API (still populated in OpenCode 1.18 for v1 plugins). If the
  * API is unavailable the command is simply not registered and `/preset` is a
@@ -409,7 +548,22 @@ function buildPresetCommand(
   };
 }
 
-const plugin: TuiPluginModule & { id: string } = {
+/**
+ * Dual-contract TUI plugin module.
+ *
+ * OpenCode v1 hosts validate `{ id, tui }` and ignore extra keys, while
+ * opencode2 (beta-17793) validates `{ id, setup }` and ignores extra keys.
+ * The legacy `tui` hook is kept byte-for-byte for v1 hosts; `setup`
+ * implements the v2 contract. Shipping both fixes `Invalid V2 TUI plugin
+ * module: oh-my-opencode-slim` (upstream issue #1002).
+ */
+interface TuiDualContractModule {
+  id: string;
+  tui: TuiPlugin;
+  setup: (ctx: V2TuiContext) => Promise<void | (() => void)>;
+}
+
+const plugin: TuiDualContractModule = {
   id: `${PLUGIN_NAME}:tui`,
   tui: async (api, _options, meta) => {
     if (isPluginDisabledByEnv()) return;
@@ -422,11 +576,11 @@ const plugin: TuiPluginModule & { id: string } = {
       ownerPid: process.pid,
       lastRecordedAt: 0,
     };
-    syncTmuxPaneRegistration(api, tmuxRegistration);
+    syncTmuxPaneRegistration(api.route.current, tmuxRegistration);
     const renderTimer = setInterval(async () => {
       try {
         const currentDirectory = getTuiDirectory(api);
-        syncTmuxPaneRegistration(api, tmuxRegistration);
+        syncTmuxPaneRegistration(api.route.current, tmuxRegistration);
         snapshot = await readTuiSnapshotAsync(currentDirectory);
         if (currentDirectory !== configDirectory) {
           configDirectory = currentDirectory;
@@ -479,6 +633,7 @@ const plugin: TuiPluginModule & { id: string } = {
       api.lifecycle.onDispose(disposeCommands);
     }
   },
+  setup,
 };
 
 export default plugin;

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -87,15 +87,7 @@ export interface ActiveTmuxPaneRegistration {
   lastRecordedAt: number;
 }
 
-/**
- * Route views accepted by `syncTmuxPaneRegistration`. OpenCode v1 exposes
- * `{ name, params: { sessionID } }` while opencode2 exposes
- * `{ type: 'session', sessionID }`; both are normalized internally.
- *
- * `params.sessionID` is typed `unknown` because the v1 host type allows
- * arbitrary `Record<string, unknown>` params; the runtime typeof guard
- * below keeps normalization safe.
- */
+/** Route shapes accepted by `syncTmuxPaneRegistration`: v1 `{ name, params }` and v2 `{ type, sessionID }`. */
 export type TuiRouteView =
   | {
       name?: string;
@@ -411,12 +403,8 @@ export function readCompactSidebar(directory: string): boolean {
   return readConfigState(directory).compactSidebar;
 }
 
-/**
- * Local structural subset of the OpenCode v2 TUI plugin context, mirroring
- * `@opencode-ai/plugin@0.0.0-beta-17793` `dist/tui/context.d.ts`. These
- * types are declared locally because the pinned dependency (1.18.13) still
- * ships the old v1 TUI types.
- */
+// Mirrors @opencode-ai/plugin@0.0.0-beta-17793 dist/tui/context.d.ts;
+// declared locally because the pinned dep ships v1 types only.
 interface V2TuiThemeTokens {
   text: { default: unknown; subdued: unknown };
   background: { default: unknown };
@@ -442,11 +430,7 @@ interface V2TuiContext {
   };
 }
 
-/**
- * Map the v2 resolved theme tokens onto the flat theme shape that
- * `renderSidebar` consumes. v2 has no `accent` token, so the badge renders
- * without a chip background (`element()` skips undefined props).
- */
+/** Map v2 theme tokens onto the flat shape `renderSidebar` consumes (v2 has no `accent` token). */
 function v2ThemeView(theme: V2TuiThemeTokens): {
   accent: undefined;
   background: unknown;
@@ -464,16 +448,8 @@ function v2ThemeView(theme: V2TuiThemeTokens): {
 }
 
 /**
- * OpenCode v2 TUI plugin entry point (`setup(context)` contract). Mirrors
- * the v1 `tui` hook behavior for the sidebar and tmux pane registration:
- * a 1000ms interval refreshes the snapshot, follows config directory
- * changes, heartbeats the tmux pane registration, and requests a render.
- *
- * No command/preset registration happens here: `/preset` relies on the
- * legacy `api.command` API which does not exist on v2.
- *
- * Returns a cleanup function disposing the slot, the interval timer, and
- * the tmux pane registration.
+ * V2 entry point: sidebar slot + refresh loop; returns cleanup.
+ * `/preset` stays v1-only (`api.command` is absent on v2).
  */
 async function setup(ctx: V2TuiContext): Promise<void | (() => void)> {
   if (isPluginDisabledByEnv()) return;
@@ -487,11 +463,14 @@ async function setup(ctx: V2TuiContext): Promise<void | (() => void)> {
     lastRecordedAt: 0,
   };
   syncTmuxPaneRegistration(ctx.ui.router.current(), tmuxRegistration);
+  let disposed = false;
   const renderTimer = setInterval(async () => {
+    if (disposed) return;
     try {
       const currentDirectory = ctx.location?.directory ?? process.cwd();
       syncTmuxPaneRegistration(ctx.ui.router.current(), tmuxRegistration);
       snapshot = await readTuiSnapshotAsync(currentDirectory);
+      if (disposed) return;
       if (currentDirectory !== configDirectory) {
         configDirectory = currentDirectory;
         ({ configInvalid, compactSidebar } =
@@ -516,6 +495,7 @@ async function setup(ctx: V2TuiContext): Promise<void | (() => void)> {
   });
 
   return () => {
+    disposed = true;
     disposeSlot();
     clearInterval(renderTimer);
     clearTmuxPaneRegistration(tmuxRegistration);
@@ -549,13 +529,8 @@ function buildPresetCommand(
 }
 
 /**
- * Dual-contract TUI plugin module.
- *
- * OpenCode v1 hosts validate `{ id, tui }` and ignore extra keys, while
- * opencode2 (beta-17793) validates `{ id, setup }` and ignores extra keys.
- * The legacy `tui` hook is kept byte-for-byte for v1 hosts; `setup`
- * implements the v2 contract. Shipping both fixes `Invalid V2 TUI plugin
- * module: oh-my-opencode-slim` (upstream issue #1002).
+ * Dual contract: v1 hosts validate `{ id, tui }`, opencode2 validates
+ * `{ id, setup }`; both ignore extra keys. Fixes #1002.
  */
 interface TuiDualContractModule {
   id: string;


### PR DESCRIPTION
## Problem

opencode2 (`@opencode-ai/cli@0.0.0-beta-17793`) fails to load the plugin's TUI module:

```
Plugin failed: oh-my-opencode-slim
Invalid V2 TUI plugin module: oh-my-opencode-slim
```

Tracked in #1002 (multiple users confirmed this exact error).

## Root cause

The beta's V2 TUI plugin loader imports each registered package's `./tui` subpath and validates the default export as `{ id: string, setup: function }` (mirroring `@opencode-ai/plugin@0.0.0-beta-17793` `dist/tui/plugin.d.ts`), then calls `setup(context)` with a single context argument and treats the return value as cleanup.

The shipped module only exported the v1 contract `{ id, tui(api, options, meta) }`, so validation failed. OpenCode v1 hosts validate `{ id, tui }` and ignore extra keys — both contracts must be satisfied simultaneously from one module.

## Fix

Dual-contract default export `{ id, tui, setup }`:

- **`tui`** — v1 hook, byte-for-byte unchanged behavior (sidebar slot, `/preset` command, tmux pane sync). Only mechanical change: two call sites now pass `api.route.current` after generalizing `syncTmuxPaneRegistration`.
- **`setup`** — new v2 path reusing the same internals:
  - sidebar via `ctx.ui.slot({ append: 'sidebar.content', render })`
  - v2 `ResolvedTheme` tokens mapped onto the flat shape `renderSidebar` already consumes (`text.default→text`, `text.subdued→textMuted`, `border.default→borderActive`, `background.default→background`; v2 has no `accent` token so the badge renders without a chip background)
  - directory from `ctx.location?.directory`, render loop via `ctx.renderer.requestRender()`
  - returns cleanup disposing slot + timer + tmux registration
  - no `/preset` registration (legacy `api.command` doesn't exist on v2) — matches the documented compatibility matrix
- `syncTmuxPaneRegistration` accepts both route shapes (v1 `{name, params:{sessionID}}`, v2 `{type:'session', sessionID}`) with runtime guards.
- v2 context types declared locally, mirroring the beta's `context.d.ts` (pinned `@opencode-ai/plugin@1.18.13` still ships old types).

## Verification

- `tsc --noEmit`: clean
- `bun test`: 2164 pass / 0 fail (full suite), incl. new dual-contract tests (module shape, slot claim + dispose, disabled-env short-circuit)
- Live against `@opencode-ai/cli@0.0.0-beta-17793`: TUI starts with **no** plugin-failed toast; server-side v2 adapter registers all bridges (health check passed)

## Notes

- No dependency changes; only `src/tui.ts` + `src/tui.test.ts` touched.
- Docs unchanged: no user-facing command/config/output differences on v1; v2 sidebar behavior matches the existing compatibility doc.