### PR TITLE
feat(tui): show active agent spinners

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,2 +1,3 @@
 [test]
 root = "./src"
+preload = ["@opentui/solid/preload"]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,6 +37,10 @@ The TUI sidebar uses the compact layout by default. Set `compactSidebar` to
 }
 ```
 
+While an agent session reports `busy` or `retry`, the sidebar shows an
+animated Braille indicator before that agent's name. The indicator disappears
+after every active session for that agent becomes idle or is deleted.
+
 ---
 
 ## Prompt Overriding

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,7 +38,7 @@ The TUI sidebar uses the compact layout by default. Set `compactSidebar` to
 ```
 
 While an agent session reports `busy` or `retry`, the sidebar shows an
-animated Braille indicator before that agent's name. The indicator disappears
+animated Braille indicator after that agent's name. The indicator disappears
 after every active session for that agent becomes idle or is deleted.
 
 ---

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   ],
   "scripts": {
     "clean:dist": "bun -e \"import { rmSync } from 'node:fs'; rmSync('dist', { recursive: true, force: true })\"",
-    "build:plugin": "bun build src/index.ts src/tui.ts --outdir dist --target node --format esm --external @opencode-ai/plugin --external @opencode-ai/plugin/tui --external @opencode-ai/sdk --external @opencode-ai/sdk/v2 --external @opentui/core --external @opentui/solid --external jsdom --external zod",
+    "build:plugin": "bun build src/index.ts src/tui.ts --outdir dist --target node --format esm --external @opencode-ai/plugin --external @opencode-ai/plugin/tui --external @opencode-ai/sdk --external @opencode-ai/sdk/v2 --external @opentui/core --external @opentui/solid --external solid-js --external jsdom --external zod",
     "build:v2": "bun build src/index.ts --outfile dist/server.js --target node --format esm --external jsdom",
     "build:cli": "bun build src/cli/index.ts --outdir dist/cli --target node --format esm --external @opencode-ai/plugin --external @opencode-ai/plugin/tui --external @opencode-ai/sdk --external @opencode-ai/sdk/v2 --external jsdom --external zod",
     "build": "bun run clean:dist && bun run build:plugin && bun run build:v2 && bun run build:cli && tsc --emitDeclarationOnly && bun run generate-schema",

--- a/src/codemap.md
+++ b/src/codemap.md
@@ -69,15 +69,18 @@ OpenCode Core → Plugin Initialization (index.ts)
 1. **Plugin Registration**: TUI plugin registered with OpenCode's TUI system via `tui` export
 2. **Version Detection**: Reads plugin version from package.json or uses 'dev'
 3. **Config Validation**: Checks if current directory has valid plugin config
-4. **Snapshot Loading**: Reads agent models/variants from `tui-state.ts`
-5. **Live Updates**: Sets up interval to refresh snapshot every 1000ms
+4. **Snapshot Loading**: Reads agent models, variants, and per-session activity
+   from `tui-state.ts`
+5. **Live Updates**: Refreshes persisted state every 1000ms and requests
+   160ms animation frames only while agents are active
 6. **Tmux registration**: Refreshes the active session-to-`TMUX_PANE`
    registration for parent-aware child-pane routing
 7. **Sidebar Rendering**: Renders sidebar with:
    - Plugin header (OMO-Slim + version)
    - Config status warning (if invalid)
-   - Agent list with model/variant details
-8. **Lifecycle Management**: Cleans up interval and owned tmux registration on dispose
+   - Agent list with model/variant details and Braille activity indicators
+8. **Lifecycle Management**: Cleans up refresh/animation timers and owned tmux
+   registration on dispose
 
 ### State Persistence Flow (tui-state.ts)
 
@@ -87,6 +90,10 @@ OpenCode Core → Plugin Initialization (index.ts)
    - `readTuiSnapshotAsync()`: Async variant for TUI rendering
    - `recordTuiAgentModels()`: Updates both agent models and variants atomically
    - `recordTuiAgentModel()`: Updates single agent's model/variant
+   - `recordTuiAgentActivity()`: Tracks active agents by session so concurrent
+     runs of the same agent remain visible until all runs finish
+   - `clearTuiAgentActivities()`: Removes stale activity during startup and
+     shutdown
 3. **Atomic Writes**: State updates are atomic (read → mutate → write with timestamp)
 4. **Error Handling**: All operations are best-effort; failures don't crash plugin
 
@@ -96,8 +103,10 @@ Key event flows:
 
 1. **Session Lifecycle**:
    - `session.created` → register child session
-   - `session.status` → multiplexer session management and companion updates
-   - `session.deleted` → cleanup session agent map and companion state
+   - `session.status` → multiplexer session management, Companion updates, and
+     TUI activity state
+   - `session.deleted` → cleanup session agent map, Companion state, and TUI
+     activity state
 
 2. **Message Updates**:
    - `message.updated` → record agent/model usage in TUI state
@@ -107,7 +116,7 @@ Key event flows:
    - `tool.execute.after` → post-tool hooks (retry guidance, JSON error recovery, file-tool nudges)
 
 4. **Chat Integration**:
-   - `chat.message` → track session → agent mapping
+   - `chat.message` → track session → agent mapping and mark TUI activity
    - `experimental.chat.system.transform` → inject orchestrator prompt for serve mode
    - `experimental.chat.messages.transform` → phase reminders, skill filtering, image attachment processing
 
@@ -171,7 +180,8 @@ Key event flows:
 
 ## Performance Considerations
 
-- **Live Updates**: TUI refreshes every 1000ms (configurable via interval)
+- **Live Updates**: TUI reads state every 1000ms and animates active Braille
+  indicators every 160ms without extra disk reads
 - **Atomic State**: State writes are atomic to prevent corruption
 - **Lazy Initialization**: Some subsystems (e.g., webfetch probe) run async without blocking init
 - **Event-Driven**: Minimal polling; relies on OpenCode's event system

--- a/src/codemap.md
+++ b/src/codemap.md
@@ -71,8 +71,8 @@ OpenCode Core → Plugin Initialization (index.ts)
 3. **Config Validation**: Checks if current directory has valid plugin config
 4. **Snapshot Loading**: Reads agent models, variants, and per-session activity
    from `tui-state.ts`
-5. **Live Updates**: Refreshes persisted state every 1000ms and requests
-   160ms animation frames only while agents are active
+5. **Live Updates**: Refreshes persisted state every 1000ms and reactively
+   advances 160ms animation frames only while agents are active
 6. **Tmux registration**: Refreshes the active session-to-`TMUX_PANE`
    registration for parent-aware child-pane routing
 7. **Sidebar Rendering**: Renders sidebar with:

--- a/src/codemap.md
+++ b/src/codemap.md
@@ -72,7 +72,7 @@ OpenCode Core → Plugin Initialization (index.ts)
 4. **Snapshot Loading**: Reads agent models, variants, and per-session activity
    from `tui-state.ts`
 5. **Live Updates**: Refreshes persisted state every 1000ms and reactively
-   advances 160ms animation frames only while agents are active
+   advances 120ms animation frames only while agents are active
 6. **Tmux registration**: Refreshes the active session-to-`TMUX_PANE`
    registration for parent-aware child-pane routing
 7. **Sidebar Rendering**: Renders sidebar with:
@@ -181,7 +181,7 @@ Key event flows:
 ## Performance Considerations
 
 - **Live Updates**: TUI reads state every 1000ms and animates active Braille
-  indicators every 160ms without extra disk reads
+  indicators every 120ms without extra disk reads
 - **Atomic State**: State writes are atomic to prevent corruption
 - **Lazy Initialization**: Some subsystems (e.g., webfetch probe) run async without blocking init
 - **Event-Driven**: Minimal polling; relies on OpenCode's event system

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { OhMyOpenCodeLite as plugin } from './index';
+import { readTuiSnapshot } from './tui-state';
 
 function createPluginClient(
   noop: () => Promise<unknown>,
@@ -279,6 +280,87 @@ describe('plugin tool registration', () => {
       Date.now = originalNow;
       await rm(configDir, { recursive: true, force: true });
     }
+  });
+});
+
+describe('plugin TUI agent activity', () => {
+  let originalEnv: typeof process.env;
+  let projectDir: string;
+  let hooks: Awaited<ReturnType<typeof plugin>> | undefined;
+
+  beforeEach(async () => {
+    originalEnv = { ...process.env };
+    projectDir = await mkdtemp('/tmp/oh-my-opencode-slim-tui-activity-');
+    process.env = {
+      ...originalEnv,
+      OPENCODE_CONFIG_DIR: projectDir,
+      XDG_DATA_HOME: `${projectDir}/data`,
+      XDG_CACHE_HOME: `${projectDir}/cache`,
+      OPENCODE_LOG_DIR: `${projectDir}/logs`,
+    };
+    delete process.env.OH_MY_OPENCODE_SLIM_DISABLE;
+    await Bun.write(
+      `${projectDir}/oh-my-opencode-slim.json`,
+      JSON.stringify({ companion: { enabled: false } }),
+    );
+
+    hooks = await plugin({
+      client: createPluginClient(async () => ({})),
+      directory: projectDir,
+      worktree: projectDir,
+      serverUrl: new URL('http://127.0.0.1:4096'),
+    } as never);
+  });
+
+  afterEach(async () => {
+    await hooks?.dispose?.();
+    process.env = originalEnv;
+    await rm(projectDir, { recursive: true, force: true });
+  });
+
+  test('keeps an agent active until all of its sessions stop', async () => {
+    const chatMessage = hooks?.['chat.message'];
+    expect(chatMessage).toBeFunction();
+
+    await chatMessage?.(
+      { sessionID: 'fixer-a', agent: 'fixer' } as never,
+      {} as never,
+    );
+    await chatMessage?.(
+      { sessionID: 'fixer-b', agent: 'fixer' } as never,
+      {} as never,
+    );
+
+    await hooks?.event?.({
+      event: {
+        type: 'session.status',
+        properties: { sessionID: 'fixer-a', status: { type: 'idle' } },
+      },
+    } as never);
+
+    expect(readTuiSnapshot(projectDir).activeSessions).toEqual({
+      'fixer-b': 'fixer',
+    });
+
+    await hooks?.event?.({
+      event: {
+        type: 'session.deleted',
+        properties: { info: { id: 'fixer-b' } },
+      },
+    } as never);
+
+    expect(readTuiSnapshot(projectDir).activeSessions).toEqual({});
+  });
+
+  test('clears active sessions when plugin disposes', async () => {
+    await hooks?.['chat.message']?.(
+      { sessionID: 'oracle-a', agent: 'oracle' } as never,
+      {} as never,
+    );
+
+    await hooks?.dispose?.();
+
+    expect(readTuiSnapshot(projectDir).activeSessions).toEqual({});
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,12 @@ import {
   resolveEventSessionID,
   TaskActivityTracker,
 } from './tools/task-activity';
-import { recordTuiAgentModel, recordTuiAgentModels } from './tui-state';
+import {
+  clearTuiAgentActivities,
+  recordTuiAgentActivity,
+  recordTuiAgentModel,
+  recordTuiAgentModels,
+} from './tui-state';
 import {
   BackgroundJobBoard,
   BackgroundJobCoordinator,
@@ -161,6 +166,30 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
       });
     },
   });
