### PR TITLE
fix(v2): preserve replay attachments in fallback prompt translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ v2 auto-refreshes unpinned plugins on startup, so pin an exact version while
 both v2 and this adapter evolve quickly:
 
 ```json
-{ "plugin": ["oh-my-opencode-slim@2.0.3"] }
+{ "plugin": ["oh-my-opencode-slim@2.2.17"] }
 ```
 
 Details, the feature matrix, and per-feature minimum v2 builds:

--- a/docs/opencode-v2-compatibility.md
+++ b/docs/opencode-v2-compatibility.md
@@ -152,7 +152,7 @@ this adapter are changing quickly), pin an exact version:
 
 ```json
 {
-  "plugin": ["oh-my-opencode-slim@2.0.3"]
+  "plugin": ["oh-my-opencode-slim@2.2.17"]
 }
 ```
 
@@ -188,7 +188,7 @@ Add to `~/.config/opencode2/opencode.json`:
 
 ```json
 {
-  "plugin": ["oh-my-opencode-slim@2.0.3"]
+  "plugin": ["oh-my-opencode-slim@2.2.17"]
 }
 ```
 

--- a/src/v2/client-shim.test.ts
+++ b/src/v2/client-shim.test.ts
@@ -396,3 +396,96 @@ describe('v2 client shim foreground-fallback integration', () => {
     ]);
   });
 });
+
+describe('v2 client shim replay attachment preservation', () => {
+  test('promptAsync maps image/file parts into v2 prompt files', async () => {
+    const prompts: Array<Record<string, unknown>> = [];
+    const input = buildPluginInput(
+      makeCtx({
+        prompt: async (i: Record<string, unknown>) => {
+          prompts.push(i);
+          return {};
+        },
+      } as never),
+    );
+    await (
+      input.client as {
+        session: { promptAsync: (a: unknown) => Promise<unknown> };
+      }
+    ).session.promptAsync({
+      path: { id: 'ses_1' },
+      body: {
+        parts: [
+          { type: 'text', text: 'analyze this' },
+          {
+            type: 'image',
+            url: 'data:image/png;base64,AAAA',
+            filename: 'shot.png',
+          },
+          { type: 'file', url: 'file:///proj/report.pdf' },
+          { type: 'reasoning', text: 'not user-visible' },
+        ],
+      },
+    });
+    expect(prompts).toHaveLength(1);
+    expect(prompts[0]?.text).toContain('analyze this');
+    expect(prompts[0]?.files).toEqual([
+      { uri: 'data:image/png;base64,AAAA', name: 'shot.png' },
+      { uri: 'file:///proj/report.pdf' },
+    ]);
+  });
+
+  test('non-text parts without uri are dropped and logged, prompt proceeds', async () => {
+    const prompts: Array<Record<string, unknown>> = [];
+    const input = buildPluginInput(
+      makeCtx({
+        prompt: async (i: Record<string, unknown>) => {
+          prompts.push(i);
+          return {};
+        },
+      } as never),
+    );
+    await (
+      input.client as {
+        session: { promptAsync: (a: unknown) => Promise<unknown> };
+      }
+    ).session.promptAsync({
+      path: { id: 'ses_1' },
+      body: {
+        parts: [
+          { type: 'text', text: 'retry me' },
+          { type: 'image', mime: 'image/png' },
+        ],
+      },
+    });
+    expect(prompts).toHaveLength(1);
+    expect(prompts[0]?.text).toBe('retry me');
+    expect(prompts[0]?.files).toBeUndefined();
+  });
+
+  test('prompt translation carries files too', async () => {
+    const prompts: Array<Record<string, unknown>> = [];
+    const input = buildPluginInput(
+      makeCtx({
+        prompt: async (i: Record<string, unknown>) => {
+          prompts.push(i);
+          return {};
+        },
+      } as never),
+    );
+    await (
+      input.client as {
+        session: { prompt: (a: unknown) => Promise<unknown> };
+      }
+    ).session.prompt({
+      path: { id: 'ses_1' },
+      body: {
+        parts: [
+          { type: 'text', text: 'look' },
+          { type: 'image', url: 'https://example.com/x.png' },
+        ],
+      },
+    });
+    expect(prompts[0]?.files).toEqual([{ uri: 'https://example.com/x.png' }]);
+  });
+});

--- a/src/v2/client-shim.ts
+++ b/src/v2/client-shim.ts
@@ -64,6 +64,38 @@ function textFromBody(args: Record<string, unknown>): string {
     .join('\n');
 }
 
