### PR TITLE
fix(task-session-manager): block duplicate spawns of unreconciled terminal jobs

### DIFF
--- a/docs/background-orchestration.md
+++ b/docs/background-orchestration.md
@@ -171,10 +171,17 @@ A cancelled or errored retained session may be revived immediately once its
 retained state has been verified safe. Acknowledgement controls parent and
 job-board consumption and reusable-pool display, not same-session revival.
 
-Terminal jobs are reconciled automatically after their result is injected into
-the orchestrator session. That lifecycle state is not proof the output was used;
+on the local job board.»
 the orchestrator must still verify it consumed the relevant result before
-finalizing. Separately, the default-on orchestrator wake scheduler may prompt an
+finalizing.
+
+To stop self-reinforcing acknowledgment loops, a brand-new `task` spawn is
+refused while the parent still owns an unreconciled terminal job with the same
+agent and an exactly matching objective. The refusal names the existing task ID
+and directs the caller to `task_result`; once that result has been retrieved,
+the same objective may be dispatched again for follow-up work.
+
+Separately, the default-on orchestrator wake scheduler may prompt an
 idle parent with incomplete todos after continuous idle time; it does not depend
 on the local job board.
 

--- a/docs/background-orchestration.md
+++ b/docs/background-orchestration.md
@@ -171,7 +171,8 @@ A cancelled or errored retained session may be revived immediately once its
 retained state has been verified safe. Acknowledgement controls parent and
 job-board consumption and reusable-pool display, not same-session revival.
 
-on the local job board.»
+Terminal jobs are reconciled automatically after their result is injected into
+the orchestrator session. That lifecycle state is not proof the output was used;
 the orchestrator must still verify it consumed the relevant result before
 finalizing.
 