+  const tuiActivityDirectories = new Set([ctx.directory]);
+  const tuiActivityDirectory = (sessionID: string): string => {
+    const directory = sessionMetadata.getDirectory(sessionID) ?? ctx.directory;
+    tuiActivityDirectories.add(directory);
+    return directory;
+  };
+  const markTuiAgentActive = (sessionID: string, agentName: string): void => {
+    recordTuiAgentActivity(
+      { sessionID, agentName, active: true },
+      tuiActivityDirectory(sessionID),
+    );
+  };
+  const markTuiAgentInactive = (sessionID: string): void => {
+    recordTuiAgentActivity(
+      { sessionID, active: false },
+      tuiActivityDirectory(sessionID),
+    );
+  };
+  const clearTuiActivities = (): void => {
+    for (const directory of tuiActivityDirectories) {
+      clearTuiAgentActivities(directory);
+    }
+  };
+  clearTuiAgentActivities(ctx.directory);
   let sessionLifecycle: SessionLifecycle;
 
   let chatHeadersHook: ReturnType<typeof createChatHeadersHook>;
@@ -973,12 +1002,17 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
           (statusType === 'busy' || statusType === 'retry')
         ) {
           sessionMetadata.markOrchestratorActive(eventSessionID);
+          const agentName = sessionMetadata.getAgent(eventSessionID);
+          if (agentName) {
+            markTuiAgentActive(eventSessionID, agentName);
+          }
         } else if (
           event.type === 'session.idle' ||
           (event.type === 'session.status' && statusType === 'idle') ||
           event.type === 'session.deleted'
         ) {
           sessionMetadata.markOrchestratorIdle(eventSessionID);
+          markTuiAgentInactive(eventSessionID);
         }
       }
 
