### PR TITLE
fix(revived-run-tracker): gate background task notifications behind shouldManageSession

### DIFF
--- a/src/hooks/task-session-manager/revived-run-tracker.test.ts
+++ b/src/hooks/task-session-manager/revived-run-tracker.test.ts
@@ -6,6 +6,7 @@ function createHarness(
   messages: () => unknown,
   prompt = mock(async () => ({})),
   assertBound = false,
+  shouldManageSession?: (sessionID: string) => boolean,
 ) {
   const board = new BackgroundJobBoard();
   board.registerLaunch({
@@ -59,6 +60,7 @@ function createHarness(
     notificationRetryDelayMs: 0,
     onSettled: settled,
     pruneContext: pruned,
+    shouldManageSession,
   });
   return {
     board,
@@ -320,6 +322,31 @@ describe('revived run tracker', () => {
     harness.tracker.onTerminal(terminal);
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(harness.prompt).toHaveBeenCalledTimes(1);
+  });
+
+  test('skips parent notification when shouldManageSession returns false', async () => {
+    const harness = createHarness(
+      () => ({ data: [] }),
+      undefined,
+      false,
+      () => false,
+    );
+    harness.tracker.register({
+      taskID: harness.run.taskID,
+      generation: harness.run.generation,
+      parentSessionID: 'parent',
+      description: 'inspect the change',
+    });
+    const terminal = harness.board.updateStatus({
+      taskID: harness.run.taskID,
+      expectedGeneration: harness.run.generation,
+      state: 'completed',
+      resultSummary: 'done',
+    });
+    if (!terminal) throw new Error('missing terminal record');
+    harness.tracker.onTerminal(terminal);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(harness.prompt).toHaveBeenCalledTimes(0);
   });
 
   test('discards a retry when the task generation is relaunched', async () => {

--- a/src/hooks/task-session-manager/revived-run-tracker.ts
+++ b/src/hooks/task-session-manager/revived-run-tracker.ts
@@ -68,6 +68,7 @@ export function createRevivedRunTracker(options: {
   onSettled?: (taskID: string) => void;
   contextFilesForPrompt?: (taskID: string) => ContextFile[];
   pruneContext?: () => void;
+  shouldManageSession?: (sessionID: string) => boolean;
 }): RevivedRunTracker {
   const runs = new Map<string, RevivedRun>();
   const maxNotificationRetries =
@@ -230,6 +231,11 @@ export function createRevivedRunTracker(options: {
     record: BackgroundJobRecord,
   ): Promise<void> {
     if (disposed || run.notification.sent || run.notification.pending) return;
+    if (
+      options.shouldManageSession &&
+      !options.shouldManageSession(run.parentSessionID)
+    )
+      return;
     run.notification.pending = true;
     run.notification.attempts += 1;
     try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -316,6 +316,8 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
       onSettled: (taskID) => markRevivedRunSettled(taskID),
       contextFilesForPrompt: (taskID) => getRevivedContextFiles(taskID),
       pruneContext: () => pruneRevivedContext(),
+      shouldManageSession: (sessionID) =>
+        sessionMetadata.getAgent(sessionID) === 'orchestrator',
     });
     backgroundJobCoordinator.addTerminalOutcomeListener((record) => {
       revivedRunTracker.onTerminal(record);


### PR DESCRIPTION
Fixes #1079

## What problem are you solving?

Background task completion notifications inject `promptAsync({ agent: 'orchestrator' })` regardless of the parent session's current mode. When a user switches to Plan or Build, the notification still fires and its `agent: 'orchestrator'` flows through `chat.message` → `sessionMetadata.setAgent()` → flips the session metadata back to orchestrator, re-arming all orchestrator machinery (wake scheduler, tool gates, etc.).

## What does this change?

Adds `shouldManageSession` gate to `createRevivedRunTracker`. Guard in `notifyParent` checks whether parent session is still in orchestrator mode before injecting the synthetic prompt. 3 lines in source + 1 test case.

## Why this approach?

`shouldManageSession` is already the canonical predicate for orchestrator-mode gating, used 6+ times across the codebase (wake scheduler, task-session-manager, input-wait-tracker, cancel-task, task-revive, wait-for-user). Direct `sessionMetadata` access inside the tracker would couple it to a module it does not import. The optional callback preserves backward compatibility — callers that do not pass it get the old behavior.

## Related work

- [x] I checked open AND closed PRs/issues for duplicates
- Related: #1079 (root issue). No duplicate open/closed PR found for this exact bug.

## AI assistance

- Model / harness: OpenCode (deepseek-v4-flash) orchestrator; 4 @skeptic subagents for code review ran on opencode/x-preview-f-free (primary, with fallbacks opencode-go/qwen3.7-plus and opencode/qwen3.7-plus per `oh-my-opencode-slim.jsonc` skeptic preset).
- [x] Human reviewed the full diff before creating the PR.

## Checklist

- [x] `bun run check:ci`, `bun run typecheck`, and `bun test` pass
- [x] Docs updated if behavior changed — no doc change needed (internal callback only)
- [x] One logical change per PR
- [x] PR targets the `master` branch