### PR TITLE
fix(tui): isolate activity cleanup and speed up spinner

### DIFF
--- a/src/codemap.md
+++ b/src/codemap.md
@@ -92,10 +92,11 @@ OpenCode Core → Plugin Initialization (index.ts)
    - `recordTuiAgentModel()`: Updates single agent's model/variant
    - `recordTuiAgentActivity()`: Tracks active agents by session so concurrent
      runs of the same agent remain visible until all runs finish
-   - `clearTuiAgentActivities()`: Removes stale activity during startup and
-     shutdown
+   - `clearTuiAgentActivities()`: Removes stale activity during startup
 3. **Atomic Writes**: State updates are atomic (read → mutate → write with timestamp)
 4. **Error Handling**: All operations are best-effort; failures don't crash plugin
+5. **Instance Cleanup**: On shutdown, each plugin instance removes only sessions
+   it marked active, preserving activity owned by other running instances
 
 ### Event Handling Flow (index.ts)
 

--- a/src/codemap.md
+++ b/src/codemap.md
@@ -93,7 +93,8 @@ OpenCode Core → Plugin Initialization (index.ts)
    - `recordTuiAgentActivity()`: Tracks active agents by session so concurrent
      runs of the same agent remain visible until all runs finish
    - `clearTuiAgentActivities()`: Removes stale activity during startup
-3. **Atomic Writes**: State updates are atomic (read → mutate → write with timestamp)
+3. **Atomic Writes**: Cross-process file locking serializes each read → mutate →
+   atomic rename transaction, with dead-owner and aged-lock recovery
 4. **Error Handling**: All operations are best-effort; failures don't crash plugin
 5. **Instance Cleanup**: On shutdown, each plugin instance removes only sessions
    it marked active, preserving activity owned by other running instances

--- a/src/codemap.md
+++ b/src/codemap.md
@@ -72,7 +72,7 @@ OpenCode Core → Plugin Initialization (index.ts)
 4. **Snapshot Loading**: Reads agent models, variants, and per-session activity
    from `tui-state.ts`
 5. **Live Updates**: Refreshes persisted state every 1000ms and reactively
-   advances 120ms animation frames only while agents are active
+   advances 100ms animation frames only while agents are active
 6. **Tmux registration**: Refreshes the active session-to-`TMUX_PANE`
    registration for parent-aware child-pane routing
 7. **Sidebar Rendering**: Renders sidebar with:
@@ -182,7 +182,7 @@ Key event flows:
 ## Performance Considerations
 
 - **Live Updates**: TUI reads state every 1000ms and animates active Braille