@@ -1043,6 +1077,9 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
           await multiplexerSessionManager.cleanupOnInstanceDisposed();
         },
       );
+      if (event.type === 'server.instance.disposed') {
+        clearTuiActivities();
+      }
 
       await orchestratorWakeScheduler.event(
         input as {
@@ -1121,6 +1158,7 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
       });
       await interviewManager.dispose();
       await multiplexerSessionManager.cleanupOnInstanceDisposed();
+      clearTuiActivities();
     },
 
     'tool.execute.before': async (input, output) => {
@@ -1221,6 +1259,7 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
       if (agent) {
         foregroundFallback.registerSessionAgent(input.sessionID, agent);
         sessionMetadata.setAgent(input.sessionID, agent);
+        markTuiAgentActive(input.sessionID, agent);
         // A chat message means this session is actively working. This also
         // covers the race where session.status busy fires before the
         // session's agent is known.

--- a/src/tui-state.test.ts
+++ b/src/tui-state.test.ts
@@ -3,8 +3,10 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import {
+  clearTuiAgentActivities,
   getTuiStatePath,
   readTuiSnapshot,
+  recordTuiAgentActivity,
   recordTuiAgentModel,
   recordTuiAgentModels,
 } from './tui-state';
@@ -110,6 +112,42 @@ describe('tui-state persistence', () => {
     });
   });
 
