### PR TITLE
fix(foreground-fallback): make replay notification self-explanatory to the model

### DIFF
--- a/src/hooks/foreground-fallback/index.ts
+++ b/src/hooks/foreground-fallback/index.ts
@@ -778,7 +778,9 @@ export class ForegroundFallbackManager {
         body: {
           parts: [
             ...replayParts,
-            createInternalAgentTextPart('Foreground fallback replay.'),
+            createInternalAgentTextPart(
+              "<system-reminder>\nThe previous model request failed and is being retried with a fallback model. Continue processing the user's original request above. Do not respond to this reminder.\n</system-reminder>",
+            ),
           ],
           model: ref,
           ...(agentName ? { agent: agentName } : {}),


### PR DESCRIPTION
Fixes #1072

## What problem are you solving?

The foreground-fallback hook replays the last user message with a fallback model and appends an internal synthetic part whose text is the terse string `Foreground fallback replay.` (plus the `<!-- SLIM_INTERNAL_INITIATOR -->` marker). This part is sent to the model (intended — synthetic parts are hidden from the UI but reach the model), but the text is ambiguous: the model does not recognize it as an internal system instruction, treats it as a leak, and does not know how to handle it.

## What does this change?

Replaces the terse `Foreground fallback replay.` text with a self-explanatory `<system-reminder>` block that tells the model the previous request failed, is being retried with a fallback model, to continue processing the user's original request, and not to respond to the reminder.

## Why this approach?

The `orchestrator-wake` hook already uses the `<system-reminder>` wrapper pattern for internal initiators (`ORCHESTRATOR_WAKE_TEXT` / `ORCHESTRATOR_STOPPED_JOB_WAKE_TEXT`), which the model understands as an internal notification. The foreground-fallback replay is the same kind of system-level notification, so matching that pattern is the consistent choice. No other alternatives were considered — this is the established pattern for internal initiators in this repo.

## Related work

- [x] I checked open AND closed PRs/issues for duplicates
- Related: #1072 (this fix); #1011, #951, #976 (other foreground-fallback PRs, different concerns)

## AI assistance

- Model / harness: OpenCode (deepseek-ai/deepseek-v4-flash-0731). The code edit was made directly by the orchestrator; no subagents were used for the edit. Root-cause investigation used @explorer subagents to verify SDK serialization preserves `synthetic` and to inspect TUI rendering.
- Human reviewed the full diff? [x] (sign-off given before submission)

## Checklist

- [x] `bun run typecheck` and `bun test` pass; `bun run check:ci` has pre-existing unrelated failures in other files (tracked by #1067) — this change's file passes Biome cleanly
- [x] Docs (README.md, docs/) updated if behavior/commands changed — no doc change needed; this is an internal prompt text change, not user-facing behavior/config
- [x] One logical change per PR
- [x] PR targets the `master` branch