### PR TITLE
fix: drop `tui: true` marker that rejects the plugin on v1.18.23+ hosts

### DIFF
--- a/docs/opencode-v2-compatibility.md
+++ b/docs/opencode-v2-compatibility.md
@@ -12,22 +12,28 @@ The package's default export is an object:
 ```ts
 export default {
   id: 'oh-my-opencode-slim',
-  tui: true,             // marker: this package ships a `./tui` entry for v2 TUI hosts
   server: OhMyOpenCodeLite, // v1 plugin function (PluginInput) => Promise<Hooks>
   setup: createV2Setup(),   // v2 promise-plugin setup (ctx) => Promise<cleanup>
 };
 ```
 
+There is deliberately **no `tui` key** on this export: hosts validate a
+server plugin module's `tui` field (it must be a function and must not
+coexist with `server`), so a boolean `tui: true` marker makes every
+v1.18.23+ host — and v2's byte-identical `readV1Plugin` — reject the whole
+plugin with "invalid tui export".
+
 - **v1 loader** (`readV1Plugin` in `packages/opencode/src/plugin/shared.ts`)
   detects an object with a `server` field and calls `plugin.server(input)`.
-  This is the original, unchanged v1 code path — v1 behavior is identical to
-  previous releases.
+  Extra keys (such as `setup`) are ignored on this path.
 - **v2 loader** (`PluginModule` schema in
   `packages/core/src/plugin/supervisor.ts`) decodes `default` as
   `{ id, setup }` (Effect Schema 4 rejects function defaults) and calls
   `setup(ctx)` via the promise-plugin bridge.
-- **v2 TUI** additionally loads the `./tui` entry (below) when the server-side
-  export declares `tui: true`.
+- **v2 TUI** loads the `./tui` entry (below) unconditionally: the TUI
+  runtime runs its own `kind: "tui"` loader pass over the same plugin list
+  and resolves the entry through the package's `exports["./tui"]` map —
+  the server-side export plays no role in that discovery.
 
 Three builds are produced:
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { mkdtemp, rm } from 'node:fs/promises';
 import type { MultiplexerConfig } from './config';