-  indicators every 120ms without extra disk reads
+  indicators every 100ms without extra disk reads
 - **Atomic State**: State writes are atomic to prevent corruption
 - **Lazy Initialization**: Some subsystems (e.g., webfetch probe) run async without blocking init
 - **Event-Driven**: Minimal polling; relies on OpenCode's event system

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -287,6 +287,13 @@ describe('plugin TUI agent activity', () => {
   let originalEnv: typeof process.env;
   let projectDir: string;
   let hooks: Awaited<ReturnType<typeof plugin>> | undefined;
+  const createActivityPlugin = () =>
+    plugin({
+      client: createPluginClient(async () => ({})),
+      directory: projectDir,
+      worktree: projectDir,
+      serverUrl: new URL('http://127.0.0.1:4096'),
+    } as never);
 
   beforeEach(async () => {
     originalEnv = { ...process.env };
@@ -304,12 +311,7 @@ describe('plugin TUI agent activity', () => {
       JSON.stringify({ companion: { enabled: false } }),
     );
 
-    hooks = await plugin({
-      client: createPluginClient(async () => ({})),
-      directory: projectDir,
-      worktree: projectDir,
-      serverUrl: new URL('http://127.0.0.1:4096'),
-    } as never);
+    hooks = await createActivityPlugin();
   });
 
   afterEach(async () => {
@@ -361,6 +363,31 @@ describe('plugin TUI agent activity', () => {
     await hooks?.dispose?.();
 
     expect(readTuiSnapshot(projectDir).activeSessions).toEqual({});
+  });
+
+  test('server disposal preserves activity owned by another plugin instance', async () => {
+    const otherHooks = await createActivityPlugin();
+
+    try {
+      await hooks?.['chat.message']?.(
+        { sessionID: 'oracle-a', agent: 'oracle' } as never,
+        {} as never,
+      );
+      await otherHooks['chat.message']?.(
+        { sessionID: 'explorer-b', agent: 'explorer' } as never,
+        {} as never,
+      );
+
+      await hooks?.event?.({
+        event: { type: 'server.instance.disposed' },
+      } as never);
+
+      expect(readTuiSnapshot(projectDir).activeSessions).toEqual({
+        'explorer-b': 'explorer',
+      });
+    } finally {
+      await otherHooks.dispose?.();
+    }
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,28 +166,27 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
       });
     },
   });
-  const tuiActivityDirectories = new Set([ctx.directory]);
+  const ownedTuiActivitySessions = new Map<string, string>();
   const tuiActivityDirectory = (sessionID: string): string => {
-    const directory = sessionMetadata.getDirectory(sessionID) ?? ctx.directory;
-    tuiActivityDirectories.add(directory);
-    return directory;
+    return sessionMetadata.getDirectory(sessionID) ?? ctx.directory;
   };
   const markTuiAgentActive = (sessionID: string, agentName: string): void => {
-    recordTuiAgentActivity(
-      { sessionID, agentName, active: true },
-      tuiActivityDirectory(sessionID),
-    );
+    const directory = tuiActivityDirectory(sessionID);
+    recordTuiAgentActivity({ sessionID, agentName, active: true }, directory);
+    ownedTuiActivitySessions.set(sessionID, directory);
   };
   const markTuiAgentInactive = (sessionID: string): void => {
-    recordTuiAgentActivity(
-      { sessionID, active: false },
-      tuiActivityDirectory(sessionID),
-    );
+    const directory =
+      ownedTuiActivitySessions.get(sessionID) ??
+      tuiActivityDirectory(sessionID);
+    recordTuiAgentActivity({ sessionID, active: false }, directory);
+    ownedTuiActivitySessions.delete(sessionID);
   };
   const clearTuiActivities = (): void => {
-    for (const directory of tuiActivityDirectories) {
-      clearTuiAgentActivities(directory);
+    for (const [sessionID, directory] of ownedTuiActivitySessions) {
+      recordTuiAgentActivity({ sessionID, active: false }, directory);
     }
+    ownedTuiActivitySessions.clear();
   };
   clearTuiAgentActivities(ctx.directory);
   let sessionLifecycle: SessionLifecycle;

--- a/src/tui-state.test.ts
+++ b/src/tui-state.test.ts
@@ -129,6 +129,140 @@ describe('tui-state persistence', () => {
     });
   });
 
+  test('does not restore stale activity during concurrent process cleanup', async () => {
+    recordTuiAgentActivity(
+      { sessionID: 'oracle-a', agentName: 'oracle', active: true },
+      tempDir,
+    );
+    recordTuiAgentActivity(
+      { sessionID: 'explorer-b', agentName: 'explorer', active: true },
+      tempDir,
+    );
+
+    const barrierDir = path.join(tempDir, 'cleanup-barrier');
+    const readReleasePath = path.join(barrierDir, 'read-release');
+    const startReleasePath = path.join(barrierDir, 'start-release');
+    fs.mkdirSync(barrierDir, { recursive: true });
+    const statePath = getTuiStatePath(tempDir);
+    const moduleUrl = new URL('./tui-state.ts', import.meta.url).href;
+    const workerSource = `
+      import { mock } from 'bun:test';
+      import fs from 'node:fs';
+
+      const originalReadFileSync = fs.readFileSync.bind(fs);
+      let paused = false;
+      mock.module('node:fs', () => ({
+        ...fs,
+        readFileSync: (...args) => {
+          const value = originalReadFileSync(...args);
+          if (
+            !paused &&
+            String(args[0]) === process.env.TUI_STATE_PATH &&
+            !fs.existsSync(process.env.TUI_STATE_LOCK_PATH)
+          ) {
+            paused = true;
+            fs.writeFileSync(process.env.READ_MARKER, 'ready');
+            const sleeper = new Int32Array(new SharedArrayBuffer(4));
+            while (!fs.existsSync(process.env.READ_RELEASE)) {
+              Atomics.wait(sleeper, 0, 0, 10);
+            }
+          }
+          return value;
+        },
+      }));
+
+      const { recordTuiAgentActivity } = await import(
+        process.env.TUI_STATE_MODULE_URL
+      );
+      fs.writeFileSync(process.env.START_MARKER, 'ready');
+      const starter = new Int32Array(new SharedArrayBuffer(4));
+      while (!fs.existsSync(process.env.START_RELEASE)) {
+        Atomics.wait(starter, 0, 0, 10);
+      }
+      recordTuiAgentActivity(
+        { sessionID: process.env.SESSION_ID, active: false },
+        process.env.PROJECT_DIR,
+      );
+    `;
+    const sessions = ['oracle-a', 'explorer-b'];
+    const workers = sessions.map((sessionID, index) =>
+      Bun.spawn([process.execPath, '-e', workerSource], {
+        cwd: import.meta.dir,
+        env: {
+          ...process.env,
+          PROJECT_DIR: tempDir,
+          READ_MARKER: path.join(barrierDir, `read-${index}`),
+          READ_RELEASE: readReleasePath,
+          SESSION_ID: sessionID,
+          START_MARKER: path.join(barrierDir, `start-${index}`),
+          START_RELEASE: startReleasePath,
+          TUI_STATE_MODULE_URL: moduleUrl,
+          TUI_STATE_LOCK_PATH: `${statePath}.lock`,
+          TUI_STATE_PATH: statePath,
+        },
+        stdout: 'ignore',
+        stderr: 'pipe',
+      }),
+    );
+
+    const deadline = Date.now() + 5_000;
+    while (
+      !workers.every((_, index) =>
+        fs.existsSync(path.join(barrierDir, `start-${index}`)),
+      )
+    ) {
+      if (Date.now() >= deadline) {
+        throw new Error('Timed out waiting for cleanup workers to start');
+      }
+      await Bun.sleep(10);
+    }
+    fs.writeFileSync(startReleasePath, 'release');
+
+    while (workers.some((worker) => worker.exitCode === null)) {
+      const allReadsPaused = workers.every((_, index) =>
+        fs.existsSync(path.join(barrierDir, `read-${index}`)),
+      );
+      if (allReadsPaused) {
+        fs.writeFileSync(readReleasePath, 'release');
+        break;
+      }
+      if (Date.now() >= deadline) {
+        throw new Error('Timed out waiting for concurrent cleanup');
+      }
+      await Bun.sleep(10);
+    }
+
+    const exitCodes = await Promise.all(workers.map((worker) => worker.exited));
+    for (const [index, exitCode] of exitCodes.entries()) {
+      if (exitCode !== 0) {
+        const stderr = await new Response(workers[index]?.stderr).text();
+        throw new Error(`Cleanup worker ${index} failed: ${stderr}`);
+      }
+    }
+
+    expect(readTuiSnapshot(tempDir).activeSessions).toEqual({});
+    expect(fs.existsSync(`${statePath}.lock`)).toBe(false);
+  });
+
+  test('recovers an abandoned state lock', () => {
+    const statePath = getTuiStatePath(tempDir);
+    const lockPath = `${statePath}.lock`;
+    fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+    fs.writeFileSync(lockPath, '{}');
+    const staleTime = new Date('2000-01-01T00:00:00Z');
+    fs.utimesSync(lockPath, staleTime, staleTime);
+
+    recordTuiAgentModel(
+      { agentName: 'explorer', model: 'openai/gpt-5.6-luna' },
+      tempDir,
+    );
+
+    expect(readTuiSnapshot(tempDir).agentModels.explorer).toBe(
+      'openai/gpt-5.6-luna',
+    );
+    expect(fs.existsSync(lockPath)).toBe(false);
+  });
+
   test('clears persisted activity while preserving model state', () => {
     recordTuiAgentModels(
       { agentModels: { explorer: 'openai/gpt-5.6-luna' } },

--- a/src/tui-state.ts
+++ b/src/tui-state.ts
@@ -13,6 +13,15 @@ export interface TuiSnapshot {
 
 const STATE_DIR = 'oh-my-opencode-slim';
 const STATE_FILE = 'tui-state.json';
+const STATE_LOCK_RETRY_MS = 5;
+const STATE_LOCK_TIMEOUT_MS = 1_000;
+const STATE_LOCK_STALE_MS = 30_000;
+const STATE_LOCK_SLEEPER = new Int32Array(new SharedArrayBuffer(4));
+
+interface TuiStateLock {
+  path: string;
+  token: string;
+}
 
 function dataDir(): string {
   return (
@@ -105,24 +114,117 @@ function writeTuiSnapshot(snapshot: TuiSnapshot, projectDir: string): void {
   }
 }
 
+function isProcessRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+function isStateLockStale(lockPath: string): boolean {
+  try {
+    const metadata = JSON.parse(fs.readFileSync(lockPath, 'utf8')) as {
+      pid?: unknown;
+    };
+    if (typeof metadata.pid === 'number' && metadata.pid > 0) {
+      return !isProcessRunning(metadata.pid);
+    }
+  } catch {
+    // A creator may still be writing metadata; use age as fallback.
+  }
+
+  try {
+    return Date.now() - fs.statSync(lockPath).mtimeMs > STATE_LOCK_STALE_MS;
+  } catch {
+    return false;
+  }
+}
+
+function acquireStateLock(statePath: string): TuiStateLock | undefined {
+  const lockPath = `${statePath}.lock`;
+  const deadline = Date.now() + STATE_LOCK_TIMEOUT_MS;
+
+  while (Date.now() <= deadline) {
+    const token = randomUUID();
+    let created = false;
+    try {
+      const handle = fs.openSync(lockPath, 'wx');
+      created = true;
+      try {
+        fs.writeFileSync(
+          handle,
+          JSON.stringify({ pid: process.pid, token, createdAt: Date.now() }),
+        );
+      } finally {
+        fs.closeSync(handle);
+      }
+      return { path: lockPath, token };
+    } catch (error) {
+      if (created) {
+        try {
+          fs.unlinkSync(lockPath);
+        } catch {
+          // Best-effort cleanup after lock metadata creation fails.
+        }
+      }
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') return;
+      if (isStateLockStale(lockPath)) {
+        try {
+          fs.unlinkSync(lockPath);
+        } catch {
+          // Another process may have recovered or released it first.
+        }
+        continue;
+      }
+      Atomics.wait(STATE_LOCK_SLEEPER, 0, 0, STATE_LOCK_RETRY_MS);
+    }
+  }
+}
+
+function releaseStateLock(lock: TuiStateLock): void {
+  try {
+    const metadata = JSON.parse(fs.readFileSync(lock.path, 'utf8')) as {
+      token?: unknown;
+    };
+    if (metadata.token === lock.token) fs.unlinkSync(lock.path);
+  } catch {
+    // Best-effort state must not crash the plugin during lock cleanup.
+  }
+}
+
 function updateSnapshot(
   projectDir: string,
   mutator: (snapshot: TuiSnapshot) => void,
 ): void {
-  const snapshot = readTuiSnapshot(projectDir);
-  const beforeModels = JSON.stringify(snapshot.agentModels);
-  const beforeVariants = JSON.stringify(snapshot.agentVariants);
-  const beforeActiveSessions = JSON.stringify(snapshot.activeSessions);
-  mutator(snapshot);
-  if (
-    JSON.stringify(snapshot.agentModels) === beforeModels &&
-    JSON.stringify(snapshot.agentVariants) === beforeVariants &&
-    JSON.stringify(snapshot.activeSessions) === beforeActiveSessions
-  ) {
-    return; // state unchanged — skip the disk write
+  const statePath = getTuiStatePath(projectDir);
+  try {
+    fs.mkdirSync(path.dirname(statePath), { recursive: true });
+  } catch {
+    return;
   }
-  snapshot.updatedAt = Date.now();
-  writeTuiSnapshot(snapshot, projectDir);
+  const lock = acquireStateLock(statePath);
+  if (!lock) return;
+
+  try {
+    const snapshot = readTuiSnapshot(projectDir);
+    const beforeModels = JSON.stringify(snapshot.agentModels);
+    const beforeVariants = JSON.stringify(snapshot.agentVariants);
+    const beforeActiveSessions = JSON.stringify(snapshot.activeSessions);
+    mutator(snapshot);
+    if (
+      JSON.stringify(snapshot.agentModels) === beforeModels &&
+      JSON.stringify(snapshot.agentVariants) === beforeVariants &&
+      JSON.stringify(snapshot.activeSessions) === beforeActiveSessions
+    ) {
+      return; // state unchanged — skip the disk write
+    }
+    snapshot.updatedAt = Date.now();
+    writeTuiSnapshot(snapshot, projectDir);
+  } finally {
+    releaseStateLock(lock);
+  }
 }
 
 export function recordTuiAgentModels(

--- a/src/tui.test.ts
+++ b/src/tui.test.ts
@@ -79,8 +79,8 @@ describe('tui sidebar agents', () => {
   test('renders a stable blank column or deterministic braille frame', () => {
     expect(getSidebarActivityIndicator(false, 0)).toBe(' ');
     expect(getSidebarActivityIndicator(true, 0)).toBe('⠋');
-    expect(getSidebarActivityIndicator(true, 120)).toBe('⠙');
-    expect(getSidebarActivityIndicator(true, 1_200)).toBe('⠋');
+    expect(getSidebarActivityIndicator(true, 100)).toBe('⠙');
+    expect(getSidebarActivityIndicator(true, 1_000)).toBe('⠋');
   });
 });
 

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -31,7 +31,7 @@ const FALLBACK_SIDEBAR_AGENTS = SUBAGENT_NAMES.filter(
 );
 const BORDER = { type: 'single' };
 const TMUX_PANE_HEARTBEAT_MS = 10_000;
-const ACTIVITY_FRAME_MS = 120;
+const ACTIVITY_FRAME_MS = 100;
 const ACTIVITY_FRAMES = [
   '⠋',
   '⠙',


### PR DESCRIPTION
## Summary

- remove only TUI activity sessions owned by the disposing plugin instance
- preserve active indicators from other instances sharing the same project state
- add a two-instance regression test for `server.instance.disposed`
- reduce Braille spinner frame interval from 120ms to 100ms

Follow-up to #1099.

## Testing

- `bun run check:ci`
- `bun run typecheck`
- `bun run build`
- `bun test` — 2,258 tests passed
