### PR TITLE
fix(foreground-fallback): reset the descent when a new turn returns to the chain primary

### DIFF
--- a/src/hooks/foreground-fallback/index.test.ts
+++ b/src/hooks/foreground-fallback/index.test.ts
@@ -1578,6 +1578,303 @@ describe('ForegroundFallbackManager session.status', () => {
 // ---------------------------------------------------------------------------
 
 describe('ForegroundFallbackManager chain exhaustion', () => {
+  test('re-walks from the second chain entry on each new user turn', async () => {
+    const { mocks } = createMockClient();
+    const mgr = new ForegroundFallbackManager(makeChains(), true, {
+      directory: '/test',
+    } as any);
+    const sessionID = 'sess-turns';
+
+    await mgr.handleEvent({
+      type: 'message.updated',
+      properties: {
+        info: {
+          sessionID,
+          agent: 'orchestrator',
+          providerID: 'anthropic',
+          modelID: 'claude-opus-4-5',
+          role: 'assistant',
+        },
+      },
+    });
+
+    const realNowFn = Date.now;
+    let fakeNow = realNowFn();
+    Date.now = () => fakeNow;
+    try {
+      fakeNow += 6_000;
+      await mgr.handleEvent({
+        type: 'session.error',
+        properties: { sessionID, error: { message: 'rate limit exceeded' } },
+      });
+      expect(mocks.promptAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.objectContaining({
+            model: { providerID: 'openai', modelID: 'gpt-4o' },
+          }),
+        }),
+      );
+
+      await mgr.handleEvent({
+        type: 'message.updated',
+        properties: {
+          info: {
+            sessionID,
+            agent: 'orchestrator',
+            role: 'assistant',
+            providerID: 'openai',
+            modelID: 'gpt-4o',
+            time: { created: 1, completed: 2 },
+          },
+        },
+      });
+      await mgr.handleEvent({
+        type: 'message.updated',
+        properties: {
+          info: {
+            sessionID,
+            agent: 'orchestrator',
+            role: 'assistant',
+            providerID: 'anthropic',
+            modelID: 'claude-opus-4-5',
+          },
+        },
+      });
+
+      fakeNow += 6_000;
+      await mgr.handleEvent({
+        type: 'session.error',
+        properties: { sessionID, error: { message: 'rate limit exceeded' } },
+      });
+
+      expect(mocks.promptAsync.mock.calls[1]?.[0]).toEqual(
+        expect.objectContaining({
+          body: expect.objectContaining({
+            model: { providerID: 'openai', modelID: 'gpt-4o' },
+          }),
+        }),
+      );
+    } finally {
+      Date.now = realNowFn;
+    }
+  });
+
+  test('recovers fallback after a chain-exhaustion abort when a new turn returns to the primary', async () => {
+    const { mocks } = createMockClient();
+    const mgr = new ForegroundFallbackManager(
+      { orchestrator: ['openai/gpt-b', 'openai/gpt-c'] },
+      true,
+      { directory: '/test' } as any,
+    );
+    const sessionID = 'sess-recover-after-abort';
+
+    await mgr.handleEvent({
+      type: 'message.updated',
+      properties: {
+        info: {
+          sessionID,
+          agent: 'orchestrator',
+          providerID: 'openai',
+          modelID: 'gpt-b',
+          role: 'assistant',
+        },
+      },
+    });
+
+    const realNowFn = Date.now;
+    let fakeNow = realNowFn();
+    Date.now = () => fakeNow;
+    try {
+      const fail = async () => {
+        fakeNow += 6_000;
+        await mgr.handleEvent({
+          type: 'session.error',
+          properties: {
+            sessionID,
+            error: { message: 'rate limit exceeded' },
+          },
+        });
+      };
+
+      await fail();
+      await fail();
+      await fail();
+      expect(mocks.promptAsync).toHaveBeenCalledTimes(2);
+      expect(mocks.abort).toHaveBeenCalledTimes(1);
+
+      // Deliberately omit time.completed: this is not a successful response;
+      // recovery must come from the fresh descent reset instead.
+      await mgr.handleEvent({
+        type: 'message.updated',
+        properties: {
+          info: {
+            sessionID,
+            agent: 'orchestrator',
+            providerID: 'openai',
+            modelID: 'gpt-b',
+            role: 'assistant',
+          },
+        },
+      });
+
+      await fail();
+      expect(mocks.promptAsync).toHaveBeenCalledTimes(3);
+      expect(mocks.promptAsync.mock.calls[2]?.[0]).toEqual(
+        expect.objectContaining({
+          body: expect.objectContaining({
+            model: { providerID: 'openai', modelID: 'gpt-c' },
+          }),
+        }),
+      );
+      expect(mgr.willAttemptFallback(sessionID)).toBe(true);
+    } finally {
+      Date.now = realNowFn;
+    }
+  });
+
+  test('does not fall back onto an earlier chain entry', async () => {
+    const { mocks } = createMockClient();
+    const mgr = new ForegroundFallbackManager(makeChains(), true, {
+      directory: '/test',
+    } as any);
+    const sessionID = 'sess-mid-chain';
+
+    await mgr.handleEvent({
+      type: 'message.updated',
+      properties: {
+        info: {
+          sessionID,
+          agent: 'orchestrator',
+          providerID: 'openai',
+          modelID: 'gpt-4o',
+          role: 'assistant',
+        },
+      },
+    });
+    await mgr.handleEvent({
+      type: 'session.error',
+      properties: { sessionID, error: { message: 'rate limit exceeded' } },
+    });
+
+    expect(mocks.promptAsync.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          model: { providerID: 'google', modelID: 'gemini-2.5-pro' },
+        }),
+      }),
+    );
+    expect(mocks.promptAsync.mock.calls[0]?.[0].body.model).not.toEqual({
+      providerID: 'anthropic',
+      modelID: 'claude-opus-4-5',
+    });
+  });
+
+  test('does not fall back onto the primary when the current model is off-chain', async () => {
+    const { mocks } = createMockClient();
+    const mgr = new ForegroundFallbackManager(makeChains(), true, {
+      directory: '/test',
+    } as any);
+    const sessionID = 'sess-off-chain';
+
+    await mgr.handleEvent({
+      type: 'message.updated',
+      properties: {
+        info: {
+          sessionID,
+          agent: 'orchestrator',
+          providerID: 'anthropic',
+          modelID: 'claude-opus-4-5',
+          role: 'assistant',
+        },
+      },
+    });
+
+    const realNowFn = Date.now;
+    let fakeNow = realNowFn();
+    Date.now = () => fakeNow;
+    try {
+      fakeNow += 6_000;
+      await mgr.handleEvent({
+        type: 'session.error',
+        properties: { sessionID, error: { message: 'rate limit exceeded' } },
+      });
+      await mgr.handleEvent({
+        type: 'message.updated',
+        properties: {
+          info: {
+            sessionID,
+            agent: 'orchestrator',
+            providerID: 'openai',
+            modelID: 'gpt-4o-mini',
+            role: 'assistant',
+          },
+        },
+      });
+
+      fakeNow += 6_000;
+      await mgr.handleEvent({
+        type: 'session.error',
+        properties: { sessionID, error: { message: 'rate limit exceeded' } },
+      });
+
+      expect(mocks.promptAsync.mock.calls[1]?.[0]).toEqual(
+        expect.objectContaining({
+          body: expect.objectContaining({
+            model: { providerID: 'google', modelID: 'gemini-2.5-pro' },
+          }),
+        }),
+      );
+      expect(mocks.promptAsync.mock.calls[1]?.[0].body.model).not.toEqual({
+        providerID: 'anthropic',
+        modelID: 'claude-opus-4-5',
+      });
+    } finally {
+      Date.now = realNowFn;
+    }
+  });
+
+  test('does not reset the descent when the current model was inferred, not observed', async () => {
+    createMockClient({ messagesData: [] });
+    const mgr = new ForegroundFallbackManager(
+      { orchestrator: ['a/1', 'b/2', 'c/3'] },
+      true,
+      { directory: '/test' } as any,
+    );
+    const sessionID = 'sess-inferred-model';
+
+    await mgr.handleEvent({
+      type: 'subagent.session.created',
+      properties: { sessionID, agentName: 'orchestrator' },
+    });
+
+    const realNowFn = Date.now;
+    let fakeNow = realNowFn();
+    Date.now = () => fakeNow;
+    try {
+      const fail = async () => {
+        fakeNow += 6_000;
+        await mgr.handleEvent({
+          type: 'session.error',
+          properties: {
+            sessionID,
+            error: { message: 'rate limit exceeded' },
+          },
+        });
+      };
+
+      await fail();
+      await fail();
+
+      expect([...(mgr as any).sessionTried.get(sessionID)]).toEqual([
+        'a/1',
+        'b/2',
+        'c/3',
+      ]);
+    } finally {
+      Date.now = realNowFn;
+    }
+  });
+
   test('does not call promptAsync when the only chain model is already the current model', async () => {
     // Scenario: chain = ['openai/gpt-b'], current model IS 'openai/gpt-b'.
     // tryFallback adds 'openai/gpt-b' to tried → chain.find() returns undefined → exhausted.
@@ -1853,6 +2150,8 @@ describe('ForegroundFallbackManager chain exhaustion', () => {
     }
   });
 
+  // Protects the tried.size > 1 invariant in execFallback: a single-model
+  // chain must not re-abort repeatedly after exhaustion.
   test('does not abort repeatedly for single-model chains after exhaustion', async () => {
     const { mocks } = createMockClient();
     const mgr = new ForegroundFallbackManager(

--- a/src/hooks/foreground-fallback/index.ts
+++ b/src/hooks/foreground-fallback/index.ts
@@ -654,11 +654,8 @@ export class ForegroundFallbackManager {
   ): Promise<void> {
     const session = getClient(this.input).session;
     try {
-      // After the chain has been exhausted twice (reset retry failed and we
-      // aborted), do not intervene again for this session: re-entering would
-      // keep aborting in a loop. Surface errors to the user instead.
-      if (this.chainExhaustion.get(sessionID) === 2) return;
-      let currentModel = this.sessionModel.get(sessionID);
+      const observedModel = this.sessionModel.get(sessionID);
+      let currentModel = observedModel;
       const agentName = this.sessionAgent.get(sessionID);
       const chain = this.resolveChain(agentName, currentModel);
       // Callers pre-check via hasFallbackChain; keep as defensive guard only.
@@ -678,6 +675,44 @@ export class ForegroundFallbackManager {
       }
       // biome-ignore lint/style/noNonNullAssertion: We just set this above
       let tried = this.sessionTried.get(sessionID)!;
+
+      // A new user turn always re-sends the agent's configured primary:
+      // promptAsync's `model` is a per-message override, so a fallback never
+      // persists past the message it was applied to. Landing here on chain[0]
+      // with a tried set that already walked past it therefore means the
+      // previous descent has ended and its state is stale. Without this the
+      // next descent resumes one link deeper every turn (link 2, then 3, then
+      // 4...) until the chain is spent and the session aborts, instead of
+      // re-walking from link 2 each turn.
+      //
+      // This does not weaken the backward-fallback guard below: currentModel
+      // is re-added immediately after, so chain[0] still can never be picked.
+      // Only an OBSERVED chain[0] counts. execFallback infers
+      // `currentModel = chain[0]` above when no model was ever captured for
+      // this session, which is the opposite situation — resetting there would
+      // re-pick chain[1] on every error instead of descending.
+      // size > 1 means a previous descent actually selected a fallback
+      // (tried.add(nextModel) below), so there is stale state to clear. A
+      // single-entry chain never gets there and must stay terminal after its
+      // one abort rather than re-aborting on every error.
+      if (
+        observedModel !== undefined &&
+        observedModel === chain[0] &&
+        tried.size > 1
+      ) {
+        tried = new Set();
+        this.sessionTried.set(sessionID, tried);
+        // A descent that ended in a stage-2 abort is never followed by a
+        // successful assistant message, so the message.updated recovery path
+        // cannot clear chainExhaustion and fallback would stay disabled for
+        // the rest of the session. A fresh descent earns a fresh chance.
+        this.chainExhaustion.delete(sessionID);
+      }
+
+      // After the chain has been exhausted twice (reset retry failed and we
+      // aborted), do not intervene again for this session: re-entering would
+      // keep aborting in a loop. Surface errors to the user instead.
+      if (this.chainExhaustion.get(sessionID) === 2) return;
       if (currentModel) tried.add(currentModel);
       // ponytail: seed chain entries at or before the current model's index
       // to prevent backward fallback onto models the session already left.


### PR DESCRIPTION
## What

A fallback descent is scoped to a **turn**, but half its state is scoped to the **session**.

- `chainExhaustion` is turn-scoped — cleared on a completed successful response (`index.ts:436`).
- `sessionTried` is session-scoped — cleared only on session deletion (`index.ts:374`).

That inconsistency is the bug. It has two visible symptoms.

## Symptom 1 — each new turn falls back one link deeper than the last

`promptAsync`'s `model` is a per-message override, so a fallback never persists past the message it was applied to; every new user turn re-sends the agent's configured primary. The index seeding added in #1088 reconstructs only the prefix `chain[0..idx-1]`, so at `idx === 0` it is a no-op and the stale `sessionTried` carries over:

- **Turn 1** — `currentModel=A`, `tried={}` → add(A), `idx=0` (no-op) → `find` → **B**. `tried={A,B}`. B answers successfully.
- **Turn 2** — the turn re-sends A. `tried` still `{A,B}` → `find` → **C**.

Observed on a 5-model chain with the primary rate-limited, one session, four consecutive turns:

```
14:20:46  anthropic/claude-opus-5 → openai/gpt-5.6-terra
14:30:26  anthropic/claude-opus-5 → xai/grok-4.6
14:40:36  anthropic/claude-opus-5 → openrouter/moonshotai/kimi-k3
14:47:35  anthropic/claude-opus-5 → openrouter/minimax/minimax-m3
```

`from` is always link 1; `to` walks one deeper each turn until the chain is spent and the session aborts, instead of re-walking from link 2 every turn.

This may also be what #530 and #526 were seeing. Both were investigated as dedup-window issues; the timings here (419–610s between turns, `DEDUP_WINDOW_MS` = 5000) point at `sessionTried` instead.

## Symptom 2 — a stage-2 abort disables fallback for the rest of the session

Same root cause, other half of the state. `chainExhaustion` is set to `2` at `:701`/`:728`, and the only non-deletion reset is `:436`, behind `isCompletedSuccessfulAssistant` → `!info.error` (`:423`). An aborted assistant message carries `MessageAbortedError`, so after a stage-2 abort that reset never runs: `execFallback` early-returns at `:660` and `willAttemptFallback` returns false at `:329` for the remainder of the session. Fallback is off exactly when it is needed, and only recovers if the primary starts succeeding again on its own.

## The fix

Reset the whole descent — both halves — at the turn boundary:

```ts
if (observedModel !== undefined && observedModel === chain[0] && tried.size > 1) {
  tried = new Set();
  this.sessionTried.set(sessionID, tried);
  this.chainExhaustion.delete(sessionID);
}
```

`observedModel` is captured *before* the `!currentModel && agentName` inference below it. That distinction is load-bearing: the inference fabricates `currentModel = chain[0]` when no model was ever captured for the session, which is the opposite situation — resetting there would re-pick `chain[1]` on every error instead of descending. Only an **observed** primary means a new turn re-sent it.

`tried.size > 1` means a previous descent actually selected a fallback (`tried.add(nextModel)`), so there is stale state to clear. A single-entry chain never gets there and stays terminal after its one abort.

## #1088 is preserved

`currentModel` is re-added to `tried` immediately after the reset, so `chain[0]` still can never be selected, and the seeding loop and `chain.find` are untouched. The condition is false mid-descent (`observedModel !== chain[0]`), so the reset only fires between descents. The off-chain case #1088 guards — where `indexOf` returns `-1` and the seeding loop cannot rebuild the prefix — is now covered by a test, which it previously was not.

## What this does not change

- The `isCompletedSuccessfulAssistant` gate at `:436` is untouched — no reset on partial or incomplete streaming updates.
- No config flag, no new state fields, no changes to deduplication or prompt replay.
- No doc update needed (internal logic only): no user-facing behaviour, command, or output changes, and `fallback.enabled` / `fallback.maxRetries` in `docs/configuration.md` are unaffected.
- Nothing here touches prompt assembly, so the cache-safety rules in `AGENTS.md` do not apply; the property, snapshot, and tripwire suites pass unchanged.

## Tests

Six cases in `src/hooks/foreground-fallback/index.test.ts`. Three fail on `master`:

| Test | On `master` |
|---|---|
| `re-walks from the second chain entry on each new user turn` | ✗ expected `openai/gpt-4o`, got `google/gemini-2.5-pro` |
| `recovers fallback after a chain-exhaustion abort when a new turn returns to the primary` | ✗ expected 3 prompt calls, got 2 |
| `does not reset the descent when the current model was inferred, not observed` | ✗ descent repeats `b/2` instead of advancing to `c/3` |
| `does not fall back onto an earlier chain entry` | ✓ (new coverage for #1088) |
| `does not fall back onto the primary when the current model is off-chain` | ✓ (new coverage for #1088) |
| `does not abort repeatedly for single-model chains after exhaustion` (existing) | ✓ pins the `tried.size > 1` invariant |

`c7b9bcb` added one test for the Bailian regex; the seeding loop itself had no coverage, so two of the above lock it in.

Verified with the CI steps from `.github/workflows/ci.yml`:

```
bun run check:ci   # 341 files, clean
bun run typecheck  # clean
bun test           # 2367 pass, 0 fail, 137 files
bun run build      # clean, no drift in the generated schema
```

## Known trade-off

On a chain where every model is permanently dead, each new user turn now re-walks the chain once (~N-1 re-prompts plus aborts) instead of going quiet after the first walk. That is the cost of fixing symptom 2: the manager cannot distinguish "temporarily rate-limited" from "permanently dead", and a fresh user turn is the user explicitly asking it to try again.

If you would rather bound it, gating the `chainExhaustion.delete` on a per-session cooldown would do it. I left it out to keep this change to a single concern — happy to add it here or as a follow-up, whichever you prefer.

## Notes for review

- **The moved guard.** The stage-2 early return now runs after `resolveChain` rather than first, because the reset needs `chain[0]` in scope. Everything newly above it is non-side-effecting (`sessionModel`/`sessionAgent` reads, `resolveChain`, local assignment) except allocating an empty `sessionTried` entry, and the reset itself — which is what the un-bricking requires. It still sits above every path that aborts, re-prompts, or contacts the server.
- **`willAttemptFallback` can now go false → true more often.** `task-session-manager/event-router.ts` terminalises a job as `error` when it returns false. That false→true transition already exists on `master` via `:436`; this change increases its frequency rather than introducing it.
- **v2 hosts.** `src/v2/client-shim.ts` calls `switchModel` before each prompt, so the model genuinely persists there and `observedModel === chain[0]` will not hold on a later turn. The fix simply does not fire on v2, which is correct — there is nothing to fix on that path.
