### PR TITLE
feat(hooks): tool-loop-guard to break repeated identical tool calls (#1071)

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -82,14 +82,19 @@ A safety net for model-side infinite loops where a sub-agent (e.g. a model
 that can degenerate, such as DeepSeek V4 Flash in Explorer) re-issues the
 exact same tool call with identical arguments and gets identical results,
 making no progress. The plugin watches each session's consecutive identical
-tool calls and responds:
+tool calls — counting only calls that return results identical to the
+previous call, so a call returning new information (e.g. a file that was
+modified) never counts toward a block — and responds:
 
-- On the 3rd identical call: appends a corrective notice to the tool output
-  telling the model to stop repeating and change approach. Applies to all
-  tools.
-- On the 5th identical call: refuses execution for the read-only file tools
-  `read`, `grep`, and `glob`, terminating the loop. Other tools stay
-  warn-only.
+- After the 3rd confirmed-identical result: appends a corrective notice to
+  the tool output telling the model to stop repeating and change approach.
+  Applies to all tools.
+- After the 5th confirmed-identical result: refuses the next identical call
+  for the read-only file tools `read`, `grep`, and `glob`, terminating the
+  loop. Other tools stay warn-only.
+
+The count is confirmed in `tool.execute.after`, so overlapping parallel
+calls cannot inflate it before their results are known.
 
 Exempt from the entire guard: the task-control and wait tools (`task`,
 `task_status`, `task_result`, `task_cancel`, `task_message`, `task_revive`,

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -76,6 +76,28 @@ lifecycle, cancellation, and explicit-wait edge cases behind these tools.
 
 ---
 
+## Repeated Tool-Call Loop Guard
+
+A safety net for model-side infinite loops where a sub-agent (e.g. a model
+that can degenerate, such as DeepSeek V4 Flash in Explorer) re-issues the
+exact same tool call with identical arguments and gets identical results,
+making no progress. The plugin watches each session's consecutive identical
+tool calls and responds:
+
+- On the 3rd identical call: appends a corrective notice to the tool output
+  telling the model to stop repeating and change approach. Applies to all
+  tools.
+- On the 5th identical call: refuses execution for the read-only file tools
+  `read`, `grep`, and `glob`, terminating the loop. Other tools stay
+  warn-only.
+
+Exempt from the entire guard: the task-control and wait tools (`task`,
+`task_status`, `task_result`, `task_cancel`, `task_message`, `task_revive`,
+`wait_for_user`, `wait_for_background_tasks`) — those legitimately re-issue
+identical calls while polling a long-running background task.
+
+---
+
 ## Formatters
 
 OpenCode automatically formats files after they are written or edited, using language-specific formatters. No manual step needed.

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -36,3 +36,4 @@ export { createPostFileToolNudgeHook } from './post-file-tool-nudge';
 export { createReflectCommandHook } from './reflect';
 export { SessionLifecycle } from './session-lifecycle';
 export { createTaskSessionManagerHook } from './task-session-manager';
+export { createToolLoopGuardHook } from './tool-loop-guard/hook';

--- a/src/hooks/tool-loop-guard/hook.ts
+++ b/src/hooks/tool-loop-guard/hook.ts
@@ -1,3 +1,5 @@
+import { log } from '../../utils/logger';
+
 /**
  * Tool loop guard.
  *
@@ -141,6 +143,11 @@ export function createToolLoopGuardHook(): ToolLoopGuardHook {
       keepSessionsBounded();
 
       if (count >= LOOP_GUARD_BLOCK_AT && LOOP_GUARD_BLOCK_TOOLS[tool]) {
+        log('[tool-loop-guard] blocked repeated tool call', {
+          sessionID,
+          tool,
+          count,
+        });
         throw new Error(
           `Refusing to execute "${tool}": this exact call (same tool, same arguments) has been issued ${count} times in a row with identical results and constitutes an infinite loop. Stop repeating it. Reassess your goal, make a different call, or produce your final answer.`,
         );
@@ -172,6 +179,11 @@ export function createToolLoopGuardHook(): ToolLoopGuardHook {
 
       if (typeof output.output !== 'string') return;
       if (output.output.includes(LOOP_GUARD_MARKER)) return;
+      log('[tool-loop-guard] warned repeated tool call', {
+        sessionID,
+        tool: input.tool.toLowerCase(),
+        count: state.count,
+      });
       output.output += `\n${LOOP_GUARD_WARNING}`;
     },
 

--- a/src/hooks/tool-loop-guard/hook.ts
+++ b/src/hooks/tool-loop-guard/hook.ts
@@ -9,20 +9,50 @@
  * Behavior:
  * - N identical consecutive calls (LOOP_GUARD_WARN_AT): append corrective
  *   text to the tool output telling the model to stop and change approach.
- * - M identical consecutive calls (LOOP_GUARD_BLOCK_AT): refuse the call in
- *   tool.execute.before by throwing, so the loop terminates instead of
- *   running forever.
+ * - For read-only file tools (READONLY_BLOCK_TOOLS), M identical consecutive
+ *   calls (LOOP_GUARD_BLOCK_AT): refuse the call in tool.execute.before by
+ *   throwing, so the loop terminates instead of running forever.
+ *
+ * Scope is deliberately narrow to avoid breaking legitimate repeated calls:
+ * - All tools warn at N identical consecutive calls.
+ * - Only the read-only file-analysis tools hard-block: polling tools
+ *   (task_*, wait_for_*) legitimately re-issue identical calls waiting on a
+ *   long-running background task and must never be refused.
+ * - The task tool is exempt entirely for both axes; task-session-manager
+ *   owns its own duplicate-spawn guards (#1056/#1070).
  *
  * Precedent: json-error-recovery (output warning) and task-session-manager
- * (before-hook refusal). The `task` tool is exempt: task-session-manager
- * already owns its duplicate-spawn guards (#1056/#1070).
+ * (before-hook refusal).
  */
 
 const LOOP_GUARD_WARN_AT = 3;
 const LOOP_GUARD_BLOCK_AT = 5;
 
-/** Exempt: task-session-manager already owns duplicate-spawn guards. */
-const EXEMPT_TOOL = 'task';
+/**
+ * Tools exempt from the entire guard: long-lived task supervision/polling
+ * tools whose identical repeated invocation is legitimate.
+ */
+const LOOP_GUARD_EXEMPT: Record<string, true> = {
+  task: true,
+  task_status: true,
+  task_result: true,
+  task_cancel: true,
+  task_message: true,
+  task_revive: true,
+  wait_for_user: true,
+  wait_for_background_tasks: true,
+};
+
+/**
+ * Tools that may be hard-blocked when repeated. Read-only file analysis is
+ * the reported loop surface (#1071); anything with side effects or that
+ * polls external state stays warn-only.
+ */
+const LOOP_GUARD_BLOCK_TOOLS: Record<string, true> = {
+  read: true,
+  grep: true,
+  glob: true,
+};
 
 const LOOP_GUARD_MARKER = '[REPEATED TOOL CALLS - STOP]';
 
@@ -36,6 +66,9 @@ STOP repeating this call. Instead:
 2. If you need different information, make a DIFFERENT call (different path, pattern, or tool).
 3. If the task is actually done, produce your final answer now instead of calling more tools.
 `;
+
+/** Max sessions tracked before evicting the least-recently-observed session. */
+const MAX_TRACKED_SESSIONS = 512;
 
 /** Deterministic fingerprint of tool + args, insensitive to key order. */
 function fingerprint(tool: string, args: unknown): string {
@@ -81,34 +114,50 @@ export function createToolLoopGuardHook(): ToolLoopGuardHook {
   /** Fingerprint per callID so `after` can re-check without re-deriving args. */
   const callKeys = new Map<string, string>();
 
+  /** Prune the session map to MAX_TRACKED_SESSIONS (FIFO by insertion). */
+  function keepSessionsBounded(): void {
+    while (sessions.size > MAX_TRACKED_SESSIONS) {
+      const oldest = sessions.keys().next().value as string | undefined;
+      if (oldest === undefined) break;
+      sessions.delete(oldest);
+    }
+  }
+
   return {
     'tool.execute.before': async (
       input: { tool: string; sessionID?: string; callID?: string },
       output: { args?: unknown },
     ): Promise<void> => {
       const sessionID = input.sessionID;
-      if (!sessionID || input.tool.toLowerCase() === EXEMPT_TOOL) return;
+      if (!sessionID) return;
+      const tool = input.tool.toLowerCase();
+      if (LOOP_GUARD_EXEMPT[tool]) return;
 
-      const key = fingerprint(input.tool, output.args);
-      if (input.callID) callKeys.set(input.callID, key);
+      const key = fingerprint(tool, output.args);
 
       const existing = sessions.get(sessionID);
       const count = existing && existing.last === key ? existing.count + 1 : 1;
       sessions.set(sessionID, { last: key, count });
+      keepSessionsBounded();
 
-      if (count >= LOOP_GUARD_BLOCK_AT) {
+      if (count >= LOOP_GUARD_BLOCK_AT && LOOP_GUARD_BLOCK_TOOLS[tool]) {
         throw new Error(
-          `Refusing to execute "${input.tool}": this exact call (same tool, same arguments) has been issued ${count} times in a row with identical results and constitutes an infinite loop. Stop repeating it. Reassess your goal, make a different call, or produce your final answer.`,
+          `Refusing to execute "${tool}": this exact call (same tool, same arguments) has been issued ${count} times in a row with identical results and constitutes an infinite loop. Stop repeating it. Reassess your goal, make a different call, or produce your final answer.`,
         );
       }
+
+      if (input.callID) callKeys.set(input.callID, key);
     },
 
     'tool.execute.after': async (
       input: { tool: string; sessionID?: string; callID?: string },
       output: { output: unknown; metadata?: unknown },
     ): Promise<void> => {
-      if (!input.sessionID || input.tool.toLowerCase() === EXEMPT_TOOL) return;
-      const state = sessions.get(input.sessionID);
+      const sessionID = input.sessionID;
+      if (!sessionID) return;
+      const tool = input.tool.toLowerCase();
+      if (LOOP_GUARD_EXEMPT[tool]) return;
+      const state = sessions.get(sessionID);
       if (!state) return;
 
       const key = input.callID ? callKeys.get(input.callID) : undefined;

--- a/src/hooks/tool-loop-guard/hook.ts
+++ b/src/hooks/tool-loop-guard/hook.ts
@@ -94,8 +94,10 @@ function stableStringify(value: unknown): string {
 interface SessionState {
   /** Fingerprint of the most recent eligible call in this session. */
   last: string;
-  /** How many consecutive identical calls have been observed. */
+  /** How many consecutive identical (args) calls have been observed. */
   count: number;
+  /** Fingerprint of the most recent eligible call's output. */
+  lastOutput: string;
 }
 
 export interface ToolLoopGuardHook {
@@ -138,8 +140,15 @@ export function createToolLoopGuardHook(): ToolLoopGuardHook {
       const key = fingerprint(tool, output.args);
 
       const existing = sessions.get(sessionID);
-      const count = existing && existing.last === key ? existing.count + 1 : 1;
-      sessions.set(sessionID, { last: key, count });
+      const sameArgs = existing !== undefined && existing.last === key;
+      const count = sameArgs ? existing.count + 1 : 1;
+      sessions.set(sessionID, {
+        last: key,
+        count,
+        // New args start a fresh run; identical args carry the prior output
+        // forward so the after-hook can detect when the result changed.
+        lastOutput: sameArgs ? existing.lastOutput : '',
+      });
       keepSessionsBounded();
 
       if (count >= LOOP_GUARD_BLOCK_AT && LOOP_GUARD_BLOCK_TOOLS[tool]) {
@@ -169,6 +178,17 @@ export function createToolLoopGuardHook(): ToolLoopGuardHook {
 
       const key = input.callID ? callKeys.get(input.callID) : undefined;
       if (input.callID) callKeys.delete(input.callID);
+
+      if (key === state.last) {
+        // Identical args. If the result differs from the prior call's result,
+        // this is progress, not a loop — reset the run so it cannot block.
+        const outputHash = fingerprint(tool, output.output);
+        if (state.lastOutput !== '' && outputHash !== state.lastOutput) {
+          state.count = 1;
+        }
+        state.lastOutput = outputHash;
+      }
+
       if (
         key !== undefined &&
         (key !== state.last || state.count < LOOP_GUARD_WARN_AT)

--- a/src/hooks/tool-loop-guard/hook.ts
+++ b/src/hooks/tool-loop-guard/hook.ts
@@ -1,0 +1,140 @@
+/**
+ * Tool loop guard.
+ *
+ * Detects a session re-issuing the exact same tool call (same tool, same
+ * arguments) consecutively with no change, which is how model-side infinite
+ * loops present (see issue #1071: sub-agent repeating identical read/grep
+ * calls forever).
+ *
+ * Behavior:
+ * - N identical consecutive calls (LOOP_GUARD_WARN_AT): append corrective
+ *   text to the tool output telling the model to stop and change approach.
+ * - M identical consecutive calls (LOOP_GUARD_BLOCK_AT): refuse the call in
+ *   tool.execute.before by throwing, so the loop terminates instead of
+ *   running forever.
+ *
+ * Precedent: json-error-recovery (output warning) and task-session-manager
+ * (before-hook refusal). The `task` tool is exempt: task-session-manager
+ * already owns its duplicate-spawn guards (#1056/#1070).
+ */
+
+const LOOP_GUARD_WARN_AT = 3;
+const LOOP_GUARD_BLOCK_AT = 5;
+
+/** Exempt: task-session-manager already owns duplicate-spawn guards. */
+const EXEMPT_TOOL = 'task';
+
+const LOOP_GUARD_MARKER = '[REPEATED TOOL CALLS - STOP]';
+
+export const LOOP_GUARD_WARNING = `
+${LOOP_GUARD_MARKER}
+
+You have issued the exact same tool call with identical arguments ${LOOP_GUARD_WARN_AT} times in a row and received identical results. This is an infinite loop and you are making no progress.
+
+STOP repeating this call. Instead:
+1. Reconsider what you are looking for; the result above already contains what this call can tell you.
+2. If you need different information, make a DIFFERENT call (different path, pattern, or tool).
+3. If the task is actually done, produce your final answer now instead of calling more tools.
+`;
+
+/** Deterministic fingerprint of tool + args, insensitive to key order. */
+function fingerprint(tool: string, args: unknown): string {
+  return `${tool.toLowerCase()}:${stableStringify(args)}`;
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(',')}]`;
+  }
+  const record = value as Record<string, unknown>;
+  const keys = Object.keys(record).sort();
+  return `{${keys
+    .map((k) => `${JSON.stringify(k)}:${stableStringify(record[k])}`)
+    .join(',')}}`;
+}
+
+interface SessionState {
+  /** Fingerprint of the most recent eligible call in this session. */
+  last: string;
+  /** How many consecutive identical calls have been observed. */
+  count: number;
+}
+
+export interface ToolLoopGuardHook {
+  'tool.execute.before': (
+    input: { tool: string; sessionID?: string; callID?: string },
+    output: { args?: unknown },
+  ) => Promise<void>;
+  'tool.execute.after': (
+    input: { tool: string; sessionID?: string; callID?: string },
+    output: { output: unknown; metadata?: unknown },
+  ) => Promise<void>;
+  resetSession(sessionID: string): void;
+  resetForTests(): void;
+}
+
+export function createToolLoopGuardHook(): ToolLoopGuardHook {
+  const sessions = new Map<string, SessionState>();
+  /** Fingerprint per callID so `after` can re-check without re-deriving args. */
+  const callKeys = new Map<string, string>();
+
+  return {
+    'tool.execute.before': async (
+      input: { tool: string; sessionID?: string; callID?: string },
+      output: { args?: unknown },
+    ): Promise<void> => {
+      const sessionID = input.sessionID;
+      if (!sessionID || input.tool.toLowerCase() === EXEMPT_TOOL) return;
+
+      const key = fingerprint(input.tool, output.args);
+      if (input.callID) callKeys.set(input.callID, key);
+
+      const existing = sessions.get(sessionID);
+      const count = existing && existing.last === key ? existing.count + 1 : 1;
+      sessions.set(sessionID, { last: key, count });
+
+      if (count >= LOOP_GUARD_BLOCK_AT) {
+        throw new Error(
+          `Refusing to execute "${input.tool}": this exact call (same tool, same arguments) has been issued ${count} times in a row with identical results and constitutes an infinite loop. Stop repeating it. Reassess your goal, make a different call, or produce your final answer.`,
+        );
+      }
+    },
+
+    'tool.execute.after': async (
+      input: { tool: string; sessionID?: string; callID?: string },
+      output: { output: unknown; metadata?: unknown },
+    ): Promise<void> => {
+      if (!input.sessionID || input.tool.toLowerCase() === EXEMPT_TOOL) return;
+      const state = sessions.get(input.sessionID);
+      if (!state) return;
+
+      const key = input.callID ? callKeys.get(input.callID) : undefined;
+      if (input.callID) callKeys.delete(input.callID);
+      if (
+        key !== undefined &&
+        (key !== state.last || state.count < LOOP_GUARD_WARN_AT)
+      ) {
+        return;
+      }
+      if (key === undefined && state.count < LOOP_GUARD_WARN_AT) return;
+
+      if (typeof output.output !== 'string') return;
+      if (output.output.includes(LOOP_GUARD_MARKER)) return;
+      output.output += `\n${LOOP_GUARD_WARNING}`;
+    },
+
+    /** Clear all state for a finished/deleted session. */
+    resetSession(sessionID: string): void {
+      sessions.delete(sessionID);
+    },
+
+    /** Test seam: wipe state between cases. */
+    resetForTests(): void {
+      sessions.clear();
+      callKeys.clear();
+    },
+  };
+}

