### PR TITLE
Reject textless completed task results

### DIFF
--- a/src/hooks/task-session-manager/revived-run-tracker.test.ts
+++ b/src/hooks/task-session-manager/revived-run-tracker.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, mock, test } from 'bun:test';
+import { afterEach, describe, expect, mock, test } from 'bun:test';
 import { BackgroundJobBoard } from '../../utils/background-job-board';
 import { createRevivedRunTracker } from './revived-run-tracker';
 
@@ -6,6 +6,7 @@ function createHarness(
   messages: () => unknown,
   prompt = mock(async () => ({})),
   assertBound = false,
+  options: { stabilizationProbeDelayMs?: number } = {},
 ) {
   const board = new BackgroundJobBoard();
   board.registerLaunch({
@@ -57,6 +58,7 @@ function createHarness(
     input,
     backgroundJobBoard: board,
     notificationRetryDelayMs: 0,
+    ...options,
     onSettled: settled,
     pruneContext: pruned,
   });
@@ -69,6 +71,14 @@ function createHarness(
     pruned,
   };
 }
+
+const realSetTimeout = globalThis.setTimeout;
+const realClearTimeout = globalThis.clearTimeout;
+
+afterEach(() => {
+  globalThis.setTimeout = realSetTimeout;
+  globalThis.clearTimeout = realClearTimeout;
+});
 
 describe('revived run tracker', () => {
   test('publishes a newer completed assistant turn and notifies the parent', async () => {
@@ -149,8 +159,15 @@ describe('revived run tracker', () => {
     expect(harness.prompt).not.toHaveBeenCalled();
   });
 
-  test('keeps terminal-empty output running until stabilization probes are exhausted', async () => {
+  test('settles terminal-empty output after scheduled stabilization probes', async () => {
     let toolCallFinish = true;
+    const scheduled: Array<() => void> = [];
+    globalThis.setTimeout = ((callback: () => void) => {
+      scheduled.push(callback);
+      return { unref() {} } as unknown as ReturnType<typeof setTimeout>;
+    }) as typeof setTimeout;
+    globalThis.clearTimeout = (() => {}) as typeof clearTimeout;
+
     const harness = createHarness(() => ({
       data: [
         { info: { id: 'baseline', role: 'user' }, parts: [] },
@@ -172,21 +189,30 @@ describe('revived run tracker', () => {
       baselineMessageID: 'baseline',
       description: 'inspect the change',
     });
+
     expect(
       await harness.tracker.probe(harness.run.taskID, harness.run.generation),
     ).toBe(false);
-    expect(harness.board.get('ses_child')?.state).toBe('running');
+    expect(scheduled).toHaveLength(0);
 
     toolCallFinish = false;
-    for (let attempt = 0; attempt < 3; attempt += 1) {
-      expect(
-        await harness.tracker.probe(harness.run.taskID, harness.run.generation),
-      ).toBe(false);
-      expect(harness.board.get('ses_child')?.state).toBe('running');
-    }
     expect(
       await harness.tracker.probe(harness.run.taskID, harness.run.generation),
-    ).toBe(true);
+    ).toBe(false);
+    expect(scheduled).toHaveLength(1);
+
+    for (
+      let attempt = 0;
+      harness.board.get('ses_child')?.state === 'running' && attempt < 4;
+      attempt += 1
+    ) {
+      const callback = scheduled.shift();
+      if (!callback) throw new Error('missing stabilization probe');
+      callback();
+      await Promise.resolve();
+      await Promise.resolve();
+    }
+
     expect(harness.board.get('ses_child')).toMatchObject({
       state: 'error',
       resultSummary:

--- a/src/hooks/task-session-manager/revived-run-tracker.test.ts
+++ b/src/hooks/task-session-manager/revived-run-tracker.test.ts
@@ -149,7 +149,7 @@ describe('revived run tracker', () => {
     expect(harness.prompt).not.toHaveBeenCalled();
   });
 
-  test('publishes an explicitly empty completed turn but rejects tool-call finishes', async () => {
+  test('keeps terminal-empty output running until stabilization probes are exhausted', async () => {
     let toolCallFinish = true;
     const harness = createHarness(() => ({
       data: [
@@ -178,12 +178,19 @@ describe('revived run tracker', () => {
     expect(harness.board.get('ses_child')?.state).toBe('running');
 
     toolCallFinish = false;
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      expect(
+        await harness.tracker.probe(harness.run.taskID, harness.run.generation),
+      ).toBe(false);
+      expect(harness.board.get('ses_child')?.state).toBe('running');
+    }
     expect(
       await harness.tracker.probe(harness.run.taskID, harness.run.generation),
     ).toBe(true);
     expect(harness.board.get('ses_child')).toMatchObject({
-      state: 'completed',
-      resultSummary: '',
+      state: 'error',
+      resultSummary:
+        'Task ended without a public text result; completion is not confirmed',
     });
   });
 

--- a/src/hooks/task-session-manager/revived-run-tracker.ts
+++ b/src/hooks/task-session-manager/revived-run-tracker.ts
@@ -7,10 +7,13 @@ import type {
 import type { BackgroundJobStore } from '../../utils/background-job-store';
 import type { BackgroundJobSupervisor } from '../../utils/background-job-supervisor';
 import { getClient } from '../../utils/opencode-client';
+import { COMPLETED_WITHOUT_TEXT_DIAGNOSTIC } from '../../utils/task';
 
 const DEFAULT_NOTIFICATION_RETRIES = 3;
 const DEFAULT_RETRY_DELAY_MS = 1_000;
 const TERMINAL_NOTIFICATION_TIMEOUT_MS = 10_000;
+const DEFAULT_STABILIZATION_PROBES = 3;
+const DEFAULT_STABILIZATION_DELAY_MS = 150;
 
 type SessionMessage = {
   info?: {
@@ -39,6 +42,8 @@ type RevivedRun = {
     pending: boolean;
     retryTimer?: ReturnType<typeof setTimeout>;
   };
+  stabilizationProbes: number;
+  stabilizationTimer?: ReturnType<typeof setTimeout>;
   terminalState?: 'completed' | 'error';
   probeInFlight?: Promise<boolean>;
 };
@@ -64,6 +69,8 @@ export function createRevivedRunTracker(options: {
   backgroundJobSupervisor?: BackgroundJobSupervisor;
   maxNotificationRetries?: number;
   notificationRetryDelayMs?: number;
+  maxStabilizationProbes?: number;
+  stabilizationProbeDelayMs?: number;
   onRegister?: (taskID: string) => void;
   onSettled?: (taskID: string) => void;
   contextFilesForPrompt?: (taskID: string) => ContextFile[];
@@ -74,6 +81,10 @@ export function createRevivedRunTracker(options: {
     options.maxNotificationRetries ?? DEFAULT_NOTIFICATION_RETRIES;
   const retryDelayMs =
     options.notificationRetryDelayMs ?? DEFAULT_RETRY_DELAY_MS;
+  const maxStabilizationProbes =
+    options.maxStabilizationProbes ?? DEFAULT_STABILIZATION_PROBES;
+  const stabilizationProbeDelayMs =
+    options.stabilizationProbeDelayMs ?? DEFAULT_STABILIZATION_DELAY_MS;
   let disposed = false;
 
   const captureBaseline = async (
@@ -136,6 +147,9 @@ export function createRevivedRunTracker(options: {
       if (run.notification.retryTimer) {
         clearTimeout(run.notification.retryTimer);
       }
+      if (run.stabilizationTimer) {
+        clearTimeout(run.stabilizationTimer);
+      }
     }
     runs.clear();
   };
@@ -188,24 +202,45 @@ export function createRevivedRunTracker(options: {
     const text = (last.parts ?? [])
       .filter(
         (part) =>
-          (part.type === 'text' || part.type === 'reasoning') &&
+          part.type === 'text' &&
           typeof part.text === 'string' &&
           part.text.length > 0,
       )
       .map((part) => part.text as string)
       .join('\n\n')
       .trim();
+    if (text.length > 0) {
+      const updated = options.backgroundJobBoard.updateStatus({
+        taskID: run.taskID,
+        expectedGeneration: run.generation,
+        state: 'completed',
+        resultSummary: text,
+      });
+      return updated?.generation === run.generation && finish(run, updated);
+    }
+
+    if (run.stabilizationProbes < maxStabilizationProbes) {
+      run.stabilizationProbes += 1;
+      scheduleStabilizationProbe(run);
+      return false;
+    }
+
     const updated = options.backgroundJobBoard.updateStatus({
       taskID: run.taskID,
       expectedGeneration: run.generation,
-      state: 'completed',
-      resultSummary: text,
+      state: 'error',
+      resultSummary: COMPLETED_WITHOUT_TEXT_DIAGNOSTIC,
+      lastStatusError: COMPLETED_WITHOUT_TEXT_DIAGNOSTIC,
     });
     return updated?.generation === run.generation && finish(run, updated);
   }
 
   function finish(run: RevivedRun, record: BackgroundJobRecord): boolean {
     if (record.state !== 'completed' && record.state !== 'error') return false;
+    if (run.stabilizationTimer) {
+      clearTimeout(run.stabilizationTimer);
+      run.stabilizationTimer = undefined;
+    }
     if (run.terminalState && run.terminalState !== record.state) return true;
     run.terminalState = record.state;
     settleRun(run, record);
@@ -325,6 +360,22 @@ export function createRevivedRunTracker(options: {
     run.notification.retryTimer.unref?.();
   }
 
+  function scheduleStabilizationProbe(run: RevivedRun): void {
+    if (
+      disposed ||
+      runs.get(run.taskID) !== run ||
+      run.stabilizationProbes >= maxStabilizationProbes ||
+      run.stabilizationTimer
+    ) {
+      return;
+    }
+    run.stabilizationTimer = setTimeout(() => {
+      run.stabilizationTimer = undefined;
+      void probe(run.taskID, run.generation);
+    }, stabilizationProbeDelayMs);
+    run.stabilizationTimer.unref?.();
+  }
+
   function register(input: {
     taskID: string;
     generation: number;
@@ -334,9 +385,11 @@ export function createRevivedRunTracker(options: {
   }): void {
     const old = runs.get(input.taskID);
     if (old?.notification.retryTimer) clearTimeout(old.notification.retryTimer);
+    if (old?.stabilizationTimer) clearTimeout(old.stabilizationTimer);
     runs.set(input.taskID, {
       ...input,
       notification: { attempts: 0, sent: false, pending: false },
+      stabilizationProbes: 0,
     });
     options.onRegister?.(input.taskID);
   }
@@ -344,6 +397,7 @@ export function createRevivedRunTracker(options: {
   function discardRun(run: RevivedRun): void {
     if (runs.get(run.taskID) !== run) return;
     if (run.notification.retryTimer) clearTimeout(run.notification.retryTimer);
+    if (run.stabilizationTimer) clearTimeout(run.stabilizationTimer);
     runs.delete(run.taskID);
   }
 

--- a/src/hooks/task-session-manager/revived-run-tracker.ts
+++ b/src/hooks/task-session-manager/revived-run-tracker.ts
@@ -219,20 +219,20 @@ export function createRevivedRunTracker(options: {
       return updated?.generation === run.generation && finish(run, updated);
     }
 
-    if (run.stabilizationProbes < maxStabilizationProbes) {
-      run.stabilizationProbes += 1;
-      scheduleStabilizationProbe(run);
-      return false;
+    if (run.stabilizationProbes >= maxStabilizationProbes) {
+      const updated = options.backgroundJobBoard.updateStatus({
+        taskID: run.taskID,
+        expectedGeneration: run.generation,
+        state: 'error',
+        resultSummary: COMPLETED_WITHOUT_TEXT_DIAGNOSTIC,
+        lastStatusError: COMPLETED_WITHOUT_TEXT_DIAGNOSTIC,
+      });
+      return updated?.generation === run.generation && finish(run, updated);
     }
 
-    const updated = options.backgroundJobBoard.updateStatus({
-      taskID: run.taskID,
-      expectedGeneration: run.generation,
-      state: 'error',
-      resultSummary: COMPLETED_WITHOUT_TEXT_DIAGNOSTIC,
-      lastStatusError: COMPLETED_WITHOUT_TEXT_DIAGNOSTIC,
-    });
-    return updated?.generation === run.generation && finish(run, updated);
+    run.stabilizationProbes += 1;
+    scheduleStabilizationProbe(run);
+    return false;
   }
 
   function finish(run: RevivedRun, record: BackgroundJobRecord): boolean {
@@ -361,12 +361,7 @@ export function createRevivedRunTracker(options: {
   }
 
   function scheduleStabilizationProbe(run: RevivedRun): void {
-    if (
-      disposed ||
-      runs.get(run.taskID) !== run ||
-      run.stabilizationProbes >= maxStabilizationProbes ||
-      run.stabilizationTimer
-    ) {
+    if (disposed || runs.get(run.taskID) !== run || run.stabilizationTimer) {
       return;
     }
     run.stabilizationTimer = setTimeout(() => {

--- a/src/hooks/task-session-manager/status-utils.test.ts
+++ b/src/hooks/task-session-manager/status-utils.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { BackgroundJobBoard } from '../../utils/background-job-board';
+import { COMPLETED_WITHOUT_TEXT_DIAGNOSTIC } from '../../utils/task';
+import { updateBackgroundJobFromOutput } from './status-utils';
+
+function harness() {
+  const board = new BackgroundJobBoard();
+  board.registerLaunch({
+    taskID: 'child-1',
+    parentSessionID: 'parent-1',
+    agent: 'explorer',
+    description: 'trace bug',
+  });
+  const taskContextTracker = {
+    pendingManagedTaskIds: new Set<string>(),
+    contextFilesForPrompt: () => [],
+    prune: mock(() => {}),
+  };
+  return { board, taskContextTracker };
+}
+
+describe('updateBackgroundJobFromOutput', () => {
+  test('does not enter completed from an empty completed status', () => {
+    const { board, taskContextTracker } = harness();
+    const updated = updateBackgroundJobFromOutput(
+      [
+        'task_id: child-1',
+        'state: completed',
+        '',
+        '<task_result>',
+        '</task_result>',
+      ].join('\n'),
+      board,
+      taskContextTracker,
+    );
+
+    expect(updated).toMatchObject({
+      state: 'error',
+      resultSummary: COMPLETED_WITHOUT_TEXT_DIAGNOSTIC,
+    });
+    expect(board.get('child-1')?.state).not.toBe('completed');
+  });
+
+  test('records completed when the status carries result text', () => {
+    const { board, taskContextTracker } = harness();
+    const updated = updateBackgroundJobFromOutput(
+      [
+        'task_id: child-1',
+        'state: completed',
+        '',
+        '<task_result>',
+        'final findings',
+        '</task_result>',
+      ].join('\n'),
+      board,
+      taskContextTracker,
+    );
+
+    expect(updated).toMatchObject({
+      state: 'completed',
+      resultSummary: 'final findings',
+    });
+  });
+});

--- a/src/hooks/task-session-manager/status-utils.ts
+++ b/src/hooks/task-session-manager/status-utils.ts
@@ -3,7 +3,7 @@ import type {
   BackgroundJobStore,
   ContextFile,
 } from '../../utils';
-import { parseTaskStatusOutput } from '../../utils';
+import { guardCompletedStatusText, parseTaskStatusOutput } from '../../utils';
 import { isRecord as isObjectRecord } from '../../utils/guards';
 import { log } from '../../utils/logger';
 
@@ -76,11 +76,18 @@ export function updateBackgroundJobFromOutput(
     return existing;
   }
 
+  const guarded = guardCompletedStatusText(
+    status.state,
+    status.result,
+    existing?.resultSummary,
+  );
+
   const updated = backgroundJobBoard.updateStatus({
     taskID: status.taskID,
-    state: status.state,
+    state: guarded.state,
     timedOut: status.timedOut,
-    resultSummary: status.result,
+    resultSummary: guarded.resultSummary,
+    lastStatusError: guarded.lastStatusError,
   });
   if (!updated) {
     log('[task-session-manager] ignored status for unknown background job', {

--- a/src/hooks/task-session-manager/tool-execute-hooks.ts
+++ b/src/hooks/task-session-manager/tool-execute-hooks.ts
@@ -13,6 +13,7 @@ import type {
 import {
   deriveFullObjective,
   deriveTaskSessionLabel,
+  guardCompletedStatusText,
   parseTaskIdFromTaskOutput,
   parseTaskLaunchOutput,
   parseTaskStatusOutput,
@@ -350,12 +351,18 @@ export async function handleToolExecuteAfter(
       deps.clearRehydrateTombstone?.(status.taskID);
       normalizeLateCancelledTaskOutput(output, deps.backgroundJobBoard);
       if (exactCallConfirmed) deps.backgroundJobSupervisor?.onLaunch(record);
+      const guarded = guardCompletedStatusText(
+        status.state,
+        status.result,
+        record.resultSummary,
+      );
       const updated = deps.backgroundJobBoard.updateStatus({
         taskID: status.taskID,
-        state: status.state,
+        state: guarded.state,
         expectedGeneration: record.generation,
         timedOut: status.timedOut,
-        resultSummary: status.result,
+        resultSummary: guarded.resultSummary,
+        lastStatusError: guarded.lastStatusError,
       });
       log('[task-session-manager] foreground task status registered', {
         taskID: status.taskID,

--- a/src/utils/background-job-board.test.ts
+++ b/src/utils/background-job-board.test.ts
@@ -677,6 +677,31 @@ describe('BackgroundJobBoard', () => {
     });
   });
 
+  test('rejects an empty completed status as an error', () => {
+    const board = new BackgroundJobBoard();
+    board.registerLaunch({
+      taskID: 'ses_1',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+      description: 'map files',
+    });
+
+    board.updateFromStatusOutput(
+      [
+        'task_id: ses_1',
+        'state: completed',
+        '<task_result>',
+        '</task_result>',
+      ].join('\n'),
+    );
+
+    expect(board.get('ses_1')).toMatchObject({
+      state: 'error',
+      resultSummary:
+        'Task ended without a public text result; completion is not confirmed',
+    });
+  });
+
   test('updates error summary from task_error output', () => {
     const board = new BackgroundJobBoard();
     board.registerLaunch({

--- a/src/utils/background-job-board.ts
+++ b/src/utils/background-job-board.ts
@@ -11,7 +11,11 @@ import {
   recordBackgroundJobSuppression,
 } from './background-job-store';
 import { log } from './logger';
-import { parseTaskStatusOutput, type TaskOutputState } from './task';
+import {
+  guardCompletedStatusText,
+  parseTaskStatusOutput,
+  type TaskOutputState,
+} from './task';
 
 export interface ContextFile {
   path: string;
@@ -413,11 +417,18 @@ export class BackgroundJobBoard implements BackgroundJobStore {
     const status = parseTaskStatusOutput(output);
     if (!status) return undefined;
 
+    const guarded = guardCompletedStatusText(
+      status.state,
+      status.result,
+      this.get(status.taskID)?.resultSummary,
+    );
+
     return this.updateStatus({
       taskID: status.taskID,
-      state: status.state,
+      state: guarded.state,
       timedOut: status.timedOut,
-      resultSummary: status.result,
+      resultSummary: guarded.resultSummary,
+      lastStatusError: guarded.lastStatusError,
     });
   }
 

--- a/src/utils/task.test.ts
+++ b/src/utils/task.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import {
+  COMPLETED_WITHOUT_TEXT_DIAGNOSTIC,
+  guardCompletedStatusText,
   parseTaskIdFromTaskOutput,
   parseTaskLaunchOutput,
   parseTaskResultFromOutput,
@@ -7,6 +9,41 @@ import {
   parseTaskStatusOutput,
   renderRunningTaskPlaceholder,
 } from './task';
+
+describe('guardCompletedStatusText', () => {
+  test('keeps completed only when non-empty result text exists', () => {
+    expect(
+      guardCompletedStatusText('completed', 'final text', undefined),
+    ).toEqual({ state: 'completed', resultSummary: 'final text' });
+  });
+
+  test('downgrades empty completed to error with a diagnostic', () => {
+    const guarded = guardCompletedStatusText('completed', undefined, undefined);
+    expect(guarded.state).toBe('error');
+    expect(guarded.resultSummary).toBe(COMPLETED_WITHOUT_TEXT_DIAGNOSTIC);
+  });
+
+  test('downgrades whitespace-only completed to error', () => {
+    expect(guardCompletedStatusText('completed', '  ', undefined).state).toBe(
+      'error',
+    );
+  });
+
+  test('keeps completed when the board already holds a summary', () => {
+    expect(
+      guardCompletedStatusText('completed', undefined, 'recorded result'),
+    ).toEqual({ state: 'completed', resultSummary: undefined });
+  });
+
+  test('passes non-completed states through unchanged', () => {
+    for (const state of ['running', 'error', 'cancelled'] as const) {
+      expect(guardCompletedStatusText(state, '', undefined)).toEqual({
+        state,
+        resultSummary: '',
+      });
+    }
+  });
+});
 
 describe('renderRunningTaskPlaceholder', () => {
   test('is deterministic and keyed only on the task ID', () => {

--- a/src/utils/task.ts
+++ b/src/utils/task.ts
@@ -134,6 +134,35 @@ export function parseTaskStateFromOutput(
   return undefined;
 }
 
+/** Diagnostic applied when a terminal `completed` report carries no text. */
+export const COMPLETED_WITHOUT_TEXT_DIAGNOSTIC =
+  'Task ended without a public text result; completion is not confirmed';
+
+export interface GuardedTaskStatus {
+  state: TaskOutputState;
+  resultSummary?: string;
+  lastStatusError?: string;
+}
+
+export function guardCompletedStatusText(
+  state: TaskOutputState,
+  result: string | undefined,
+  existingResultSummary: string | undefined,
+): GuardedTaskStatus {
+  if (
+    state === 'completed' &&
+    !result?.trim() &&
+    !existingResultSummary?.trim()
+  ) {
+    return {
+      state: 'error',
+      resultSummary: COMPLETED_WITHOUT_TEXT_DIAGNOSTIC,
+      lastStatusError: COMPLETED_WITHOUT_TEXT_DIAGNOSTIC,
+    };
+  }
+  return { state, resultSummary: result };
+}
+
 export function parseTaskResultFromOutput(output: string): string | undefined {
   // Require matching open/close tags via backreference
   const match = /<task_(result|error)>\s*([\s\S]*?)\s*<\/task_\1>/m.exec(


### PR DESCRIPTION
## Reject textless completed task results

“completed” is OMO Slim’s terminal subagent-task state. This change prevents a task with no public result text from being recorded as a successful completion.

- Reject textless completed status reports unless text was already retained.
- Re-read a revived task briefly for delayed persistence; then record an explicit error rather than false success.
- Cover direct status ingestion, board updates, and foreground task hooks.

A textless completion can occur when the host marks a turn terminal before its final text part is persisted or returned.

---
Raised with OMO Slim for review.

## Validation

- bun run check:ci
- bun run typecheck
- focused task-status, board, revived-run, and retrieval tests