+/** Map non-text v1 prompt parts (images, files) into v2 prompt `files`
+ * entries. The fallback replay must not silently drop attachments: v1's
+ * prompt API carries parts natively, so a text-only translation would
+ * resend an attachment-dependent request without its content. Parts whose
+ * uri cannot be derived are logged and skipped (honest degradation). */
+function filesFromBody(
+  args: Record<string, unknown>,
+): Array<{ uri: string; name?: string }> {
+  const body = (args?.body ?? {}) as {
+    parts?: Array<Record<string, unknown>>;
+  };
+  const parts = Array.isArray(body.parts) ? body.parts : [];
+  const files: Array<{ uri: string; name?: string }> = [];
+  for (const p of parts) {
+    if (!p || typeof p !== 'object') continue;
+    if (p.type === 'text') continue;
+    const uri = [p.uri, p.url].find((v) => typeof v === 'string' && v) as
+      | string
+      | undefined;
+    if (!uri) {
+      log('[v2][shim] non-text prompt part without uri dropped', {
+        type: typeof p.type === 'string' ? p.type : 'unknown',
+      });
+      continue;
+    }
+    const name =
+      (p.filename as string | undefined) ?? (p.name as string | undefined);
+    files.push({ uri, ...(name ? { name } : {}) });
+  }
+  return files;
+}
+
 /** v2 transcript message (content parts) → v1 SDK message view
  * (`{info: {id, role}, parts}`) expected by the v1 pipeline. */
 function toV1Message(m: Record<string, unknown>) {
@@ -140,12 +172,15 @@ export function buildPluginInput(
       // markStatusUncertain branch.
       list: async () => ({ data: [] }),
       prompt: s.prompt
-        ? async (args: Record<string, unknown>) =>
-            s.prompt?.({
+        ? async (args: Record<string, unknown>) => {
+            const files = filesFromBody(args);
+            return s.prompt?.({
               sessionID: sessionIDOf(args),
               text: textFromBody(args),
               delivery: 'steer',
-            })
+              ...(files.length > 0 ? { files } : {}),
+            });
+          }
         : async () => {
             throw new Error('[v2] session.prompt unavailable');
           },
@@ -167,10 +202,12 @@ export function buildPluginInput(
             );
           }
         }
+        const files = filesFromBody(args);
         return s.prompt({
           sessionID: sessionIDOf(args),
           text: textFromBody(args),
           delivery: 'steer',
+          ...(files.length > 0 ? { files } : {}),
         });
       },
       update: s.rename

--- a/src/v2/fallback-attachments.e2e.test.ts
+++ b/src/v2/fallback-attachments.e2e.test.ts
@@ -30,9 +30,10 @@ interface Call {
   i: unknown;
 }
 
