### PR TITLE
fix(foreground-fallback): match bailian quota-exhausted error and prevent backward chain fallback

### DIFF
--- a/src/hooks/foreground-fallback/index.test.ts
+++ b/src/hooks/foreground-fallback/index.test.ts
@@ -121,6 +121,15 @@ describe('isFailoverError', () => {
     );
   });
 
+  test('returns true for bailian "quota has been exhausted" (issue #1083)', () => {
+    expect(
+      isRetryableError({
+        message:
+          'Your token-plan 1-week quota has been exhausted. The quota will reset at 08-27 15:33:00 UTC.',
+      }),
+    ).toBe(true);
+  });
+
   test('returns true for codex quota-threshold errors', () => {
     expect(
       isFailoverError({

--- a/src/hooks/foreground-fallback/index.ts
+++ b/src/hooks/foreground-fallback/index.ts
@@ -37,6 +37,7 @@ const RETRYABLE_ERROR_PATTERNS = [
   /rate.?limit/i,
   /too many requests/i,
   /quota.?exceeded/i,
+  /\bquota\b.*\bexhausted/i,
   /quota.?threshold/i,
   /usage.?exceeded/i,
   /ExceededBudget/i,
@@ -678,6 +679,12 @@ export class ForegroundFallbackManager {
       // biome-ignore lint/style/noNonNullAssertion: We just set this above
       let tried = this.sessionTried.get(sessionID)!;
       if (currentModel) tried.add(currentModel);
+      // ponytail: seed chain entries at or before the current model's index
+      // to prevent backward fallback onto models the session already left.
+      if (currentModel) {
+        const idx = chain.indexOf(currentModel);
+        for (let i = 0; i < idx; i++) tried.add(chain[i]);
+      }
 
       let nextModel = chain.find((m) => !tried.has(m));
       if (!nextModel) {


### PR DESCRIPTION
Fixes #1083

## What problem are you solving?

Bailian token-plan quota exhaustion returns the error "Your token-plan 1-week quota has been exhausted" — this was not matched by the existing /quota.?exceeded/i pattern. The foreground fallback chain was never consulted, leaving the user stuck on a dead model.

A secondary bug: when the fallback chain is [primary, fallback-a, fallback-b] and the session is already on fallback-a, a subsequent error would re-fallback to primary (chain[0]) because the tried set only contained fallback-a. This caused infinite looping on dead models.

## What does this change?

1. Adds /\bquota\b.*\bexhausted/i to RETRYABLE_ERROR_PATTERNS to match bailian's exact error message
2. Seeds all chain entries at indices 0..idx-1 into the tried set during execFallback, preventing backward fallback onto models the session already left
3. Test case covering the exact bailian error string

## Why this approach?

Pattern matching: the existing patterns all use regex matching on error message strings — adding one more pattern is the minimal, consistent approach. The chain seeding fix addresses the root cause (incomplete tried set) rather than patching individual callers.

Alternatives considered: mapping SDK status codes (deferred to separate tracking in #955 because the error may arrive via message content rather than structured status fields).

## Related work

- [x] I checked open AND closed PRs/issues for duplicates
- none found

## AI assistance (optional)

- Model / harness: OpenCode (clinepass/cline-pass/deepseek-v4-flash) with @oracle (reviewer subagents had no model — manual review substituted)
- Human reviewed the full diff? [x] Yes

## Checklist

- [x] bun run check:ci, bun run typecheck, and bun test pass
- [x] Docs (README.md, docs/) updated if behavior/commands changed — no doc change needed (internal logic only)
- [x] One logical change per PR
- [x] PR targets the master branch