+  test('tracks concurrent activity by session without clearing the agent early', () => {
+    recordTuiAgentActivity(
+      { sessionID: 'fixer-a', agentName: 'fixer', active: true },
+      tempDir,
+    );
+    recordTuiAgentActivity(
+      { sessionID: 'fixer-b', agentName: 'fixer', active: true },
+      tempDir,
+    );
+
+    recordTuiAgentActivity({ sessionID: 'fixer-a', active: false }, tempDir);
+
+    expect(readTuiSnapshot(tempDir).activeSessions).toEqual({
+      'fixer-b': 'fixer',
+    });
+  });
+
+  test('clears persisted activity while preserving model state', () => {
+    recordTuiAgentModels(
+      { agentModels: { explorer: 'openai/gpt-5.6-luna' } },
+      tempDir,
+    );
+    recordTuiAgentActivity(
+      { sessionID: 'explorer-a', agentName: 'explorer', active: true },
+      tempDir,
+    );
+
+    clearTuiAgentActivities(tempDir);
+
+    const snapshot = readTuiSnapshot(tempDir);
+    expect(snapshot.activeSessions).toEqual({});
+    expect(snapshot.agentModels).toEqual({
+      explorer: 'openai/gpt-5.6-luna',
+    });
+  });
+
   test('ignores legacy config status fields in old snapshots', () => {
     const filePath = getTuiStatePath(tempDir);
     fs.mkdirSync(path.dirname(filePath), { recursive: true });
@@ -129,6 +167,7 @@ describe('tui-state persistence', () => {
       explorer: 'openai/gpt-5.6-luna',
     });
     expect(snapshot.agentVariants).toEqual({});
+    expect(snapshot.activeSessions).toEqual({});
   });
 
   test('cross-project isolation — different directories write independent state files', () => {

--- a/src/tui-state.ts
+++ b/src/tui-state.ts
@@ -8,6 +8,7 @@ export interface TuiSnapshot {
   updatedAt: number;
   agentModels: Record<string, string>;
   agentVariants: Record<string, string>;
+  activeSessions: Record<string, string>;
 }
 
 const STATE_DIR = 'oh-my-opencode-slim';
@@ -44,6 +45,7 @@ function emptySnapshot(): TuiSnapshot {
     updatedAt: Date.now(),
     agentModels: {},
     agentVariants: {},
+    activeSessions: {},
   };
 }
 
@@ -57,6 +59,7 @@ function parseSnapshot(value: string): TuiSnapshot {
       typeof parsed.updatedAt === 'number' ? parsed.updatedAt : Date.now(),
     agentModels: parsed.agentModels ?? {},
     agentVariants: parsed.agentVariants ?? {},
+    activeSessions: parsed.activeSessions ?? {},
   };
 }
 
@@ -109,10 +112,12 @@ function updateSnapshot(
   const snapshot = readTuiSnapshot(projectDir);
   const beforeModels = JSON.stringify(snapshot.agentModels);
   const beforeVariants = JSON.stringify(snapshot.agentVariants);
+  const beforeActiveSessions = JSON.stringify(snapshot.activeSessions);
   mutator(snapshot);
   if (
     JSON.stringify(snapshot.agentModels) === beforeModels &&
-    JSON.stringify(snapshot.agentVariants) === beforeVariants
+    JSON.stringify(snapshot.agentVariants) === beforeVariants &&
+    JSON.stringify(snapshot.activeSessions) === beforeActiveSessions
   ) {
     return; // state unchanged — skip the disk write
   }
@@ -150,5 +155,26 @@ export function recordTuiAgentModel(
         snapshot.agentVariants[input.agentName] = input.variant;
       }
     }
+  });
+}
+
+export function recordTuiAgentActivity(
+  input:
+    | { sessionID: string; agentName: string; active: true }
+    | { sessionID: string; active: false },
+  projectDir: string,
+): void {
+  updateSnapshot(projectDir, (snapshot) => {
+    if (input.active) {
+      snapshot.activeSessions[input.sessionID] = input.agentName;
+    } else {
+      delete snapshot.activeSessions[input.sessionID];
+    }
+  });
+}
+
+export function clearTuiAgentActivities(projectDir: string): void {
+  updateSnapshot(projectDir, (snapshot) => {
+    snapshot.activeSessions = {};
   });
 }

--- a/src/tui.test.ts
+++ b/src/tui.test.ts
@@ -6,7 +6,9 @@ import { RGBA } from '@opentui/core';
 import { readTmuxPane } from './multiplexer/tmux-pane-registry';
 import {
   type ActiveTmuxPaneRegistration,
+  getActiveSidebarAgentNames,
   getContrastForeground,
+  getSidebarActivityIndicator,
   getSidebarAgentNames,
   readCompactSidebar,
   readConfigInvalid,
@@ -22,6 +24,7 @@ function createSnapshot(overrides: Partial<TuiSnapshot> = {}): TuiSnapshot {
     updatedAt: 0,
     agentModels: {},
     agentVariants: {},
+    activeSessions: {},
     ...overrides,
   };
 }