-import {
+import pluginModuleDefault, {
   OhMyOpenCodeLite as plugin,
   sessionManagerMultiplexerConfig,
   shouldEnableMultiplexer,
@@ -572,5 +572,29 @@ describe('multiplexer host gating', () => {
     expect(sessionManagerMultiplexerConfig(undefined, multiplexerConfig)).toBe(
       multiplexerConfig,
     );
+  });
+});
+
+describe('v1 host plugin module contract', () => {
+  // OpenCode v1.18.23+ validates a plugin module's default export before
+  // loading it:
+  //   - `server`, when present, must be a function
+  //   - `tui`, when present, must be a function
+  //   - a module must not declare both `server` and `tui`
+  // A boolean `tui: true` marker on the server entry violates the second
+  // and third rules, so the whole plugin fails to load with
+  // "Plugin ... has invalid tui export" (observed on v1.18.25). The TUI
+  // entry ships separately via the `./tui` package export.
+  test('server entry keeps a callable server export and no tui key', () => {
+    expect(typeof pluginModuleDefault).toBe('object');
+    expect(pluginModuleDefault).not.toBeNull();
+
+    const module = pluginModuleDefault as Record<string, unknown>;
+
+    // v1 loader: `server` present must be a function.
+    expect(typeof module.server).toBe('function');
+    // v1 loader: `tui` must be absent (or a function in a tui-only module);
+    // a server module declaring `tui` is rejected outright.
+    expect('tui' in module).toBe(false);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1455,13 +1455,13 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
 
 export default {
   id: 'oh-my-opencode-slim',
-  /**
-   * Marker for v2 TUI hosts: this package ships a TUI plugin entry (the
-   * `./tui` export → dist/tui2.js, which also serves v1 hosts). v1 hosts
-   * probe only the `server` field and ignore extra keys, so this field is
-   * inert on v1.
-   */
-  tui: true,
+  // NOTE: do not add a `tui` key here. OpenCode v1.18.23+ (and v2's
+  // byte-identical readV1Plugin) validate the default export of a server
+  // plugin module: `tui`, when present, must be a function and must not
+  // coexist with `server` — a boolean marker makes the whole plugin fail
+  // to load with "invalid tui export". The TUI entry is discovered
+  // separately by hosts through the package.json `./tui` export
+  // (dist/tui2.js), never through this module.
   server: OhMyOpenCodeLite,
   setup: createV2Setup(),
 };

--- a/src/v2/codemap.md
+++ b/src/v2/codemap.md
@@ -112,7 +112,9 @@ expanding the global v2 client surface.
 ## Integration Points
 
 - `src/index.ts`: imports `createV2Setup` for the dual `default` export
-  (`tui: true` marker included) and exports `OhMyOpenCodeLite` (named) for the
+  (`{ id, server, setup }` — no `tui` key; hosts validate that a server
+  module's `tui` field is a function and never coexists with `server`) and
+  exports `OhMyOpenCodeLite` (named) for the
   adapter to wrap. The `hostFlavor: 'v2'` marker from the shim gates the
   multiplexer off (`shouldEnableMultiplexer` /
   `sessionManagerMultiplexerConfig`).

--- a/src/v2/tui.ts
+++ b/src/v2/tui.ts
@@ -7,8 +7,10 @@
  * flow — v2 hosts get the sidebar plus an interactive preset switcher
  * (dialog select → on-disk persist → toast feedback).
  *
- * On v2 hosts this entry is loaded only when the server-side default export
- * (src/index.ts) declares `tui: true`.
+ * Hosts discover this entry through the package.json `./tui` export
+ * (exports-map probe in the host's `kind: "tui"` loader pass); the
+ * server-side default export (src/index.ts) plays no role in that — in
+ * fact it must stay free of any `tui` key (see the note there).
  */
 import type { PluginConfig } from '../config';
 import { loadPluginConfig } from '../config/loader';


### PR DESCRIPTION
## What changed, and why

PR #1109 added a boolean `tui: true` marker to the server-side default export, on the assumption that v1 hosts only probe the `server` field and ignore extra keys. That assumption is wrong: **OpenCode v1.18.23+ validates the default export of a plugin module** (`readV1Plugin` in `packages/opencode/src/plugin/shared.ts`):

- `tui`, when present, must be a **function**
- a module must not declare both `server` and `tui`

A boolean marker violates both rules, so v1.18.23+ hosts reject the whole plugin with:

```
failed to load plugin path=.../dist/server.js error="Plugin ... has invalid tui export"
```

Observed on a real v1.18.25 host (4 occurrences in `opencode.log`).

## Why removal is safe for v2 (and was actually breaking it too)

Verified against upstream `anomalyco/opencode` dev @ `dc4449d` and the `f0afb675` snapshot (loading logic identical):

- **No v2 code reads `default.tui === true`.** The `./tui` entry is discovered by a separate `kind: "tui"` loader pass that probes `package.json.exports["./tui"]` (`packages/opencode/src/plugin/tui/runtime.ts`, `shared.ts:103-114`) — the server-side export plays no role.
- **v2's `readV1Plugin` is byte-identical to v1.18.23+'s**, so the marker was *also* getting the server plugin skipped on v2 with the same error. Removing it fixes both hosts.
- The `missing`/retry classification runs entirely pre-import from `package.json`; the marker is structurally unreachable from any retry path.
- `{ id, server, setup }` passes v2's server validation (`setup` is an ignored extra key there) and satisfies the published `PluginModule` type (`tui?: never`).

## Changes

- `src/index.ts`: remove `tui: true`; leave an inline note documenting the loader contract so the marker doesn't come back
- `src/index.test.ts`: regression test pinning the v1 loader validation (callable `server`, no `tui` key) — fails on the old export, passes now
- `src/v2/tui.ts`, `src/v2/codemap.md`, `docs/opencode-v2-compatibility.md`: correct the docs that claimed the marker gates v2 TUI discovery

## Verification

- Regression test: RED before the fix (`'tui' in module` → true), GREEN after
- Full suite: `bun test` → **2363 pass / 0 fail**; `bun run typecheck` clean; `bun run check:ci` clean
- End-to-end on a real isolated v1.18.25 host: a build containing `tui: true` never reaches the plugin factory (no plugin log file, `invalid tui export`); the fixed build loads with **0 load errors** and passes the plugin health check (agents 7 / tools 9 / mcps 2)