### PR TITLE
fix(orchestrator): suppress periodic wake during active children

### DIFF
--- a/src/hooks/orchestrator-wake/index.test.ts
+++ b/src/hooks/orchestrator-wake/index.test.ts
@@ -327,11 +327,14 @@ describe('orchestrator wake scheduler', () => {
 
   test('suppresses a periodic wake when the initial snapshot has an active child', async () => {
     const promptAsync = mock(async () => ({}));
+    let statusReads = 0;
     const { scheduler } = createScheduler({
       sessionClient: makeClient({
         promptAsync,
         childrenData: [{ id: 'child-1', time: { updated: 1 } }],
-        statusData: { 'child-1': { type: 'busy' } },
+        status: mock(async () => ({
+          data: statusReads++ === 0 ? { 'child-1': { type: 'busy' } } : {},
+        })),
       }),
     });
     await scheduler.event({
@@ -339,6 +342,10 @@ describe('orchestrator wake scheduler', () => {
     });
     await clock.advance(60_000);
     expect(promptAsync).not.toHaveBeenCalled();
+    expect(clock.pendingCount()).toBe(1);
+
+    await clock.advance(60_000);
+    expect(promptAsync).toHaveBeenCalledTimes(1);
   });
 
   test('suppresses a periodic wake when a child becomes active before the latest snapshot', async () => {
@@ -377,6 +384,7 @@ describe('orchestrator wake scheduler', () => {
     await clock.advance(0);
 
     expect(promptAsync).not.toHaveBeenCalled();
+    expect(clock.pendingCount()).toBe(1);
   });
 
   test('wakes when host children have no active status', async () => {

--- a/src/hooks/orchestrator-wake/index.test.ts
+++ b/src/hooks/orchestrator-wake/index.test.ts
@@ -177,10 +177,15 @@ describe('buildOrchestratorWakeFingerprint', () => {
 });
 
 describe('orchestrator wake scheduler', () => {
-  test('immediately wakes an idle parent after a stopped child', async () => {
+  test('immediately wakes an idle parent after a stopped child with an active sibling', async () => {
     const promptAsync = mock(async () => ({}));
     const { scheduler } = createScheduler({
-      sessionClient: makeClient({ todos: [], promptAsync }),
+      sessionClient: makeClient({
+        todos: [],
+        promptAsync,
+        childrenData: [{ id: 'child-2' }],
+        statusData: { 'child-2': { type: 'busy' } },
+      }),
     });
 
     scheduler.triggerStoppedJobRecovery('p1');
@@ -320,13 +325,66 @@ describe('orchestrator wake scheduler', () => {
     expect(promptAsync).toHaveBeenCalledTimes(1);
   });
 
-  test('does not consult a job board and wakes while children are active', async () => {
+  test('suppresses a periodic wake when the initial snapshot has an active child', async () => {
     const promptAsync = mock(async () => ({}));
     const { scheduler } = createScheduler({
       sessionClient: makeClient({
         promptAsync,
         childrenData: [{ id: 'child-1', time: { updated: 1 } }],
         statusData: { 'child-1': { type: 'busy' } },
+      }),
+    });
+    await scheduler.event({
+      event: { type: 'session.idle', properties: { sessionID: 'p1' } },
+    });
+    await clock.advance(60_000);
+    expect(promptAsync).not.toHaveBeenCalled();
+  });
+
+  test('suppresses a periodic wake when a child becomes active before the latest snapshot', async () => {
+    const promptAsync = mock(async () => ({}));
+    let statusReads = 0;
+    let releaseFirstGet!: () => void;
+    const firstGet = new Promise<void>((resolve) => {
+      releaseFirstGet = resolve;
+    });
+    let getCalls = 0;
+    const { scheduler } = createScheduler({
+      sessionClient: makeClient({
+        promptAsync,
+        childrenData: [{ id: 'child-1' }],
+        status: mock(async () => ({
+          data: statusReads++ === 0 ? {} : { 'child-1': { type: 'busy' } },
+        })),
+        get: mock(async () => {
+          if (getCalls++ === 0) await firstGet;
+          return {
+            data: {
+              model: { providerID: 'test', id: 'model-a', variant: 'high' },
+            },
+          };
+        }),
+      }),
+    });
+
+    await scheduler.event({
+      event: { type: 'session.idle', properties: { sessionID: 'p1' } },
+    });
+    await clock.advance(60_000);
+    expect(statusReads).toBe(1);
+
+    releaseFirstGet();
+    await clock.advance(0);
+
+    expect(promptAsync).not.toHaveBeenCalled();
+  });
+
+  test('wakes when host children have no active status', async () => {
+    const promptAsync = mock(async () => ({}));
+    const { scheduler } = createScheduler({
+      sessionClient: makeClient({
+        promptAsync,
+        childrenData: [{ id: 'child-1', time: { updated: 1 } }],
       }),
     });
     await scheduler.event({

--- a/src/hooks/orchestrator-wake/index.ts
+++ b/src/hooks/orchestrator-wake/index.ts
@@ -463,6 +463,7 @@ export function createOrchestratorWakeScheduler(
         return;
       }
       if (!recoveryWake && hasActiveChild(snapshot.children, snapshot.status)) {
+        schedule(sessionID);
         return;
       }
       if (!recoveryWake && !hasIncompleteTodos(snapshot.todos)) {
@@ -502,6 +503,7 @@ export function createOrchestratorWakeScheduler(
         return;
       }
       if (!recoveryWake && hasActiveChild(latest.children, latest.status)) {
+        schedule(sessionID);
         return;
       }
       if (!recoveryWake && !hasIncompleteTodos(latest.todos)) {

--- a/src/hooks/orchestrator-wake/index.ts
+++ b/src/hooks/orchestrator-wake/index.ts
@@ -3,7 +3,7 @@
  *
  * After continuous parent-idle time, capability-gated host session APIs may
  * receive a static internal wake prompt when incomplete todos remain. Active
- * children do not suppress wakes. Host responses are authoritative; the local
+ * children suppress periodic wakes. Host responses are authoritative; the local
  * job board is never consulted. Progress/reservation state is process-global
  * so independently created hook instances share one-flight and the two-wake
  * no-progress cap.
@@ -113,6 +113,15 @@ function hasIncompleteTodos(todos: Array<Record<string, unknown>>): boolean {
   return todos.some(
     (todo) =>
       typeof todo.status === 'string' && isIncompleteTodoStatus(todo.status),
+  );
+}
+
+function hasActiveChild(
+  children: Array<Record<string, unknown>>,
+  status: Record<string, unknown>,
+): boolean {
+  return children.some(
+    (child) => typeof child.id === 'string' && isActiveStatus(status, child.id),
   );
 }
 
@@ -453,6 +462,9 @@ export function createOrchestratorWakeScheduler(
         endIdleSpell(sessionID, true);
         return;
       }
+      if (!recoveryWake && hasActiveChild(snapshot.children, snapshot.status)) {
+        return;
+      }
       if (!recoveryWake && !hasIncompleteTodos(snapshot.todos)) {
         // No incomplete work: end the spell; do not keep polling.
         endIdleSpell(sessionID, false);
@@ -487,6 +499,9 @@ export function createOrchestratorWakeScheduler(
       }
       if (isActiveStatus(latest.status, sessionID)) {
         endIdleSpell(sessionID, true);
+        return;
+      }
+      if (!recoveryWake && hasActiveChild(latest.children, latest.status)) {
         return;
       }
       if (!recoveryWake && !hasIncompleteTodos(latest.todos)) {


### PR DESCRIPTION
## Summary
- suppress regular periodic orchestrator wakes while any host child session is active
- recheck child activity in both the initial and latest host snapshots
- preserve stopped-job recovery wakes even when another child remains active

## Verification
- `bun test src/hooks/orchestrator-wake/index.test.ts` — 28 passed
- `bun run typecheck` — passed
- `biome check src/hooks/orchestrator-wake/index.ts src/hooks/orchestrator-wake/index.test.ts` — passed

Closes #1081