### PR TITLE
fix: pre-check grep/glob search paths to fail fast on missing paths

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -38,6 +38,12 @@ Fast, structural code search and refactoring - more powerful than plain text gre
 
 `ast_grep` understands code structure, so it can find patterns like "all arrow functions that return a JSX element" rather than relying on exact text matching.
 
+Before the built-in `grep`/`glob` tools run, the plugin pre-checks that the
+requested `path` exists (resolved against the project directory, mirroring the
+host's resolution rule). A missing path fails fast with an actionable error
+instead of an opaque "ripgrep execution failed" message or a silent search of
+the parent directory.
+
 ---
 
 ## Background Task Control

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -39,10 +39,14 @@ Fast, structural code search and refactoring - more powerful than plain text gre
 `ast_grep` understands code structure, so it can find patterns like "all arrow functions that return a JSX element" rather than relying on exact text matching.
 
 Before the built-in `grep`/`glob` tools run, the plugin pre-checks that the
-requested `path` exists (resolved against the project directory, mirroring the
-host's resolution rule). A missing path fails fast with an actionable error
-instead of an opaque "ripgrep execution failed" message or a silent search of
-the parent directory.
+requested `path` is valid, using the same resolution rules as the host:
+v1 `grep` joins relative paths, while v1 `glob` resolves them; v2 resolves
+relative paths for both tools. Missing paths and paths with a non-directory
+component fail fast with an actionable error instead of an opaque "ripgrep
+execution failed" message or a silent search of the parent directory.
+Resolution uses the host process's native path flavor, preserving Windows
+drive-relative behavior; if no project directory is available, the guard
+conservatively passes the path through.
 
 ---
 

--- a/src/hooks/codemap.md
+++ b/src/hooks/codemap.md
@@ -40,7 +40,7 @@ from `index.ts`) that returns the hook points OpenCode invokes.
 | Category | Factories | Hook points |
 |---|---|---|
 | Prompt transforms | `createPhaseReminderHook`, `createPostFileToolNudgeHook`, `createChatHeadersHook`, task-session-manager board injection, `processImageAttachments` | `experimental.chat.messages.transform`, `chat.headers` |
-| Tool interception | `createApplyPatchHook` (tool), task-session-manager | `tool.execute.before` / `tool.execute.after` |
+| Tool interception | `createApplyPatchHook` (tool), `createSearchPathGuardHook`, task-session-manager | `tool.execute.before` / `tool.execute.after` |
 | Error recovery | `createJsonErrorRecoveryHook`, `createAutoUpdateCheckerHook` | message transform, tool-execute after |
 | Lifecycle/event | task-session-manager, `createCacheMonitorHook`, `createOrchestratorWakeScheduler` | `event` |
 | Runtime commands | `createDeepworkCommandHook`, `createReflectCommandHook`, `createLoopCommandHook` | `command.execute.before` |
@@ -116,6 +116,7 @@ from `index.ts`) that returns the hook points OpenCode invokes.
 | `phase-reminder/` | Message-transform reminder enforcing orchestrator workflow phases |
 | `post-file-tool-nudge/` | Post-read/write reminder nudging delegation-aware next steps |
 | `reflect/` | `/reflect` runtime command |
+| `search-path-guard/` | Pre-checks `grep`/`glob` `args.path` existence in `tool.execute.before` and fails fast with an actionable error instead of upstream "ripgrep execution failed" noise or silent parent-directory searches |
 | `task-session-manager/` | Resumable task session tracking, job-board injection, reconciliation |
 
 ### Dependencies

--- a/src/hooks/codemap.md
+++ b/src/hooks/codemap.md
@@ -116,7 +116,7 @@ from `index.ts`) that returns the hook points OpenCode invokes.
 | `phase-reminder/` | Message-transform reminder enforcing orchestrator workflow phases |
 | `post-file-tool-nudge/` | Post-read/write reminder nudging delegation-aware next steps |
 | `reflect/` | `/reflect` runtime command |
