### PR TITLE
fix(foreground-fallback): match bailian quota-exhausted error and prevent backward chain fallback

### DIFF
--- a/src/hooks/foreground-fallback/index.test.ts
+++ b/src/hooks/foreground-fallback/index.test.ts
@@ -121,6 +121,15 @@ describe('isFailoverError', () => {
     );
   });
 
+  test('returns true for bailian "quota has been exhausted" (issue #1083)', () => {
+    expect(
+      isRetryableError({
+        message:
+          'Your token-plan 1-week quota has been exhausted. The quota will reset at 08-27 15:33:00 UTC.',
+      }),
+    ).toBe(true);
+  });
+
   test('returns true for codex quota-threshold errors', () => {
     expect(
       isFailoverError({

--- a/src/hooks/foreground-fallback/index.ts
+++ b/src/hooks/foreground-fallback/index.ts
@@ -37,6 +37,7 @@ const RETRYABLE_ERROR_PATTERNS = [
   /rate.?limit/i,
   /too many requests/i,
   /quota.?exceeded/i,
+  /\bquota\b.*\bexhausted/i,
   /quota.?threshold/i,
   /usage.?exceeded/i,
   /ExceededBudget/i,
@@ -678,6 +679,12 @@ export class ForegroundFallbackManager {
       // biome-ignore lint/style/noNonNullAssertion: We just set this above
       let tried = this.sessionTried.get(sessionID)!;
       if (currentModel) tried.add(currentModel);
+      // ponytail: seed chain entries at or before the current model's index
+      // to prevent backward fallback onto models the session already left.
+      if (currentModel) {
+        const idx = chain.indexOf(currentModel);
+        for (let i = 0; i < idx; i++) tried.add(chain[i]);
+      }
 
       let nextModel = chain.find((m) => !tried.has(m));
       if (!nextModel) {


### PR DESCRIPTION
## Description

Fixes #1083 — bailian's token-plan quota exhaustion error (`"quota has been exhausted"`) was not matched by the existing `/quota.?exceeded/i` pattern, preventing the foreground fallback chain from being consulted.

### Changes

1. **Pattern fix** — added `/\bquota\b.*\bexhausted/i` to `RETRYABLE_ERROR_PATTERNS` to match bailian's exact error message: "Your token-plan 1-week quota has been exhausted. The quota will reset at 08-27 15:33:00 UTC."

2. **Backward fallback guard** — in `execFallback`, after adding `currentModel` to the `tried` set, also seed all chain entries at indices `0..idx-1`. This prevents a session that was already moved past `chain[0]` from falling backward onto the dead head model when a downstream model fails.

### Verification

- New test case covers the exact bailian error message
- All 2214 existing tests pass
- `bun run check:ci` and `bun run typecheck` clean