### PR TITLE
fix(interview): deterministic port ownership for test suites (eliminate TOCTOU port-election flake)

### DIFF
--- a/src/interview/dashboard-manager.ts
+++ b/src/interview/dashboard-manager.ts
@@ -1,3 +1,4 @@
+import type { Server } from 'node:http';
 import path from 'node:path';
 import type { PluginInput } from '@opencode-ai/plugin';
 import type { PluginConfig } from '../config';
@@ -26,6 +27,8 @@ export function createDashboardManager(
   options: {
     runtime?: InterviewSessionRuntime;
     sessionClient?: DashboardConfig['sessionClient'];
+    /** Already-listening server for the dashboard role to adopt. */
+    server?: Server;
   } = {},
 ): {
   service: ReturnType<typeof createInterviewService>;
@@ -240,6 +243,7 @@ export function createDashboardManager(
         port: dashboardPort,
         outputFolder,
         sessionClient: options.sessionClient ?? getClient(ctx).session,
+        server: options.server,
       });
 
       if (dashboard) {

--- a/src/interview/dashboard.test.ts
+++ b/src/interview/dashboard.test.ts
@@ -1,33 +1,27 @@
 import { describe, expect, mock, test } from 'bun:test';
 import * as fs from 'node:fs/promises';
-import { createServer, get } from 'node:http';
+import { get } from 'node:http';
 import * as path from 'node:path';
 import { createDashboardServer } from './dashboard';
+import { bindFreePort } from './test-port';
 
-// Helper to find a free port (matches interview.test.ts pattern)
-function findFreePort(): Promise<number> {
-  return new Promise((resolve, reject) => {
-    const server = createServer();
-    server.listen(0, () => {
-      const address = server.address();
-      if (address && typeof address !== 'string') {
-        const port = address.port;
-        server.close(() => resolve(port));
-      } else {
-        server.close(() => reject(new Error('Failed to get port')));
-      }
-    });
-  });
-}
-
-// Helper to start a dashboard on a free port
+// Helper to start a dashboard on a held port (bindFreePort keeps the
+// listener open, the dashboard adopts it — no TOCTOU window).
 async function startDashboard() {
-  const port = await findFreePort();
+  const { port, server } = await bindFreePort();
   const dashboard = createDashboardServer({
     port,
     outputFolder: 'interview',
+    server,
   });
-  const baseUrl = await dashboard.start();
+  let baseUrl: string;
+  try {
+    baseUrl = await dashboard.start();
+  } catch (error) {
+    server.closeAllConnections();
+    server.close();
+    throw error;
+  }
 
   return {
     dashboard,

--- a/src/interview/dashboard.ts
+++ b/src/interview/dashboard.ts
@@ -158,6 +158,8 @@ export interface DashboardConfig {
   port: number;
   outputFolder: string;
   sessionClient?: Pick<PluginInput['client']['session'], 'list'>;
+  /** Already-listening server to adopt instead of binding `port`. */
+  server?: Server;
 }
 
 // ─── Dashboard Server ─────────────────────────────────────────────────
@@ -1514,14 +1516,21 @@ export function createDashboardServer(config: DashboardConfig): {
     }
 
     startPromise = new Promise((resolve, reject) => {
-      const server = createServer((request, response) => {
+      const requestHandler = (
+        request: IncomingMessage,
+        response: ServerResponse,
+      ) => {
         handleRequest(request, response).catch((error: unknown) => {
           sendJson(response, 500, {
             error:
               error instanceof Error ? error.message : 'Internal server error',
           });
         });
-      });
+      };
+
+      // Adopt an already-listening server (deterministic port ownership)
+      // or bind a fresh one on config.port.
+      const server = config.server ?? createServer(requestHandler);
 
       server.requestTimeout = 30_000;
       server.headersTimeout = 10_000;
@@ -1535,6 +1544,30 @@ export function createDashboardServer(config: DashboardConfig): {
           reject(error);
         }
       });
+
+      if (config.server) {
+        // Adoption path: already listening. Swap the placeholder handler
+        // for the dashboard handler and read the port from the address.
+        const address = server.address();
+        if (!address || typeof address === 'string') {
+          reject(new Error('Failed to start dashboard server'));
+          return;
+        }
+        server.removeAllListeners('request');
+        server.on('request', requestHandler);
+        activeServer = server;
+        baseUrl = `http://127.0.0.1:${address.port}`;
+        if (closed) {
+          activeServer = null;
+          baseUrl = null;
+          closeServer(server);
+          reject(new Error('Dashboard server is closed.'));
+          return;
+        }
+        writeAuthFile(config.port, authToken);
+        resolve(baseUrl);
+        return;
+      }
 
       pendingServer = server;
       server.listen(config.port, '127.0.0.1', () => {

--- a/src/interview/interview.test.ts
+++ b/src/interview/interview.test.ts
@@ -9,6 +9,7 @@ import {
   createInterviewService as createRealInterviewService,
   MAX_RETAINED_ABANDONED,
 } from './service';
+import { bindFreePort } from './test-port';
 import type { InterviewAnswer } from './types';
 import { renderInterviewPage } from './ui';
 
@@ -1852,24 +1853,6 @@ describe('renderInterviewPage', () => {
   });
 });
 
-/** Discover a free port by briefly binding to port 0, then closing. */
-async function findFreePort(): Promise<number> {
-  return new Promise((resolve, reject) => {
-    const srv = createServer();
-    srv.listen(0, '127.0.0.1', () => {
-      const addr = srv.address();
-      srv.close(() => {
-        if (!addr || typeof addr === 'string') {
-          reject(new Error('Failed to find free port'));
-          return;
-        }
-        resolve(addr.port);
-      });
-    });
-    srv.on('error', reject);
-  });
-}
-
 describe('interview server port configuration', () => {
   const noopDeps = {
     getState: mock(
@@ -1896,13 +1879,18 @@ describe('interview server port configuration', () => {
   };
 
   test('server starts on a specific port when port is non-zero', async () => {
-    const freePort = await findFreePort();
-    const server = createInterviewServer({ ...noopDeps, port: freePort });
+    const held = await bindFreePort();
+    const server = createInterviewServer({
+      ...noopDeps,
+      port: held.port,
+      server: held.server,
+    });
     try {
       const baseUrl = await server.ensureStarted();
-      expect(baseUrl).toBe(`http://127.0.0.1:${freePort}`);
+      expect(baseUrl).toBe(`http://127.0.0.1:${held.port}`);
     } finally {
       server.close();
+      if (held.server.listening) held.server.close();
     }
   });
 
@@ -1920,15 +1908,20 @@ describe('interview server port configuration', () => {
   });
 
   test('baseUrl contains the correct port number for fixed port', async () => {
-    const freePort = await findFreePort();
-    const server = createInterviewServer({ ...noopDeps, port: freePort });
+    const held = await bindFreePort();
+    const server = createInterviewServer({
+      ...noopDeps,
+      port: held.port,
+      server: held.server,
+    });
     try {
       const baseUrl = await server.ensureStarted();
       const portStr = baseUrl.split(':').pop();
       const port = Number.parseInt(portStr ?? '0', 10);
-      expect(port).toBe(freePort);
+      expect(port).toBe(held.port);
     } finally {
       server.close();
+      if (held.server.listening) held.server.close();
     }
   });
 

--- a/src/interview/manager.test.ts
+++ b/src/interview/manager.test.ts
@@ -1,11 +1,12 @@
 import { afterEach, describe, expect, mock, test } from 'bun:test';
 import * as fs from 'node:fs/promises';
-import { createServer as createHttpServer } from 'node:http';
+import type { Server } from 'node:http';
 import { createServer as createNetServer } from 'node:net';
 import type { PluginConfig } from '../config';
 import { readDashboardAuthFile } from './dashboard';
 import { createDashboardManager } from './dashboard-manager';
 import { createInterviewManager as createInterviewManagerImpl } from './manager';
+import { bindFreePort } from './test-port';
 
 // Intercept getClient so the manager's service uses the same session mocks.
 mock.module('../utils/opencode-client', () => ({
@@ -15,6 +16,8 @@ mock.module('../utils/opencode-client', () => ({
 }));
 
 const managers = new Set<ReturnType<typeof createInterviewManagerImpl>>();
+// Held-port servers from bindFreePort that await dashboard adoption.
+const heldServers = new Set<Server>();
 
 function createInterviewManager(
   ...args: Parameters<typeof createInterviewManagerImpl>
@@ -28,23 +31,16 @@ afterEach(async () => {
   const pending = [...managers];
   managers.clear();
   await Promise.all(pending.map((manager) => manager.dispose()));
+  // Safety net: close held-port servers no manager adopted. Adopted ones
+  // are already closed by their manager's dispose() above.
+  for (const server of heldServers) {
+    heldServers.delete(server);
+    if (server.listening) {
+      server.closeAllConnections();
+      server.close();
+    }
+  }
 });
-
-// Helper to find a free port (matches interview.test.ts pattern)
-async function findFreePort(): Promise<number> {
-  return new Promise((resolve, reject) => {
-    const server = createHttpServer();
-    server.listen(0, () => {
-      const address = server.address();
-      if (address && typeof address !== 'string') {
-        const port = address.port;
-        server.close(() => resolve(port));
-      } else {
-        server.close(() => reject(new Error('Failed to get port')));
-      }
-    });
-  });
-}
 
 // Mock context pattern from interview.test.ts
 function createMockContext(overrides?: {
@@ -207,13 +203,14 @@ describe('interview manager - per-session mode', () => {
       const tempDir = await fs.mkdtemp('/tmp/manager-test-');
       const ctx = createMockContext({ directory: tempDir });
 
-      const freePort = await findFreePort();
+      const { port: freePort, server } = await bindFreePort();
+      heldServers.add(server);
       const config = createTestConfig({
         port: freePort,
         dashboard: true,
       });
 
-      const manager = createInterviewManager(ctx, config);
+      const manager = createInterviewManager(ctx, config, { server });
 
       // Wait for dashboard init
       await new Promise((r) => setTimeout(r, 100));
@@ -249,6 +246,7 @@ describe('interview manager - per-session mode', () => {
         // Verify session is registered (interview exists in cache)
         const listResponse = await fetch(
           `http://127.0.0.1:${freePort}/api/interviews/${interviewId}/state?token=${auth?.token}`,
+          { signal: AbortSignal.timeout(2000) },
         );
         expect(listResponse.status).toBe(200);
       } finally {
@@ -259,7 +257,8 @@ describe('interview manager - per-session mode', () => {
 
   describe('dashboard: true with port 0', () => {
     test('activates dashboard mode and creates interview', async () => {
-      const freePort = await findFreePort();
+      const { port: freePort, server } = await bindFreePort();
+      heldServers.add(server);
       const tempDir = await fs.mkdtemp('/tmp/manager-test-');
       const ctx = createMockContext({ directory: tempDir });
 
@@ -268,7 +267,7 @@ describe('interview manager - per-session mode', () => {
         dashboard: true,
       });
 
-      const manager = createInterviewManager(ctx, config);
+      const manager = createInterviewManager(ctx, config, { server });
 
       // Wait for async init
       await new Promise((r) => setTimeout(r, 100));
@@ -298,13 +297,14 @@ describe('interview manager - state push callback wiring', () => {
     const tempDir = await fs.mkdtemp('/tmp/manager-test-');
     const ctx = createMockContext({ directory: tempDir });
 
-    const freePort = await findFreePort();
+    const { port: freePort, server } = await bindFreePort();
+    heldServers.add(server);
     const config = createTestConfig({
       port: freePort,
       dashboard: true,
     });
 
-    const manager = createInterviewManager(ctx, config);
+    const manager = createInterviewManager(ctx, config, { server });
 
     // Wait for dashboard init
     await new Promise((r) => setTimeout(r, 100));
@@ -340,6 +340,7 @@ describe('interview manager - state push callback wiring', () => {
       // Verify state was pushed to dashboard cache
       const stateResponse = await fetch(
         `http://127.0.0.1:${freePort}/api/interviews/${interviewId}/state?token=${auth?.token}`,
+        { signal: AbortSignal.timeout(2000) },
       );
       expect(stateResponse.status).toBe(200);
 
@@ -387,13 +388,14 @@ describe('interview manager - session registration', () => {
     const tempDir = await fs.mkdtemp('/tmp/manager-test-');
     const ctx = createMockContext({ directory: tempDir });
 
-    const freePort = await findFreePort();
+    const { port: freePort, server } = await bindFreePort();
+    heldServers.add(server);
     const config = createTestConfig({
       port: freePort,
       dashboard: true,
     });
 
-    const manager = createInterviewManager(ctx, config);
+    const manager = createInterviewManager(ctx, config, { server });
 
     // Wait for dashboard init
     await new Promise((r) => setTimeout(r, 100));
@@ -429,6 +431,7 @@ describe('interview manager - session registration', () => {
       // Verify session was registered by checking the interview state
       const stateResponse = await fetch(
         `http://127.0.0.1:${freePort}/api/interviews/${interviewId}/state?token=${auth?.token}`,
+        { signal: AbortSignal.timeout(2000) },
       );
       expect(stateResponse.status).toBe(200);
     } finally {
@@ -440,13 +443,14 @@ describe('interview manager - session registration', () => {
     const tempDir = await fs.mkdtemp('/tmp/manager-test-');
     const ctx = createMockContext({ directory: tempDir });
 
-    const freePort = await findFreePort();
+    const { port: freePort, server } = await bindFreePort();
+    heldServers.add(server);
     const config = createTestConfig({
       port: freePort,
       dashboard: true,
     });
 
-    const manager = createInterviewManager(ctx, config);
+    const manager = createInterviewManager(ctx, config, { server });
 
     // Wait for dashboard init
     await new Promise((r) => setTimeout(r, 100));
@@ -491,6 +495,7 @@ describe('interview manager - session registration', () => {
       const stateResponse = await fetch(
         `http://127.0.0.1:${freePort}/api/interviews/${_interviewId}` +
           `/state?token=${auth?.token}`,
+        { signal: AbortSignal.timeout(2000) },
       );
       expect(stateResponse.status).toBe(404);
 
@@ -510,7 +515,8 @@ describe('interview manager - session registration', () => {
     const dashboardCtx = createMockContext({ directory: dashboardDir });
     const clientCtx = createMockContext({ directory: clientDir });
 
-    const freePort = await findFreePort();
+    const { port: freePort, server } = await bindFreePort();
+    heldServers.add(server);
     const config = createTestConfig({
       port: freePort,
       dashboard: true,
@@ -530,7 +536,7 @@ describe('interview manager - session registration', () => {
       (globalThis as any).setInterval = setIntervalSpy;
       (globalThis as any).clearInterval = clearIntervalSpy;
 
-      createInterviewManager(dashboardCtx, config);
+      createInterviewManager(dashboardCtx, config, { server });
 
       // Wait for dashboard init
       await new Promise((r) => setTimeout(r, 100));
@@ -575,10 +581,12 @@ describe('interview manager - session registration', () => {
   test('disposes dashboard resources idempotently', async () => {
     const tempDir = await fs.mkdtemp('/tmp/manager-test-');
     const ctx = createMockContext({ directory: tempDir });
-    const freePort = await findFreePort();
+    const { port: freePort, server } = await bindFreePort();
+    heldServers.add(server);
     const manager = createInterviewManager(
       ctx,
       createTestConfig({ port: freePort, dashboard: true }),
+      { server },
     );
 
     try {
@@ -605,7 +613,8 @@ describe('interview manager - edge cases', () => {
   test('does not roll back a claim during an overlapping in-process delivery', async () => {
     const tempDir = await fs.mkdtemp('/tmp/manager-test-');
     const ctx = createMockContext({ directory: tempDir });
-    const freePort = await findFreePort();
+    const { port: freePort, server } = await bindFreePort();
+    heldServers.add(server);
     const config = createTestConfig({ port: freePort, dashboard: true });
     const messages: Array<{
       info?: { role: string };
@@ -636,6 +645,7 @@ describe('interview manager - edge cases', () => {
     };
     const manager = createDashboardManager(ctx, config, freePort, 'interview', {
       runtime,
+      server,
     });
 
     try {
@@ -670,6 +680,7 @@ describe('interview manager - edge cases', () => {
           body: JSON.stringify({
             answers: [{ questionId: 'q-1', answer: 'A' }],
           }),
+          signal: AbortSignal.timeout(2000),
         },
       );
       expect(queued.status).toBe(202);
@@ -706,7 +717,8 @@ describe('interview manager - edge cases', () => {
   test('waits for accepted delivery before disposal and replacement polling', async () => {
     const tempDir = await fs.mkdtemp('/tmp/manager-test-');
     const ctx = createMockContext({ directory: tempDir });
-    const freePort = await findFreePort();
+    const { port: freePort, server } = await bindFreePort();
+    heldServers.add(server);
     const config = createTestConfig({ port: freePort, dashboard: true });
     const messages: Array<{
       info?: { role: string };
@@ -733,6 +745,7 @@ describe('interview manager - edge cases', () => {
     };
     const manager = createDashboardManager(ctx, config, freePort, 'interview', {
       runtime,
+      server,
     });
 
     try {
@@ -767,6 +780,7 @@ describe('interview manager - edge cases', () => {
           body: JSON.stringify({
             answers: [{ questionId: 'q-1', answer: 'A' }],
           }),
+          signal: AbortSignal.timeout(2000),
         },
       );
       expect(queued.status).toBe(202);
@@ -944,13 +958,14 @@ describe('interview manager - integration with real dashboard', () => {
     const ctx1 = createMockContext({ directory: tempDir1 });
     const ctx2 = createMockContext({ directory: tempDir2 });
 
-    const freePort = await findFreePort();
+    const { port: freePort, server } = await bindFreePort();
+    heldServers.add(server);
     const config = createTestConfig({
       port: freePort,
       dashboard: true,
     });
 
-    const manager1 = createInterviewManager(ctx1, config);
+    const manager1 = createInterviewManager(ctx1, config, { server });
 
     // Wait for manager1 to become dashboard
     await new Promise((r) => setTimeout(r, 100));
@@ -959,6 +974,7 @@ describe('interview manager - integration with real dashboard', () => {
       // Manager1 should be the dashboard
       const healthResponse = await fetch(
         `http://127.0.0.1:${freePort}/api/health`,
+        { signal: AbortSignal.timeout(2000) },
       );
       expect(healthResponse.status).toBe(200);
 
@@ -1014,6 +1030,7 @@ describe('interview manager - integration with real dashboard', () => {
       // Both interviews should be in dashboard cache
       const state1Response = await fetch(
         `http://127.0.0.1:${freePort}/api/interviews/${interviewId1}/state?token=${auth?.token}`,
+        { signal: AbortSignal.timeout(2000) },
       );
       expect(state1Response.status).toBe(200);
 
@@ -1030,6 +1047,7 @@ describe('interview manager - integration with real dashboard', () => {
 
       const state2Response = await fetch(
         `http://127.0.0.1:${freePort}/api/interviews/${interviewId2}/state?token=${auth?.token}`,
+        { signal: AbortSignal.timeout(2000) },
       );
       expect(state2Response.status).toBe(200);
     } finally {
@@ -1041,9 +1059,12 @@ describe('interview manager - integration with real dashboard', () => {
   test('does not redeliver after a successful delivery loses its ACK response', async () => {
     const tempDir1 = await fs.mkdtemp('/tmp/manager-test-');
     const tempDir2 = await fs.mkdtemp('/tmp/manager-test-');
-    const port = await findFreePort();
+    const { port, server } = await bindFreePort();
+    heldServers.add(server);
     const config = createTestConfig({ port, dashboard: true });
-    createInterviewManager(createMockContext({ directory: tempDir1 }), config);
+    createInterviewManager(createMockContext({ directory: tempDir1 }), config, {
+      server,
+    });
     await new Promise((resolve) => setTimeout(resolve, 100));
     const ctx2 = createMockContext({ directory: tempDir2 });
     const manager2 = createInterviewManager(ctx2, config);
@@ -1085,6 +1106,7 @@ describe('interview manager - integration with real dashboard', () => {
           method: 'POST',
           headers: { 'content-type': 'application/json' },
           body: JSON.stringify({ action: 'more-questions' }),
+          signal: AbortSignal.timeout(2000),
         },
       );
       expect(nudgeResponse.status).toBe(202);
@@ -1121,9 +1143,12 @@ describe('interview manager - integration with real dashboard', () => {
   test('delivers a new answer claim after an earlier claim ACK is uncertain', async () => {
     const tempDir1 = await fs.mkdtemp('/tmp/manager-test-');
     const tempDir2 = await fs.mkdtemp('/tmp/manager-test-');
-    const port = await findFreePort();
+    const { port, server } = await bindFreePort();
+    heldServers.add(server);
     const config = createTestConfig({ port, dashboard: true });
-    createInterviewManager(createMockContext({ directory: tempDir1 }), config);
+    createInterviewManager(createMockContext({ directory: tempDir1 }), config, {
+      server,
+    });
     await new Promise((resolve) => setTimeout(resolve, 100));
     const messagesData: Array<{
       info?: { role: string };
@@ -1190,12 +1215,14 @@ describe('interview manager - integration with real dashboard', () => {
           body: JSON.stringify({
             answers: [{ questionId: 'q-1', answer: 'First answer' }],
           }),
+          signal: AbortSignal.timeout(2000),
         },
       );
       expect(firstAnswer.status).toBe(202);
 
       const firstClaimResponse = await originalFetch(
         `${interviewUrl}/pending${authQuery}`,
+        { signal: AbortSignal.timeout(2000) },
       );
       const firstClaim = (await firstClaimResponse.json()) as {
         claimId: string;
@@ -1224,6 +1251,7 @@ describe('interview manager - integration with real dashboard', () => {
           method: 'POST',
           headers: { 'content-type': 'application/json' },
           body: JSON.stringify({ claimId: firstClaim.claimId }),
+          signal: AbortSignal.timeout(2000),
         },
       );
       expect(recoveredAck.status).toBe(200);
@@ -1236,6 +1264,7 @@ describe('interview manager - integration with real dashboard', () => {
           body: JSON.stringify({
             answers: [{ questionId: 'q-1', answer: 'Second answer' }],
           }),
+          signal: AbortSignal.timeout(2000),
         },
       );
       expect(secondAnswer.status).toBe(202);

--- a/src/interview/manager.ts
+++ b/src/interview/manager.ts
@@ -1,3 +1,4 @@
+import type { Server } from 'node:http';
 import type { PluginInput } from '@opencode-ai/plugin';
 import type { PluginConfig } from '../config';
 import { DEFAULT_DASHBOARD_PORT } from './dashboard';
@@ -7,6 +8,10 @@ import { createPerSessionInterviewServer } from './session-server';
 export function createInterviewManager(
   ctx: PluginInput,
   config: PluginConfig,
+  options: {
+    /** Already-listening server for the dashboard role to adopt. */
+    server?: Server;
+  } = {},
 ): {
   registerCommand: (config: Record<string, unknown>) => void;
   handleCommandExecuteBefore: (
@@ -33,5 +38,11 @@ export function createInterviewManager(
   const dashboardPort =
     effectivePort > 0 ? effectivePort : DEFAULT_DASHBOARD_PORT;
 
-  return createDashboardManager(ctx, config, dashboardPort, outputFolder);
+  return createDashboardManager(
+    ctx,
+    config,
+    dashboardPort,
+    outputFolder,
+    options,
+  );
 }

--- a/src/interview/server.ts
+++ b/src/interview/server.ts
@@ -90,6 +90,8 @@ export function createInterviewServer(deps: {
   ) => Promise<void>;
   outputFolder: string;
   port: number;
+  /** Already-listening server to adopt instead of binding `port`. */
+  server?: Server;
 }): {
   ensureStarted: () => Promise<string>;
   close: () => void;
@@ -314,14 +316,21 @@ export function createInterviewServer(deps: {
     }
 
     startPromise = new Promise((resolve, reject) => {
-      const server = createServer((request, response) => {
+      const requestHandler = (
+        request: IncomingMessage,
+        response: ServerResponse,
+      ) => {
         handle(request, response).catch((error) => {
           sendJson(response, 500, {
             error:
               error instanceof Error ? error.message : 'Internal server error',
           });
         });
-      });
+      };
+
+      // Adopt an already-listening server (deterministic port ownership)
+      // or bind a fresh one on deps.port.
+      const server = deps.server ?? createServer(requestHandler);
       server.requestTimeout = 30_000;
       server.headersTimeout = 10_000;
 
@@ -341,6 +350,23 @@ export function createInterviewServer(deps: {
           reject(error);
         }
       });
+
+      if (deps.server) {
+        // Adoption path: already listening. Swap the placeholder handler
+        // for the interview server handler and read the port from the
+        // address.
+        const address = server.address();
+        if (!address || typeof address === 'string') {
+          startPromise = null;
+          reject(new Error('Failed to start interview server'));
+          return;
+        }
+        server.removeAllListeners('request');
+        server.on('request', requestHandler);
+        baseUrl = `http://127.0.0.1:${address.port}`;
+        resolve(baseUrl);
+        return;
+      }
 
       server.listen(deps.port, '127.0.0.1', () => {
         const address = server.address();

--- a/src/interview/test-port.ts
+++ b/src/interview/test-port.ts
@@ -1,0 +1,32 @@
+import { createServer, type Server } from 'node:http';
+
+/**
+ * Bind an OS-assigned port on localhost and keep the server listening.
+ *
+ * Tests hand `server` to the interview server factories (via their
+ * optional `server` config) so the real server adopts the already-bound
+ * listener instead of racing through a bind/close/bind TOCTOU window
+ * between port discovery and the real bind.
+ *
+ * The placeholder 404 handler makes dashboard health probes fail fast
+ * (non-OK response, no timeout wait), so a held port never looks like a
+ * live dashboard to `tryBecomeDashboard`.
+ */
+export function bindFreePort(): Promise<{ port: number; server: Server }> {
+  return new Promise((resolve, reject) => {
+    const server = createServer((_request, response) => {
+      response.writeHead(404, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({ error: 'Not found' }));
+    });
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        server.close();
+        reject(new Error('Failed to bind a free port'));
+        return;
+      }
+      resolve({ port: address.port, server });
+    });
+  });
+}

--- a/src/v2/interview-bridge.test.ts
+++ b/src/v2/interview-bridge.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, mock, test } from 'bun:test';
 import * as fs from 'node:fs/promises';
-import { createServer } from 'node:http';
+import { bindFreePort } from '../interview/test-port';
 import {
   applyInterviewCommandParts,
   createV2InterviewBridge,
@@ -20,21 +20,6 @@ function createContext(overrides?: {
       prompt: overrides?.prompt,
     },
   };
-}
-
-async function findFreePort(): Promise<number> {
-  return new Promise((resolve, reject) => {
-    const server = createServer();
-    server.listen(0, () => {
-      const address = server.address();
-      if (!address || typeof address === 'string') {
-        server.close(() => reject(new Error('Failed to get free port')));
-        return;
-      }
-      const port = address.port;
-      server.close(() => resolve(port));
-    });
-  });
 }
 
 describe('markerText', () => {
@@ -299,7 +284,7 @@ describe('v2 interview bridge', () => {
 
   test('shares one configured dashboard across multiple v2 sessions', async () => {
     const directory = `.tmp-v2-dashboard-${Date.now()}`;
-    const port = await findFreePort();
+    const { port, server } = await bindFreePort();
     const config = {
       outputFolder: directory,
       dashboard: true,
@@ -310,6 +295,7 @@ describe('v2 interview bridge', () => {
     const bridge1 = createV2InterviewBridge(
       createContext({ synthetic: synthetic1 }),
       config,
+      { server },
     );
     await new Promise((resolve) => setTimeout(resolve, 100));
     const bridge2 = createV2InterviewBridge(
@@ -352,6 +338,11 @@ describe('v2 interview bridge', () => {
     } finally {
       await bridge1.dispose();
       await bridge2.dispose();
+      // Safety net: close the held server if the dashboard never adopted it.
+      if (server.listening) {
+        server.closeAllConnections();
+        server.close();
+      }
       await fs.rm(`${process.cwd()}/${directory}`, {
         recursive: true,
         force: true,

--- a/src/v2/interview-bridge.ts
+++ b/src/v2/interview-bridge.ts
@@ -1,3 +1,4 @@
+import type { Server } from 'node:http';
 import type { InterviewConfig, PluginConfig } from '../config';
 import { DEFAULT_DASHBOARD_PORT } from '../interview/dashboard';
 import { createDashboardManager } from '../interview/dashboard-manager';
@@ -75,6 +76,10 @@ export function applyInterviewCommandParts(
 export function createV2InterviewBridge(
   ctx: V2Context,
   config?: InterviewConfig,
+  options: {
+    /** Already-listening server for the dashboard role to adopt. */
+    server?: Server;
+  } = {},
 ): V2InterviewBridge {
   const transcripts = new Map<string, InterviewMessage[]>();
   const activeText = new Map<string, string>();
@@ -145,6 +150,7 @@ export function createV2InterviewBridge(
           sessionClient: {
             list: async () => ({ data: [] }),
           } as never,
+          server: options.server,
         },
       )
     : null;


### PR DESCRIPTION
## Problem

The interview test suites have a long-standing flaky port-election race (present on current master — e.g. `findFreePort` appears 13× in `src/interview/manager.test.ts`):

- Four private `findFreePort()` copies share the same TOCTOU pattern: bind `:0` → read port → **close() → hand the port number over**. Between the close and the actual dashboard `listen()`, any concurrently running suite can steal the port.
- Bun runs test files in parallel, so `manager.test.ts`, `interview.test.ts`, `dashboard.test.ts`, and `src/v2/interview-bridge.test.ts` race each other's port elections.
- When a bare probe server steals a port, the test's unbounded health fetch hangs ~3s and then fails with a misleading assertion; when another dashboard steals it, per-port auth files cross-contaminate.

Observed impact: consecutive full-suite runs failed on 3 of 4 attempts in one environment (`manager.test.ts > two managers on same port` and dashboard port races); multiple isolated occurrences during development.

## Fix

Deterministic port ownership instead of fire-and-forget election:

- New shared helper `src/interview/test-port.ts` — `bindFreePort()` returns `{ port, server }` with the server **held open** (404 handler so `probeDashboard` fails fast instead of waiting out its 2s timeout).
- Optional **server-adoption seam**: `dashboard.ts`, `dashboard-manager.ts`, `manager.ts`, `server.ts`, and `src/v2/interview-bridge.ts` accept an already-listening server instance and adopt it (skip `listen()`, read the port from `address()`, existing `close()` cleans up the adopted instance). When no server is passed, every path is byte-identical to current behavior — no production behavior change.
- All four suites migrated to the helper; private `findFreePort` copies removed.
- 14 test-side localhost fetches bounded with `AbortSignal.timeout(2000)`.

## Verification

- 3 dashboard suites back-to-back ×3 on this branch (rebased on current master): **94 pass / 0 fail each run**
- Full suite: **2295 pass / 0 fail**; `tsc --noEmit` clean; `biome check` clean
- On the pre-rebase base: 3 suites ×3 (103×3) and full suite ×3 green
- Non-adoption paths independently reviewed as expression-equivalent to current behavior

## Notes

Known hardening minors logged for future touches (all unreachable paths): close the held server on `address()` failure, retryability symmetry in `server.ts`, auth-file port seam, stale error listener in the helper.