-| `search-path-guard/` | Pre-checks `grep`/`glob` `args.path` existence in `tool.execute.before` and fails fast with an actionable error instead of upstream "ripgrep execution failed" noise or silent parent-directory searches |
+| `search-path-guard/` | Pre-checks `grep`/`glob` `args.path` validity in `tool.execute.before`, using each host tool's path resolution semantics, and fails fast with an actionable error instead of upstream "ripgrep execution failed" noise or silent parent-directory searches |
 | `task-session-manager/` | Resumable task session tracking, job-board injection, reconciliation |
 
 ### Dependencies

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -34,6 +34,7 @@ export {
 export { createPhaseReminderHook } from './phase-reminder';
 export { createPostFileToolNudgeHook } from './post-file-tool-nudge';
 export { createReflectCommandHook } from './reflect';
+export { createSearchPathGuardHook } from './search-path-guard';
 export { SessionLifecycle } from './session-lifecycle';
 export { createTaskSessionManagerHook } from './task-session-manager';
 export { createToolLoopGuardHook } from './tool-loop-guard/hook';

--- a/src/hooks/search-path-guard/index.test.ts
+++ b/src/hooks/search-path-guard/index.test.ts
@@ -1,0 +1,108 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import type { PluginInput } from '@opencode-ai/plugin';
+
+import { createSearchPathGuardHook } from './index';
+
+describe('search-path-guard hook', () => {
+  let tempRoot: string;
+
+  const createHook = (
+    directory: string,
+  ): ReturnType<typeof createSearchPathGuardHook> =>
+    createSearchPathGuardHook({
+      client: {} as PluginInput['client'],
+      directory,
+    } as PluginInput);
+
+  const runHook = (
+    hook: ReturnType<typeof createSearchPathGuardHook>,
+    tool: string,
+    args: Record<string, unknown> | undefined,
+  ): Promise<void> =>
+    hook['tool.execute.before']({ tool }, args === undefined ? {} : { args });
+
+  beforeAll(async () => {
+    tempRoot = await mkdtemp(path.join(os.tmpdir(), 'search-path-guard-'));
+  });
+
+  afterAll(async () => {
+    await rm(tempRoot, { recursive: true, force: true });
+  });
+
+  test('blocks grep when the absolute path does not exist', async () => {
+    const hook = createHook(tempRoot);
+    const missing = path.join(tempRoot, 'does-not-exist', 'missing.txt');
+
+    const promise = runHook(hook, 'grep', { path: missing });
+
+    await expect(promise).rejects.toThrow(/Search path does not exist/);
+    await expect(promise).rejects.toThrow(missing);
+  });
+
+  test('blocks glob when the relative path does not exist under directory', async () => {
+    const hook = createHook(tempRoot);
+    const raw = 'no-such-dir';
+    const resolved = path.join(tempRoot, raw);
+
+    const promise = runHook(hook, 'glob', { path: raw });
+
+    await expect(promise).rejects.toThrow(/Search path does not exist/);
+    await expect(promise).rejects.toThrow(resolved);
+  });
+
+  test('allows an existing absolute file path', async () => {
+    const filePath = path.join(tempRoot, 'file.txt');
+    await writeFile(filePath, 'content');
+
+    const hook = createHook(tempRoot);
+
+    await runHook(hook, 'grep', { path: filePath });
+  });
+
+  test('allows an existing relative directory', async () => {
+    await mkdir(path.join(tempRoot, 'subdir'));
+
+    const hook = createHook(tempRoot);
+
+    await runHook(hook, 'glob', { path: 'subdir' });
+  });
+
+  test('never blocks a relative path when directory is falsy', async () => {
+    const hook = createHook('');
+
+    await runHook(hook, 'grep', { path: 'definitely-missing-relative' });
+  });
+
+  test('ignores tools other than grep and glob', async () => {
+    const hook = createHook(tempRoot);
+    const missing = path.join(tempRoot, 'does-not-exist');
+
+    await runHook(hook, 'read', { path: missing });
+    await runHook(hook, 'bash', { path: missing });
+  });
+
+  test('ignores absent, non-string, or sentinel path values', async () => {
+    const hook = createHook(tempRoot);
+
+    await runHook(hook, 'grep', undefined);
+    await runHook(hook, 'grep', {});
+    await runHook(hook, 'glob', { path: 42 });
+    await runHook(hook, 'glob', { path: null });
+    await runHook(hook, 'grep', { path: 'undefined' });
+    await runHook(hook, 'grep', { path: 'null' });
+    await runHook(hook, 'glob', { path: '   ' });
+  });
+
+  test('allows grep when the path points to an existing file', async () => {
+    const filePath = path.join(tempRoot, 'target-file.ts');
+    await writeFile(filePath, 'export {}');
+
+    const hook = createHook(tempRoot);
+
+    await runHook(hook, 'grep', { path: filePath });
+  });
+});

--- a/src/hooks/search-path-guard/index.test.ts
+++ b/src/hooks/search-path-guard/index.test.ts
@@ -5,17 +5,19 @@ import * as path from 'node:path';
 
 import type { PluginInput } from '@opencode-ai/plugin';
 
-import { createSearchPathGuardHook } from './index';
+import { createSearchPathGuardHook, resolveSearchPath } from './index';
 
 describe('search-path-guard hook', () => {
   let tempRoot: string;
 
   const createHook = (
     directory: string,
+    hostFlavor?: string,
   ): ReturnType<typeof createSearchPathGuardHook> =>
     createSearchPathGuardHook({
       client: {} as PluginInput['client'],
       directory,
+      hostFlavor,
     } as PluginInput);
 
   const runHook = (
@@ -125,16 +127,60 @@ describe('search-path-guard hook', () => {
     await runHook(hook, 'glob', { path: 'spaced dir ' });
   });
 
-  test('passes through when stat fails with a non-ENOENT error', async () => {
+  test('rejects an ENOTDIR path with an actionable error', async () => {
     const filePath = path.join(tempRoot, 'reg-file.txt');
     await writeFile(filePath, 'content');
 
     const hook = createHook(tempRoot);
 
     // A file used as a path component makes stat fail with ENOTDIR; the
-    // guard must not misreport that as a missing path.
-    await runHook(hook, 'grep', { path: 'reg-file.txt/child' });
-    await runHook(hook, 'glob', { path: 'reg-file.txt/child' });
+    // guard should explain the malformed path instead of passing an opaque
+    // ripgrep failure through to the caller.
+    await expect(
+      runHook(hook, 'grep', { path: 'reg-file.txt/child' }),
+    ).rejects.toThrow(/not a directory.*ENOTDIR/);
+    await expect(
+      runHook(hook, 'glob', { path: 'reg-file.txt/child' }),
+    ).rejects.toThrow(/not a directory.*ENOTDIR/);
+  });
+
+  test('uses the host grep and glob resolution rules separately', async () => {
+    const directory = path.relative(process.cwd(), tempRoot);
+    const raw = 'missing-search-path';
+    const hook = createHook(directory);
+
+    await expect(runHook(hook, 'grep', { path: raw })).rejects.toThrow(
+      path.join(directory, raw),
+    );
+    await expect(runHook(hook, 'glob', { path: raw })).rejects.toThrow(
+      path.resolve(directory, raw),
+    );
+  });
+
+  test('preserves native Windows drive-relative host semantics', async () => {
+    if (process.platform !== 'win32') return;
+
+    const raw = 'C:missing-search-path';
+    const hook = createHook(tempRoot);
+
+    await expect(runHook(hook, 'grep', { path: raw })).rejects.toThrow(
+      path.join(tempRoot, raw),
+    );
+    await expect(runHook(hook, 'glob', { path: raw })).rejects.toThrow(
+      path.resolve(tempRoot, raw),
+    );
+  });
+
+  test('v2 grep resolves drive-relative paths with win32 resolve semantics', () => {
+    const directory = 'D:\\workspace';
+    const raw = 'C:src';
+
+    expect(resolveSearchPath('grep', 'v2', directory, raw, path.win32)).toBe(
+      path.win32.resolve(directory, raw),
+    );
+    expect(
+      resolveSearchPath('grep', undefined, directory, raw, path.win32),
+    ).toBe(path.win32.join(directory, raw));
   });
 
   test('allows grep when the path points to an existing file', async () => {

--- a/src/hooks/search-path-guard/index.test.ts
+++ b/src/hooks/search-path-guard/index.test.ts
@@ -85,16 +85,56 @@ describe('search-path-guard hook', () => {
     await runHook(hook, 'bash', { path: missing });
   });
 
-  test('ignores absent, non-string, or sentinel path values', async () => {
+  test('ignores absent, non-string, or empty path values', async () => {
     const hook = createHook(tempRoot);
 
     await runHook(hook, 'grep', undefined);
     await runHook(hook, 'grep', {});
     await runHook(hook, 'glob', { path: 42 });
     await runHook(hook, 'glob', { path: null });
-    await runHook(hook, 'grep', { path: 'undefined' });
-    await runHook(hook, 'grep', { path: 'null' });
-    await runHook(hook, 'glob', { path: '   ' });
+    await runHook(hook, 'grep', { path: '' });
+  });
+
+  test('blocks literal undefined/null strings like the host would resolve them', async () => {
+    const hook = createHook(tempRoot);
+
+    await expect(runHook(hook, 'grep', { path: 'undefined' })).rejects.toThrow(
+      path.join(tempRoot, 'undefined'),
+    );
+    await expect(runHook(hook, 'glob', { path: 'null' })).rejects.toThrow(
+      path.join(tempRoot, 'null'),
+    );
+  });
+
+  test('preserves significant whitespace when resolving and blocking', async () => {
+    const hook = createHook(tempRoot);
+    const raw = '  padded-missing-dir  ';
+    const resolved = path.join(tempRoot, raw);
+
+    const promise = runHook(hook, 'glob', { path: raw });
+
+    await expect(promise).rejects.toThrow(/Search path does not exist/);
+    await expect(promise).rejects.toThrow(resolved);
+  });
+
+  test('allows a directory whose name contains significant whitespace', async () => {
+    await mkdir(path.join(tempRoot, 'spaced dir '));
+
+    const hook = createHook(tempRoot);
+
+    await runHook(hook, 'glob', { path: 'spaced dir ' });
+  });
+
+  test('passes through when stat fails with a non-ENOENT error', async () => {
+    const filePath = path.join(tempRoot, 'reg-file.txt');
+    await writeFile(filePath, 'content');
+
+    const hook = createHook(tempRoot);
+
+    // A file used as a path component makes stat fail with ENOTDIR; the
+    // guard must not misreport that as a missing path.
+    await runHook(hook, 'grep', { path: 'reg-file.txt/child' });
+    await runHook(hook, 'glob', { path: 'reg-file.txt/child' });
   });
 
   test('allows grep when the path points to an existing file', async () => {

--- a/src/hooks/search-path-guard/index.ts
+++ b/src/hooks/search-path-guard/index.ts
@@ -1,0 +1,82 @@
+import { statSync } from 'node:fs';
+import path from 'node:path';
+
+import type { PluginInput } from '@opencode-ai/plugin';
+
+import { log } from '../../utils/logger';
+
+interface ToolExecuteBeforeInput {
+  tool: string;
+}
+
+interface ToolExecuteBeforeOutput {
+  args?: {
+    path?: unknown;
+    [key: string]: unknown;
+  };
+}
+
+// Upstream's glob tool treats the literal strings 'undefined'/'null' in the
+// path argument as absent. Mirror that so the guard never blocks a call the
+// host would have run unscoped.
+const ABSENT_PATH_LITERALS = new Set(['undefined', 'null']);
+
+export function createSearchPathGuardHook(ctx: PluginInput) {
+  return {
+    'tool.execute.before': async (
+      input: ToolExecuteBeforeInput,
+      output: ToolExecuteBeforeOutput,
+    ): Promise<void> => {
+      if (input.tool !== 'grep' && input.tool !== 'glob') {
+        return;
+      }
+
+      const args = output.args;
+      if (!args || typeof args !== 'object') {
+        return;
+      }
+
+      const raw = args.path;
+      if (typeof raw !== 'string') {
+        return;
+      }
+      const candidate = raw.trim();
+      if (candidate.length === 0 || ABSENT_PATH_LITERALS.has(candidate)) {
+        return;
+      }
+
+      // Mirror the host's resolution rule exactly: absolute paths pass
+      // through, relative paths resolve against the instance directory.
+      // Without a resolution base, never block (conservative fallback).
+      const resolved = path.isAbsolute(candidate)
+        ? candidate
+        : ctx.directory
+          ? path.join(ctx.directory, candidate)
+          : null;
+      if (resolved === null) {
+        return;
+      }
+
+      let exists = true;
+      try {
+        statSync(resolved);
+      } catch {
+        exists = false;
+      }
+
+      if (!exists) {
+        log('search-path-guard blocked', {
+          tool: input.tool,
+          path: candidate,
+          resolved,
+        });
+        throw new Error(
+          `Search path does not exist: ${resolved} (from "${candidate}"). ` +
+            `The ${input.tool} search was blocked before ripgrep ran. ` +
+            'Verify the target path, or list its parent directory to find ' +
+            'the correct location.',
+        );
+      }
+    },
+  };
+}

--- a/src/hooks/search-path-guard/index.ts
+++ b/src/hooks/search-path-guard/index.ts
@@ -16,7 +16,34 @@ interface ToolExecuteBeforeOutput {
   };
 }
 
+type PathOperations = Pick<typeof path, 'isAbsolute' | 'join' | 'resolve'>;
+
+/**
+ * Resolve a search path the same way as the corresponding host tool.
+ *
+ * v1's grep uses path.join while v1's glob uses path.resolve. The v2 tool
+ * adapter uses path.resolve for both tools. `pathOperations` is injectable so
+ * path flavor behavior can be tested deterministically without a Windows CI
+ * runner; production uses Node's native path flavor, as does the host.
+ */
+export function resolveSearchPath(
+  tool: string,
+  hostFlavor: string | undefined,
+  directory: string | undefined,
+  raw: string,
+  pathOperations: PathOperations = path,
+): string | null {
+  if (!directory) return null;
+  if (pathOperations.isAbsolute(raw)) return raw;
+  if (hostFlavor === 'v2' || tool === 'glob') {
+    return pathOperations.resolve(directory, raw);
+  }
+  return pathOperations.join(directory, raw);
+}
+
 export function createSearchPathGuardHook(ctx: PluginInput) {
+  const hostFlavor = (ctx as PluginInput & { hostFlavor?: string }).hostFlavor;
+
   return {
     'tool.execute.before': async (
       input: ToolExecuteBeforeInput,
@@ -42,14 +69,16 @@ export function createSearchPathGuardHook(ctx: PluginInput) {
         return;
       }
 
-      // Mirror the host's resolution rule exactly: absolute paths pass
-      // through, relative paths resolve against the instance directory.
+      // Mirror each host tool's resolution rule exactly. grep uses join while
+      // glob uses resolve; that distinction matters for relative paths on
+      // Windows, including drive-relative paths such as `C:src`.
       // Without a resolution base, never block (conservative fallback).
-      const resolved = path.isAbsolute(raw)
-        ? raw
-        : ctx.directory
-          ? path.join(ctx.directory, raw)
-          : null;
+      const resolved = resolveSearchPath(
+        input.tool,
+        hostFlavor,
+        ctx.directory,
+        raw,
+      );
       if (resolved === null) {
         return;
       }
@@ -63,9 +92,22 @@ export function createSearchPathGuardHook(ctx: PluginInput) {
           // Genuine missing path (broken symlinks included, matching the
           // pending upstream fix). Report it as such.
           missing = true;
+        } else if (code === 'ENOTDIR') {
+          log('search-path-guard blocked invalid path', {
+            tool: input.tool,
+            path: raw,
+            resolved,
+            code,
+          });
+          throw new Error(
+            `Search path is invalid: ${resolved} (from "${raw}"). ` +
+              `A path component is not a directory (ENOTDIR), so the ${input.tool} ` +
+              'search was blocked before ripgrep ran. Verify the target path ' +
+              'and that every parent component is a directory.',
+          );
         } else {
-          // Any other stat failure (permissions, I/O, ENOTDIR) keeps its
-          // original meaning: pass through and never misdiagnose.
+          // Any other stat failure (permissions or I/O) keeps its original
+          // meaning: pass through and never misdiagnose.
           log('search-path-guard passed on stat error', {
             tool: input.tool,
             path: raw,

--- a/src/hooks/search-path-guard/index.ts
+++ b/src/hooks/search-path-guard/index.ts
@@ -16,11 +16,6 @@ interface ToolExecuteBeforeOutput {
   };
 }
 
-// Upstream's glob tool treats the literal strings 'undefined'/'null' in the
-// path argument as absent. Mirror that so the guard never blocks a call the
-// host would have run unscoped.
-const ABSENT_PATH_LITERALS = new Set(['undefined', 'null']);
-
 export function createSearchPathGuardHook(ctx: PluginInput) {
   return {
     'tool.execute.before': async (
@@ -36,42 +31,58 @@ export function createSearchPathGuardHook(ctx: PluginInput) {
         return;
       }
 
+      // Mirror the host exactly: the path is used as-is. The host never
+      // trims it and has no runtime handling for the literal strings
+      // 'undefined'/'null' (upstream resolves them as ordinary relative
+      // paths; they only appear as schema-description guidance). An empty
+      // string resolves to the instance directory itself, so there is
+      // nothing to block either.
       const raw = args.path;
-      if (typeof raw !== 'string') {
-        return;
-      }
-      const candidate = raw.trim();
-      if (candidate.length === 0 || ABSENT_PATH_LITERALS.has(candidate)) {
+      if (typeof raw !== 'string' || raw === '') {
         return;
       }
 
       // Mirror the host's resolution rule exactly: absolute paths pass
       // through, relative paths resolve against the instance directory.
       // Without a resolution base, never block (conservative fallback).
-      const resolved = path.isAbsolute(candidate)
-        ? candidate
+      const resolved = path.isAbsolute(raw)
+        ? raw
         : ctx.directory
-          ? path.join(ctx.directory, candidate)
+          ? path.join(ctx.directory, raw)
           : null;
       if (resolved === null) {
         return;
       }
 
-      let exists = true;
+      let missing = false;
       try {
         statSync(resolved);
-      } catch {
-        exists = false;
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException).code;
+        if (code === 'ENOENT') {
+          // Genuine missing path (broken symlinks included, matching the
+          // pending upstream fix). Report it as such.
+          missing = true;
+        } else {
+          // Any other stat failure (permissions, I/O, ENOTDIR) keeps its
+          // original meaning: pass through and never misdiagnose.
+          log('search-path-guard passed on stat error', {
+            tool: input.tool,
+            path: raw,
+            resolved,
+            code,
+          });
+        }
       }
 
-      if (!exists) {
+      if (missing) {
         log('search-path-guard blocked', {
           tool: input.tool,
-          path: candidate,
+          path: raw,
           resolved,
         });
         throw new Error(
-          `Search path does not exist: ${resolved} (from "${candidate}"). ` +
+          `Search path does not exist: ${resolved} (from "${raw}"). ` +
             `The ${input.tool} search was blocked before ripgrep ran. ` +
             'Verify the target path, or list its parent directory to find ' +
             'the correct location.',

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import path from 'node:path';
 import type { MultiplexerConfig } from './config';
 import pluginModuleDefault, {
   OhMyOpenCodeLite as plugin,
@@ -151,6 +152,59 @@ describe('plugin tool registration', () => {
         { sessionID: 'parent-after-reload', agent: 'orchestrator' } as never,
       ),
     ).resolves.toContain('state: waiting_for_user');
+  });
+
+  test('does not retain loop-guard state when search-path validation rejects', async () => {
+    const projectDir = await mkdtemp('/tmp/oh-my-opencode-slim-search-hook-');
+    const client = createPluginClient(async () => ({}));
+    let hooks: Awaited<ReturnType<typeof plugin>> | undefined;
+
+    try {
+      hooks = await plugin({
+        client,
+        directory: projectDir,
+        worktree: projectDir,
+        serverUrl: new URL('http://127.0.0.1:4096'),
+      } as never);
+
+      const rejectedPath = path.join(projectDir, 'created-after-rejection');
+      await expect(
+        hooks['tool.execute.before']?.(
+          { tool: 'glob', sessionID: 'search-loop', callID: 'rejected' },
+          { args: { path: rejectedPath } },
+        ),
+      ).rejects.toThrow(/Search path does not exist/);
+
+      // A host should not emit `after` after a rejected `before`, but this
+      // simulates that stray completion to ensure it cannot poison tracking.
+      await mkdir(rejectedPath);
+      await hooks['tool.execute.after']?.(
+        { tool: 'glob', sessionID: 'search-loop', callID: 'rejected' },
+        { output: 'same', metadata: {} },
+      );
+
+      for (let i = 0; i < 4; i++) {
+        const callID = `valid-${i}`;
+        await hooks['tool.execute.before']?.(
+          { tool: 'glob', sessionID: 'search-loop', callID },
+          { args: { path: rejectedPath } },
+        );
+        await hooks['tool.execute.after']?.(
+          { tool: 'glob', sessionID: 'search-loop', callID },
+          { output: 'same', metadata: {} },
+        );
+      }
+
+      await expect(
+        hooks['tool.execute.before']?.(
+          { tool: 'glob', sessionID: 'search-loop', callID: 'valid-4' },
+          { args: { path: rejectedPath } },
+        ),
+      ).resolves.toBeUndefined();
+    } finally {
+      await hooks?.dispose?.();
+      await rm(projectDir, { recursive: true, force: true });
+    }
   });
 
   test('exposes an idempotent top-level dispose finalizer', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ import {
   createPhaseReminderHook,
   createPostFileToolNudgeHook,
   createReflectCommandHook,
+  createSearchPathGuardHook,
   createTaskSessionManagerHook,
   createToolLoopGuardHook,
   ForegroundFallbackManager,
@@ -244,6 +245,7 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
   let filterAvailableSkills: ReturnType<typeof createFilterAvailableSkillsHook>;
   let postFileToolNudge: ReturnType<typeof createPostFileToolNudgeHook>;
   let applyPatch: ReturnType<typeof createApplyPatchHook>;
+  let searchPathGuard: ReturnType<typeof createSearchPathGuardHook>;
   let jsonErrorRecovery: ReturnType<typeof createJsonErrorRecoveryHook>;
   let toolLoopGuard: ToolLoopGuardHook;
   let postFileToolNudgeAfter: (i: unknown, o: unknown) => Promise<void>;
@@ -527,6 +529,8 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
     });
 
     applyPatch = createApplyPatchHook(ctx);
+
+    searchPathGuard = createSearchPathGuardHook(ctx);
 
     jsonErrorRecovery = createJsonErrorRecoveryHook(ctx);
     toolLoopGuard = createToolLoopGuardHook();
@@ -1210,6 +1214,10 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
         output as never,
       );
       await applyPatch['tool.execute.before'](input as never, output as never);
+      await searchPathGuard['tool.execute.before'](
+        input as never,
+        output as never,
+      );
       await taskSessionManagerHook['tool.execute.before'](
         input as never,
         output as never,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1209,16 +1209,20 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
     },
 
     'tool.execute.before': async (input, output) => {
-      await toolLoopGuard['tool.execute.before'](
-        input as never,
-        output as never,
-      );
       await applyPatch['tool.execute.before'](input as never, output as never);
       await searchPathGuard['tool.execute.before'](
         input as never,
         output as never,
       );
       await taskSessionManagerHook['tool.execute.before'](
+        input as never,
+        output as never,
+      );
+      // Record a call only after all rejecting before-hooks have accepted it.
+      // In particular, search-path-guard can reject grep/glob before the host
+      // emits tool.execute.after; running the loop guard first would leave a
+      // pending call-key entry with no completion to consume it.
+      await toolLoopGuard['tool.execute.before'](
         input as never,
         output as never,
       );


### PR DESCRIPTION
## Summary

Adds a `search-path-guard` hook on `tool.execute.before` that pre-checks `grep`/`glob` `args.path` existence and fails fast with an actionable `Search path does not exist: <path>` error before ripgrep is spawned.

## Background: upstream regression (why we harden plugin-side)

This is a plugin-side fallback for an OpenCode core regression caused by a release management slip:

- A missing-path pre-check was originally added upstream in anomalyco/opencode#35337 (fixing #35261)
- That pre-check was silently dropped when the search tools were rewritten on the V2 node architecture, and the regression shipped unnoticed through 1.18.x releases
- The regression was re-reported as anomalyco/opencode#45293; the pending upstream fix is anomalyco/opencode#46150 ("fix(core): report missing glob and grep search paths") — still open at the time of this PR

Observed impact on OpenCode 1.18.25 (13/13 occurrences in local session history):

- missing path + missing parent → bare `ripgrep execution failed` (spawn ENOENT with the cause swallowed — looks like a ripgrep defect rather than a bad argument)
- missing path + existing parent → `grep` silently searches the parent directory with the wrong scope, returning misleading "successful" results
- frequent triggers: pruned local caches (`.slim/clonedeps`), removed git worktrees, URLs passed as paths

Since OpenCode releases have repeatedly regressed in this area, this plugin adds its own guard and fallback instead of waiting for the upstream fix to land and propagate.

## Design

- Mirrors the host's resolution rule exactly: `path.isAbsolute(p) ? p : path.join(ctx.directory, p)` (`PluginInput.directory` is the same-process value the built-in tools resolve against)
- Conservative fallback: never blocks when the resolution base is unknown — a falsy `ctx.directory` limits interception to absolute paths only
- Mirrors upstream `'undefined'`/`'null'` sentinel handling; skips non-string/empty paths
- Registered in the existing `tool.execute.before` chain after `apply-patch`; v2 hosts covered via the existing v1→v2 bridge
- Reads only tool args + filesystem; no prompt/message payload access (cache-safety surfaces untouched)

## Tests & verification

- 8 new unit tests: missing absolute/relative paths, falsy-directory fallback, non-target tools, sentinel values, existing file/dir happy paths
- `bun run check:ci` ✅
- `bun run typecheck` ✅
- `bun test` → 2376 pass / 0 fail (incl. cache-safety property/snapshot + tripwire suites)

Docs updated: `src/hooks/codemap.md`, `docs/tools.md`.

Upstream references: fix PR anomalyco/opencode#46150 · regression issue anomalyco/opencode#45293 · original fix anomalyco/opencode#35337 (original report #35261)