@@ -50,6 +53,27 @@ describe('tui sidebar agents', () => {
     expect(agentNames).not.toContain('observer');
     expect(agentNames).not.toContain('council');
     expect(agentNames).not.toContain('councillor');
+  });
+
+  test('derives active agents from concurrent session activity', () => {
+    const activeAgents = getActiveSidebarAgentNames(
+      createSnapshot({
+        activeSessions: {
+          'fixer-a': 'fixer',
+          'fixer-b': 'fixer',
+          'oracle-a': 'oracle',
+        },
+      }),
+    );
+
+    expect([...activeAgents]).toEqual(['fixer', 'oracle']);
+  });
+
+  test('renders a stable blank column or deterministic braille frame', () => {
+    expect(getSidebarActivityIndicator(false, 0)).toBe(' ');
+    expect(getSidebarActivityIndicator(true, 0)).toBe('⠋');
+    expect(getSidebarActivityIndicator(true, 160)).toBe('⠙');
+    expect(getSidebarActivityIndicator(true, 1_600)).toBe('⠋');
   });
 });
 

--- a/src/tui.test.ts
+++ b/src/tui.test.ts
@@ -3,6 +3,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { RGBA } from '@opentui/core';
+import { testRender } from '@opentui/solid';
 import { readTmuxPane } from './multiplexer/tmux-pane-registry';
 import {
   type ActiveTmuxPaneRegistration,
@@ -16,7 +17,13 @@ import {
   syncTmuxPaneRegistration,
   default as tuiPlugin,
 } from './tui';
-import type { TuiSnapshot } from './tui-state';
+import {
+  recordTuiAgentActivity,
+  recordTuiAgentModels,
+  type TuiSnapshot,
+} from './tui-state';
+
+const ACTIVITY_FRAME_PATTERN = /[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]/;
 
 function createSnapshot(overrides: Partial<TuiSnapshot> = {}): TuiSnapshot {
   return {
@@ -74,6 +81,97 @@ describe('tui sidebar agents', () => {
     expect(getSidebarActivityIndicator(true, 0)).toBe('⠋');
     expect(getSidebarActivityIndicator(true, 160)).toBe('⠙');
     expect(getSidebarActivityIndicator(true, 1_600)).toBe('⠋');
+  });
+});
+
+describe('live TUI activity rendering', () => {
+  test('updates a mounted v1 sidebar when an agent becomes active', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'omos-spinner-live-'));
+    const projectDir = path.join(root, 'project');
+    const originalDataHome = process.env.XDG_DATA_HOME;
+    const disposers: Array<() => void> = [];
+    let slotPlugin: { slots: { sidebar_content: () => unknown } } | undefined;
+    let setup: Awaited<ReturnType<typeof testRender>> | undefined;
+
+    try {
+      fs.mkdirSync(projectDir, { recursive: true });
+      process.env.XDG_DATA_HOME = path.join(root, 'data');
+      recordTuiAgentModels(
+        { agentModels: { explorer: 'openai/gpt-5.6-luna-fast' } },
+        projectDir,
+      );
+
+      await tuiPlugin.tui(
+        {
+          state: { path: { directory: projectDir } },
+          route: { current: { name: 'home' } },
+          lifecycle: {
+            onDispose: (callback: () => void) => {
+              disposers.push(callback);
+              return () => {};
+            },
+          },
+          renderer: { requestRender: () => {} },
+          slots: {
+            register: (plugin: typeof slotPlugin) => {
+              slotPlugin = plugin;
+              return 'activity-test-slot';
+            },
+          },
+          theme: {
+            current: {
+              accent: '#22c55e',
+              background: '#111111',
+              borderActive: '#555555',
+              text: '#ffffff',
+              textMuted: '#aaaaaa',
+            },
+          },
+        } as Parameters<typeof tuiPlugin.tui>[0],
+        {},
+        { version: 'test' } as Parameters<typeof tuiPlugin.tui>[2],
+      );
+
+      setup = await testRender(
+        () => slotPlugin?.slots.sidebar_content() as never,
+        { width: 52, height: 14 },
+      );
+      await setup.renderOnce();
+      expect(setup.captureCharFrame()).not.toMatch(ACTIVITY_FRAME_PATTERN);
+
+      recordTuiAgentActivity(
+        {
+          sessionID: 'explorer-session',
+          agentName: 'explorer',
+          active: true,
+        },
+        projectDir,
+      );
+      await Bun.sleep(1_100);
+      await setup.renderOnce();
+
+      const firstFrame = setup
+        .captureCharFrame()
+        .match(ACTIVITY_FRAME_PATTERN)?.[0];
+      expect(firstFrame).toBeDefined();
+
+      await Bun.sleep(200);
+      await setup.renderOnce();
+      const nextFrame = setup
+        .captureCharFrame()
+        .match(ACTIVITY_FRAME_PATTERN)?.[0];
+      expect(nextFrame).toBeDefined();
+      expect(nextFrame).not.toBe(firstFrame);
+    } finally {
+      setup?.renderer.destroy();
+      for (const dispose of disposers) dispose();
+      fs.rmSync(root, { recursive: true, force: true });
+      if (originalDataHome === undefined) {
+        delete process.env.XDG_DATA_HOME;
+      } else {
+        process.env.XDG_DATA_HOME = originalDataHome;
+      }
+    }
   });
 });
 