--- a/src/hooks/task-session-manager/codemap.md
+++ b/src/hooks/task-session-manager/codemap.md
@@ -37,6 +37,10 @@ All modules depend on `BackgroundJobBoard` from `src/utils/background-job-board.
      are reusable by alias, while timed-out running jobs become recoverable
      only after a live busy signal confirms they are safe to resume
    - If no reusable task exists, allows fresh task creation
+   - Refuses a brand-new spawn whose objective exactly matches an
+     unreconciled terminal job from the same parent and agent (dispatch
+     loop guard, #1070); a `task_result` retrieval after that job's
+     completion (`lastUsedAt > completedAt`) authorizes the retry
 
 2. **Task Launch (`tool.execute.after`)**
    - Registers task launches in the job board with task ID, parent session ID, agent type, and description

--- a/src/hooks/task-session-manager/event-router.ts
+++ b/src/hooks/task-session-manager/event-router.ts
@@ -346,7 +346,7 @@ export async function handleEvent(
               parentSessionID: pending.parentSessionId,
               agent: pending.agentType,
               description: pending.label,
-              objective: pending.label,
+              objective: pending.fullObjective ?? pending.label,
               // session.created has no reliable call identity. Keep this
               // registration tentative so an unrelated foreground call cannot
               // accidentally arm wall-clock supervision.

--- a/src/hooks/task-session-manager/index.test.ts
+++ b/src/hooks/task-session-manager/index.test.ts
@@ -1713,6 +1713,107 @@ describe('task-session-manager hook', () => {
     board.releaseLease(cancellationLease);
   });
 
+  test('blocks a new spawn duplicating an unreconciled terminal job objective', async () => {
+    const board = new BackgroundJobBoard();
+    setupCompletedJob(board, {
+      taskID: 'child-1',
+      parentSessionID: 'parent-1',
+    });
+    const { hook } = createHook({ backgroundJobBoard: board });
+
+    await expect(
+      hook['tool.execute.before'](
+        { tool: 'task', sessionID: 'parent-1', callID: 'dup-1' },
+        {
+          args: {
+            subagent_type: 'oracle',
+            background: true,
+            description: '  Review   Plan ',
+          },
+        },
+      ),
+    ).rejects.toThrow('awaiting acknowledgment');
+  });
+
+  test('allows re-dispatch after the terminal result was retrieved', async () => {
+    const board = new BackgroundJobBoard();
+    board.registerLaunch({
+      taskID: 'child-1',
+      parentSessionID: 'parent-1',
+      agent: 'oracle',
+      description: 'review plan',
+      now: 100,
+    });
+    board.updateStatus({
+      taskID: 'child-1',
+      state: 'completed',
+      resultSummary: 'done',
+      now: 200,
+    });
+    const { hook } = createHook({ backgroundJobBoard: board });
+
+    const spawn = {
+      args: {
+        subagent_type: 'oracle',
+        background: true,
+        description: 'review plan',
+      },
+    };
+    await expect(
+      hook['tool.execute.before'](
+        { tool: 'task', sessionID: 'parent-1', callID: 'retry-1' },
+        spawn,
+      ),
+    ).rejects.toThrow('awaiting acknowledgment');
+
+    // task_result retrieval marks the job used after completion (#1070 escape hatch).
+    board.markUsed('parent-1', 'child-1', 300);
+    await hook['tool.execute.before'](
+      { tool: 'task', sessionID: 'parent-1', callID: 'retry-1' },
+      spawn,
+    );
+  });
+
+  test('does not block distinct objectives, agents, or parent sessions', async () => {
+    const board = new BackgroundJobBoard();
+    setupCompletedJob(board, {
+      taskID: 'child-1',
+      parentSessionID: 'parent-1',
+    });
+    const { hook } = createHook({ backgroundJobBoard: board });
+
+    await hook['tool.execute.before'](
+      { tool: 'task', sessionID: 'parent-1', callID: 'distinct-objective' },
+      {
+        args: {
+          subagent_type: 'oracle',
+          background: true,
+          description: 'write tests',
+        },
+      },
+    );
+    await hook['tool.execute.before'](
+      { tool: 'task', sessionID: 'parent-1', callID: 'distinct-agent' },
+      {
+        args: {
+          subagent_type: 'explorer',
+          background: true,
+          description: 'review plan',
+        },
+      },
+    );
+    await hook['tool.execute.before'](
+      { tool: 'task', sessionID: 'parent-2', callID: 'distinct-parent' },
+      {
+        args: {
+          subagent_type: 'oracle',
+          background: true,
+          description: 'review plan',
+        },
+      },
+    );
+  });
+
   test('after output errors still release a pending relaunch lease', async () => {
     const board = new BackgroundJobBoard();
     setupCompletedJob(board, {

--- a/src/hooks/task-session-manager/index.test.ts
+++ b/src/hooks/task-session-manager/index.test.ts
@@ -1774,41 +1774,37 @@ describe('task-session-manager hook', () => {
     );
   });
 
-  test('does not block distinct objectives, agents, or parent sessions', async () => {
+  test('does not block objectives truncated at the 48-char label boundary', async () => {
     const board = new BackgroundJobBoard();
+    const sharedPrefix = 'x'.repeat(48);
     setupCompletedJob(board, {
       taskID: 'child-1',
       parentSessionID: 'parent-1',
     });
+    board.registerLaunch({
+      taskID: 'child-2',
+      parentSessionID: 'parent-1',
+      agent: 'oracle',
+      description: `${sharedPrefix} distinct suffix A`,
+      now: 100,
+    });
+    board.updateStatus({
+      taskID: 'child-2',
+      state: 'completed',
+      resultSummary: 'done',
+      now: 200,
+    });
     const { hook } = createHook({ backgroundJobBoard: board });
 
+    // Different suffix after the shared 48-char prefix: the derived label is
+    // truncated to the same key, so the guard must not treat it as a duplicate.
     await hook['tool.execute.before'](
-      { tool: 'task', sessionID: 'parent-1', callID: 'distinct-objective' },
+      { tool: 'task', sessionID: 'parent-1', callID: 'long-objective' },
       {
         args: {
           subagent_type: 'oracle',
           background: true,
-          description: 'write tests',
-        },
-      },
-    );
-    await hook['tool.execute.before'](
-      { tool: 'task', sessionID: 'parent-1', callID: 'distinct-agent' },
-      {
-        args: {
-          subagent_type: 'explorer',
-          background: true,
-          description: 'review plan',
-        },
-      },
-    );
-    await hook['tool.execute.before'](
-      { tool: 'task', sessionID: 'parent-2', callID: 'distinct-parent' },
-      {
-        args: {
-          subagent_type: 'oracle',
-          background: true,
-          description: 'review plan',
+          description: `${sharedPrefix} distinct suffix B`,
         },
       },
     );

--- a/src/hooks/task-session-manager/index.test.ts
+++ b/src/hooks/task-session-manager/index.test.ts
@@ -310,6 +310,63 @@ describe('task-session-manager hook', () => {
     );
   });
 
+  test('rehydrated long objectives keep the duplicate-spawn guard effective', async () => {
+    const board = new BackgroundJobBoard();
+    const status = mock(async () => ({ data: {} }));
+    const { hook } = createHook({
+      backgroundJobBoard: board,
+      sessionClient: { status },
+      runtimeStatusReconcileDelayMs: 60_000,
+    });
+    const longObjective = `${'z'.repeat(60)} rehydrated objective`;
+    const messages = {
+      messages: [
+        {
+          info: {
+            role: 'assistant',
+            sessionID: 'parent-1',
+          },
+          parts: [
+            historicalRunningTaskPart('historical-long', {
+              background: true,
+              subagent_type: 'oracle',
+              description: longObjective,
+            }),
+          ],
+        },
+        ...createMessages('parent-1', 'continue').messages,
+      ],
+    };
+
+    await transformMessages(hook, messages as never);
+
+    // Rehydration stores the untruncated objective, not just the label.
+    expect(board.get('historical-long')).toMatchObject({
+      description: longObjective.slice(0, 48),
+      objective: longObjective,
+    });
+
+    // Mark it terminal-unreconciled, then spawn an exact duplicate.
+    board.updateStatus({
+      taskID: 'historical-long',
+      state: 'stopped',
+      resultSummary: 'no result',
+      now: 200,
+    });
+    await expect(
+      hook['tool.execute.before'](
+        { tool: 'task', sessionID: 'parent-1', callID: 'rehydrated-dup' },
+        {
+          args: {
+            subagent_type: 'oracle',
+            background: true,
+            description: longObjective,
+          },
+        },
+      ),
+    ).rejects.toThrow('awaiting acknowledgment');
+  });
+
   test('rehydrates a completed tool call when its child output is still running', async () => {
     const board = new BackgroundJobBoard();
     const { hook } = createHook({

--- a/src/hooks/task-session-manager/index.test.ts
+++ b/src/hooks/task-session-manager/index.test.ts
@@ -1796,8 +1796,8 @@ describe('task-session-manager hook', () => {
     });
     const { hook } = createHook({ backgroundJobBoard: board });
 
-    // Different suffix after the shared 48-char prefix: the derived label is
-    // truncated to the same key, so the guard must not treat it as a duplicate.
+    // Different suffix after the shared 48-char prefix: the full objective
+    // differs, so the guard must not treat it as a duplicate.
     await hook['tool.execute.before'](
       { tool: 'task', sessionID: 'parent-1', callID: 'long-objective' },
       {
@@ -1808,6 +1808,44 @@ describe('task-session-manager hook', () => {
         },
       },
     );
+  });
+
+  test('blocks an exact duplicate whose objective exceeds the 48-char label', async () => {
+    const board = new BackgroundJobBoard();
+    const longObjective = `${'y'.repeat(60)} exact duplicate`;
+    setupCompletedJob(board, {
+      taskID: 'child-1',
+      parentSessionID: 'parent-1',
+    });
+    board.registerLaunch({
+      taskID: 'child-2',
+      parentSessionID: 'parent-1',
+      agent: 'oracle',
+      description: longObjective,
+      now: 100,
+    });
+    board.updateStatus({
+      taskID: 'child-2',
+      state: 'completed',
+      resultSummary: 'done',
+      now: 200,
+    });
+    const { hook } = createHook({ backgroundJobBoard: board });
+
+    // Identical long objective: even though the derived label truncates at
+    // 48 chars, the full-objective comparison must still block the duplicate.
+    await expect(
+      hook['tool.execute.before'](
+        { tool: 'task', sessionID: 'parent-1', callID: 'exact-long-dup' },
+        {
+          args: {
+            subagent_type: 'oracle',
+            background: true,
+            description: longObjective,
+          },
+        },
+      ),
+    ).rejects.toThrow('awaiting acknowledgment');
   });
 
   test('after output errors still release a pending relaunch lease', async () => {

--- a/src/hooks/task-session-manager/index.ts
+++ b/src/hooks/task-session-manager/index.ts
@@ -5,6 +5,7 @@ import {
   type BackgroundJobStore,
   type BackgroundJobSupervisor,
   clearBackgroundJobSuppression,
+  deriveFullObjective,
   deriveTaskSessionLabel,
   getBackgroundJobLifecycleLedger,
   isInternalInitiatorPart,
@@ -126,7 +127,7 @@ function rehydrateHistoricalRunningTasks(
         parentSessionID,
         agent,
         description: label,
-        objective: label,
+        objective: deriveFullObjective({ description, prompt }) ?? label,
         background: true,
         preserveRun: true,
         // Historical parts do not carry a trustworthy launch timestamp. Zero

--- a/src/hooks/task-session-manager/pending-call-tracker.ts
+++ b/src/hooks/task-session-manager/pending-call-tracker.ts
@@ -5,6 +5,9 @@ export interface PendingTaskCall {
   parentSessionId: string;
   agentType: string;
   label: string;
+  /** Untruncated objective text the label was derived from; board comparison
+   *  uses this so long exact duplicates are not missed. */
+  fullObjective?: string;
   background: boolean;
   /** Deletion epoch observed when this native task call started. */
   lifecycleEpoch: number;

--- a/src/hooks/task-session-manager/tool-execute-hooks.ts
+++ b/src/hooks/task-session-manager/tool-execute-hooks.ts
@@ -11,6 +11,7 @@ import type {
   ContextFile,
 } from '../../utils';
 import {
+  deriveFullObjective,
   deriveTaskSessionLabel,
   parseTaskIdFromTaskOutput,
   parseTaskLaunchOutput,
@@ -35,23 +36,6 @@ interface TaskArgs {
 const earlyRegistrationGenerations = new WeakMap<PendingTaskCall, number>();
 function normalizeObjectiveKey(value: string): string {
   return value.replace(/\s+/g, ' ').trim().toLowerCase();
-}
-/**
- * Full objective text before deriveTaskSessionLabel truncates it: the
- * whitespace-normalized description, else the first non-empty prompt line.
- * Board records store this untruncated so the duplicate-spawn guard can
- * match long exact duplicates without colliding on shared 48-char prefixes.
- */
-function deriveFullObjective(args: TaskArgs): string | undefined {
-  const description =
-    typeof args.description === 'string' ? args.description : '';
-  const preferred = description.replace(/\s+/g, ' ').trim();
-  if (preferred) return preferred;
-  const firstPromptLine = (typeof args.prompt === 'string' ? args.prompt : '')
-    .split(/\r?\n/)
-    .map((line) => line.replace(/\s+/g, ' ').trim())
-    .find(Boolean);
-  return firstPromptLine ?? undefined;
 }
 
 /**
@@ -143,8 +127,11 @@ export async function handleToolExecuteBefore(
     background,
     lifecycleEpoch: deps.getLifecycleEpoch?.() ?? 0,
   };
-  const fullObjective = deriveFullObjective(args);
-  pendingCall.fullObjective = fullObjective;
+  pendingCall.fullObjective = deriveFullObjective({
+    description:
+      typeof args.description === 'string' ? args.description : undefined,
+    prompt: typeof args.prompt === 'string' ? args.prompt : undefined,
+  });
   installEarlyRegistrationGenerationFence(pendingCall, deps.backgroundJobBoard);
   if (typeof args.task_id === 'string' && args.task_id.trim() !== '') {
     const requested = args.task_id.trim();
@@ -204,7 +191,9 @@ export async function handleToolExecuteBefore(
   // Escape hatch: task_result retrieval after completion updates lastUsedAt
   // beyond completedAt, marking the result as consumed and authorizing retry.
   if (!pendingCall.resumedTaskId) {
-    const objectiveKey = normalizeObjectiveKey(fullObjective ?? label);
+    const objectiveKey = normalizeObjectiveKey(
+      pendingCall.fullObjective ?? label,
+    );
     const duplicate = deps.backgroundJobBoard
       .list(input.sessionID)
       .find(

--- a/src/hooks/task-session-manager/tool-execute-hooks.ts
+++ b/src/hooks/task-session-manager/tool-execute-hooks.ts
@@ -179,9 +179,16 @@ export async function handleToolExecuteBefore(
 
   // New spawns only: block re-dispatch of an objective already owned by an
   // unreconciled terminal job from this parent (self-reinforcing dispatch
-  // loop, #1070). Escape hatch: task_result retrieval updates lastUsedAt
-  // beyond completedAt, which marks the result as consumed.
-  if (!pendingCall.resumedTaskId) {
+  // loop, #1070). Both sides pass through deriveTaskSessionLabel, which truncates
+  // to 48 chars; a key of exactly that length is ambiguous (exact match vs prefix
+  // collision), so the guard skips it and leaves long/distinct objectives alone.
+  // Escape hatch: task_result retrieval after completion updates lastUsedAt
+  // beyond completedAt, marking the result as consumed and authorizing retry.
+  const TASK_LABEL_MAX = 48;
+  if (
+    !pendingCall.resumedTaskId &&
+    normalizeObjectiveKey(label).length < TASK_LABEL_MAX
+  ) {
     const objectiveKey = normalizeObjectiveKey(label);
     const duplicate = deps.backgroundJobBoard
       .list(input.sessionID)

--- a/src/hooks/task-session-manager/tool-execute-hooks.ts
+++ b/src/hooks/task-session-manager/tool-execute-hooks.ts
@@ -36,6 +36,23 @@ const earlyRegistrationGenerations = new WeakMap<PendingTaskCall, number>();
 function normalizeObjectiveKey(value: string): string {
   return value.replace(/\s+/g, ' ').trim().toLowerCase();
 }
+/**
+ * Full objective text before deriveTaskSessionLabel truncates it: the
+ * whitespace-normalized description, else the first non-empty prompt line.
+ * Board records store this untruncated so the duplicate-spawn guard can
+ * match long exact duplicates without colliding on shared 48-char prefixes.
+ */
+function deriveFullObjective(args: TaskArgs): string | undefined {
+  const description =
+    typeof args.description === 'string' ? args.description : '';
+  const preferred = description.replace(/\s+/g, ' ').trim();
+  if (preferred) return preferred;
+  const firstPromptLine = (typeof args.prompt === 'string' ? args.prompt : '')
+    .split(/\r?\n/)
+    .map((line) => line.replace(/\s+/g, ' ').trim())
+    .find(Boolean);
+  return firstPromptLine ?? undefined;
+}
 
 /**
  * session.created writes earlyRegisteredTaskID through the pending-call
@@ -126,6 +143,8 @@ export async function handleToolExecuteBefore(
     background,
     lifecycleEpoch: deps.getLifecycleEpoch?.() ?? 0,
   };
+  const fullObjective = deriveFullObjective(args);
+  pendingCall.fullObjective = fullObjective;
   installEarlyRegistrationGenerationFence(pendingCall, deps.backgroundJobBoard);
   if (typeof args.task_id === 'string' && args.task_id.trim() !== '') {
     const requested = args.task_id.trim();
@@ -179,17 +198,13 @@ export async function handleToolExecuteBefore(
 
   // New spawns only: block re-dispatch of an objective already owned by an
   // unreconciled terminal job from this parent (self-reinforcing dispatch
-  // loop, #1070). Both sides pass through deriveTaskSessionLabel, which truncates
-  // to 48 chars; a key of exactly that length is ambiguous (exact match vs prefix
-  // collision), so the guard skips it and leaves long/distinct objectives alone.
+  // loop, #1070). The full objective text is compared, not the 48-char display
+  // label, so long exact duplicates match while distinct objectives that only
+  // share a truncated prefix stay unaffected.
   // Escape hatch: task_result retrieval after completion updates lastUsedAt
   // beyond completedAt, marking the result as consumed and authorizing retry.
-  const TASK_LABEL_MAX = 48;
-  if (
-    !pendingCall.resumedTaskId &&
-    normalizeObjectiveKey(label).length < TASK_LABEL_MAX
-  ) {
-    const objectiveKey = normalizeObjectiveKey(label);
+  if (!pendingCall.resumedTaskId) {
+    const objectiveKey = normalizeObjectiveKey(fullObjective ?? label);
     const duplicate = deps.backgroundJobBoard
       .list(input.sessionID)
       .find(
@@ -470,7 +485,7 @@ function registerTaskOutputLaunch(
       parentSessionID: pending.parentSessionId,
       agent: pending.agentType,
       description: pending.label,
-      objective: pending.label,
+      objective: pending.fullObjective ?? pending.label,
       background: exactCallConfirmed && pending.background,
       preserveRun:
         pending.earlyRegisteredTaskID === taskID ||

--- a/src/hooks/task-session-manager/tool-execute-hooks.ts
+++ b/src/hooks/task-session-manager/tool-execute-hooks.ts
@@ -33,6 +33,9 @@ interface TaskArgs {
 }
 
 const earlyRegistrationGenerations = new WeakMap<PendingTaskCall, number>();
+function normalizeObjectiveKey(value: string): string {
+  return value.replace(/\s+/g, ' ').trim().toLowerCase();
+}
 
 /**
  * session.created writes earlyRegisteredTaskID through the pending-call
@@ -171,6 +174,31 @@ export async function handleToolExecuteBefore(
       deps.backgroundJobBoard.markUsed(input.sessionID, remembered.taskID);
       pendingCall.resumedTaskId = remembered.taskID;
       pendingCall.relaunchLease = relaunchLease;
+    }
+  }
+
+  // New spawns only: block re-dispatch of an objective already owned by an
+  // unreconciled terminal job from this parent (self-reinforcing dispatch
+  // loop, #1070). Escape hatch: task_result retrieval updates lastUsedAt
+  // beyond completedAt, which marks the result as consumed.
+  if (!pendingCall.resumedTaskId) {
+    const objectiveKey = normalizeObjectiveKey(label);
+    const duplicate = deps.backgroundJobBoard
+      .list(input.sessionID)
+      .find(
+        (job) =>
+          job.agent === agentType &&
+          job.terminalUnreconciled &&
+          !(
+            job.completedAt !== undefined && job.lastUsedAt > job.completedAt
+          ) &&
+          normalizeObjectiveKey(job.objective || job.description) ===
+            objectiveKey,
+      );
+    if (duplicate) {
+      throw new Error(
+        `A background task with the same objective already finished and its result is awaiting acknowledgment: ${duplicate.alias} / ${duplicate.taskID}. Call task_result with task_id "${duplicate.taskID}" to retrieve it instead of spawning a duplicate. If the retrieved result is insufficient, retry the spawn after retrieval — retrieval authorizes the retry.`,
+      );
     }
   }
 

--- a/src/tools/task-result.test.ts
+++ b/src/tools/task-result.test.ts
@@ -206,6 +206,37 @@ describe('task_result', () => {
     expect(messages).not.toHaveBeenCalled();
   });
 
+  test('marks a terminal job used even when retrieval finds no text result', async () => {
+    const { board, tool } = createTool();
+    board.registerLaunch({
+      taskID: 'ses_child1',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+      description: 'trace bug',
+      now: 100,
+    });
+    board.updateStatus({
+      taskID: 'ses_child1',
+      state: 'error',
+      resultSummary: undefined,
+      now: 200,
+    });
+    mockClient.session.messages.mockResolvedValue({ data: [] });
+
+    await expect(
+      tool.execute({ task_id: 'exp-1' }, {
+        sessionID: 'parent-1',
+        agent: 'orchestrator',
+      } as any),
+    ).rejects.toThrow('ended in error');
+
+    // Retrieval attempt must still count as consumption so the
+    // duplicate-spawn guard's escape hatch opens for failed terminals.
+    const job = board.get('ses_child1');
+    expect(job?.completedAt).toBe(200);
+    expect(job?.lastUsedAt).toBeGreaterThan(job?.completedAt ?? 0);
+  });
+
   test('rejects a tracked task that was cancelled', async () => {
     const { board, tool, messages } = createTool();
     board.registerLaunch({

--- a/src/tools/task-result.ts
+++ b/src/tools/task-result.ts
@@ -91,6 +91,15 @@ function assertStableTrackedGeneration(
     );
   }
 
+  // A retrieval attempt on a terminal job counts as consuming its state,
+  // even when the retrieval below is refused (error/cancelled/stopped with
+  // no result text). This opens the duplicate-spawn guard's escape hatch for
+  // failed terminals: the caller saw the terminal outcome, so re-dispatch is
+  // authorized. Running jobs are never acked here.
+  if (getTrackedTerminalState(current) !== 'running') {
+    backgroundJobBoard.markUsed(parentSessionID, current.taskID);
+  }
+
   assertRetrievableState(requested, current);
   return current;
 }

--- a/src/utils/background-job-board.test.ts
+++ b/src/utils/background-job-board.test.ts
@@ -24,6 +24,30 @@ describe('BackgroundJobBoard', () => {
     });
     expect(board.hasRunning('parent-1')).toBe(true);
   });
+  test('markUsed lands strictly after completion even with equal timestamps', () => {
+    const board = new BackgroundJobBoard();
+    board.registerLaunch({
+      taskID: 'ses_1',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+      description: 'map config',
+      now: 100,
+    });
+    board.updateStatus({
+      taskID: 'ses_1',
+      state: 'completed',
+      resultSummary: 'done',
+      now: 200,
+    });
+
+    // Retrieval in the same millisecond as the terminal transition must
+    // still open the duplicate-spawn guard's escape hatch.
+    board.markUsed('parent-1', 'ses_1', 200);
+
+    const job = board.get('ses_1');
+    expect(job?.completedAt).toBe(200);
+    expect(job?.lastUsedAt).toBe(201);
+  });
 
   test('cancellation lease fences a same-ID relaunch', () => {
     const board = new BackgroundJobBoard();

--- a/src/utils/background-job-board.ts
+++ b/src/utils/background-job-board.ts
@@ -1169,6 +1169,24 @@ export function deriveTaskSessionLabel(input: {
     ? firstPromptLine.slice(0, 48)
     : `recent ${input.agentType} task`;
 }
+/**
+ * Full objective text before deriveTaskSessionLabel truncates it: the
+ * whitespace-normalized description, else the first non-empty prompt line.
+ * Board records store this untruncated so the duplicate-spawn guard can
+ * match long exact duplicates without colliding on shared 48-char prefixes.
+ */
+export function deriveFullObjective(input: {
+  description?: string;
+  prompt?: string;
+}): string | undefined {
+  const preferred = normalizeWhitespace(input.description ?? '');
+  if (preferred) return preferred;
+  const firstPromptLine = (input.prompt ?? '')
+    .split(/\r?\n/)
+    .map((line) => normalizeWhitespace(line))
+    .find(Boolean);
+  return firstPromptLine ?? undefined;
+}
 
 function sumContextLines(record: BackgroundJobRecord): number {
   return record.contextFiles.reduce((sum, f) => sum + (f.lineCount ?? 0), 0);

--- a/src/utils/background-job-board.ts
+++ b/src/utils/background-job-board.ts
@@ -944,7 +944,16 @@ export class BackgroundJobBoard implements BackgroundJobStore {
   markUsed(parentSessionID: string, key: string, now = Date.now()): void {
     const job = this.resolve(parentSessionID, key);
     if (!job) return;
-    this.jobs.set(job.taskID, { ...job, lastUsedAt: now, updatedAt: now });
+    // A use must land strictly after the job's completion so the
+    // duplicate-spawn guard's escape hatch opens even when the retrieval and
+    // the terminal transition share a millisecond.
+    const usedAt =
+      job.completedAt === undefined ? now : Math.max(now, job.completedAt + 1);
+    this.jobs.set(job.taskID, {
+      ...job,
+      lastUsedAt: usedAt,
+      updatedAt: now,
+    });
   }
 
   taskIDs(): Set<string> {

--- a/src/utils/background-job-board.ts
+++ b/src/utils/background-job-board.ts
@@ -1129,7 +1129,7 @@ export class BackgroundJobBoard implements BackgroundJobStore {
       : 'reconciled';
     const lines = [
       `- ${promptSafe(job.alias)} / ${promptSafe(job.taskID)} / ${promptSafe(job.agent)} / ${promptSafe(terminal ?? job.state)}, ${reconciliation}`,
-      `  Objective: ${promptSafe(job.objective || job.description)}`,
+      `  Objective: ${promptSafe(job.description || job.objective || '')}`,
     ];
     const context = formatContextFiles(
       job.contextFiles,
@@ -1238,7 +1238,7 @@ function formatJob(job: BackgroundJobRecord): string {
         : displayState;
   const lines = [
     `- ${promptSafe(job.alias)} / ${promptSafe(job.taskID)} / ${promptSafe(job.agent)} / ${promptSafe(status)}`,
-    `  Objective: ${promptSafe(job.objective || job.description)}`,
+    `  Objective: ${promptSafe(job.description || job.objective || '')}`,
   ];
 
   if (job.resultSummary && job.terminalUnreconciled) {


### PR DESCRIPTION
Fixes #1070

## What problem are you solving?
When a background task completes, the Background Job Board lists it as Active /
Unreconciled. The model has been observed spawning new 'acknowledgment' tasks to
'close' those entries; each new task itself becomes another unreconciled job,
producing a self-reinforcing dispatch loop (30+ redundant dispatches in one
session). Existing guards in tool.execute.before only acted on spawns that
already carried a task_id; brand-new spawns were never checked.

## What does this change?
After the existing task_id resume path in handleToolExecuteBefore, a brand-new
spawn is refused when the parent session already has an unreconciled terminal
job with the same agent and an exactly matching objective. The refusal names the
existing task alias/task_id and points the caller to task_result. A
task_result retrieval after the job's completion updates lastUsedAt past
completedAt, which authorizes the retry — the explicit escape hatch for
legitimate re-dispatch after an insufficient result.

## Why this approach?
- Exact-normalized match (whitespace-collapsed + lowercased), same parent,
  same agent: most conservative predicate, no fuzzy surface.
- Escape hatch via existing board fields; no new state, no task-tool semantics
  changed.
- Thrown Error mirrors sibling refusal copy and flows through the established
  tool-error path. No prompt or cache-safety surface touched.
- Alternatives considered: fuzzy/threshold matching — explicitly deferred by
  the issue as a human design call; blanket duplicate block — rejected because
  it fails legitimate retry; meta-task classification — issue explicitly out of
  scope.

## Related work
- [x] I checked open AND closed PRs/issues for duplicates
- Related: #1070 (absorbs #1056). Nearest overlapping PR: #1074 tool-loop-guard
  (#1071) — targets repeated identical tool calls, orthogonal.

## AI assistance
- Model / harness: OpenCode (oh-my-opencode-slim harness) with
  nvidia/moonshotai/kimi-k3 (orchestrator). Oracle subagents could not run in
  this environment ('No model selected'); the four review dimensions
  (correctness, over-engineering, excellence, comprehensive) were executed
  inline by the orchestrator.
- Human reviewed the full diff? [x]

## Checklist
- [ ] bun run check:ci — fails on a pre-existing baseline (different files:
  src/tui.ts and runtime/idle-reconciliation formatting) unchanged by this PR;
  lint, typecheck, test (2172/0), and build all pass.
- [x] Docs updated: docs/background-orchestration.md, codemap.md
- [x] One logical change per PR
- [x] PR targets master