### PR TITLE
fix: resolve pre-existing check:ci failures (tui.ts + format)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -11,7 +11,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
+      "preset": "recommended",
       "suspicious": {
         "noExplicitAny": "warn"
       }

--- a/src/hooks/task-session-manager/idle-reconciliation.test.ts
+++ b/src/hooks/task-session-manager/idle-reconciliation.test.ts
@@ -71,8 +71,13 @@ describe('idle reconciliation stop confirmation', () => {
   });
 
   test('repeated idle beyond confirmation grace becomes stopped exactly once', async () => {
-    const { board, reconciler, terminalListener, contextFilesForPrompt, prune } =
-      createHarness();
+    const {
+      board,
+      reconciler,
+      terminalListener,
+      contextFilesForPrompt,
+      prune,
+    } = createHarness();
     const generation = board.get('child-1')?.generation ?? 1;
 
     await observeIdle(reconciler, 10, generation);

--- a/src/hooks/task-session-manager/runtime-status-reconciliation.test.ts
+++ b/src/hooks/task-session-manager/runtime-status-reconciliation.test.ts
@@ -287,11 +287,12 @@ describe('runtime status reconciliation', () => {
   });
 
   test('repeated idle beyond confirmation grace becomes stopped exactly once', async () => {
-    const { board, reconciler, contextFilesForPrompt, prune } = createReconciler(
-      async () => ({ data: { 'child-1': { type: 'idle' } } }),
-      undefined,
-      0,
-    );
+    const { board, reconciler, contextFilesForPrompt, prune } =
+      createReconciler(
+        async () => ({ data: { 'child-1': { type: 'idle' } } }),
+        undefined,
+        0,
+      );
     const listener = mock(() => {});
     board.addTerminalStateListener(listener);
 

--- a/src/hooks/task-session-manager/runtime-status-reconciliation.ts
+++ b/src/hooks/task-session-manager/runtime-status-reconciliation.ts
@@ -97,7 +97,10 @@ export function createRuntimeStatusReconciler(options: {
         );
         continue;
       }
-      if (status === undefined && snapshot.malformedSessionIDs.has(job.taskID)) {
+      if (
+        status === undefined &&
+        snapshot.malformedSessionIDs.has(job.taskID)
+      ) {
         options.backgroundJobBoard.markStatusUncertain(
           job.taskID,
           'Runtime status response did not contain a recognized session state.',

--- a/src/tui.test.ts
+++ b/src/tui.test.ts
@@ -392,10 +392,11 @@ describe('dual-contract plugin module', () => {
           };
         },
         router: {
-          current: () => ({ type: 'home' }) as {
-            type?: string;
-            sessionID?: string;
-          },
+          current: () =>
+            ({ type: 'home' }) as {
+              type?: string;
+              sessionID?: string;
+            },
         },
       },
     };

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -451,7 +451,7 @@ function v2ThemeView(theme: V2TuiThemeTokens): {
  * V2 entry point: sidebar slot + refresh loop; returns cleanup.
  * `/preset` stays v1-only (`api.command` is absent on v2).
  */
-async function setup(ctx: V2TuiContext): Promise<void | (() => void)> {
+async function setup(ctx: V2TuiContext): Promise<undefined | (() => void)> {
   if (isPluginDisabledByEnv()) return;
 
   const version = (await readPackageVersion()) ?? 'dev';
@@ -473,8 +473,7 @@ async function setup(ctx: V2TuiContext): Promise<void | (() => void)> {
       if (disposed) return;
       if (currentDirectory !== configDirectory) {
         configDirectory = currentDirectory;
-        ({ configInvalid, compactSidebar } =
-          readConfigState(configDirectory));
+        ({ configInvalid, compactSidebar } = readConfigState(configDirectory));
       }
       ctx.renderer.requestRender();
     } catch {
@@ -535,7 +534,7 @@ function buildPresetCommand(
 interface TuiDualContractModule {
   id: string;
   tui: TuiPlugin;
-  setup: (ctx: V2TuiContext) => Promise<void | (() => void)>;
+  setup: (ctx: V2TuiContext) => Promise<undefined | (() => void)>;
 }
 
 const plugin: TuiDualContractModule = {


### PR DESCRIPTION
Fixes #1065

## What problem are you solving?

`bun run check:ci` fails on `master` with 5 errors and 1 warning that predate any recent PR: two `noConfusingVoidType` lint errors in `src/tui.ts`, four Biome format violations, and a deprecated `biome.json` option. These block the CI gate for every branch that runs the full check.

## What does this change?

Replaces `void` with `undefined` in the two `Promise<... | (() => void)>` union types in `src/tui.ts` (fixing `noConfusingVoidType`), applies Biome formatting to `src/tui.ts`, `src/tui.test.ts`, and three `task-session-manager` files, and migrates `biome.json`'s deprecated `recommended` field to `preset: recommended`.

## Why this approach?

The `void`→`undefined` change is Biome's suggested fix for `noConfusingVoidType` and is safe here: the `setup` function's early `return;` already yields `undefined`, and no callers reference the return value (verified against `src/v2/` and `src/index.ts`). The format and config changes are the standard Biome auto-fix / `biome migrate` paths.

## Related work

- [x] I checked open AND closed PRs/issues for duplicates
- Related: #1065 (the issue this PR fixes)

## AI assistance

- Model / harness: OpenCode (balanced preset) — orchestrator `opencode/hy3-free`; fix implemented by `@fixer` (`opencode/mimo-v2.5-free`). Code review performed by the orchestrator directly (the `@oracle` review task failed to return a result; the diff was small enough to review inline).
- Human reviewed the full diff? [x]

## Checklist

- [x] `bun run check:ci`, `bun run typecheck`, and `bun test` pass — check:ci (0 errors/0 warnings), typecheck (clean), bun test (2169 pass, 0 fail)
- [x] Docs (README.md, docs/) updated if behavior/commands changed — no user-facing behavior change; internal lint/format/config fix only
- [x] One logical change per PR
- [x] PR targets the `master` branch