### PR TITLE
fix: drop default agent color pinning that collapsed TUI agent colors

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -120,7 +120,7 @@ Presets can also be switched at runtime without restarting using the `/preset` c
 | `presets.<name>.<agent>.temperature` | number | - | Optional temperature (0–2); when omitted, OpenCode chooses its default |
 | `presets.<name>.<agent>.variant` | string | - | Reasoning effort: `"low"`, `"medium"`, `"high"`, or `"max"` (provider-specific) |
 | `presets.<name>.<agent>.displayName` | string | - | Custom user-facing alias for the agent (e.g. `"advisor"` for `oracle`) |
-| `presets.<name>.<agent>.color` | string | built-in agent default | Agent display color as `#RRGGBB` or a theme color: `primary`, `secondary`, `accent`, `success`, `warning`, `error`, or `info` |
+| `presets.<name>.<agent>.color` | string | - | Agent display color as `#RRGGBB` or a theme color: `primary`, `secondary`, `accent`, `success`, `warning`, `error`, or `info` |
 | `presets.<name>.<agent>.skills` | string[] | - | Skills the agent can use (`"*"`, `"!item"`, explicit list) |
 | `presets.<name>.<agent>.mcps` | string[] | - | MCPs the agent can use (`"*"`, `"!item"`, explicit list) |
 | `presets.<name>.<agent>.options` | object | - | Provider-specific model options passed to the AI SDK (e.g., `textVerbosity`, `thinking` budget) |