-function makeCtx(
-  overrides: Partial<V2Context['session']>,
-): { ctx: V2Context; seq: Call[] } {
+function makeCtx(overrides: Partial<V2Context['session']>): {
+  ctx: V2Context;
+  seq: Call[];
+} {
   const seq: Call[] = [];
   const ctx = {
     app: { name: 'opencode2', version: 'test' },

--- a/src/v2/fallback-attachments.e2e.test.ts
+++ b/src/v2/fallback-attachments.e2e.test.ts
@@ -1,0 +1,182 @@
+/**
+ * End-to-end verification for the fallback attachment-preservation fix
+ * (PR #1111 / commit 4a5a553).
+ *
+ * Drives the PRODUCTION chain — real `ForegroundFallbackManager` → real
+ * `getClient` → real v2 client shim (`buildPluginInput`) — with only the
+ * v2 host context mocked. Asserts that a rate-limit failover after an
+ * attachment-bearing user message replays the attachment through the v2
+ * prompt `files` field instead of dropping it:
+ *
+ *   transcript (`session.context`) → shim `messages` mapping →
+ *   `isReplayableUserMessage` → `partsFromReplayMessage` → v1 promptBody
+ *   assembly → shim `promptAsync` (switchModel + steer) → v2 prompt.
+ */
+import { describe, expect, mock, test } from 'bun:test';
+import { ForegroundFallbackManager } from '../hooks/foreground-fallback';
+import { buildPluginInput } from './client-shim';
+import type { V2Context } from './types';
+
+// The foreground-fallback suite (which runs earlier in the single-process
+// full-suite run) replaces `opencode-client` with a client lacking
+// `messages`. Re-mock it back to the passthrough so this e2e exercises the
+// REAL getClient → shim wiring instead of that leaked fixture.
+mock.module('../utils/opencode-client', () => ({
+  getClient: (input: { client?: unknown }) => input?.client,
+}));
+
+interface Call {
+  m: string;
+  i: unknown;
+}
+
+function makeCtx(
+  overrides: Partial<V2Context['session']>,
+): { ctx: V2Context; seq: Call[] } {
+  const seq: Call[] = [];
+  const ctx = {
+    app: { name: 'opencode2', version: 'test' },
+    options: {},
+    agent: {
+      transform: async () => ({ dispose() {} }),
+      reload: async () => {},
+      list: async () => [],
+    },
+    tool: {
+      transform: async () => ({ dispose() {} }),
+      hook: async () => ({ dispose() {} }),
+    },
+    command: {
+      transform: async () => ({ dispose() {} }),
+      list: async () => [],
+    },
+    session: {
+      hook: async () => ({ dispose() {} }),
+      interrupt: async (i: unknown) => {
+        seq.push({ m: 'interrupt', i });
+        return { interrupted: true };
+      },
+      switchModel: async (i: unknown) => {
+        seq.push({ m: 'switchModel', i });
+      },
+      prompt: async (i: Record<string, unknown>) => {
+        seq.push({ m: 'prompt', i });
+        return {};
+      },
+      ...overrides,
+    },
+    event: {
+      subscribe() {
+        return {} as never;
+      },
+    },
+    location: {
+      directory: '/proj',
+      project: { id: 'proj_1', directory: '/proj', canonical: '/proj' },
+    },
+  } as unknown as V2Context;
+  return { ctx, seq };
+}
+
+const ATTACHMENT_TRANSCRIPT = [
+  {
+    id: 'm0',
+    role: 'assistant',
+    content: [{ type: 'text', text: 'prior answer' }],
+  },
+  {
+    id: 'm1',
+    role: 'user',
+    content: [
+      { type: 'text', text: 'analyze the chart' },
+      {
+        type: 'image',
+        url: 'data:image/png;base64,BBBB',
+        filename: 'att.png',
+      },
+    ],
+  },
+];
+
+async function triggerFailover(
+  ctx: V2Context,
+): Promise<ForegroundFallbackManager> {
+  const input = buildPluginInput(ctx);
+  const mgr = new ForegroundFallbackManager(
+    { orchestrator: ['anthropic/claude-a', 'anthropic/claude-b'] },
+    true,
+    input as never,
+  );
+  await mgr.handleEvent({
+    type: 'message.updated',
+    properties: {
+      info: {
+        sessionID: 'ses_e2e',
+        providerID: 'anthropic',
+        modelID: 'claude-a',
+        agent: 'orchestrator',
+        role: 'assistant',
+      },
+    },
+  });
+  await mgr.handleEvent({
+    type: 'session.error',
+    properties: {
+      sessionID: 'ses_e2e',
+      error: { message: 'Rate limit exceeded' },
+    },
+  });
+  return mgr;
+}
+
+describe('v2 fallback replay attachment preservation (e2e)', () => {
+  test('rate-limit failover replays attachments through prompt files', async () => {
+    const { ctx, seq } = makeCtx({
+      context: async () => ATTACHMENT_TRANSCRIPT,
+    });
+    await triggerFailover(ctx);
+
+    const promptCall = seq.find((e) => e.m === 'prompt');
+    if (!promptCall) {
+      throw new Error('no v2 prompt call captured — fallback did not fire');
+    }
+    const pi = promptCall.i as Record<string, unknown>;
+    expect(pi.files).toEqual([
+      { uri: 'data:image/png;base64,BBBB', name: 'att.png' },
+    ]);
+    expect(pi.delivery).toBe('steer');
+    expect(pi.sessionID).toBe('ses_e2e');
+    expect(pi.text).toContain('analyze the chart');
+    expect(pi.text).toContain('system-reminder');
+
+    const switchIdx = seq.findIndex((e) => e.m === 'switchModel');
+    const promptIdx = seq.indexOf(promptCall);
+    expect(switchIdx).toBeGreaterThanOrEqual(0);
+    expect(switchIdx).toBeLessThan(promptIdx);
+    expect(seq[switchIdx]?.i).toMatchObject({
+      sessionID: 'ses_e2e',
+      model: { id: 'claude-b', providerID: 'anthropic' },
+    });
+  });
+
+  test('transcript without attachments prompts without a files key', async () => {
+    const { ctx, seq } = makeCtx({
+      context: async () => [
+        {
+          id: 'm1',
+          role: 'user',
+          content: [{ type: 'text', text: 'plain retry' }],
+        },
+      ],
+    });
+    await triggerFailover(ctx);
+
+    const promptCall = seq.find((e) => e.m === 'prompt');
+    if (!promptCall) {
+      throw new Error('no v2 prompt call captured — fallback did not fire');
+    }
+    const pi = promptCall.i as Record<string, unknown>;
+    expect(pi.files).toBeUndefined();
+    expect(pi.text).toContain('plain retry');
+  });
+});


### PR DESCRIPTION
Follow-up to #1109 addressing the Greptile review findings (P1/P2).

## P1 — fallback drops attachments

Verified the finding against code: the v1 fallback replays **all** parts of the last user message (`partsFromReplayMessage` returns the full array and the v1 prompt API carries parts natively), while the v2 shim's `textFromBody` translation kept only `type:'text'` parts and never mapped anything into v2's prompt `files` — so a failover after an image/file-bearing request replayed text only.

Fix in `src/v2/client-shim.ts`: new `filesFromBody` maps non-text parts (`image`/`file`, uri from `uri`/`url`, name from `filename`/`name`) into `files` entries on both the `prompt` and `promptAsync` translations. Parts with no derivable uri are logged and skipped (honest degradation). Three regression tests cover mixed-part replay, unmappable-part dropping, and the plain `prompt` path.

## P2 — stale pinned-version examples

`2.0.3` → `2.2.17` (current `package.json` version) in `README.md` and both examples in `docs/opencode-v2-compatibility.md`.

## Verification

- `bun test` 2365/2365 · `bun run typecheck` clean · `bun run check:ci` clean