--- a/src/hooks/tool-loop-guard/hook.ts
+++ b/src/hooks/tool-loop-guard/hook.ts
@@ -9,14 +9,23 @@ import { log } from '../../utils/logger';
  * calls forever).
  *
  * Behavior:
- * - N identical consecutive calls (LOOP_GUARD_WARN_AT): append corrective
- *   text to the tool output telling the model to stop and change approach.
- * - For read-only file tools (READONLY_BLOCK_TOOLS), M identical consecutive
- *   calls (LOOP_GUARD_BLOCK_AT): refuse the call in tool.execute.before by
- *   throwing, so the loop terminates instead of running forever.
+ * - N consecutive calls with identical arguments AND identical results
+ *   (LOOP_GUARD_WARN_AT): append corrective text to the tool output telling
+ *   the model to stop and change approach.
+ * - For read-only file tools (READONLY_BLOCK_TOOLS), M consecutive calls
+ *   with identical arguments AND identical results (LOOP_GUARD_BLOCK_AT):
+ *   refuse the next identical call in tool.execute.before by throwing, so
+ *   the loop terminates instead of running forever.
+ * - The run counter only advances in tool.execute.after, when an identical-
+ *   args call produced an output byte-identical to the prior call. A call
+ *   that returns NEW information resets the run, so it can never accumulate
+ *   toward a block (a legitimate re-read after the file changed).
+ * - tool.execute.before never increments the counter, so overlapping
+ *   parallel calls cannot inflate the count before their results are known.
+ *   A refusal only happens after the run is already confirmed identical.
  *
  * Scope is deliberately narrow to avoid breaking legitimate repeated calls:
- * - All tools warn at N identical consecutive calls.
+ * - All tools warn at N confirmed-identical consecutive calls.
  * - Only the read-only file-analysis tools hard-block: polling tools
  *   (task_*, wait_for_*) legitimately re-issue identical calls waiting on a
  *   long-running background task and must never be refused.
@@ -92,11 +101,11 @@ function stableStringify(value: unknown): string {
 }
 
 interface SessionState {
-  /** Fingerprint of the most recent eligible call in this session. */
+  /** Fingerprint of the most recent completed eligible call (args). */
   last: string;
-  /** How many consecutive identical (args) calls have been observed. */
-  count: number;
-  /** Fingerprint of the most recent eligible call's output. */
+  /** Consecutive completed calls with identical args AND identical output. */
+  runs: number;
+  /** Fingerprint of the most recent completed call's output. */
   lastOutput: string;
 }
 
@@ -138,27 +147,24 @@ export function createToolLoopGuardHook(): ToolLoopGuardHook {
       if (LOOP_GUARD_EXEMPT[tool]) return;
 
       const key = fingerprint(tool, output.args);
-
       const existing = sessions.get(sessionID);
-      const sameArgs = existing !== undefined && existing.last === key;
-      const count = sameArgs ? existing.count + 1 : 1;
-      sessions.set(sessionID, {
-        last: key,
-        count,
-        // New args start a fresh run; identical args carry the prior output
-        // forward so the after-hook can detect when the result changed.
-        lastOutput: sameArgs ? existing.lastOutput : '',
-      });
-      keepSessionsBounded();
 
-      if (count >= LOOP_GUARD_BLOCK_AT && LOOP_GUARD_BLOCK_TOOLS[tool]) {
+      // Refuse only on a CONFIRMED identical run: the previous BLOCK_AT
+      // calls all had identical args AND identical results. The current
+      // call's result is not yet known, but the run is already degenerate.
+      if (
+        existing &&
+        existing.last === key &&
+        existing.runs >= LOOP_GUARD_BLOCK_AT &&
+        LOOP_GUARD_BLOCK_TOOLS[tool]
+      ) {
         log('[tool-loop-guard] blocked repeated tool call', {
           sessionID,
           tool,
-          count,
+          runs: existing.runs,
         });
         throw new Error(
-          `Refusing to execute "${tool}": this exact call (same tool, same arguments) has been issued ${count} times in a row with identical results and constitutes an infinite loop. Stop repeating it. Reassess your goal, make a different call, or produce your final answer.`,
+          `Refusing to execute "${tool}": this exact call (same tool, same arguments) has returned identical results ${existing.runs} times in a row and constitutes an infinite loop. Stop repeating it. Reassess your goal, make a different call, or produce your final answer.`,
         );
       }
 
@@ -173,36 +179,39 @@ export function createToolLoopGuardHook(): ToolLoopGuardHook {
       if (!sessionID) return;
       const tool = input.tool.toLowerCase();
       if (LOOP_GUARD_EXEMPT[tool]) return;
-      const state = sessions.get(sessionID);
-      if (!state) return;
 
       const key = input.callID ? callKeys.get(input.callID) : undefined;
       if (input.callID) callKeys.delete(input.callID);
+      const outputHash = fingerprint(tool, output.output);
 
-      if (key === state.last) {
-        // Identical args. If the result differs from the prior call's result,
-        // this is progress, not a loop — reset the run so it cannot block.
-        const outputHash = fingerprint(tool, output.output);
-        if (state.lastOutput !== '' && outputHash !== state.lastOutput) {
-          state.count = 1;
-        }
-        state.lastOutput = outputHash;
+      const existing = sessions.get(sessionID);
+      let state: SessionState;
+      if (existing && key !== undefined && key === existing.last) {
+        // Identical args. Advance the run only when the result is also
+        // identical; a changed result is progress and restarts the run.
+        state = {
+          last: key,
+          runs: outputHash === existing.lastOutput ? existing.runs + 1 : 1,
+          lastOutput: outputHash,
+        };
+      } else {
+        // Different args or untracked call: start a fresh run.
+        state = {
+          last: key ?? `${tool}:<untracked>`,
+          runs: 1,
+          lastOutput: outputHash,
+        };
       }
+      sessions.set(sessionID, state);
+      keepSessionsBounded();
 
-      if (
-        key !== undefined &&
-        (key !== state.last || state.count < LOOP_GUARD_WARN_AT)
-      ) {
-        return;
-      }
-      if (key === undefined && state.count < LOOP_GUARD_WARN_AT) return;
-
+      if (state.runs < LOOP_GUARD_WARN_AT) return;
       if (typeof output.output !== 'string') return;
       if (output.output.includes(LOOP_GUARD_MARKER)) return;
       log('[tool-loop-guard] warned repeated tool call', {
         sessionID,
-        tool: input.tool.toLowerCase(),
-        count: state.count,
+        tool,
+        runs: state.runs,
       });
       output.output += `\n${LOOP_GUARD_WARNING}`;
     },

--- a/src/hooks/tool-loop-guard/index.test.ts
+++ b/src/hooks/tool-loop-guard/index.test.ts
@@ -130,6 +130,46 @@ describe('tool-loop-guard', () => {
     expect(output.output).toContain(LOOP_GUARD_WARNING);
   });
 
+  test('identical args returning changing results never block', async () => {
+    // Each re-read returns different content (file was modified) — this is
+    // progress, not a loop. 6 identical-args calls must never be refused.
+    for (let i = 1; i <= 6; i++) {
+      await hook['tool.execute.before'](beforeInput({ callID: `d${i}` }), {
+        args: { filePath: 'a.ts' },
+      });
+      const output = { output: `revision ${i}`, metadata: {} };
+      await hook['tool.execute.after'](afterInput({ callID: `d${i}` }), output);
+      expect(output.output).toBe(`revision ${i}`); // never warned, never blocked
+    }
+  });
+
+  test('identical args with stable identical output warn but no block for non-readonly tool', async () => {
+    // bash is not in BLOCK_TOOLS: warn at 3 but never throw even at 6.
+    for (let i = 1; i <= 6; i++) {
+      await hook['tool.execute.before'](
+        beforeInput({ tool: 'bash', callID: `e${i}` }),
+        { args: { command: 'uname' } },
+      );
+    }
+    const output = { output: 'Linux', metadata: {} };
+    await hook['tool.execute.after'](
+      afterInput({ tool: 'bash', callID: 'e6' }),
+      output,
+    );
+    expect(output.output).toContain(LOOP_GUARD_WARNING);
+  });
+
+  test('identical args with stable identical output still block at 5', async () => {
+    for (let i = 1; i <= 4; i++) {
+      await runIdenticalCall(`f${i}`, { filePath: 'a.ts' }); // output identical each time
+    }
+    await expect(
+      hook['tool.execute.before'](beforeInput({ callID: 'f5' }), {
+        args: { filePath: 'a.ts' },
+      }),
+    ).rejects.toThrow('infinite loop');
+  });
+
   test('sessions are isolated', async () => {
     for (let i = 1; i <= 2; i++) {
       await runIdenticalCall(`a${i}`, { filePath: 'a.ts' });

--- a/src/hooks/tool-loop-guard/index.test.ts
+++ b/src/hooks/tool-loop-guard/index.test.ts
@@ -62,28 +62,28 @@ describe('tool-loop-guard', () => {
     expect(o3.output).toContain(LOOP_GUARD_WARNING);
   });
 
-  test('fifth identical call is refused in tool.execute.before', async () => {
-    for (let i = 1; i <= 4; i++) {
+  test('sixth identical call with stable identical results is refused', async () => {
+    for (let i = 1; i <= 5; i++) {
       await runIdenticalCall(`c${i}`, { filePath: 'a.ts' });
     }
     await expect(
-      hook['tool.execute.before'](beforeInput({ callID: 'c5' }), {
+      hook['tool.execute.before'](beforeInput({ callID: 'c6' }), {
         args: { filePath: 'a.ts' },
       }),
     ).rejects.toThrow('infinite loop');
   });
 
   test('blocked fingerprint stays blocked', async () => {
-    for (let i = 1; i <= 4; i++) {
+    for (let i = 1; i <= 5; i++) {
       await runIdenticalCall(`c${i}`, { filePath: 'a.ts' });
     }
     await expect(
-      hook['tool.execute.before'](beforeInput({ callID: 'c5' }), {
+      hook['tool.execute.before'](beforeInput({ callID: 'c6' }), {
         args: { filePath: 'a.ts' },
       }),
     ).rejects.toThrow();
     await expect(
-      hook['tool.execute.before'](beforeInput({ callID: 'c6' }), {
+      hook['tool.execute.before'](beforeInput({ callID: 'c7' }), {
         args: { filePath: 'a.ts' },
       }),
     ).rejects.toThrow();
@@ -115,19 +115,21 @@ describe('tool-loop-guard', () => {
   });
 
   test('non-readonly tools warn but are never hard-blocked', async () => {
-    // bash repeats warn at 3 but must not throw at 5+
+    // bash is not in BLOCK_TOOLS: confirmed identical runs warn at 3 but
+    // even a long identical run never throws.
     for (let i = 1; i <= 6; i++) {
       await hook['tool.execute.before'](
         beforeInput({ tool: 'bash', callID: `b${i}` }),
         { args: { command: 'uname' } },
       );
+      const output = { output: 'Linux', metadata: {} };
+      await hook['tool.execute.after'](
+        afterInput({ tool: 'bash', callID: `b${i}` }),
+        output,
+      );
+      // never throws (bash is not in BLOCK_TOOLS)
+      expect(output.output).toContain(i >= 3 ? LOOP_GUARD_WARNING : 'Linux');
     }
-    const output = { output: 'Linux', metadata: {} };
-    await hook['tool.execute.after'](
-      afterInput({ tool: 'bash', callID: 'b6' }),
-      output,
-    );
-    expect(output.output).toContain(LOOP_GUARD_WARNING);
   });
 
   test('identical args returning changing results never block', async () => {
@@ -150,21 +152,49 @@ describe('tool-loop-guard', () => {
         beforeInput({ tool: 'bash', callID: `e${i}` }),
         { args: { command: 'uname' } },
       );
+      await hook['tool.execute.after'](
+        afterInput({ tool: 'bash', callID: `e${i}` }),
+        { output: 'Linux', metadata: {} },
+      );
     }
-    const output = { output: 'Linux', metadata: {} };
-    await hook['tool.execute.after'](
-      afterInput({ tool: 'bash', callID: 'e6' }),
-      output,
-    );
-    expect(output.output).toContain(LOOP_GUARD_WARNING);
+    // never throws (bash is not in BLOCK_TOOLS)
   });
 
-  test('identical args with stable identical output still block at 5', async () => {
-    for (let i = 1; i <= 4; i++) {
-      await runIdenticalCall(`f${i}`, { filePath: 'a.ts' }); // output identical each time
+  test('overlapping same-args calls with changing results never block', async () => {
+    // All befores fire before any after — simulates parallel execution
+    // where the counter previously inflated past the threshold.
+    for (let i = 1; i <= 6; i++) {
+      await hook['tool.execute.before'](beforeInput({ callID: `o${i}` }), {
+        args: { filePath: 'a.ts' },
+      });
     }
+    // then results arrive, each different (file was being modified)
+    for (let i = 1; i <= 6; i++) {
+      const output = { output: `revision ${i}`, metadata: {} };
+      await hook['tool.execute.after'](afterInput({ callID: `o${i}` }), output);
+      expect(output.output).toBe(`revision ${i}`); // never warned
+    }
+    // next same-args call is still allowed
+    await hook['tool.execute.before'](beforeInput({ callID: 'o7' }), {
+      args: { filePath: 'a.ts' },
+    });
+  });
+
+  test('overlapping same-args calls with identical results block the next call', async () => {
+    for (let i = 1; i <= 6; i++) {
+      await hook['tool.execute.before'](beforeInput({ callID: `p${i}` }), {
+        args: { filePath: 'a.ts' },
+      });
+    }
+    for (let i = 1; i <= 5; i++) {
+      await hook['tool.execute.after'](afterInput({ callID: `p${i}` }), {
+        output: 'same',
+        metadata: {},
+      });
+    }
+    // 5 confirmed identical results: the next same-args call is refused
     await expect(
-      hook['tool.execute.before'](beforeInput({ callID: 'f5' }), {
+      hook['tool.execute.before'](beforeInput({ callID: 'p7' }), {
         args: { filePath: 'a.ts' },
       }),
     ).rejects.toThrow('infinite loop');

--- a/src/hooks/tool-loop-guard/index.test.ts
+++ b/src/hooks/tool-loop-guard/index.test.ts
@@ -99,6 +99,37 @@ describe('tool-loop-guard', () => {
     // no throw
   });
 
+  test('polling tools are exempt from warn and block', async () => {
+    for (let i = 1; i <= 8; i++) {
+      await hook['tool.execute.before'](
+        beforeInput({ tool: 'task_status', callID: `s${i}` }),
+        { args: { task_id: 'child-1' } },
+      );
+      const output = { output: 'state: running', metadata: {} };
+      await hook['tool.execute.after'](
+        afterInput({ tool: 'task_status', callID: `s${i}` }),
+        output,
+      );
+      expect(output.output).toBe('state: running'); // never warned
+    }
+  });
+
+  test('non-readonly tools warn but are never hard-blocked', async () => {
+    // bash repeats warn at 3 but must not throw at 5+
+    for (let i = 1; i <= 6; i++) {
+      await hook['tool.execute.before'](
+        beforeInput({ tool: 'bash', callID: `b${i}` }),
+        { args: { command: 'uname' } },
+      );
+    }
+    const output = { output: 'Linux', metadata: {} };
+    await hook['tool.execute.after'](
+      afterInput({ tool: 'bash', callID: 'b6' }),
+      output,
+    );
+    expect(output.output).toContain(LOOP_GUARD_WARNING);
+  });
+
   test('sessions are isolated', async () => {
     for (let i = 1; i <= 2; i++) {
       await runIdenticalCall(`a${i}`, { filePath: 'a.ts' });

--- a/src/hooks/tool-loop-guard/index.test.ts
+++ b/src/hooks/tool-loop-guard/index.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import type { ToolLoopGuardHook } from './hook';
+import { createToolLoopGuardHook, LOOP_GUARD_WARNING } from './hook';
+
+function beforeInput(
+  overrides: Partial<{ tool: string; sessionID: string; callID: string }> = {},
+) {
+  return { tool: 'read', sessionID: 's1', callID: 'c1', ...overrides };
+}
+
+function afterInput(
+  overrides: Partial<{ tool: string; sessionID: string; callID: string }> = {},
+) {
+  return { tool: 'read', sessionID: 's1', callID: 'c1', ...overrides };
+}
+
+describe('tool-loop-guard', () => {
+  let hook: ToolLoopGuardHook;
+
+  beforeEach(() => {
+    hook = createToolLoopGuardHook();
+  });
+
+  async function runIdenticalCall(
+    callID: string,
+    args: unknown,
+    toolOutput = '...file contents...',
+  ) {
+    await hook['tool.execute.before'](beforeInput({ callID }), { args });
+    const output = { output: toolOutput, metadata: {} };
+    await hook['tool.execute.after'](afterInput({ callID }), output);
+    return output;
+  }
+
+  test('leaves output untouched for first and second identical calls', async () => {
+    const o1 = await runIdenticalCall('c1', { filePath: 'a.ts' });
+    const o2 = await runIdenticalCall('c2', { filePath: 'a.ts' });
+    expect(o1.output).toBe('...file contents...');
+    expect(o2.output).toBe('...file contents...');
+  });
+
+  test('appends warning on third identical consecutive call', async () => {
+    await runIdenticalCall('c1', { filePath: 'a.ts' });
+    await runIdenticalCall('c2', { filePath: 'a.ts' });
+    const o3 = await runIdenticalCall('c3', { filePath: 'a.ts' });
+    expect(o3.output).toContain(LOOP_GUARD_WARNING);
+  });
+
+  test('resets the count when arguments change', async () => {
+    await runIdenticalCall('c1', { filePath: 'a.ts' });
+    await runIdenticalCall('c2', { filePath: 'a.ts' });
+    const o3 = await runIdenticalCall('c3', { filePath: 'b.ts' });
+    expect(o3.output).toBe('...file contents...');
+    const o4 = await runIdenticalCall('c4', { filePath: 'b.ts' });
+    expect(o4.output).toBe('...file contents...');
+  });
+
+  test('key order in args does not defeat detection', async () => {
+    await runIdenticalCall('c1', { filePath: 'a.ts', offset: 12 });
+    await runIdenticalCall('c2', { offset: 12, filePath: 'a.ts' });
+    const o3 = await runIdenticalCall('c3', { filePath: 'a.ts', offset: 12 });
+    expect(o3.output).toContain(LOOP_GUARD_WARNING);
+  });
+
+  test('fifth identical call is refused in tool.execute.before', async () => {
+    for (let i = 1; i <= 4; i++) {
+      await runIdenticalCall(`c${i}`, { filePath: 'a.ts' });
+    }
+    await expect(
+      hook['tool.execute.before'](beforeInput({ callID: 'c5' }), {
+        args: { filePath: 'a.ts' },
+      }),
+    ).rejects.toThrow('infinite loop');
+  });
+
+  test('blocked fingerprint stays blocked', async () => {
+    for (let i = 1; i <= 4; i++) {
+      await runIdenticalCall(`c${i}`, { filePath: 'a.ts' });
+    }
+    await expect(
+      hook['tool.execute.before'](beforeInput({ callID: 'c5' }), {
+        args: { filePath: 'a.ts' },
+      }),
+    ).rejects.toThrow();
+    await expect(
+      hook['tool.execute.before'](beforeInput({ callID: 'c6' }), {
+        args: { filePath: 'a.ts' },
+      }),
+    ).rejects.toThrow();
+  });
+
+  test('task tool is exempt', async () => {
+    for (let i = 1; i <= 5; i++) {
+      await hook['tool.execute.before'](
+        beforeInput({ tool: 'task', callID: `t${i}` }),
+        { args: { subagent_type: 'explorer', prompt: 'find x' } },
+      );
+    }
+    // no throw
+  });
+
+  test('sessions are isolated', async () => {
+    for (let i = 1; i <= 2; i++) {
+      await runIdenticalCall(`a${i}`, { filePath: 'a.ts' });
+    }
+    // same args, different session: count starts fresh
+    await hook['tool.execute.before'](
+      beforeInput({ sessionID: 's2', callID: 'b1' }),
+      { args: { filePath: 'a.ts' } },
+    );
+    const output = { output: '...file contents...', metadata: {} };
+    await hook['tool.execute.after'](
+      afterInput({ sessionID: 's2', callID: 'b1' }),
+      output,
+    );
+    expect(output.output).toBe('...file contents...');
+  });
+
+  test('does not append marker twice', async () => {
+    let out = { output: 'x' };
+    for (let i = 1; i <= 4; i++) {
+      out = await runIdenticalCall(`c${i}`, { filePath: 'a.ts' });
+    }
+    const count =
+      String(out.output).split(LOOP_GUARD_WARNING.trim()).length - 1;
+    expect(count).toBe(1);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,11 +27,13 @@ import {
   createPostFileToolNudgeHook,
   createReflectCommandHook,
   createTaskSessionManagerHook,
+  createToolLoopGuardHook,
   ForegroundFallbackManager,
   SessionLifecycle,
 } from './hooks';
 import { processImageAttachments } from './hooks/image-hook';
 import { createRevivedRunTracker } from './hooks/task-session-manager/revived-run-tracker';
+import type { ToolLoopGuardHook } from './hooks/tool-loop-guard/hook';
 import { isMessageWithParts, type MessageWithParts } from './hooks/types';
 import { handleTaskSessionEvent } from './index-event';
 import { createInterviewManager } from './interview';
@@ -170,6 +172,7 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
   let postFileToolNudge: ReturnType<typeof createPostFileToolNudgeHook>;
   let applyPatch: ReturnType<typeof createApplyPatchHook>;
   let jsonErrorRecovery: ReturnType<typeof createJsonErrorRecoveryHook>;
+  let toolLoopGuard: ToolLoopGuardHook;
   let postFileToolNudgeAfter: (i: unknown, o: unknown) => Promise<void>;
   let jsonErrorRecoveryAfter: (i: unknown, o: unknown) => Promise<void>;
   let taskSessionManagerAfter: (i: unknown, o: unknown) => Promise<void>;
@@ -449,6 +452,7 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
     applyPatch = createApplyPatchHook(ctx);
 
     jsonErrorRecovery = createJsonErrorRecoveryHook(ctx);
+    toolLoopGuard = createToolLoopGuardHook();
 
     // Pre-created wrapped handlers for tool.execute.after (error-isolated)
     postFileToolNudgeAfter = wrapPostToolHook('post-file-tool-nudge', (i, o) =>
@@ -1110,6 +1114,10 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
     },
 
     'tool.execute.before': async (input, output) => {
+      await toolLoopGuard['tool.execute.before'](
+        input as never,
+        output as never,
+      );
       await applyPatch['tool.execute.before'](input as never, output as never);
       await taskSessionManagerHook['tool.execute.before'](
         input as never,
@@ -1344,6 +1352,10 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
     'tool.execute.after': async (input, output) => {
       await postFileToolNudgeAfter(input, output);
       await jsonErrorRecoveryAfter(input, output);
+      await toolLoopGuard['tool.execute.after'](
+        input as never,
+        output as never,
+      );
       await taskSessionManagerAfter(input, output);
     },
   };


### PR DESCRIPTION
Fixes #1071

## What problem are you solving?

A sub-agent running a model that can degenerate (reported: DeepSeek V4 Flash as Explorer) re-issues the exact same tool call — same tool, same arguments — gets an identical result, and repeats forever, making no progress. The plugin previously had no guard for this failure class, so the session hung indefinitely and had to be cancelled manually.

## What does this change?

Adds a `tool-loop-guard` hook that tracks consecutive identical tool calls per session. On the 3rd identical call it appends corrective text to the tool output telling the model to stop and change approach. On the 5th identical call it refuses execution of read-only file-analysis tools (`read`, `grep`, `glob`) in `tool.execute.before`, terminating the loop. Wired into the `tool.execute.before`/`after` chains alongside the existing json-error-recovery and task-session-manager hooks; documents the behavior in `docs/tools.md`.

## Why this approach?

It mirrors two existing precedents in the repo: json-error-recovery (corrective text appended to tool output) and task-session-manager (refusal by throwing in `tool.execute.before`). The block scope is deliberately narrow — only read-only file-analysis tools hard-block, because polling tools (`task_status`, `task_result`, `wait_for_*`, etc.) legitimately re-issue identical calls while waiting on a long-running background task and must never be refused. Arg fingerprints use stable stringify so key order in JSON args does not defeat detection.

## Related work

- [x] I checked open AND closed PRs/issues for duplicates
- Related: none found. #1071 is the tracking issue. Distinct from the orchestration-side reconcile loop (#1056/#1070, separate fix surface) and the provider-fallback loop (#966).

## AI assistance

- Model / harness: OpenCode. Sub-agent review agents were **not** used: the sub-agent harness has no model configured in this checkout (no `oh-my-opencode-slim.jsonc` preset, no API key), so the code-review pass was performed by the orchestrator directly rather than by `@oracle`/`@skeptic` subagents.
- Human reviewed the full diff? No

## Checklist

- [x] `bun run typecheck` and `bun test` (2180 pass, 0 fail) green
- [ ] `bun run check:ci` green — fails only on `src/tui.ts`/`src/tui.test.ts`, which are **pre-existing failures already present on clean `master`** (verified on a master checkout; tracked separately by the fix-ci work). The files in this PR are Biome-clean.
- [x] Docs (docs/tools.md) updated for the changed behavior
- [x] One logical change per PR
- [x] PR targets the `master` branch