### PR TITLE
docs: record apply-patch model caveat decision as out of scope

### DIFF
--- a/.out-of-scope/apply-patch-model-caveats.md
+++ b/.out-of-scope/apply-patch-model-caveats.md
@@ -1,0 +1,26 @@
+# Apply-patch model caveats in preset docs
+
+This project does not add per-model `apply_patch` reliability caveats to the
+preset docs, and does not move preset defaults based on single-environment
+failure-rate reports.
+
+## Why this is out of scope
+
+Failure rates reported from one user's session history are hard to
+generalize: request volume, task mix, plugin and OpenCode versions, provider
+transport, whitespace handling, and the effort variant all confound the
+numbers. The #918 audit (44% Luna vs 10% Terra `apply_patch` failure rate in
+the fixer lane) was measured while the fixer still ran at `xhigh`, a setting
+later removed across the board in 0c2dea34, so the effort level may have been
+the real variable. Putting a warning against a specific model into canonical
+docs on that basis risks recording a causal claim nobody has verified.
+
+Users who hit a misbehaving model already have an escape hatch: model-level
+fallback chains via `ForegroundFallbackManager` (see
+`.out-of-scope/preset-fallback.md`). Variant choices get revisited
+periodically for cost-performance balance, which is how fixer landed on Luna
+`high`.
+
+## Prior requests
+
+- #918: "Reconsider Luna defaults for Fixer and Designer after repeated apply_patch failures"


### PR DESCRIPTION
Closes #918.

## What

Adds `.out-of-scope/apply-patch-model-caveats.md`, recording the decision to not add per-model `apply_patch` reliability caveats to preset docs, and to not move preset defaults based on single-environment failure-rate reports.

## Why

The #918 audit (44% Luna vs 10% Terra `apply_patch` failure rate in the fixer lane) was measured while the fixer still ran at `xhigh`, a setting later removed across the board in 0c2dea34, so the effort level may have been the real variable. A per-model warning in canonical docs would enshrine a causal claim nobody has verified. Users who hit a misbehaving model already have model-level fallback chains via `ForegroundFallbackManager` (see existing `.out-of-scope/preset-fallback.md`).

## Verification

- [x] File follows the existing `.out-of-scope/` format (see `preset-fallback.md`)
- [x] No code or docs changes; docs/tests stay in sync at fixer = Luna `high`
- [x] Closes #918