@@ -129,7 +129,7 @@ Presets can also be switched at runtime without restarting using the `/preset` c
 | `agents.<customAgent>.orchestratorPrompt` | string | - | Exact `@agent` block injected into the orchestrator prompt; must start with `@<agent-name>` |
 | `agents.<agent>.permission` | object \| string | - | Tool-level permission rules enforced by the SDK. See [Agent Permissions](#agent-permissions) |
 | `agents.<agent>.displayName` | string | - | Custom user-facing alias for the agent in the active config |
-| `agents.<agent>.color` | string | built-in agent default | Agent display color as `#RRGGBB` or a theme color: `primary`, `secondary`, `accent`, `success`, `warning`, `error`, or `info` |
+| `agents.<agent>.color` | string | - | Agent display color as `#RRGGBB` or a theme color: `primary`, `secondary`, `accent`, `success`, `warning`, `error`, or `info` |
 | `agents.<agent>.description` | string | generated | Description shown to OpenCode and the orchestrator; defaults to `Custom subagent '<name>'` for custom agents |
 | `acpAgents.<name>.command` | string | - | Command for an external ACP-compatible agent; creates a wrapper subagent named `<name>` See [ACP-connected agents](#acp-connected-agents). |
 | `acpAgents.<name>.args` | string[] | `[]` | Arguments for the ACP agent command See [ACP-connected agents](#acp-connected-agents). |
@@ -410,21 +410,10 @@ The setting works in both root `agents` overrides and preset agent overrides.
 
 ### Agent Colors
 
-Built-in agents use theme-aware colors by default:
-
-| Agent | Default color |
-|-------|---------------|
-| `orchestrator` | `primary` |
-| `explorer` | `info` |
-| `librarian` | `secondary` |
-| `oracle` | `accent` |
-| `designer` | `success` |
-| `fixer` | `warning` |
-| `observer` | `info` |
-| `council` and councillors | `accent` |
-
-Override a built-in color or color a custom agent with a six-digit hex value
-or an OpenCode theme color:
+Built-in agents ship without a default `color`, so the OpenCode TUI assigns
+each one a distinct color from its own theme-aware palette. Set `color`
+explicitly if you want a fixed color for a built-in or custom agent, using a
+six-digit hex value or an OpenCode theme color:
 
 ```jsonc
 {
@@ -440,8 +429,7 @@ or an OpenCode theme color:
 
 Theme colors adapt to the active OpenCode theme. Dynamic councillors inherit
 the configured `council` color unless `agents.councillor.color` overrides it.
-Custom agents have no default color. `color` works in top-level `agents`
-overrides and inside `presets`.
+`color` works in top-level `agents` overrides and inside `presets`.
 
 ### Per-preset agent configuration
 

--- a/src/agents/codemap.md
+++ b/src/agents/codemap.md
@@ -26,7 +26,7 @@ Each agent is a **prompt-driven specialist** with a factory function that create
 
 - **Default prompts**: Each agent factory has a base prompt defined in its file (e.g., `explorer.ts`, `oracle.ts`)
 - **User overrides**: From `~/.config/opencode/oh-my-opencode-slim.json` via `loadAgentPrompt()`
-- **Agent colors**: Built-in theme-aware defaults with per-agent hex or theme-color overrides
+- **Agent colors**: Optional per-agent hex or theme-color overrides; no defaults (colorless agents get the host TUI's distinct palette colors)
 - **Permission wildcards**: Applied via `applyDefaultPermissions()` in `index.ts`
 - **Model resolution**: Supports string models, explicit `inheritModelFrom` policies, and priority-ordered arrays (`_modelArray`) for runtime fallback
 - **Skill permissions**: Per-agent MCP and tool access controlled via `getSkillPermissionsForAgent()`

--- a/src/agents/index.test.ts
+++ b/src/agents/index.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, test } from 'bun:test';
 import type { PluginConfig } from '../config';
 import {
   AgentOverrideConfigSchema,
+  ALL_AGENT_NAMES,
   CouncilConfigSchema,
-  DEFAULT_AGENT_COLORS,
   DEFAULT_DISABLED_AGENTS,
   DEFAULT_MODELS,
   PluginConfigSchema,
@@ -905,20 +905,20 @@ describe('getAgentConfigs', () => {
     expect(configs.fixer.temperature).toBe(0);
   });
 
-  test('applies default colors to every built-in agent', () => {
+  test('built-in agents get no default color', () => {
+    // No default pinning: colorless agents keep the distinct palette colors
+    // the OpenCode TUI assigns by round-robin (see issue #1116).
     const configs = getAgentConfigs(
       runtimeFor({ disabled_agents: [], council: councilConfig() }),
     );
 
-    for (const [name, color] of Object.entries(DEFAULT_AGENT_COLORS)) {
-      expect(configs[name]?.color).toBe(color);
+    for (const name of ALL_AGENT_NAMES) {
+      expect(configs[name]?.color).toBeUndefined();
     }
-    expect(configs['councillor-alpha']?.color).toBe(
-      DEFAULT_AGENT_COLORS.councillor,
-    );
+    expect(configs['councillor-alpha']?.color).toBeUndefined();
   });
 
-  test('configured colors override defaults and flow to custom agents', () => {
+  test('configured colors flow to built-in and custom agents', () => {
     const configs = getAgentConfigs(
       runtimeFor({
         agents: {

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -4,7 +4,6 @@ import {
   AGENT_ALIASES,
   type AgentOverrideConfig,
   ALL_AGENT_NAMES,
-  DEFAULT_AGENT_COLORS,
   DEFAULT_DISABLED_AGENTS,
   DEFAULT_MODELS,
   loadAgentPrompt,
@@ -478,7 +477,6 @@ export function createAgents(
     .map(([name, factory]) => {
       // Get base agent definition using the subagent factory with undefined prompts
       const agent = factory(getModelForAgent(name), undefined, undefined);
-      agent.config.color ??= DEFAULT_AGENT_COLORS[name];
 
       const customPrompts = loadAgentPrompt(name, {
         preset: runtime.preset,
@@ -603,13 +601,15 @@ export function createAgents(
   // Build dynamic councillor agents from council config (flatten mode).
   // Each councillor becomes a dispatchable subagent with its own model,
   // so the orchestrator can task() them with native panes at depth 1.
+  // Only a *configured* color is inherited: councillor override first, then
+  // council override. No default fallback — unconfigured councillors stay
+  // colorless so the host TUI palette keeps assigning distinct colors.
   const councillorColor =
     getOverrideFromAgents(mergedAgents, 'councillor')?.color ??
-    getOverrideFromAgents(mergedAgents, 'council')?.color ??
-    DEFAULT_AGENT_COLORS.councillor;
+    getOverrideFromAgents(mergedAgents, 'council')?.color;
   const councillorAgents = buildCouncillorAgents(runtime, disabled).map(
     (agent) => {
-      agent.config.color ??= councillorColor;
+      if (councillorColor) agent.config.color ??= councillorColor;
       applyDefaultPermissions(agent, undefined, runtime.disabledSkills);
       return agent;
     },
@@ -646,7 +646,6 @@ export function createAgents(
     !runtime.disabledTools.includes('wait_for_user'),
     runtime.backgroundJobs.orchestratorWake.enabled,
   );
-  orchestrator.config.color ??= DEFAULT_AGENT_COLORS.orchestrator;
 
   const inlineOrchestratorPrompt = orchestratorOverride?.prompt;
   const defaultOrchestratorPrompt = orchestrator.config.prompt ?? '';

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -32,19 +32,6 @@ export const AGENT_THEME_COLORS = [
 
 export type AgentThemeColor = (typeof AGENT_THEME_COLORS)[number];
 
-/** Theme-aware colors used for built-in agents unless users override them. */
-export const DEFAULT_AGENT_COLORS: Record<AgentName, AgentThemeColor> = {
-  orchestrator: 'primary',
-  explorer: 'info',
-  librarian: 'secondary',
-  oracle: 'accent',
-  designer: 'success',
-  fixer: 'warning',
-  observer: 'info',
-  council: 'accent',
-  councillor: 'accent',
-};
-
 /** Agents that cannot be disabled even if listed in disabled_agents config. */
 export const PROTECTED_AGENTS = new Set(['orchestrator', 'councillor']);
 


### PR DESCRIPTION
Fixes #1116

## What changed, and why was it needed?

Since #1093, every built-in agent had `agent.config.color` pinned to an OpenCode theme token. On v1 hosts this **opts agents out of the TUI's round-robin palette** — the mechanism that previously gave each agent a distinct color — and resolves through `theme[color]`, where tokens collide:

- the mapping itself reuses `accent` (oracle, council, councillors) and `info` (explorer, observer);
- themes collapse keys further (nord: `primary == info == #88C0D0`; system/ANSI theme: `primary == accent == info == cyan`; tokyonight: `primary == info`).

Net effect: most agents render the same lake-blue color (#1116).

This PR stops setting colors by default:

- `src/agents/index.ts`: removed the three `color ??=` pinning sites (built-in loop, orchestrator); councillor inheritance now applies only a **configured** `councillor`/`council` color, with no default fallback.
- `src/config/constants.ts`: removed `DEFAULT_AGENT_COLORS` (`AGENT_THEME_COLORS` stays — the override schema still validates hex ∪ theme tokens).
- Colorless agents get the host TUI's distinct, theme-aware palette again — the same behavior as v2.2.17.

## What is preserved

- `agents.<name>.color` and preset `color` overrides (hex or theme token) — user-configured colors are unaffected.
- Configured `council` → dynamic-councillor color inheritance.
- Schema validation and the generated JSON schema (unchanged).

## Testing

- `bun run check:ci`
- `bun run typecheck`
- `bun test` — 2368 pass, 0 fail
- Tests updated: built-in agents now asserted to have **no** default color; override and inheritance tests unchanged in behavior.