### PR TITLE
fix(config): preserve legacy continueOnIdle opt-out

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -315,6 +315,12 @@ Set `enabled: false` to keep idle reconciliation and background-job orchestratio
 without periodic wake prompts. See the
 [Background Orchestration](background-orchestration.md) guide for the concept,
 defaults, and examples.
+
+Configurations that still use the removed `backgroundJobs.continueOnIdle` key
+emit a deprecation warning and migrate its boolean value to
+`orchestratorWake.enabled`. An `orchestratorWake.enabled` value in the same
+config file takes precedence; replace the legacy key with that setting.
+
 `wallClockTimeoutMs` is a hard deadline that only supervises explicitly
 background native task calls; foreground calls or calls with `background`
 omitted are not supervised. It is independent from OpenCode's external

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -605,6 +605,94 @@ describe('onWarning callback', () => {
     );
   });
 
+  test('migrates deprecated backgroundJobs.continueOnIdle and warns', () => {
+    const projectDir = path.join(tempDir, 'project');
+    const projectConfigDir = path.join(projectDir, '.opencode');
+    fs.mkdirSync(projectConfigDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(projectConfigDir, 'oh-my-opencode-slim.json'),
+      JSON.stringify({
+        autoUpdate: false,
+        backgroundJobs: {
+          continueOnIdle: false,
+          orchestratorWake: { intervalMs: 120_000 },
+        },
+      }),
+    );
+
+    const warnings: ConfigLoadWarning[] = [];
+    const config = loadPluginConfig(projectDir, {
+      silent: true,
+      onWarning: (warning) => warnings.push(warning),
+    });
+
+    expect(config.backgroundJobs?.orchestratorWake).toEqual({
+      enabled: false,
+      intervalMs: 120_000,
+    });
+    expect(config.backgroundJobs).not.toHaveProperty('continueOnIdle');
+    expect(config.autoUpdate).toBe(false);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]?.kind).toBe('deprecated-key');
+    expect(warnings[0]?.message).toContain(
+      'Deprecated backgroundJobs.continueOnIdle',
+    );
+  });
+
+  test('prefers explicit orchestratorWake.enabled over deprecated continueOnIdle', () => {
+    const projectDir = path.join(tempDir, 'project');
+    const projectConfigDir = path.join(projectDir, '.opencode');
+    fs.mkdirSync(projectConfigDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(projectConfigDir, 'oh-my-opencode-slim.json'),
+      JSON.stringify({
+        backgroundJobs: {
+          continueOnIdle: false,
+          orchestratorWake: { enabled: true },
+        },
+      }),
+    );
+
+    const warnings: ConfigLoadWarning[] = [];
+    const config = loadPluginConfig(projectDir, {
+      silent: true,
+      onWarning: (warning) => warnings.push(warning),
+    });
+
+    expect(config.backgroundJobs?.orchestratorWake.enabled).toBe(true);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]?.kind).toBe('deprecated-key');
+  });
+
+  test('preserves migrated continueOnIdle across a partial project override', () => {
+    const userConfigPath = path.join(tempDir, 'opencode');
+    const projectDir = path.join(tempDir, 'project');
+    const projectConfigDir = path.join(projectDir, '.opencode');
+    fs.mkdirSync(userConfigPath, { recursive: true });
+    fs.mkdirSync(projectConfigDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(userConfigPath, 'oh-my-opencode-slim.json'),
+      JSON.stringify({ backgroundJobs: { continueOnIdle: false } }),
+    );
+    fs.writeFileSync(
+      path.join(projectConfigDir, 'oh-my-opencode-slim.json'),
+      JSON.stringify({
+        backgroundJobs: { strategy: 'checkpoint-compatible' },
+      }),
+    );
+
+    const warnings: ConfigLoadWarning[] = [];
+    const config = loadPluginConfig(projectDir, {
+      silent: true,
+      onWarning: (warning) => warnings.push(warning),
+    });
+
+    expect(config.backgroundJobs?.orchestratorWake.enabled).toBe(false);
+    expect(config.backgroundJobs?.strategy).toBe('checkpoint-compatible');
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]?.kind).toBe('deprecated-key');
+  });
+
   test('both deprecated keys fire two warnings', () => {
     const projectDir = path.join(tempDir, 'project');
     const projectConfigDir = path.join(projectDir, '.opencode');

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -4,6 +4,7 @@ import { stripJsonComments } from '../cli/config-io';
 import { getConfigSearchDirs } from '../cli/paths';
 import { DEFAULT_DISABLED_AGENTS } from './constants';
 import {
+  BackgroundJobsConfigSchema,
   InterviewConfigSchema,
   LEGACY_FALLBACK_KEYS,
   type PluginConfig,
@@ -56,6 +57,7 @@ const INTERVIEW_CONFIG_KEYS = [
   'port',
   'dashboard',
 ] as const;
+const LEGACY_BACKGROUND_JOBS_KEYS = ['continueOnIdle'] as const;
 
 // Config keys that must be arrays. A string value (e.g. "explorer") is
 // normalized to a single-element array; any other non-array value is
@@ -112,6 +114,50 @@ export function normalizeDisabledArrayKeys(
   }
 }
 
+function migrateLegacyBackgroundJobsConfig(rawConfig: unknown): unknown {
+  if (
+    typeof rawConfig !== 'object' ||
+    rawConfig === null ||
+    Array.isArray(rawConfig)
+  ) {
+    return rawConfig;
+  }
+
+  const configRecord = rawConfig as Record<string, unknown>;
+  const backgroundJobs = configRecord.backgroundJobs;
+  if (
+    typeof backgroundJobs !== 'object' ||
+    backgroundJobs === null ||
+    Array.isArray(backgroundJobs) ||
+    !Object.hasOwn(backgroundJobs, 'continueOnIdle')
+  ) {
+    return rawConfig;
+  }
+
+  const migratedBackgroundJobs = {
+    ...(backgroundJobs as Record<string, unknown>),
+  };
+  const legacyContinueOnIdle = migratedBackgroundJobs.continueOnIdle;
+  delete migratedBackgroundJobs.continueOnIdle;
+
+  const wake = migratedBackgroundJobs.orchestratorWake;
+  if (
+    typeof legacyContinueOnIdle === 'boolean' &&
+    (wake === undefined ||
+      (typeof wake === 'object' && wake !== null && !Array.isArray(wake)))
+  ) {
+    const wakeConfig = (wake ?? {}) as Record<string, unknown>;
+    if (!Object.hasOwn(wakeConfig, 'enabled')) {
+      migratedBackgroundJobs.orchestratorWake = {
+        ...wakeConfig,
+        enabled: legacyContinueOnIdle,
+      };
+    }
+  }
+
+  return { ...configRecord, backgroundJobs: migratedBackgroundJobs };
+}
+
 function retainExplicitInterviewFields(
   parsedConfig: PluginConfig,
   rawConfig: unknown,
@@ -147,6 +193,69 @@ function retainExplicitInterviewFields(
   return {
     ...parsedConfig,
     interview: interview as PluginConfig['interview'],
+  };
+}
+
+function retainExplicitBackgroundJobsFields(
+  parsedConfig: PluginConfig,
+  rawConfig: unknown,
+): PluginConfig {
+  if (!parsedConfig.backgroundJobs) {
+    return parsedConfig;
+  }
+
+  const rawBackgroundJobs =
+    typeof rawConfig === 'object' &&
+    rawConfig !== null &&
+    !Array.isArray(rawConfig) &&
+    typeof (rawConfig as Record<string, unknown>).backgroundJobs === 'object' &&
+    (rawConfig as Record<string, unknown>).backgroundJobs !== null &&
+    !Array.isArray((rawConfig as Record<string, unknown>).backgroundJobs)
+      ? ((rawConfig as Record<string, unknown>).backgroundJobs as Record<
+          string,
+          unknown
+        >)
+      : undefined;
+
+  if (!rawBackgroundJobs) {
+    return parsedConfig;
+  }
+
+  const backgroundJobs: Record<string, unknown> = {};
+  const parsedBackgroundJobs = parsedConfig.backgroundJobs as unknown as Record<
+    string,
+    unknown
+  >;
+  for (const key of Object.keys(rawBackgroundJobs)) {
+    if (
+      key !== 'orchestratorWake' &&
+      Object.hasOwn(parsedBackgroundJobs, key)
+    ) {
+      backgroundJobs[key] = parsedBackgroundJobs[key];
+    }
+  }
+
+  const rawWake =
+    typeof rawBackgroundJobs.orchestratorWake === 'object' &&
+    rawBackgroundJobs.orchestratorWake !== null &&
+    !Array.isArray(rawBackgroundJobs.orchestratorWake)
+      ? (rawBackgroundJobs.orchestratorWake as Record<string, unknown>)
+      : undefined;
+  const orchestratorWake: Record<string, unknown> = {};
+  const parsedWake = parsedConfig.backgroundJobs
+    .orchestratorWake as unknown as Record<string, unknown>;
+  for (const key of Object.keys(rawWake ?? {})) {
+    if (Object.hasOwn(parsedWake, key)) {
+      orchestratorWake[key] = parsedWake[key];
+    }
+  }
+  if (Object.keys(orchestratorWake).length > 0) {
+    backgroundJobs.orchestratorWake = orchestratorWake;
+  }
+
+  return {
+    ...parsedConfig,
+    backgroundJobs: backgroundJobs as PluginConfig['backgroundJobs'],
   };
 }
 
@@ -235,6 +344,38 @@ function loadConfigFromPath(
       }
     }
 
+    // Preserve the opt-out behavior of the removed continueOnIdle key for
+    // one compatibility window by migrating it before schema validation.
+    if (
+      typeof rawConfig === 'object' &&
+      rawConfig !== null &&
+      typeof (rawConfig as Record<string, unknown>).backgroundJobs ===
+        'object' &&
+      (rawConfig as Record<string, unknown>).backgroundJobs !== null
+    ) {
+      const backgroundJobs = (rawConfig as Record<string, unknown>)
+        .backgroundJobs as Record<string, unknown>;
+      const present = LEGACY_BACKGROUND_JOBS_KEYS.filter(
+        (key) => key in backgroundJobs,
+      );
+      if (present.length > 0) {
+        const backgroundJobsMsg =
+          'Deprecated backgroundJobs.continueOnIdle config key found. ' +
+          'Boolean values are migrated to backgroundJobs.orchestratorWake.enabled ' +
+          'unless that replacement is explicit in the same config file; other values are ignored. ' +
+          'Use backgroundJobs.orchestratorWake.enabled instead.';
+        options?.onWarning?.({
+          path: configPath,
+          kind: 'deprecated-key',
+          message: backgroundJobsMsg,
+        });
+        if (!options?.silent) {
+          console.warn(`[oh-my-opencode-slim] ${backgroundJobsMsg}`);
+        }
+      }
+    }
+    rawConfig = migrateLegacyBackgroundJobsConfig(rawConfig);
+
     // Warn about deprecated fallback.* keys. The schema strips these before
     // validation so the rest of the config still loads; without this warning
     // users would not know their stale keys are ignored.
@@ -294,7 +435,8 @@ function loadConfigFromPath(
     // Zod applies nested defaults while parsing each layer. Keep interview
     // defaults from masquerading as explicitly configured overrides; the
     // merged interview config is normalized after all layers are merged.
-    const layerConfig = retainExplicitInterviewFields(result.data, rawConfig);
+    let layerConfig = retainExplicitInterviewFields(result.data, rawConfig);
+    layerConfig = retainExplicitBackgroundJobsFields(layerConfig, rawConfig);
 
     // Zod applies webfetch.enabled's default while parsing each layer. Keep
     // that default from masquerading as an explicitly configured override;
@@ -548,6 +690,11 @@ export function loadPluginConfig(
   }
   if (config.interview) {
     config.interview = InterviewConfigSchema.parse(config.interview);
+  }
+  if (config.backgroundJobs) {
+    config.backgroundJobs = BackgroundJobsConfigSchema.parse(
+      config.backgroundJobs,
+    );
   }
 
   // Override preset from environment variable if set


### PR DESCRIPTION
What changed, and why was it needed?

`backgroundJobs.continueOnIdle: false` was silently stripped after that key was
removed, allowing the replacement wake scheduler to default to enabled. This
change migrates boolean legacy values at the config-file loading boundary,
emits a deprecation warning, and preserves the opt-out across user/project
config layers. An explicit `orchestratorWake.enabled` in the same file wins.

The current five-minute wake interval was intentionally restored on `master`,
so this change leaves that default untouched.

Closes #1050

## Summary

- Fixes: A config containing backgroundJobs.continueOnIdle=false is accepted but the key is stripped, so orchestratorWake defaults to enabled and periodic wake prompts run against the user's explicit opt-out.
- Root cause: The background-jobs schema strips the removed key before the loader can preserve its boolean meaning, and per-layer nested defaults can overwrite a migrated user-level opt-out when a project-level backgroundJobs override is partial.

## Regression evidence

- Before: `bun test src/config/loader.test.ts -t "migrates deprecated backgroundJobs.continueOnIdle and warns"` exited `1`

- After: `bun test src/config/loader.test.ts -t "migrates deprecated backgroundJobs.continueOnIdle and warns"` exited `0`

## Verification

- `bun test src/config`
- `bun test`
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `./node_modules/.bin/biome check docs/configuration.md src/config/loader.ts src/config/loader.test.ts`

`bun run check:ci` was also run. It currently reports formatting drift in five
untouched files whose worktree hashes match `master`; the changed TypeScript
files pass the same pinned Biome check, and the repository's CI lint, typecheck,
test, and build commands all pass.

## Scope

- 3 files changed, +242 / -1 lines