--- a/src/tui.test.ts
+++ b/src/tui.test.ts
@@ -79,8 +79,8 @@ describe('tui sidebar agents', () => {
   test('renders a stable blank column or deterministic braille frame', () => {
     expect(getSidebarActivityIndicator(false, 0)).toBe(' ');
     expect(getSidebarActivityIndicator(true, 0)).toBe('⠋');
-    expect(getSidebarActivityIndicator(true, 160)).toBe('⠙');
-    expect(getSidebarActivityIndicator(true, 1_600)).toBe('⠋');
+    expect(getSidebarActivityIndicator(true, 120)).toBe('⠙');
+    expect(getSidebarActivityIndicator(true, 1_200)).toBe('⠋');
   });
 });
 

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -6,6 +6,7 @@ import type {
 import { type ColorInput, parseColor, RGBA } from '@opentui/core';
 import type { JSX } from '@opentui/solid';
 import { createElement, insert, setProp } from '@opentui/solid';
+import { createSignal } from 'solid-js';
 import { DEFAULT_DISABLED_AGENTS, SUBAGENT_NAMES } from './config/constants';
 import { loadPluginConfig } from './config/loader';
 import {
@@ -85,6 +86,12 @@ function text(props: Record<string, unknown>, children: Child[]) {
 
 function box(props: Record<string, unknown>, children: Child[] = []) {
   return element('box', props, children);
+}
+
+function reactiveElement(render: () => JSX.Element): JSX.Element {
+  const root = box({ width: '100%', flexDirection: 'column' });
+  insert(root, render);
+  return root;
 }
 
 function getTuiDirectory(api: {
@@ -352,10 +359,10 @@ function renderSidebar(
   },
   configInvalid: boolean,
   compactSidebar: boolean,
+  now = Date.now(),
 ): JSX.Element {
   const configStatusRow = buildConfigStatusRow(configInvalid, theme);
   const activeAgents = getActiveSidebarAgentNames(snapshot);
-  const now = Date.now();
   return box(
     {
       width: '100%',
@@ -518,7 +525,10 @@ async function setup(ctx: V2TuiContext): Promise<undefined | (() => void)> {
   const version = (await readPackageVersion()) ?? 'dev';
   let configDirectory = ctx.location?.directory ?? process.cwd();
   let { configInvalid, compactSidebar } = readConfigState(configDirectory);
-  let snapshot = readTuiSnapshot(configDirectory);
+  const [snapshot, setSnapshot] = createSignal(
+    readTuiSnapshot(configDirectory),
+  );
+  const [animationNow, setAnimationNow] = createSignal(Date.now());
   const tmuxRegistration: ActiveTmuxPaneRegistration = {
     ownerPid: process.pid,
     lastRecordedAt: 0,
@@ -530,32 +540,36 @@ async function setup(ctx: V2TuiContext): Promise<undefined | (() => void)> {
     try {
       const currentDirectory = ctx.location?.directory ?? process.cwd();
       syncTmuxPaneRegistration(ctx.ui.router.current(), tmuxRegistration);
-      snapshot = await readTuiSnapshotAsync(currentDirectory);
+      const nextSnapshot = await readTuiSnapshotAsync(currentDirectory);
       if (disposed) return;
       if (currentDirectory !== configDirectory) {
         configDirectory = currentDirectory;
         ({ configInvalid, compactSidebar } = readConfigState(configDirectory));
       }
+      setSnapshot(nextSnapshot);
       ctx.renderer.requestRender();
     } catch {
       // Ignore render errors; this is best-effort live status.
     }
   }, 1000);
   const animationTimer = setInterval(() => {
-    if (!disposed && Object.keys(snapshot.activeSessions).length > 0) {
-      ctx.renderer.requestRender();
+    if (!disposed && Object.keys(snapshot().activeSessions).length > 0) {
+      setAnimationNow(Date.now());
     }
   }, ACTIVITY_FRAME_MS);
 
   const disposeSlot = ctx.ui.slot({
     append: 'sidebar.content',
     render: () =>
-      renderSidebar(
-        snapshot,
-        version,
-        v2ThemeView(ctx.theme),
-        configInvalid,
-        compactSidebar,
+      reactiveElement(() =>
+        renderSidebar(
+          snapshot(),
+          version,
+          v2ThemeView(ctx.theme),
+          configInvalid,
+          compactSidebar,
+          animationNow(),
+        ),
       ),
   });
 
@@ -612,7 +626,10 @@ const plugin: TuiDualContractModule = {
     const version = meta.version ?? (await readPackageVersion()) ?? 'dev';
     let configDirectory = getTuiDirectory(api);
     let { configInvalid, compactSidebar } = readConfigState(configDirectory);
-    let snapshot = readTuiSnapshot(configDirectory);
+    const [snapshot, setSnapshot] = createSignal(
+      readTuiSnapshot(configDirectory),
+    );
+    const [animationNow, setAnimationNow] = createSignal(Date.now());
     const tmuxRegistration: ActiveTmuxPaneRegistration = {
       ownerPid: process.pid,
       lastRecordedAt: 0,
@@ -622,20 +639,21 @@ const plugin: TuiDualContractModule = {
       try {
         const currentDirectory = getTuiDirectory(api);
         syncTmuxPaneRegistration(api.route.current, tmuxRegistration);
-        snapshot = await readTuiSnapshotAsync(currentDirectory);
+        const nextSnapshot = await readTuiSnapshotAsync(currentDirectory);
         if (currentDirectory !== configDirectory) {
           configDirectory = currentDirectory;
           ({ configInvalid, compactSidebar } =
             readConfigState(configDirectory));
         }
+        setSnapshot(nextSnapshot);
         api.renderer.requestRender();
       } catch {
         // Ignore render errors; this is best-effort live status.
       }
     }, 1000);
     const animationTimer = setInterval(() => {
-      if (Object.keys(snapshot.activeSessions).length > 0) {
-        api.renderer.requestRender();
+      if (Object.keys(snapshot().activeSessions).length > 0) {
+        setAnimationNow(Date.now());
       }
     }, ACTIVITY_FRAME_MS);
 
@@ -649,12 +667,15 @@ const plugin: TuiDualContractModule = {
       order: 900,
       slots: {
         sidebar_content() {
-          return renderSidebar(
-            snapshot,
-            version,
-            api.theme.current,
-            configInvalid,
-            compactSidebar,
+          return reactiveElement(() =>
+            renderSidebar(
+              snapshot(),
+              version,
+              api.theme.current,
+              configInvalid,
+              compactSidebar,
+              animationNow(),
+            ),
           );
         },
       },
@@ -668,10 +689,10 @@ const plugin: TuiDualContractModule = {
     if (api.command) {
       const snapshotRef: { snapshot: TuiSnapshot } = {
         get snapshot() {
-          return snapshot;
+          return snapshot();
         },
         set snapshot(value: TuiSnapshot) {
-          snapshot = value;
+          setSnapshot(value);
         },
       };
       const disposeCommands = api.command.register(() => [

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -253,8 +253,8 @@ function agentRow(
 
   return box({ width: '100%', flexDirection: 'column', marginBottom: 1 }, [
     box({ width: '100%', flexDirection: 'row' }, [
+      text({ fg: theme.textMuted, width: 14 }, [label]),
       activityIndicator(active, now, theme),
-      text({ fg: theme.textMuted }, [label]),
     ]),
     ...detailRows,
   ]);
@@ -277,8 +277,8 @@ function compactAgentRow(
     },
     [
       box({ width: 16, flexDirection: 'row' }, [
-        activityIndicator(active, now, theme),
         text({ fg: theme.textMuted, width: 14 }, [label]),
+        activityIndicator(active, now, theme),
       ]),
       text({ fg: theme.textMuted }, [modelName]),
     ],

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -31,7 +31,7 @@ const FALLBACK_SIDEBAR_AGENTS = SUBAGENT_NAMES.filter(
 );
 const BORDER = { type: 'single' };
 const TMUX_PANE_HEARTBEAT_MS = 10_000;
-const ACTIVITY_FRAME_MS = 160;
+const ACTIVITY_FRAME_MS = 120;
 const ACTIVITY_FRAMES = [
   '⠋',
   '⠙',

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -30,6 +30,19 @@ const FALLBACK_SIDEBAR_AGENTS = SUBAGENT_NAMES.filter(
 );
 const BORDER = { type: 'single' };
 const TMUX_PANE_HEARTBEAT_MS = 10_000;
+const ACTIVITY_FRAME_MS = 160;
+const ACTIVITY_FRAMES = [
+  '⠋',
+  '⠙',
+  '⠹',
+  '⠸',
+  '⠼',
+  '⠴',
+  '⠦',
+  '⠧',
+  '⠇',
+  '⠏',
+] as const;
 
 type Child = JSX.Element | string | number | null | undefined | false;
 
@@ -177,11 +190,48 @@ export function getSidebarAgentNames(snapshot: TuiSnapshot): string[] {
     : FALLBACK_SIDEBAR_AGENTS;
 }
 
+export function getActiveSidebarAgentNames(
+  snapshot: TuiSnapshot,
+): ReadonlySet<string> {
+  return new Set(Object.values(snapshot.activeSessions));
+}
+
+export function getSidebarActivityIndicator(
+  active: boolean,
+  now = Date.now(),
+): string {
+  if (!active) return ' ';
+  const frame = Math.floor(now / ACTIVITY_FRAME_MS) % ACTIVITY_FRAMES.length;
+  return ACTIVITY_FRAMES[frame];
+}
+
+interface AgentRowTheme {
+  accent: unknown;
+  text: unknown;
+  textMuted: unknown;
+}
+
+function activityIndicator(
+  active: boolean,
+  now: number,
+  theme: AgentRowTheme,
+): JSX.Element {
+  return text(
+    {
+      fg: active ? (theme.accent ?? theme.text) : theme.textMuted,
+      width: 2,
+    },
+    [getSidebarActivityIndicator(active, now)],
+  );
+}
+
 function agentRow(
   label: string,
   model: string,
   variant: string | undefined,
-  theme: { textMuted: unknown },
+  active: boolean,
+  now: number,
+  theme: AgentRowTheme,
 ): JSX.Element {
   const modelParts = splitSidebarModelId(model);
   const detailRows: JSX.Element[] = [];
@@ -202,7 +252,10 @@ function agentRow(
   }
 
   return box({ width: '100%', flexDirection: 'column', marginBottom: 1 }, [
-    text({ fg: theme.textMuted }, [label]),
+    box({ width: '100%', flexDirection: 'row' }, [
+      activityIndicator(active, now, theme),
+      text({ fg: theme.textMuted }, [label]),
+    ]),
     ...detailRows,
   ]);
 }
@@ -211,7 +264,9 @@ function compactAgentRow(
   label: string,
   model: string,
   _variant: string | undefined,
-  theme: { textMuted: unknown },
+  active: boolean,
+  now: number,
+  theme: AgentRowTheme,
 ): JSX.Element {
   const modelName = splitSidebarModelId(model).model;
   return box(
@@ -221,7 +276,10 @@ function compactAgentRow(
       justifyContent: 'space-between',
     },
     [
-      text({ fg: theme.textMuted, width: 14 }, [label]),
+      box({ width: 16, flexDirection: 'row' }, [
+        activityIndicator(active, now, theme),
+        text({ fg: theme.textMuted, width: 14 }, [label]),
+      ]),
       text({ fg: theme.textMuted }, [modelName]),
     ],
   );
@@ -296,6 +354,8 @@ function renderSidebar(
   compactSidebar: boolean,
 ): JSX.Element {
   const configStatusRow = buildConfigStatusRow(configInvalid, theme);
+  const activeAgents = getActiveSidebarAgentNames(snapshot);
+  const now = Date.now();
   return box(
     {
       width: '100%',
@@ -341,10 +401,11 @@ function renderSidebar(
       ...getSidebarAgentNames(snapshot).map((agentName) => {
         const model = snapshot.agentModels[agentName] ?? 'pending';
         const variant = snapshot.agentVariants[agentName];
+        const active = activeAgents.has(agentName);
         if (compactSidebar) {
-          return compactAgentRow(agentName, model, variant, theme);
+          return compactAgentRow(agentName, model, variant, active, now, theme);
         }
-        return agentRow(agentName, model, variant, theme);
+        return agentRow(agentName, model, variant, active, now, theme);
       }),
     ],
   );
@@ -480,6 +541,11 @@ async function setup(ctx: V2TuiContext): Promise<undefined | (() => void)> {
       // Ignore render errors; this is best-effort live status.
     }
   }, 1000);
+  const animationTimer = setInterval(() => {
+    if (!disposed && Object.keys(snapshot.activeSessions).length > 0) {
+      ctx.renderer.requestRender();
+    }
+  }, ACTIVITY_FRAME_MS);
 
   const disposeSlot = ctx.ui.slot({
     append: 'sidebar.content',
@@ -497,6 +563,7 @@ async function setup(ctx: V2TuiContext): Promise<undefined | (() => void)> {
     disposed = true;
     disposeSlot();
     clearInterval(renderTimer);
+    clearInterval(animationTimer);
     clearTmuxPaneRegistration(tmuxRegistration);
   };
 }
@@ -566,9 +633,15 @@ const plugin: TuiDualContractModule = {
         // Ignore render errors; this is best-effort live status.
       }
     }, 1000);
+    const animationTimer = setInterval(() => {
+      if (Object.keys(snapshot.activeSessions).length > 0) {
+        api.renderer.requestRender();
+      }
+    }, ACTIVITY_FRAME_MS);
 
     api.lifecycle.onDispose(() => {
       clearInterval(renderTimer);
+      clearInterval(animationTimer);
       clearTmuxPaneRegistration(tmuxRegistration);
     });
 


### PR DESCRIPTION
## Summary

- show animated Braille activity indicators beside agents with busy or retrying sessions
- track concurrent agent sessions so indicators remain visible until every matching session stops
- update mounted v1 and v2 sidebars reactively and animate frames every 120ms
- place indicators after agent names in compact and expanded layouts

## Testing

- `bun run check:ci`
- `bun run typecheck`
- `bun run build`
- `bun test` — 2,257 tests passed
