### PR TITLE
feat(background-jobs): add admission concurrency limits for native background tasks

### DIFF
--- a/docs/background-orchestration.md
+++ b/docs/background-orchestration.md
@@ -479,6 +479,27 @@ uncertain`; they never prove that a job stopped or completed and do not confirm
 a pending stop. Each observation is generation-aware, so a delayed response
 cannot modify a relaunched task.
 
+### Background Task Concurrency
+
+`backgroundJobs.concurrency` (disabled by default, see
+[Configuration](configuration.md#background-job-management)) caps how many
+native background tasks may run at once. Admission happens in the
+`tool.execute.before` hook: a task waits for a slot before OpenCode creates
+its child session. Queued requests are admitted in order, but requests whose
+provider or model quota is saturated are skipped in favor of admittable later
+requests.
+
+Sessions that are themselves managed tasks — a background subagent running
+its own nested `task(..., background: true)` calls — are exempt from
+admission. They already hold a slot while running, so waiting for a second
+one would self-deadlock once the queue saturates.
+
+Admission itself has no timeout. A running task that never reaches a terminal
+state keeps its slot forever, and queued tasks as well as the orchestrator's
+`task` calls block behind it. When you enable `concurrency`, pair it with the
+opt-in wall-clock supervisor below so stalled tasks are eventually forced to
+a terminal state and release their slots.
+
 ### Opt-in Wall-clock Supervisor
 
 The plugin can apply a one-shot wall-clock deadline to native background task

--- a/docs/background-orchestration.md
+++ b/docs/background-orchestration.md
@@ -486,8 +486,22 @@ cannot modify a relaunched task.
 native background tasks may run at once. Admission happens in the
 `tool.execute.before` hook: a task waits for a slot before OpenCode creates
 its child session. Queued requests are admitted in order, but requests whose
-provider or model quota is saturated are skipped in favor of admittable later
-requests.
+resolved cap is saturated are skipped in favor of admittable later requests.
+
+Only the most specific configured cap applies to a task: a model cap wins
+over a provider cap, which wins over the default cap. `0` means unlimited.
+So `modelConcurrency: {"openai/gpt-4o": 10}` permits 10 concurrent
+`openai/gpt-4o` tasks even when `defaultConcurrency` is lower; other OpenAI
+models fall back to `providerConcurrency` (or the default) instead.
+
+The scheduler keeps its accounting correct across two runtime events:
+- A task that switches models mid-flight (foreground model fallback or a
+  runtime `/model` change on the child session) moves its provider/model
+  accounting to the new model instead of keeping the admission-time model.
+- The scheduler is process-scoped, so a plugin re-init (the plugin factory
+  re-runs on config updates) preserves both running slots and queued
+  tickets. Deleting a parent orchestrator also releases its children's
+  admission slots, so capacity is never leaked by recursive-delete ordering.
 
 Sessions that are themselves managed tasks — a background subagent running
 its own nested `task(..., background: true)` calls — are exempt from

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -161,6 +161,9 @@ Presets can also be switched at runtime without restarting using the `/preset` c
 | `backgroundJobs.orchestratorWake.intervalMs` | integer | `300000` | Continuous parent-idle interval between wake evaluations (`60000`–`2147483647` ms). `0` is invalid. See [Background Orchestration](background-orchestration.md#orchestrator-wake-scheduler) See [Background Job Management](#background-job-management). |
 | `backgroundJobs.wallClockTimeoutMs` | integer | `0` | **Opt-in wall-clock supervisor.** `0` disables it. Otherwise, only native `task(..., background: true)` child sessions are supervised; accepted values are `60000`–`2147483647` milliseconds See [Background Job Management](#background-job-management). |
 | `backgroundJobs.abortGraceMs` | integer | `10000` | Grace period after a wall-clock deadline for a terminal confirmation. Accepted values are `1000`–`60000` milliseconds; a hanging or failed abort does not extend this grace See [Background Job Management](#background-job-management). |
+| `backgroundJobs.concurrency.defaultConcurrency` | integer | `0` | Maximum concurrently running native background tasks. `0` disables the default cap; accepted values are `0`–`1000` See [Background Job Management](#background-job-management). |
+| `backgroundJobs.concurrency.providerConcurrency` | object | `{}` | Per-provider caps keyed by provider ID. Each value must be `1`–`1000`; provider and model caps apply alongside the default cap See [Background Job Management](#background-job-management). |
+| `backgroundJobs.concurrency.modelConcurrency` | object | `{}` | Per-model caps keyed by `provider/model` ID. Each value must be `1`–`1000`; model caps apply alongside provider and default caps See [Background Job Management](#background-job-management). |
 | `backgroundJobs.waitForUserGuard` | boolean | `true` | When true, intercepts `wait_for_user` calls while background tasks are still running and the orchestrator wake scheduler is enabled, returning guidance to end the turn instead of blocking on manual input. See [Background Job Management](#background-job-management). |
 | `disabled_mcps` | string[] | `[]` | MCP server IDs to disable globally |
 | `fallback.enabled` | boolean | `true` | Enable Slim's foreground model-chain failover. It does not configure OpenCode provider/AI-SDK retries. |
@@ -312,7 +315,16 @@ The wall-clock supervisor is separately opt-in and remains disabled unless
       "intervalMs": 300000
     },
     "wallClockTimeoutMs": 900000,
-    "abortGraceMs": 10000
+    "abortGraceMs": 10000,
+    "concurrency": {
+      "defaultConcurrency": 2,
+      "providerConcurrency": {
+        "openai": 2
+      },
+      "modelConcurrency": {
+        "openai/gpt-5.6-luna": 1
+      }
+    }
   }
 }
 ```
@@ -322,6 +334,28 @@ Set `enabled: false` to keep idle reconciliation and background-job orchestratio
 without periodic wake prompts. See the
 [Background Orchestration](background-orchestration.md) guide for the concept,
 defaults, and examples.
+
+`concurrency` limits only native background tasks with
+`task(..., background: true)`. Foreground tasks are unchanged. A task waits
+for admission before OpenCode creates its child session, so queued work does
+not consume a provider request. `defaultConcurrency: 0` means unlimited by
+default. Provider and model limits are additional caps, and the most specific
+model cap does not allow a task to exceed its provider or default cap. Queued
+tasks are admitted in order among tasks whose configured provider/model caps
+have capacity. Terminal completion, cancellation, failure, session deletion,
+and plugin disposal release the slot.
+
+Two behaviors to know about when concurrency is enabled:
+
+- Sessions that are themselves managed tasks (a background subagent
+  orchestrating its own nested `task(..., background: true)` calls) are
+  exempt from admission. They already hold a slot while running, so waiting
+  for a second one would self-deadlock once the queue saturates.
+- Admission has no timeout of its own. A running task that never reaches a
+  terminal state keeps its slot forever, and queued tasks as well as the
+  orchestrator's `task` calls block behind it. When you enable
+  `concurrency`, pair it with an opt-in `wallClockTimeoutMs` so stalled
+  tasks are eventually forced to a terminal state and release their slots.
 
 Configurations that still use the removed `backgroundJobs.continueOnIdle` key
 emit a deprecation warning and migrate its boolean value to

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -161,9 +161,9 @@ Presets can also be switched at runtime without restarting using the `/preset` c
 | `backgroundJobs.orchestratorWake.intervalMs` | integer | `300000` | Continuous parent-idle interval between wake evaluations (`60000`–`2147483647` ms). `0` is invalid. See [Background Orchestration](background-orchestration.md#orchestrator-wake-scheduler) See [Background Job Management](#background-job-management). |
 | `backgroundJobs.wallClockTimeoutMs` | integer | `0` | **Opt-in wall-clock supervisor.** `0` disables it. Otherwise, only native `task(..., background: true)` child sessions are supervised; accepted values are `60000`–`2147483647` milliseconds See [Background Job Management](#background-job-management). |
 | `backgroundJobs.abortGraceMs` | integer | `10000` | Grace period after a wall-clock deadline for a terminal confirmation. Accepted values are `1000`–`60000` milliseconds; a hanging or failed abort does not extend this grace See [Background Job Management](#background-job-management). |
-| `backgroundJobs.concurrency.defaultConcurrency` | integer | `0` | Maximum concurrently running native background tasks. `0` disables the default cap; accepted values are `0`–`1000` See [Background Job Management](#background-job-management). |
-| `backgroundJobs.concurrency.providerConcurrency` | object | `{}` | Per-provider caps keyed by provider ID. Each value must be `1`–`1000`; provider and model caps apply alongside the default cap See [Background Job Management](#background-job-management). |
-| `backgroundJobs.concurrency.modelConcurrency` | object | `{}` | Per-model caps keyed by `provider/model` ID. Each value must be `1`–`1000`; model caps apply alongside provider and default caps See [Background Job Management](#background-job-management). |
+| `backgroundJobs.concurrency.defaultConcurrency` | integer | `0` | Maximum concurrently running native background tasks. `0` means unlimited; accepted values are `0`–`1000` See [Background Job Management](#background-job-management). |
+| `backgroundJobs.concurrency.providerConcurrency` | object | `{}` | Per-provider caps keyed by provider ID. Each value must be `0`–`1000`, where `0` means unlimited for that provider. The most specific configured cap wins: model > provider > default See [Background Job Management](#background-job-management). |
+| `backgroundJobs.concurrency.modelConcurrency` | object | `{}` | Per-model caps keyed by `provider/model` ID. Each value must be `0`–`1000`, where `0` means unlimited for that model. The most specific configured cap wins: model > provider > default See [Background Job Management](#background-job-management). |
 | `backgroundJobs.waitForUserGuard` | boolean | `true` | When true, intercepts `wait_for_user` calls while background tasks are still running and the orchestrator wake scheduler is enabled, returning guidance to end the turn instead of blocking on manual input. See [Background Job Management](#background-job-management). |
 | `disabled_mcps` | string[] | `[]` | MCP server IDs to disable globally |
 | `fallback.enabled` | boolean | `true` | Enable Slim's foreground model-chain failover. It does not configure OpenCode provider/AI-SDK retries. |
@@ -338,12 +338,20 @@ defaults, and examples.
 `concurrency` limits only native background tasks with
 `task(..., background: true)`. Foreground tasks are unchanged. A task waits
 for admission before OpenCode creates its child session, so queued work does
-not consume a provider request. `defaultConcurrency: 0` means unlimited by
-default. Provider and model limits are additional caps, and the most specific
-model cap does not allow a task to exceed its provider or default cap. Queued
-tasks are admitted in order among tasks whose configured provider/model caps
-have capacity. Terminal completion, cancellation, failure, session deletion,
-and plugin disposal release the slot.
+not consume a provider request. `0` means unlimited.
+
+Only the most specific configured cap applies to a task, matching the
+reference implementation's priority: a model cap for the task's model wins
+over a provider cap for its provider, which wins over the default cap. For
+example, with `defaultConcurrency: 2`, `providerConcurrency: {"openai": 5}`
+and `modelConcurrency: {"openai/gpt-4o": 10}`, up to 10 `openai/gpt-4o`
+tasks run concurrently. Queued tasks are admitted in order among tasks whose
+resolved cap has capacity. Terminal completion, cancellation, failure,
+session deletion, and plugin disposal release the slot. A task that switches
+models mid-flight (e.g. foreground model fallback) moves its accounting to
+the new model. The scheduler is process-scoped: when the plugin re-inits on a
+config update, running slots and queued tickets survive, so admission state
+is not reset mid-run.
 
 Two behaviors to know about when concurrency is enabled:
 

--- a/oh-my-opencode-slim.schema.json
+++ b/oh-my-opencode-slim.schema.json
@@ -1166,14 +1166,14 @@
           "properties": {
             "defaultConcurrency": {
               "default": 0,
-              "description": "Maximum concurrently running native background tasks. 0 disables the default cap.",
+              "description": "Maximum concurrently running native background tasks. 0 means unlimited.",
               "type": "integer",
               "minimum": 0,
               "maximum": 1000
             },
             "providerConcurrency": {
               "default": {},
-              "description": "Per-provider concurrency caps keyed by provider ID.",
+              "description": "Per-provider concurrency caps keyed by provider ID. The most specific configured cap wins: model > provider > default. 0 means unlimited for that provider.",
               "type": "object",
               "propertyNames": {
                 "type": "string",
@@ -1181,13 +1181,13 @@
               },
               "additionalProperties": {
                 "type": "integer",
-                "minimum": 1,
+                "minimum": 0,
                 "maximum": 1000
               }
             },
             "modelConcurrency": {
               "default": {},
-              "description": "Per-model concurrency caps keyed by provider/model ID.",
+              "description": "Per-model concurrency caps keyed by provider/model ID. The most specific configured cap wins: model > provider > default. 0 means unlimited for that model.",
               "type": "object",
               "propertyNames": {
                 "type": "string",
@@ -1195,7 +1195,7 @@
               },
               "additionalProperties": {
                 "type": "integer",
-                "minimum": 1,
+                "minimum": 0,
                 "maximum": 1000
               }
             }

--- a/oh-my-opencode-slim.schema.json
+++ b/oh-my-opencode-slim.schema.json
@@ -1156,6 +1156,52 @@
           "minimum": 1000,
           "maximum": 60000
         },
+        "concurrency": {
+          "default": {
+            "defaultConcurrency": 0,
+            "providerConcurrency": {},
+            "modelConcurrency": {}
+          },
+          "type": "object",
+          "properties": {
+            "defaultConcurrency": {
+              "default": 0,
+              "description": "Maximum concurrently running native background tasks. 0 disables the default cap.",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 1000
+            },
+            "providerConcurrency": {
+              "default": {},
+              "description": "Per-provider concurrency caps keyed by provider ID.",
+              "type": "object",
+              "propertyNames": {
+                "type": "string",
+                "minLength": 1
+              },
+              "additionalProperties": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 1000
+              }
+            },
+            "modelConcurrency": {
+              "default": {},
+              "description": "Per-model concurrency caps keyed by provider/model ID.",
+              "type": "object",
+              "propertyNames": {
+                "type": "string",
+                "minLength": 1
+              },
+              "additionalProperties": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 1000
+              }
+            }
+          },
+          "additionalProperties": false
+        },
         "waitForUserGuard": {
           "default": true,
           "description": "When true, intercept wait_for_user calls made while background tasks are still running and the orchestrator wake scheduler is enabled, returning guidance to end the turn instead of blocking on manual input. Default enabled.",

--- a/src/admission-runtime.test.ts
+++ b/src/admission-runtime.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  acquireAdmissionRuntime,
+  resetAdmissionRuntimeForTests,
+} from './admission-runtime';
+
+const config = {
+  defaultConcurrency: 1,
+  providerConcurrency: {},
+  modelConcurrency: {},
+};
+
+describe('admission runtime leases', () => {
+  test('keeps state while another owner is alive', async () => {
+    resetAdmissionRuntimeForTests();
+    const firstOwner = acquireAdmissionRuntime('project', config);
+    const secondOwner = acquireAdmissionRuntime('project', config);
+    const first = firstOwner.backgroundTaskConcurrency.acquire({
+      model: 'openai/fast',
+    });
+    await first.ready;
+    first.bind('first-task');
+    const queued = firstOwner.backgroundTaskConcurrency.acquire({
+      model: 'openai/fast',
+    });
+
+    firstOwner.release();
+    await Promise.resolve();
+    expect(secondOwner.backgroundTaskConcurrency.snapshot()).toEqual({
+      active: 1,
+      queued: 1,
+    });
+
+    secondOwner.backgroundTaskConcurrency.releaseTask('first-task');
+    await queued.ready;
+    expect(secondOwner.backgroundTaskConcurrency.snapshot()).toEqual({
+      active: 1,
+      queued: 0,
+    });
+
+    secondOwner.release();
+    resetAdmissionRuntimeForTests();
+  });
+
+  test('reacquires before the next macrotask without cancelling calls', async () => {
+    resetAdmissionRuntimeForTests();
+    const firstOwner = acquireAdmissionRuntime('project', config);
+    const first = firstOwner.backgroundTaskConcurrency.acquire({
+      model: 'openai/fast',
+    });
+    await first.ready;
+    first.bind('first-task');
+    const queued = firstOwner.backgroundTaskConcurrency.acquire({
+      model: 'openai/fast',
+    });
+
+    firstOwner.release();
+    const replacement = acquireAdmissionRuntime('project', config);
+    expect(replacement.backgroundTaskConcurrency).toBe(
+      firstOwner.backgroundTaskConcurrency,
+    );
+    replacement.backgroundTaskConcurrency.releaseTask('first-task');
+    await queued.ready;
+
+    replacement.release();
+    resetAdmissionRuntimeForTests();
+  });
+
+  test('final teardown cancels pending calls and is idempotent', async () => {
+    resetAdmissionRuntimeForTests();
+    const owner = acquireAdmissionRuntime('project', config);
+    const first = owner.backgroundTaskConcurrency.acquire({
+      model: 'openai/fast',
+    });
+    await first.ready;
+    first.bind('first-task');
+    const queued = owner.backgroundTaskConcurrency.acquire({
+      model: 'openai/fast',
+    });
+    owner.pendingCallTracker.add({
+      callId: 'queued-call',
+      parentSessionId: 'parent',
+      agentType: 'explorer',
+      label: 'queued call',
+      background: true,
+      lifecycleEpoch: 0,
+      concurrencyTicket: queued,
+    });
+
+    owner.release();
+    owner.release();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await expect(queued.ready).rejects.toThrow(
+      'Background task concurrency queue was cancelled',
+    );
+    expect(owner.backgroundTaskConcurrency.snapshot()).toEqual({
+      active: 0,
+      queued: 0,
+    });
+    resetAdmissionRuntimeForTests();
+  });
+});

--- a/src/admission-runtime.ts
+++ b/src/admission-runtime.ts
@@ -1,0 +1,139 @@
+import {
+  createPendingCallTracker,
+  type PendingCallTracker,
+} from './hooks/task-session-manager/pending-call-tracker';
+import {
+  BackgroundTaskConcurrency,
+  type BackgroundTaskConcurrencyConfig,
+} from './utils/background-task-concurrency';
+
+export interface AdmissionRuntime {
+  readonly backgroundTaskConcurrency: BackgroundTaskConcurrency;
+  readonly pendingCallTracker: PendingCallTracker;
+}
+
+export interface AdmissionRuntimeLease extends AdmissionRuntime {
+  release(): void;
+}
+
+interface RuntimeEntry {
+  runtime: AdmissionRuntime;
+  owners: number;
+  teardownTimer?: ReturnType<typeof setTimeout>;
+}
+
+const runtimesByDirectory = new Map<string, RuntimeEntry>();
+const compatibilityLeases = new Map<string, AdmissionRuntimeLease>();
+
+function directoryKey(directory: string): string {
+  return directory || 'default';
+}
+
+function disposeEntry(key: string, entry: RuntimeEntry): void {
+  if (runtimesByDirectory.get(key) !== entry || entry.owners !== 0) {
+    return;
+  }
+  entry.runtime.pendingCallTracker.clearAll();
+  entry.runtime.backgroundTaskConcurrency.dispose();
+  runtimesByDirectory.delete(key);
+}
+
+/**
+ * Acquire the per-directory admission runtime.
+ *
+ * Plugin generations share this runtime while they overlap. Releasing the
+ * last generation is intentionally delayed by one macrotask: OpenCode
+ * disposes and recreates a plugin during config updates, and the new factory
+ * must be able to reclaim the scheduler and pending calls before teardown.
+ */
+export function acquireAdmissionRuntime(
+  directory: string,
+  config: BackgroundTaskConcurrencyConfig,
+): AdmissionRuntimeLease {
+  const key = directoryKey(directory);
+  let entry = runtimesByDirectory.get(key);
+
+  if (entry?.runtime.backgroundTaskConcurrency.isDisposed()) {
+    if (entry.teardownTimer !== undefined) {
+      clearTimeout(entry.teardownTimer);
+    }
+    entry.runtime.pendingCallTracker.clearAll();
+    runtimesByDirectory.delete(key);
+    entry = undefined;
+  }
+
+  if (!entry) {
+    entry = {
+      runtime: {
+        backgroundTaskConcurrency: new BackgroundTaskConcurrency(config),
+        pendingCallTracker: createPendingCallTracker(),
+      },
+      owners: 0,
+    };
+    runtimesByDirectory.set(key, entry);
+  } else {
+    entry.runtime.backgroundTaskConcurrency.updateConfig(config);
+  }
+
+  if (entry.teardownTimer !== undefined) {
+    clearTimeout(entry.teardownTimer);
+    entry.teardownTimer = undefined;
+  }
+  entry.owners += 1;
+  const ownedEntry = entry;
+
+  let released = false;
+  return {
+    ...ownedEntry.runtime,
+    release: () => {
+      if (released) return;
+      released = true;
+      if (ownedEntry.owners > 0) ownedEntry.owners -= 1;
+      if (ownedEntry.owners !== 0 || ownedEntry.teardownTimer !== undefined) {
+        return;
+      }
+      ownedEntry.teardownTimer = setTimeout(() => {
+        ownedEntry.teardownTimer = undefined;
+        disposeEntry(key, ownedEntry);
+      }, 0);
+    },
+  };
+}
+
+/** Test seam: synchronously dispose every directory runtime. */
+export function resetAdmissionRuntimeForTests(): void {
+  compatibilityLeases.clear();
+  for (const [key, entry] of runtimesByDirectory) {
+    if (entry.teardownTimer !== undefined) {
+      clearTimeout(entry.teardownTimer);
+    }
+    entry.owners = 0;
+    disposeEntry(key, entry);
+  }
+  runtimesByDirectory.clear();
+}
+
+/**
+ * Legacy test helper. Production code must acquire and release a lease so a
+ * plugin generation cannot keep a directory runtime alive accidentally.
+ */
+export function getBackgroundTaskConcurrency(
+  directory: string,
+  config: BackgroundTaskConcurrencyConfig,
+): BackgroundTaskConcurrency {
+  const key = directoryKey(directory);
+  const existing = compatibilityLeases.get(key);
+  if (existing && !existing.backgroundTaskConcurrency.isDisposed()) {
+    existing.backgroundTaskConcurrency.updateConfig(config);
+    return existing.backgroundTaskConcurrency;
+  }
+  existing?.release();
+  const lease = acquireAdmissionRuntime(directory, config);
+  compatibilityLeases.set(key, lease);
+  return lease.backgroundTaskConcurrency;
+}
+
+/** Legacy test helper paired with getBackgroundTaskConcurrency. */
+export function resetBackgroundTaskConcurrencyForTests(): void {
+  resetAdmissionRuntimeForTests();
+}

--- a/src/agents/index.test.ts
+++ b/src/agents/index.test.ts
@@ -16,6 +16,7 @@ import {
   getAgentConfigs,
   getDisabledAgents,
   isSubagent,
+  resolveAgentConfigModel,
 } from './index';
 import { TASK_REJECTION_INSTRUCTION } from './task-rejection';
 
@@ -1688,6 +1689,118 @@ describe('createAgents with malformed disabled_tools', () => {
     );
     expect(orchestrator?.config.prompt).not.toContain(
       '`wait_for_user` is disabled',
+    );
+  });
+});
+
+describe('resolveAgentConfigModel', () => {
+  test('returns the explicit model when configured', () => {
+    const config: PluginConfig = {
+      agents: { oracle: { model: 'test/oracle-explicit' } },
+    };
+    expect(resolveAgentConfigModel(runtimeFor(config), 'oracle')).toBe(
+      'test/oracle-explicit',
+    );
+  });
+
+  test('returns the primary model of an explicit model array', () => {
+    const config: PluginConfig = {
+      agents: {
+        oracle: { model: ['test/primary', 'test/fallback'] },
+      },
+    };
+    expect(resolveAgentConfigModel(runtimeFor(config), 'oracle')).toBe(
+      'test/primary',
+    );
+  });
+
+  test('session inheritance resolves to no config model (parent session serves)', () => {
+    const config: PluginConfig = {
+      agents: { oracle: { inheritModelFrom: 'session' } },
+    };
+    expect(
+      resolveAgentConfigModel(runtimeFor(config), 'oracle'),
+    ).toBeUndefined();
+  });
+
+  test('orchestrator inheritance uses the configured orchestrator model', () => {
+    const config: PluginConfig = {
+      agents: {
+        orchestrator: { model: 'test/orch' },
+        oracle: { inheritModelFrom: 'orchestrator' },
+      },
+    };
+    expect(resolveAgentConfigModel(runtimeFor(config), 'oracle')).toBe(
+      'test/orch',
+    );
+  });
+
+  test('orchestrator inheritance without an orchestrator model leaves the config model-less', () => {
+    const config: PluginConfig = {
+      agents: { oracle: { inheritModelFrom: 'orchestrator' } },
+    };
+    expect(
+      resolveAgentConfigModel(runtimeFor(config), 'oracle'),
+    ).toBeUndefined();
+  });
+
+  test('fixer with no model inherits the librarian model', () => {
+    const config: PluginConfig = {
+      agents: { librarian: { model: 'anthropic/lib' } },
+    };
+    expect(resolveAgentConfigModel(runtimeFor(config), 'fixer')).toBe(
+      'anthropic/lib',
+    );
+  });
+
+  test('fixer without librarian falls back to the preset primary model', () => {
+    const config: PluginConfig = {
+      preset: 'default',
+      presets: {
+        default: { oracle: { model: 'test/primary' } },
+      },
+    };
+    expect(resolveAgentConfigModel(runtimeFor(config), 'fixer')).toBe(
+      'test/primary',
+    );
+  });
+
+  test('matches the final config model createAgents produces for the fixer case', () => {
+    const config: PluginConfig = {
+      agents: { librarian: { model: 'anthropic/lib' } },
+    };
+    const runtime = runtimeFor(config);
+    const fixer = createAgents(runtime).find((a) => a.name === 'fixer');
+    expect(fixer?.config.model).toBe('anthropic/lib');
+    expect(resolveAgentConfigModel(runtime, 'fixer')).toBe(fixer?.config.model);
+  });
+
+  test('resolves a dynamic councillor primary model from the active council preset', () => {
+    const config: PluginConfig = {
+      council: CouncilConfigSchema.parse({
+        presets: {
+          default: {
+            alpha: { model: ['openai/primary', 'google/fallback'] },
+          },
+        },
+      }),
+    };
+    expect(
+      resolveAgentConfigModel(runtimeFor(config), 'councillor-alpha'),
+    ).toBe('openai/primary');
+  });
+
+  test('resolves an ACP wrapper model for background admission', () => {
+    const config: PluginConfig = {
+      acpAgents: {
+        research: {
+          command: 'research-agent',
+          wrapperModel: 'anthropic/sonnet',
+        },
+      },
+    };
+    expect(resolveAgentConfigModel(runtimeFor(config), 'research')).toBe(
+      'anthropic/sonnet',
     );
   });
 });

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -48,18 +48,23 @@ const TASK_CONTROL_TOOL_NAMES = [
 ] as const;
 const SAFE_AGENT_ALIAS_RE = /^[a-z][a-z0-9_-]*$/i;
 
+export function resolvePrimaryModelValue(value: unknown): string | undefined {
+  if (typeof value === 'string') return value;
+  if (!Array.isArray(value) || value.length === 0) return undefined;
+  const first = value[0];
+  return typeof first === 'string'
+    ? first
+    : first && typeof first === 'object' && 'id' in first
+      ? typeof first.id === 'string'
+        ? first.id
+        : undefined
+      : undefined;
+}
+
 function getPrimaryModelFromOverride(
   override: AgentOverrideConfig | undefined,
 ): string | undefined {
-  const model = override?.model;
-  if (typeof model === 'string') {
-    return model;
-  }
-  if (Array.isArray(model) && model.length > 0) {
-    const first = model[0];
-    return typeof first === 'string' ? first : first?.id;
-  }
-  return undefined;
+  return resolvePrimaryModelValue(override?.model);
 }
 
 /**

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -220,6 +220,62 @@ function applyModelInheritance(
 }
 
 /**
+ * Resolve the model an agent's final config carries, mirroring the combined
+ * effect of `createAgents` fallbacks, `applyOverrides`, and the inheritance
+ * passes. Returns `undefined` exactly when the agent config ends up with NO
+ * model key — i.e. `inheritModelFrom: 'session'` (or `'orchestrator'` with no
+ * configured orchestrator model) — in which case OpenCode serves the agent
+ * with the parent session's current model.
+ *
+ * This is the single resolution source for both agent definition building and
+ * background-task admission, so provider/model concurrency accounting keys off
+ * the model the spawned subagent actually uses. Explicit `model` wins; then
+ * `inheritModelFrom`; then the historical fixer → librarian fallback; then
+ * the preset primary model; then the per-agent default.
+ */
+export function resolveAgentConfigModel(
+  runtime: RuntimeConfig,
+  name: string,
+): string | undefined {
+  const mergedAgents = runtime.agents();
+  const override = getOverrideFromAgents(mergedAgents, name);
+  if (override?.model !== undefined) {
+    return getPrimaryModelFromOverride(override);
+  }
+  if (override?.inheritModelFrom === 'session') {
+    return undefined;
+  }
+  if (override?.inheritModelFrom === 'orchestrator') {
+    return getPrimaryModelFromOverride(
+      getOverrideFromAgents(mergedAgents, 'orchestrator'),
+    );
+  }
+  // Dynamic councillors are defined outside `agents()` under the selected
+  // council preset. Their generated agent config carries the preset model.
+  if (name.startsWith('councillor-')) {
+    const seat = name.slice('councillor-'.length);
+    const preset =
+      runtime.council?.presets?.[runtime.council.default_preset ?? 'default'];
+    return preset?.[seat]?.models?.[0]?.id;
+  }
+  // ACP agents are generated from `acpAgents`; admission is for the wrapper
+  // session, so account for its configured wrapper model when present.
+  if (runtime.acpAgents[name]?.wrapperModel) {
+    return runtime.acpAgents[name].wrapperModel;
+  }
+  if (name === 'fixer') {
+    const librarianModel = getPrimaryModelFromOverride(
+      getOverrideFromAgents(mergedAgents, 'librarian'),
+    );
+    return librarianModel ?? runtime.primaryModel ?? DEFAULT_MODELS.librarian;
+  }
+  return (
+    runtime.primaryModel ??
+    (DEFAULT_MODELS as Record<string, string | undefined>)[name]
+  );
+}
+
+/**
  * Apply model inheritance to the final host agent config after the host layer
  * has been merged. This clears stale host models for `session` inheritance,
  * which cannot be handled by the agent definition alone.

--- a/src/codemap.md
+++ b/src/codemap.md
@@ -22,6 +22,10 @@ This directory serves as the primary entry point for the plugin's runtime behavi
 - **Observer Pattern**: Event-driven architecture using OpenCode's event system for session lifecycle, message updates, and tool execution
 - **Strategy Pattern**: Runtime model selection and fallback via `ForegroundFallbackManager`
 - **Singleton Pattern**: `MultiplexerSessionManager` maintains single instance for task session management
+- **Admission runtime lease**: `admission-runtime.ts` scopes the background
+  scheduler and pending-call tracker per directory, retaining them across
+  immediate plugin-generation replacement and disposing them after the last
+  owner is gone.
 
 ### Data Flow
 
@@ -42,6 +46,7 @@ OpenCode Core → Plugin Initialization (index.ts)
 | File | Role | Dependencies |
 |------|------|--------------|
 | `index.ts` | Main plugin entry, orchestrates all subsystems; exports dual `server`/`setup` default | Config system, agent factories, tool creators, multiplexer, hooks, v2 adapter |
+| `admission-runtime.ts` | Per-directory scheduler/pending-call runtime lease | Background task concurrency, task-session pending calls |
 | `tui.ts` | TUI sidebar plugin for agent model display | tui-state.ts, config constants, tmux-pane-registry |
 | `tui-state.ts` | Persistent state management for TUI | Node.js fs/promises, os module |
 | `tui-preset.ts` | Three-level `/preset` manager (preset list → agents → agent edit) using `api.ui` dialogs | preset-switch.ts, config loader/constants |

--- a/src/config/codemap.md
+++ b/src/config/codemap.md
@@ -163,6 +163,7 @@ This allows consumers to import directly from `src/config` rather than individua
 - `tmux`: Legacy tmux configuration (migrated to multiplexer)
 - `interview`: Interview feature configuration
 - `backgroundJobs`: Background job configuration
+- `backgroundJobs.concurrency`: Optional default, provider, and model caps for native background task admission
 - `fallback`: Failover/retry configuration
 - `council`: Council configuration with presets and execution modes
 - `companion`: Companion animation configuration

--- a/src/config/runtime.test.ts
+++ b/src/config/runtime.test.ts
@@ -126,6 +126,11 @@ describe('RuntimeConfig', () => {
     });
     expect(runtime.backgroundJobs.maxSessionsPerAgent).toBe(2);
     expect(runtime.backgroundJobs.strategy).toBe('latest');
+    expect(runtime.backgroundJobs.concurrency).toEqual({
+      defaultConcurrency: 0,
+      providerConcurrency: {},
+      modelConcurrency: {},
+    });
     expect(runtime.fallback).toEqual({ enabled: true, maxRetries: 3 });
     expect(runtime.webfetch.enabled).toBe(true);
     expect(runtime.acpAgents).toEqual({});

--- a/src/config/runtime.ts
+++ b/src/config/runtime.ts
@@ -82,6 +82,11 @@ const DEFAULT_BACKGROUND_JOBS: BackgroundJobsConfig = {
   orchestratorWake: { enabled: true, intervalMs: 300_000 },
   wallClockTimeoutMs: 0,
   abortGraceMs: 10_000,
+  concurrency: {
+    defaultConcurrency: 0,
+    providerConcurrency: {},
+    modelConcurrency: {},
+  },
   waitForUserGuard: true,
 };
 

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -243,6 +243,48 @@ describe('PluginConfigSchema backgroundJobs', () => {
     }
   });
 
+  it('defaults background task concurrency limits to disabled', () => {
+    const result = PluginConfigSchema.safeParse({ backgroundJobs: {} });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.backgroundJobs?.concurrency).toEqual({
+        defaultConcurrency: 0,
+        providerConcurrency: {},
+        modelConcurrency: {},
+      });
+    }
+  });
+
+  it('accepts default, provider, and model concurrency limits', () => {
+    const result = PluginConfigSchema.safeParse({
+      backgroundJobs: {
+        concurrency: {
+          defaultConcurrency: 2,
+          providerConcurrency: { openai: 3 },
+          modelConcurrency: { 'openai/gpt-5.6-luna': 1 },
+        },
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid background task concurrency limits', () => {
+    for (const concurrency of [
+      { defaultConcurrency: -1 },
+      { defaultConcurrency: 1001 },
+      { defaultConcurrency: 1.5 },
+      { providerConcurrency: { openai: 0 } },
+      { modelConcurrency: { 'openai/gpt-5.6-luna': 1.5 } },
+    ]) {
+      expect(
+        PluginConfigSchema.safeParse({ backgroundJobs: { concurrency } })
+          .success,
+      ).toBe(false);
+    }
+  });
+
   it('accepts the documented wall-clock supervisor bounds', () => {
     expect(
       PluginConfigSchema.safeParse({

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -275,13 +275,37 @@ describe('PluginConfigSchema backgroundJobs', () => {
       { defaultConcurrency: -1 },
       { defaultConcurrency: 1001 },
       { defaultConcurrency: 1.5 },
-      { providerConcurrency: { openai: 0 } },
+      { providerConcurrency: { openai: -1 } },
+      { providerConcurrency: { openai: 1.5 } },
+      { modelConcurrency: { 'openai/gpt-5.6-luna': -1 } },
       { modelConcurrency: { 'openai/gpt-5.6-luna': 1.5 } },
     ]) {
       expect(
         PluginConfigSchema.safeParse({ backgroundJobs: { concurrency } })
           .success,
       ).toBe(false);
+    }
+  });
+
+  it('accepts zero as unlimited for provider and model caps', () => {
+    const result = PluginConfigSchema.safeParse({
+      backgroundJobs: {
+        concurrency: {
+          defaultConcurrency: 2,
+          providerConcurrency: { openai: 0 },
+          modelConcurrency: { 'openai/gpt-5.6-luna': 0 },
+        },
+      },
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(
+        result.data.backgroundJobs?.concurrency?.providerConcurrency,
+      ).toEqual({ openai: 0 });
+      expect(result.data.backgroundJobs?.concurrency?.modelConcurrency).toEqual(
+        { 'openai/gpt-5.6-luna': 0 },
+      );
     }
   });
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -174,7 +174,7 @@ export const InterviewConfigSchema = z.object({
 
 export type InterviewConfig = z.infer<typeof InterviewConfigSchema>;
 
-const ConcurrencyLimitSchema = z.number().int().min(1).max(1000);
+const ConcurrencyLimitSchema = z.number().int().min(0).max(1000);
 
 export const BackgroundTaskConcurrencyConfigSchema = z
   .object({
@@ -190,11 +190,15 @@ export const BackgroundTaskConcurrencyConfigSchema = z
     providerConcurrency: z
       .record(z.string().min(1), ConcurrencyLimitSchema)
       .default({})
-      .describe('Per-provider concurrency caps keyed by provider ID.'),
+      .describe(
+        'Per-provider concurrency caps keyed by provider ID. The most specific configured cap wins: model > provider > default. 0 means unlimited for that provider.',
+      ),
     modelConcurrency: z
       .record(z.string().min(1), ConcurrencyLimitSchema)
       .default({})
-      .describe('Per-model concurrency caps keyed by provider/model ID.'),
+      .describe(
+        'Per-model concurrency caps keyed by provider/model ID. The most specific configured cap wins: model > provider > default. 0 means unlimited for that model.',
+      ),
   })
   .strict()
   .default({

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -174,6 +174,39 @@ export const InterviewConfigSchema = z.object({
 
 export type InterviewConfig = z.infer<typeof InterviewConfigSchema>;
 
+const ConcurrencyLimitSchema = z.number().int().min(1).max(1000);
+
+export const BackgroundTaskConcurrencyConfigSchema = z
+  .object({
+    defaultConcurrency: z
+      .number()
+      .int()
+      .min(0)
+      .max(1000)
+      .default(0)
+      .describe(
+        'Maximum concurrently running native background tasks. 0 disables the default cap.',
+      ),
+    providerConcurrency: z
+      .record(z.string().min(1), ConcurrencyLimitSchema)
+      .default({})
+      .describe('Per-provider concurrency caps keyed by provider ID.'),
+    modelConcurrency: z
+      .record(z.string().min(1), ConcurrencyLimitSchema)
+      .default({})
+      .describe('Per-model concurrency caps keyed by provider/model ID.'),
+  })
+  .strict()
+  .default({
+    defaultConcurrency: 0,
+    providerConcurrency: {},
+    modelConcurrency: {},
+  });
+
+export type BackgroundTaskConcurrencyConfig = z.infer<
+  typeof BackgroundTaskConcurrencyConfigSchema
+>;
+
 export const BackgroundJobsConfigSchema = z.object({
   strategy: z
     .enum(['latest', 'checkpoint-compatible'])
@@ -231,6 +264,7 @@ export const BackgroundJobsConfigSchema = z.object({
     .describe(
       'Grace period after a wall-clock deadline while OpenCode confirms the child terminal state (1,000–60,000ms).',
     ),
+  concurrency: BackgroundTaskConcurrencyConfigSchema,
   waitForUserGuard: z
     .boolean()
     .default(true)

--- a/src/hooks/foreground-fallback/index.ts
+++ b/src/hooks/foreground-fallback/index.ts
@@ -307,6 +307,13 @@ export class ForegroundFallbackManager {
    *   (one retry chance); 2 = exhausted again, aborted — stop intervening.
    *   Reset to 0 on successful responses or session deletion. */
   private readonly chainExhaustion = new Map<string, number>();
+  /** sessionID → notified when the session switched to a new model mid-flight
+   *  (e.g. after a fallback re-prompt). Lets the background-task admission
+   *  scheduler migrate provider/model accounting to the new model. */
+  private readonly onSessionModelChanged?: (
+    sessionID: string,
+    model: string,
+  ) => void;
 
   /** Exposed for task-session-manager: prevents idle reconciliation
    *  while a fallback abort/re-prompt is in flight for this session. */
@@ -366,7 +373,9 @@ export class ForegroundFallbackManager {
     /** Consecutive 429s tolerated on the same model before swap/abort. */
     private readonly maxRetries: number = 3,
     coordinator?: SessionLifecycle,
+    onSessionModelChanged?: (sessionID: string, model: string) => void,
   ) {
+    this.onSessionModelChanged = onSessionModelChanged;
     if (coordinator) {
       coordinator.onSessionDeleted((id) => {
         this.sessionModel.delete(id);
@@ -806,6 +815,7 @@ export class ForegroundFallbackManager {
       }
 
       this.sessionModel.set(sessionID, nextModel);
+      this.onSessionModelChanged?.(sessionID, nextModel);
       log('[foreground-fallback] switched to fallback model', {
         sessionID,
         agentName,

--- a/src/hooks/task-session-manager/admission-runtime.ts
+++ b/src/hooks/task-session-manager/admission-runtime.ts
@@ -1,0 +1,1 @@
+export * from '../../admission-runtime';

--- a/src/hooks/task-session-manager/codemap.md
+++ b/src/hooks/task-session-manager/codemap.md
@@ -14,6 +14,9 @@ The directory follows a **Facade + Strategy** pattern where `index.ts` acts as t
 - **continuation-attempt-gate.ts**: Owns process-global continuation epochs, reservations, and explicit user waits across hook recreation. The wait is encoded as an `attempts` sentinel so pre-upgrade #856 hooks sharing the store also fail closed. Distinct external user-message identity rearms both states.
 - **continuation-model-selection.ts**: Normalizes current-session and chat-hook model shapes before forwarding runtime model and variant choices to idle continuation prompts.
 - **pending-call-tracker.ts**: Tracks in-flight task calls using a capped ordered map (`MAX_PENDING_TASK_CALLS`) to correlate launch output safely. Provides call ID generation, storage, retrieval, and cleanup for pending task invocations.
+- **admission-runtime.ts**: Re-exports the per-directory admission runtime
+  lease used by plugin generations; its scheduler and pending-call tracker are
+  torn down only after the final unclaimed owner release.
 - **task-context-tracker.ts**: Manages read context from child sessions with line-count and file caps. Stores context per task ID and provides pruning to prevent unbounded growth.
 
 All modules depend on `BackgroundJobBoard` from `src/utils/background-job-board.ts` as the single source of truth for active jobs, terminal unreconciled jobs, reusable completed sessions, aliases, read context, and LRU caps.
@@ -64,6 +67,8 @@ All modules depend on `BackgroundJobBoard` from `src/utils/background-job-board.
     - `session.idle` / `session.status` (idle): Reconciles injected terminal jobs for the parent session (backstop path), then can run the opt-in continuation evaluator in the same idle cycle under its existing guards. Child idle is a stop candidate: the first observation stays provisional, and only a confirmed idle/absent after the 5s grace marks `stopped`
     - `session.status` (busy): Marks sessions as running from live session state and resets pending stop confirmation
     - `session.deleted`: Clears job state, child jobs, and pending call records for the session
+    - `server.instance.disposed`: Clears generation-local state but leaves the
+      shared pending calls and admission queue for the next generation
 
 6. **Human-in-the-loop Waits**
    - `wait_for_user` calls the facade's `beginUserWait()` only after tool validation

--- a/src/hooks/task-session-manager/event-router.ts
+++ b/src/hooks/task-session-manager/event-router.ts
@@ -17,7 +17,10 @@ import type {
   InjectedTerminalJobs,
   RetainedBoardSnapshotState,
 } from './board-injection';
-import type { PendingTaskCall } from './pending-call-tracker';
+import type {
+  EarlyTaskRegistration,
+  PendingTaskCall,
+} from './pending-call-tracker';
 import type { RevivedRunTracker } from './revived-run-tracker';
 
 type BackgroundJobRecord = NonNullable<ReturnType<BackgroundJobStore['get']>>;
@@ -355,6 +358,12 @@ export async function handleEvent(
               background: false,
             });
             pending.earlyRegisteredTaskID = record.taskID;
+            pending.earlyRegistration = {
+              taskID: record.taskID,
+              generation: record.generation,
+              backgroundJobBoard: deps.backgroundJobBoard,
+              backgroundJobSupervisor: deps.backgroundJobSupervisor,
+            } satisfies EarlyTaskRegistration;
             deps.bindConcurrencyTicket?.(record.taskID, pending);
             log(
               '[task-session-manager] tentative early board registration from session.created',
@@ -385,7 +394,6 @@ export async function handleEvent(
   if (input.event.type === 'server.instance.disposed') {
     deps.backgroundJobSupervisor?.dispose();
     deps.revivedRunTracker?.dispose();
-    deps.pendingCallTracker.clearAll?.();
     deps.retainedBoardSnapshots.clear();
     eventFenceMap(deps.backgroundJobBoard).clear();
     const idleSessionIds = deps.idleReconciler.clearAllTimers();

--- a/src/hooks/task-session-manager/event-router.ts
+++ b/src/hooks/task-session-manager/event-router.ts
@@ -287,6 +287,8 @@ export async function handleEvent(
     >;
     retainedBoardSnapshots: Map<string, RetainedBoardSnapshotState>;
     backgroundJobSupervisor?: BackgroundJobSupervisor;
+    bindConcurrencyTicket?: (taskID: string, pending: PendingTaskCall) => void;
+    releaseConcurrencyTask?: (taskID: string) => void;
     observeSyntheticTerminalPart?: (part: unknown) => void;
     revivedRunTracker?: RevivedRunTracker;
   },
@@ -353,6 +355,7 @@ export async function handleEvent(
               background: false,
             });
             pending.earlyRegisteredTaskID = record.taskID;
+            deps.bindConcurrencyTicket?.(record.taskID, pending);
             log(
               '[task-session-manager] tentative early board registration from session.created',
               {

--- a/src/hooks/task-session-manager/index.test.ts
+++ b/src/hooks/task-session-manager/index.test.ts
@@ -18,6 +18,10 @@ import {
   BACKGROUND_JOB_BOARD_METADATA_KEY,
   createTaskSessionManagerHook,
 } from './index';
+import {
+  createPendingCallTracker,
+  type PendingCallTracker,
+} from './pending-call-tracker';
 import { resetUserWaitGateForTests } from './user-wait-gate';
 
 // Route getClient back to _ctx.client so existing _ctx.client.session
@@ -116,6 +120,7 @@ type HookOptions = {
   coordinator?: SessionLifecycle;
   backgroundJobSupervisor?: BackgroundJobSupervisor;
   backgroundTaskConcurrency?: BackgroundTaskConcurrency;
+  pendingCallTracker?: PendingCallTracker;
   getModelForAgent?: (agentType: string) => string | undefined;
 };
 
@@ -141,6 +146,7 @@ function createHook(options?: HookOptions) {
       backgroundJobBoard: options?.backgroundJobBoard,
       backgroundJobSupervisor: options?.backgroundJobSupervisor,
       backgroundTaskConcurrency: options?.backgroundTaskConcurrency,
+      pendingCallTracker: options?.pendingCallTracker,
       getModelForAgent: options?.getModelForAgent,
       shouldManageSession: options?.shouldManageSession ?? (() => true),
       registerSessionAsOrchestrator: options?.registerSessionAsOrchestrator,
@@ -284,6 +290,193 @@ describe('task-session-manager hook', () => {
     await secondAdmission;
 
     expect(concurrency.snapshot()).toEqual({ active: 1, queued: 0 });
+  });
+
+  test('finishes a queued call after its manager generation is replaced', async () => {
+    const concurrency = new BackgroundTaskConcurrency({
+      defaultConcurrency: 1,
+      providerConcurrency: {},
+      modelConcurrency: {},
+    });
+    const pendingCallTracker = createPendingCallTracker();
+    const firstGeneration = createHook({
+      backgroundTaskConcurrency: concurrency,
+      pendingCallTracker,
+    });
+
+    await firstGeneration.hook['tool.execute.before'](
+      { tool: 'task', sessionID: 'parent-1', callID: 'call-1' },
+      {
+        args: {
+          background: true,
+          subagent_type: 'explorer',
+          description: 'first generation task',
+        },
+      },
+    );
+    await firstGeneration.hook['tool.execute.after'](
+      { tool: 'task', sessionID: 'parent-1', callID: 'call-1' },
+      { output: taskLaunchOutput('child-1') },
+    );
+
+    const queuedCall = firstGeneration.hook['tool.execute.before'](
+      { tool: 'task', sessionID: 'parent-1', callID: 'call-2' },
+      {
+        args: {
+          background: true,
+          subagent_type: 'fixer',
+          description: 'handoff task',
+        },
+      },
+    );
+    expect(concurrency.snapshot()).toEqual({ active: 1, queued: 1 });
+
+    await firstGeneration.hook.event({
+      event: { type: 'server.instance.disposed' },
+    });
+
+    const secondGeneration = createHook({
+      backgroundJobBoard: new BackgroundJobBoard(),
+      backgroundTaskConcurrency: concurrency,
+      pendingCallTracker,
+    });
+    concurrency.releaseTask('child-1');
+    await queuedCall;
+    await secondGeneration.hook['tool.execute.after'](
+      { tool: 'task', sessionID: 'parent-1', callID: 'call-2' },
+      { output: taskLaunchOutput('child-2') },
+    );
+
+    expect(secondGeneration.hook).toBeDefined();
+    expect(concurrency.snapshot()).toEqual({ active: 1, queued: 0 });
+    concurrency.releaseTask('child-2');
+  });
+
+  test('hands an early session.created registration to the next generation', async () => {
+    const concurrency = new BackgroundTaskConcurrency({
+      defaultConcurrency: 1,
+      providerConcurrency: {},
+      modelConcurrency: {},
+    });
+    const pendingCallTracker = createPendingCallTracker();
+    const firstBoard = new BackgroundJobBoard();
+    // Force the source registration onto a different board-generation number
+    // than the fresh target board. The handoff must update the generation
+    // fence rather than rejecting the valid terminal result as stale.
+    firstBoard.registerLaunch({
+      taskID: 'child-early',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+      description: 'stale prior run',
+    });
+    firstBoard.drop('child-early');
+    const firstGeneration = createHook({
+      backgroundJobBoard: firstBoard,
+      backgroundTaskConcurrency: concurrency,
+      pendingCallTracker,
+    });
+
+    await firstGeneration.hook['tool.execute.before'](
+      { tool: 'task', sessionID: 'parent-1', callID: 'call-early' },
+      {
+        args: {
+          background: true,
+          subagent_type: 'explorer',
+          description: 'early handoff task',
+        },
+      },
+    );
+    await firstGeneration.hook.event({
+      event: {
+        type: 'session.created',
+        properties: {
+          info: {
+            id: 'child-early',
+            parentID: 'parent-1',
+            agent: 'explorer',
+          },
+        },
+      },
+    });
+    expect(firstBoard.get('child-early')).toMatchObject({
+      state: 'running',
+      agent: 'explorer',
+    });
+
+    await firstGeneration.hook.event({
+      event: { type: 'server.instance.disposed' },
+    });
+
+    const secondBoard = new BackgroundJobBoard();
+    const secondGeneration = createHook({
+      backgroundJobBoard: secondBoard,
+      backgroundTaskConcurrency: concurrency,
+      pendingCallTracker,
+    });
+
+    expect(firstBoard.get('child-early')).toBeUndefined();
+    expect(secondBoard.get('child-early')).toMatchObject({
+      state: 'running',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+    });
+
+    const terminalOutput = [
+      'task_id: child-early',
+      'state: completed',
+      '',
+      '<task_result>',
+      'completed after handoff',
+      '</task_result>',
+    ].join('\n');
+    // The disposed generation must not consume the transferred pending call
+    // or release its still-live admission ticket.
+    await firstGeneration.hook['tool.execute.after'](
+      { tool: 'task', sessionID: 'parent-1', callID: 'call-early' },
+      { output: terminalOutput },
+    );
+    expect(concurrency.snapshot()).toEqual({ active: 1, queued: 0 });
+
+    await secondGeneration.hook['tool.execute.after'](
+      { tool: 'task', sessionID: 'parent-1', callID: 'call-early' },
+      { output: terminalOutput },
+    );
+
+    expect(secondBoard.get('child-early')).toMatchObject({
+      state: 'completed',
+      resultSummary: 'completed after handoff',
+    });
+    expect(concurrency.snapshot()).toEqual({ active: 0, queued: 0 });
+  });
+
+  test('parent deletion cancels queued calls owned by the shared tracker', async () => {
+    const coordinator = new SessionLifecycle(() => {});
+    const concurrency = new BackgroundTaskConcurrency({
+      defaultConcurrency: 1,
+      providerConcurrency: {},
+      modelConcurrency: {},
+    });
+    const pendingCallTracker = createPendingCallTracker();
+    const { hook } = createHook({
+      coordinator,
+      backgroundTaskConcurrency: concurrency,
+      pendingCallTracker,
+    });
+
+    await hook['tool.execute.before'](
+      { tool: 'task', sessionID: 'parent-1', callID: 'call-1' },
+      { args: { background: true, subagent_type: 'explorer' } },
+    );
+    const queuedCall = hook['tool.execute.before'](
+      { tool: 'task', sessionID: 'parent-1', callID: 'call-2' },
+      { args: { background: true, subagent_type: 'fixer' } },
+    );
+
+    coordinator.dispatchSessionDeleted('parent-1');
+    await expect(queuedCall).rejects.toThrow(
+      'Background task concurrency queue was cancelled',
+    );
+    expect(concurrency.snapshot()).toEqual({ active: 0, queued: 0 });
   });
 
   test('exempts managed-task sessions from background admission (nested orchestration)', async () => {

--- a/src/hooks/task-session-manager/index.test.ts
+++ b/src/hooks/task-session-manager/index.test.ts
@@ -6657,6 +6657,55 @@ describe('task-session-manager hook', () => {
     expect(job?.state).toBe('running');
   });
 
+  test('deleting a parent releases its children admission slots (recursive-delete ordering)', async () => {
+    // A recursive delete can arrive parent-first, and a child mid-fallback
+    // is skipped entirely, so the parent's cleanup must release every
+    // child's slot itself — otherwise capacity is leaked forever.
+    const coordinator = new SessionLifecycle(() => {});
+    const board = new BackgroundJobBoard();
+    board.registerLaunch({
+      taskID: 'parent-1',
+      parentSessionID: 'grandparent',
+      agent: 'orchestrator',
+      description: 'parent orchestrator',
+    });
+    board.registerLaunch({
+      taskID: 'child-1',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+      description: 'child one',
+    });
+    board.registerLaunch({
+      taskID: 'child-2',
+      parentSessionID: 'parent-1',
+      agent: 'fixer',
+      description: 'child two',
+    });
+
+    const concurrency = new BackgroundTaskConcurrency({
+      defaultConcurrency: 10,
+      providerConcurrency: {},
+      modelConcurrency: {},
+    });
+    // Every task holds an admission slot, as if it were running.
+    concurrency.restoreTask('parent-1', 'openai/orch');
+    concurrency.restoreTask('child-1', 'openai/child1');
+    concurrency.restoreTask('child-2', 'openai/child2');
+    expect(concurrency.snapshot()).toEqual({ active: 3, queued: 0 });
+
+    createHook({
+      backgroundJobBoard: board,
+      coordinator,
+      backgroundTaskConcurrency: concurrency,
+      shouldManageSession: () => false,
+      isFallbackInProgress: () => false,
+    });
+
+    coordinator.dispatchSessionDeleted('parent-1');
+
+    expect(concurrency.snapshot()).toEqual({ active: 0, queued: 0 });
+  });
+
   test('session.created early-registers board job so after-hook cancellation cannot orphan the child', async () => {
     // Reproduces #765: parent tool may be cancelled before tool.execute.after,
     // so the job never lands on the board. Early registration from

--- a/src/hooks/task-session-manager/index.test.ts
+++ b/src/hooks/task-session-manager/index.test.ts
@@ -4,6 +4,7 @@ import { SessionLifecycle } from '../../hooks/session-lifecycle';
 import {
   BackgroundJobBoard,
   BackgroundJobSupervisor,
+  BackgroundTaskConcurrency,
   createInternalAgentTextPart,
   getBackgroundJobLifecycleLedger,
   SLIM_INTERNAL_INITIATOR_MARKER,
@@ -114,6 +115,8 @@ type HookOptions = {
   willAttemptFallback?: (sessionID: string) => boolean;
   coordinator?: SessionLifecycle;
   backgroundJobSupervisor?: BackgroundJobSupervisor;
+  backgroundTaskConcurrency?: BackgroundTaskConcurrency;
+  getModelForAgent?: (agentType: string) => string | undefined;
 };
 
 function createHook(options?: HookOptions) {
@@ -137,6 +140,8 @@ function createHook(options?: HookOptions) {
       readContextMaxFiles: options?.readContextMaxFiles,
       backgroundJobBoard: options?.backgroundJobBoard,
       backgroundJobSupervisor: options?.backgroundJobSupervisor,
+      backgroundTaskConcurrency: options?.backgroundTaskConcurrency,
+      getModelForAgent: options?.getModelForAgent,
       shouldManageSession: options?.shouldManageSession ?? (() => true),
       registerSessionAsOrchestrator: options?.registerSessionAsOrchestrator,
       isFallbackInProgress: options?.isFallbackInProgress,
@@ -234,6 +239,98 @@ describe('task-session-manager hook', () => {
   beforeEach(() => {
     // Process-global gate only — never reset inside createHook/production paths.
     resetUserWaitGateForTests();
+  });
+
+  test('queues background task admission until an earlier task releases its slot', async () => {
+    const concurrency = new BackgroundTaskConcurrency({
+      defaultConcurrency: 1,
+      providerConcurrency: {},
+      modelConcurrency: {},
+    });
+    const { hook } = createHook({
+      backgroundTaskConcurrency: concurrency,
+      getModelForAgent: () => 'openai/fast',
+    });
+
+    await hook['tool.execute.before'](
+      { tool: 'task', sessionID: 'parent-1', callID: 'call-1' },
+      {
+        args: {
+          background: true,
+          subagent_type: 'explorer',
+          description: 'first task',
+        },
+      },
+    );
+
+    const secondAdmission = hook['tool.execute.before'](
+      { tool: 'task', sessionID: 'parent-1', callID: 'call-2' },
+      {
+        args: {
+          background: true,
+          subagent_type: 'fixer',
+          description: 'second task',
+        },
+      },
+    );
+    await Promise.resolve();
+    expect(concurrency.snapshot()).toEqual({ active: 1, queued: 1 });
+
+    await hook['tool.execute.after'](
+      { tool: 'task', sessionID: 'parent-1', callID: 'call-1' },
+      { output: taskLaunchOutput('ses_first') },
+    );
+    concurrency.releaseTask('ses_first');
+    await secondAdmission;
+
+    expect(concurrency.snapshot()).toEqual({ active: 1, queued: 0 });
+  });
+
+  test('exempts managed-task sessions from background admission (nested orchestration)', async () => {
+    const concurrency = new BackgroundTaskConcurrency({
+      defaultConcurrency: 1,
+      providerConcurrency: {},
+      modelConcurrency: {},
+    });
+    // A session that is itself a managed background task.
+    const board = new BackgroundJobBoard();
+    board.registerLaunch({
+      taskID: 'ses_child',
+      parentSessionID: 'parent-1',
+      agent: 'oracle',
+      description: 'nested orchestrator',
+    });
+    const { hook } = createHook({
+      backgroundJobBoard: board,
+      backgroundTaskConcurrency: concurrency,
+      getModelForAgent: () => 'openai/fast',
+    });
+
+    await hook['tool.execute.before'](
+      { tool: 'task', sessionID: 'parent-1', callID: 'call-1' },
+      {
+        args: {
+          background: true,
+          subagent_type: 'explorer',
+          description: 'outer task',
+        },
+      },
+    );
+    expect(concurrency.snapshot()).toEqual({ active: 1, queued: 0 });
+
+    // The only slot is taken, so a non-exempt caller would queue here and
+    // never be admitted while the managed child stays blocked on itself.
+    await hook['tool.execute.before'](
+      { tool: 'task', sessionID: 'ses_child', callID: 'call-2' },
+      {
+        args: {
+          background: true,
+          subagent_type: 'librarian',
+          description: 'nested task',
+        },
+      },
+    );
+    expect(concurrency.snapshot()).toEqual({ active: 1, queued: 0 });
   });
 
   test('ignores messages without OpenCode info or parts', async () => {

--- a/src/hooks/task-session-manager/index.ts
+++ b/src/hooks/task-session-manager/index.ts
@@ -31,7 +31,10 @@ import { handleEvent } from './event-router';
 import { createIdleReconciler } from './idle-reconciliation';
 import { createIdleSessionTokens } from './idle-session-tokens';
 import { createInputWaitTracker } from './input-wait-tracker';
-import { createPendingCallTracker } from './pending-call-tracker';
+import {
+  createPendingCallTracker,
+  type PendingCallTracker,
+} from './pending-call-tracker';
 import type { RevivedRunTracker } from './revived-run-tracker';
 import { createRuntimeStatusReconciler } from './runtime-status-reconciliation';
 import { createTaskContextTracker } from './task-context-tracker';
@@ -169,6 +172,8 @@ export function createTaskSessionManagerHook(
     backgroundJobBoard?: BackgroundJobStore;
     backgroundJobSupervisor?: BackgroundJobSupervisor;
     backgroundTaskConcurrency?: BackgroundTaskConcurrency;
+    /** Shared by plugin generations for one admission runtime. */
+    pendingCallTracker?: PendingCallTracker;
     getModelForAgent?: (
       agentType: string,
       parentSessionID?: string,
@@ -219,9 +224,11 @@ export function createTaskSessionManagerHook(
     }
   };
 
-  const pendingCallTracker = createPendingCallTracker({
-    releaseLease: (lease) => backgroundJobBoard.releaseLease(lease),
-  });
+  const pendingCallTracker =
+    options.pendingCallTracker ??
+    createPendingCallTracker({
+      releaseLease: (lease) => backgroundJobBoard.releaseLease(lease),
+    });
   const taskContextTracker = createTaskContextTracker();
 
   const terminalJobsInjectedByParent = new Map<string, InjectedTerminalJobs>();
@@ -355,6 +362,14 @@ export function createTaskSessionManagerHook(
     retainedBoardSnapshots: new Map(),
     retainedTailBoards: new Map(),
   };
+
+  // Early session.created registrations belong to the pending native call,
+  // not to the factory-local board that first observed them. Move them before
+  // this generation can receive the task after-hook.
+  pendingCallTracker.adoptEarlyRegistrations(
+    backgroundJobBoard,
+    options.backgroundJobSupervisor,
+  );
 
   return {
     markRevivedRunPending: (taskID: string): void => {

--- a/src/hooks/task-session-manager/index.ts
+++ b/src/hooks/task-session-manager/index.ts
@@ -4,6 +4,7 @@ import {
   type BackgroundJobExecution,
   type BackgroundJobStore,
   type BackgroundJobSupervisor,
+  type BackgroundTaskConcurrency,
   clearBackgroundJobSuppression,
   deriveFullObjective,
   deriveTaskSessionLabel,
@@ -152,6 +153,8 @@ export function createTaskSessionManagerHook(
     readContextMaxFiles?: number;
     backgroundJobBoard?: BackgroundJobStore;
     backgroundJobSupervisor?: BackgroundJobSupervisor;
+    backgroundTaskConcurrency?: BackgroundTaskConcurrency;
+    getModelForAgent?: (agentType: string) => string | undefined;
     shouldManageSession: (sessionID: string) => boolean;
     /** Register a session as orchestrator when the transform hook detects
      *  an orchestrator message but the session isn't in the agent map yet. */
@@ -281,6 +284,7 @@ export function createTaskSessionManagerHook(
       // lose track of the task and report it as cancelled even though the
       // oracle actually completed.
       if (!options.isFallbackInProgress?.(sessionId)) {
+        options.backgroundTaskConcurrency?.releaseTask(sessionId);
         options.backgroundJobSupervisor?.onSessionDeleted(sessionId);
         const hardTimedOut =
           backgroundJobBoard.field(sessionId, 'deadlineExceededAt') !==
@@ -404,6 +408,8 @@ export function createTaskSessionManagerHook(
         registerSessionAsOrchestrator: options.registerSessionAsOrchestrator,
         backgroundJobBoard,
         backgroundJobSupervisor: options.backgroundJobSupervisor,
+        backgroundTaskConcurrency: options.backgroundTaskConcurrency,
+        getModelForAgent: options.getModelForAgent,
         pendingCallTracker,
         taskContextTracker,
         getLifecycleEpoch: () => rehydrateState.nextEpoch,
@@ -417,6 +423,10 @@ export function createTaskSessionManagerHook(
         directory: _ctx.directory,
         backgroundJobBoard,
         backgroundJobSupervisor: options.backgroundJobSupervisor,
+        bindConcurrencyTicket: (taskID, pending) =>
+          pending.concurrencyTicket?.bind(taskID),
+        releaseConcurrencyTask: (taskID) =>
+          options.backgroundTaskConcurrency?.releaseTask(taskID),
         recordLifecycleSuppression: (taskID) =>
           recordBackgroundJobSuppression(backgroundJobBoard, taskID),
         pendingCallTracker,
@@ -533,6 +543,8 @@ export function createTaskSessionManagerHook(
         pendingInjectedTerminalJobsByParent,
         retainedBoardSnapshots: injectionState.retainedBoardSnapshots,
         backgroundJobSupervisor: options.backgroundJobSupervisor,
+        bindConcurrencyTicket: (taskID, pending) =>
+          pending.concurrencyTicket?.bind(taskID),
         observeSyntheticTerminalPart: (part) =>
           observeSyntheticTerminalPart(injectionState, part),
         revivedRunTracker: options.revivedRunTracker,

--- a/src/hooks/task-session-manager/index.ts
+++ b/src/hooks/task-session-manager/index.ts
@@ -57,6 +57,11 @@ function rehydrateHistoricalRunningTasks(
   shouldManageSession: (sessionID: string) => boolean,
   registerSessionAsOrchestrator?: (sessionID: string) => void,
   rehydrateTombstones?: ReadonlySet<string>,
+  backgroundTaskConcurrency?: BackgroundTaskConcurrency,
+  getModelForAgent?: (
+    agentType: string,
+    parentSessionID?: string,
+  ) => string | undefined,
 ): number {
   let rehydrated = 0;
   const managedOrchestratorSessionIDs = new Set<string>();
@@ -136,6 +141,16 @@ function rehydrateHistoricalRunningTasks(
         // to the first runtime-status reconciliation.
         now: 0,
       });
+      // Re-claim the admission slot this still-running task already holds.
+      // The scheduler is recreated on every plugin re-init (the factory re-
+      // runs on config updates), so without this restore a fresh scheduler
+      // would admit a second concurrent task past the configured cap. The
+      // model resolution mirrors admission so provider/model caps stay
+      // correct. Idempotent per taskID.
+      backgroundTaskConcurrency?.restoreTask(
+        taskID,
+        getModelForAgent?.(agent, parentSessionID),
+      );
       rehydrated += 1;
     }
   }
@@ -154,7 +169,10 @@ export function createTaskSessionManagerHook(
     backgroundJobBoard?: BackgroundJobStore;
     backgroundJobSupervisor?: BackgroundJobSupervisor;
     backgroundTaskConcurrency?: BackgroundTaskConcurrency;
-    getModelForAgent?: (agentType: string) => string | undefined;
+    getModelForAgent?: (
+      agentType: string,
+      parentSessionID?: string,
+    ) => string | undefined;
     shouldManageSession: (sessionID: string) => boolean;
     /** Register a session as orchestrator when the transform hook detects
      *  an orchestrator message but the session isn't in the agent map yet. */
@@ -285,6 +303,14 @@ export function createTaskSessionManagerHook(
       // oracle actually completed.
       if (!options.isFallbackInProgress?.(sessionId)) {
         options.backgroundTaskConcurrency?.releaseTask(sessionId);
+        // The parent's child tasks are about to be dropped from the board.
+        // Normally each child's own session.deleted releases its admission
+        // slot, but a recursive delete can arrive parent-first, and a child
+        // mid-fallback is skipped entirely — release every child's slot here
+        // so none is left holding capacity forever. Idempotent per taskID.
+        for (const child of backgroundJobBoard.list(sessionId)) {
+          options.backgroundTaskConcurrency?.releaseTask(child.taskID);
+        }
         options.backgroundJobSupervisor?.onSessionDeleted(sessionId);
         const hardTimedOut =
           backgroundJobBoard.field(sessionId, 'deadlineExceededAt') !==
@@ -459,6 +485,8 @@ export function createTaskSessionManagerHook(
         options.shouldManageSession,
         options.registerSessionAsOrchestrator,
         rehydrateTombstones,
+        options.backgroundTaskConcurrency,
+        options.getModelForAgent,
       );
 
       for (const [messageIndex, message] of messages.entries()) {

--- a/src/hooks/task-session-manager/pending-call-tracker.ts
+++ b/src/hooks/task-session-manager/pending-call-tracker.ts
@@ -1,5 +1,14 @@
 import type { BackgroundJobLease } from '../../utils/background-job-board';
+import type { BackgroundJobStore } from '../../utils/background-job-store';
+import type { BackgroundJobSupervisor } from '../../utils/background-job-supervisor';
 import type { BackgroundTaskConcurrencyTicket } from '../../utils/background-task-concurrency';
+
+export interface EarlyTaskRegistration {
+  taskID: string;
+  generation: number;
+  backgroundJobBoard: BackgroundJobStore;
+  backgroundJobSupervisor?: BackgroundJobSupervisor;
+}
 
 export interface PendingTaskCall {
   callId: string;
@@ -14,12 +23,37 @@ export interface PendingTaskCall {
   lifecycleEpoch: number;
   resumedTaskId?: string;
   relaunchLease?: BackgroundJobLease;
+  /** Board generation that owns the relaunch lease. */
+  releaseLease?: (lease: BackgroundJobLease) => boolean;
   concurrencyTicket?: BackgroundTaskConcurrencyTicket;
   earlyRegisteredTaskID?: string;
+  earlyRegistration?: EarlyTaskRegistration;
   earlyRegistrationRejected?: boolean;
 }
 
 const MAX_PENDING_TASK_CALLS = 100;
+
+export interface PendingCallTracker {
+  add(call: PendingTaskCall): void;
+  take(
+    callId?: string,
+    parentSessionId?: string,
+    ownerBoard?: BackgroundJobStore,
+  ): PendingTaskCall | undefined;
+  release(call: PendingTaskCall): void;
+  peekByParent(parentSessionId: string): PendingTaskCall | undefined;
+  peekByParentAndAgent(
+    parentSessionId: string,
+    agentHint?: string,
+  ): PendingTaskCall | undefined;
+  adoptEarlyRegistrations(
+    backgroundJobBoard: BackgroundJobStore,
+    backgroundJobSupervisor?: BackgroundJobSupervisor,
+  ): void;
+  clearSession(sessionId: string): void;
+  clearAll(): void;
+  pendingCallId(sessionID?: string, callID?: string): string;
+}
 
 export function createPendingCallTracker(
   options: { releaseLease?: (lease: BackgroundJobLease) => boolean } = {},
@@ -28,11 +62,13 @@ export function createPendingCallTracker(
   let anonymousPendingCallId = 0;
 
   const releaseCallLease = (call: PendingTaskCall): void => {
-    if (call.relaunchLease) options.releaseLease?.(call.relaunchLease);
+    if (call.relaunchLease) {
+      (call.releaseLease ?? options.releaseLease)?.(call.relaunchLease);
+    }
     call.concurrencyTicket?.releaseIfUnbound();
   };
 
-  return {
+  const tracker: PendingCallTracker = {
     add(call: PendingTaskCall) {
       const replaced = pendingCalls.get(call.callId);
       if (replaced) releaseCallLease(replaced);
@@ -47,7 +83,11 @@ export function createPendingCallTracker(
       }
     },
 
-    take(callId?: string, parentSessionId?: string) {
+    take(
+      callId?: string,
+      parentSessionId?: string,
+      ownerBoard?: BackgroundJobStore,
+    ) {
       if (!callId && parentSessionId) {
         for (const id of pendingCalls.keys()) {
           const call = pendingCalls.get(id);
@@ -59,6 +99,13 @@ export function createPendingCallTracker(
       }
       if (!callId) return undefined;
       const pending = pendingCalls.get(callId);
+      if (
+        pending?.earlyRegistration &&
+        ownerBoard &&
+        pending.earlyRegistration.backgroundJobBoard !== ownerBoard
+      ) {
+        return undefined;
+      }
       pendingCalls.delete(callId);
       return pending;
     },
@@ -105,18 +152,72 @@ export function createPendingCallTracker(
       return fallback;
     },
 
-    clearSession(sessionId: string) {
-      for (const [callId, pending] of pendingCalls.entries()) {
-        if (pending.parentSessionId === sessionId) {
-          pendingCalls.delete(callId);
-          releaseCallLease(pending);
+    adoptEarlyRegistrations(
+      backgroundJobBoard: BackgroundJobStore,
+      backgroundJobSupervisor?: BackgroundJobSupervisor,
+    ) {
+      for (const pending of pendingCalls.values()) {
+        const registration = pending.earlyRegistration;
+        if (
+          !registration ||
+          registration.backgroundJobBoard === backgroundJobBoard
+        ) {
+          continue;
         }
+
+        const existing = backgroundJobBoard.get(registration.taskID);
+        if (
+          existing &&
+          (existing.parentSessionID !== pending.parentSessionId ||
+            existing.agent !== pending.agentType)
+        ) {
+          continue;
+        }
+
+        let adopted = existing;
+        if (!adopted) {
+          try {
+            adopted = backgroundJobBoard.registerLaunch({
+              taskID: registration.taskID,
+              parentSessionID: pending.parentSessionId,
+              agent: pending.agentType,
+              description: pending.label,
+              objective: pending.fullObjective ?? pending.label,
+              background: false,
+              preserveRun: true,
+            });
+          } catch {
+            continue;
+          }
+        }
+
+        registration.backgroundJobBoard.drop(registration.taskID);
+        registration.backgroundJobSupervisor?.drop(registration.taskID);
+        registration.backgroundJobBoard = backgroundJobBoard;
+        registration.backgroundJobSupervisor = backgroundJobSupervisor;
+        registration.generation = adopted.generation;
+      }
+    },
+
+    clearSession(sessionId: string) {
+      const removed: PendingTaskCall[] = [];
+      for (const [callId, pending] of pendingCalls.entries()) {
+        if (pending.parentSessionId !== sessionId) continue;
+        pendingCalls.delete(callId);
+        removed.push(pending);
+      }
+      // Release queued tickets before active tickets. Releasing an active
+      // ticket pumps the scheduler, so doing it in insertion order could
+      // admit a later call just as the parent is being deleted.
+      for (const pending of removed.reverse()) {
+        releaseCallLease(pending);
       }
     },
 
     clearAll() {
-      for (const pending of pendingCalls.values()) releaseCallLease(pending);
+      const removed = [...pendingCalls.values()].reverse();
       pendingCalls.clear();
+      for (const pending of removed) releaseCallLease(pending);
     },
 
     pendingCallId(sessionID?: string, callID?: string) {
@@ -126,4 +227,6 @@ export function createPendingCallTracker(
       );
     },
   };
+
+  return tracker;
 }

--- a/src/hooks/task-session-manager/pending-call-tracker.ts
+++ b/src/hooks/task-session-manager/pending-call-tracker.ts
@@ -1,4 +1,5 @@
 import type { BackgroundJobLease } from '../../utils/background-job-board';
+import type { BackgroundTaskConcurrencyTicket } from '../../utils/background-task-concurrency';
 
 export interface PendingTaskCall {
   callId: string;
@@ -13,6 +14,7 @@ export interface PendingTaskCall {
   lifecycleEpoch: number;
   resumedTaskId?: string;
   relaunchLease?: BackgroundJobLease;
+  concurrencyTicket?: BackgroundTaskConcurrencyTicket;
   earlyRegisteredTaskID?: string;
   earlyRegistrationRejected?: boolean;
 }
@@ -27,6 +29,7 @@ export function createPendingCallTracker(
 
   const releaseCallLease = (call: PendingTaskCall): void => {
     if (call.relaunchLease) options.releaseLease?.(call.relaunchLease);
+    call.concurrencyTicket?.releaseIfUnbound();
   };
 
   return {

--- a/src/hooks/task-session-manager/tool-execute-hooks.ts
+++ b/src/hooks/task-session-manager/tool-execute-hooks.ts
@@ -80,7 +80,10 @@ export async function handleToolExecuteBefore(
     taskContextTracker: { pendingManagedTaskIds: Set<string> };
     backgroundJobSupervisor?: BackgroundJobSupervisor;
     backgroundTaskConcurrency?: BackgroundTaskConcurrency;
-    getModelForAgent?: (agentType: string) => string | undefined;
+    getModelForAgent?: (
+      agentType: string,
+      parentSessionID?: string,
+    ) => string | undefined;
     getLifecycleEpoch?: () => number;
   },
 ): Promise<void> {
@@ -230,7 +233,10 @@ export async function handleToolExecuteBefore(
         .has(input.sessionID);
       if (!isManagedTask) {
         const ticket = deps.backgroundTaskConcurrency.acquire({
-          model: deps.getModelForAgent?.(agentType),
+          model: deps.getModelForAgent?.(
+            agentType,
+            pendingCall.parentSessionId,
+          ),
         });
         pendingCall.concurrencyTicket = ticket;
         await ticket.ready;

--- a/src/hooks/task-session-manager/tool-execute-hooks.ts
+++ b/src/hooks/task-session-manager/tool-execute-hooks.ts
@@ -134,6 +134,7 @@ export async function handleToolExecuteBefore(
     label,
     background,
     lifecycleEpoch: deps.getLifecycleEpoch?.() ?? 0,
+    releaseLease: (lease) => deps.backgroundJobBoard.releaseLease(lease),
   };
   pendingCall.fullObjective = deriveFullObjective({
     description:
@@ -268,7 +269,11 @@ export async function handleToolExecuteAfter(
     directory: string;
     backgroundJobBoard: BackgroundJobStore;
     pendingCallTracker: {
-      take(callID?: string, sessionID?: string): PendingTaskCall | undefined;
+      take(
+        callID?: string,
+        sessionID?: string,
+        ownerBoard?: BackgroundJobStore,
+      ): PendingTaskCall | undefined;
       release?(call: PendingTaskCall): void;
     };
     taskContextTracker: {
@@ -314,6 +319,7 @@ export async function handleToolExecuteAfter(
   const pending = deps.pendingCallTracker.take(
     exactCallID,
     exactCallID ? undefined : input.sessionID,
+    deps.backgroundJobBoard,
   );
   const exactCallConfirmed =
     exactCallID !== undefined && pending?.callId === exactCallID;
@@ -473,7 +479,9 @@ function registerTaskOutputLaunch(
   if (resumed && pending.resumedTaskId !== taskID) return undefined;
 
   const existing = deps.backgroundJobBoard.get(taskID);
-  const earlyRegistrationGeneration = earlyRegistrationGenerations.get(pending);
+  const earlyRegistrationGeneration =
+    pending.earlyRegistration?.generation ??
+    earlyRegistrationGenerations.get(pending);
   if (
     pending.earlyRegisteredTaskID === taskID &&
     earlyRegistrationGeneration !== undefined &&

--- a/src/hooks/task-session-manager/tool-execute-hooks.ts
+++ b/src/hooks/task-session-manager/tool-execute-hooks.ts
@@ -8,6 +8,7 @@
 import type {
   BackgroundJobStore,
   BackgroundJobSupervisor,
+  BackgroundTaskConcurrency,
   ContextFile,
 } from '../../utils';
 import {
@@ -72,10 +73,14 @@ export async function handleToolExecuteBefore(
     backgroundJobBoard: BackgroundJobStore;
     pendingCallTracker: {
       add(call: PendingTaskCall): void;
+      take(callID?: string, sessionID?: string): PendingTaskCall | undefined;
+      release?(call: PendingTaskCall): void;
       pendingCallId(sessionID?: string, callID?: string): string;
     };
     taskContextTracker: { pendingManagedTaskIds: Set<string> };
     backgroundJobSupervisor?: BackgroundJobSupervisor;
+    backgroundTaskConcurrency?: BackgroundTaskConcurrency;
+    getModelForAgent?: (agentType: string) => string | undefined;
     getLifecycleEpoch?: () => number;
   },
 ): Promise<void> {
@@ -215,10 +220,26 @@ export async function handleToolExecuteBefore(
 
   try {
     deps.pendingCallTracker.add(pendingCall);
-  } catch (error) {
-    if (pendingCall.relaunchLease) {
-      deps.backgroundJobBoard.releaseLease(pendingCall.relaunchLease);
+    if (pendingCall.background && deps.backgroundTaskConcurrency) {
+      // Nested orchestration exemption: a session that is itself a managed
+      // task already holds an admission slot. Waiting for another one while
+      // the queue is saturated would deadlock — this session could never
+      // finish, so its own slot could never be released.
+      const isManagedTask = deps.backgroundJobBoard
+        .taskIDs()
+        .has(input.sessionID);
+      if (!isManagedTask) {
+        const ticket = deps.backgroundTaskConcurrency.acquire({
+          model: deps.getModelForAgent?.(agentType),
+        });
+        pendingCall.concurrencyTicket = ticket;
+        await ticket.ready;
+      }
     }
+  } catch (error) {
+    const tracked = deps.pendingCallTracker.take(pendingCall.callId);
+    if (tracked) deps.pendingCallTracker.release?.(tracked);
+    else pendingCall.concurrencyTicket?.releaseIfUnbound();
     throw error;
   }
   log(
@@ -251,6 +272,8 @@ export async function handleToolExecuteAfter(
       prune(board: { taskIDs(): Set<string> }): void;
     };
     backgroundJobSupervisor?: BackgroundJobSupervisor;
+    bindConcurrencyTicket?: (taskID: string, pending: PendingTaskCall) => void;
+    releaseConcurrencyTask?: (taskID: string) => void;
     /** Record direct task cleanup even when the store is a thin facade. */
     recordLifecycleSuppression?: (taskID: string) => void;
     /** Clear a deletion guard when a new native task output proves a run exists. */
@@ -320,6 +343,7 @@ export async function handleToolExecuteAfter(
         deps,
       );
       if (!record) return;
+      deps.bindConcurrencyTicket?.(record.taskID, pending);
       deps.clearRehydrateTombstone?.(launch.taskID);
       if (exactCallConfirmed) deps.backgroundJobSupervisor?.onLaunch(record);
       log('[task-session-manager] background task launch registered', {
@@ -347,6 +371,7 @@ export async function handleToolExecuteAfter(
         deps,
       );
       if (!record) return;
+      deps.bindConcurrencyTicket?.(record.taskID, pending);
       deps.clearRehydrateTombstone?.(status.taskID);
       normalizeLateCancelledTaskOutput(output, deps.backgroundJobBoard);
       if (exactCallConfirmed) deps.backgroundJobSupervisor?.onLaunch(record);
@@ -357,6 +382,9 @@ export async function handleToolExecuteAfter(
         timedOut: status.timedOut,
         resultSummary: status.result,
       });
+      if (updated?.state !== 'running') {
+        deps.releaseConcurrencyTask?.(status.taskID);
+      }
       log('[task-session-manager] foreground task status registered', {
         taskID: status.taskID,
         alias: updated?.alias ?? record.alias,
@@ -409,6 +437,7 @@ export async function handleToolExecuteAfter(
     if (pending.relaunchLease) {
       deps.backgroundJobBoard.releaseLease(pending.relaunchLease);
     }
+    pending.concurrencyTicket?.releaseIfUnbound();
   }
 }
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -539,6 +539,79 @@ describe('plugin config model inheritance', () => {
     } as never);
   }
 
+  async function assertAdmissionUsesFinalModel(
+    subagentType: string,
+    config: Record<string, unknown>,
+    hostAgent: Record<string, unknown>,
+  ): Promise<void> {
+    const hooks = await loadConfiguredPlugin(config);
+    try {
+      await hooks.config?.({ agent: hostAgent });
+      await hooks['chat.message']?.(
+        {
+          sessionID: 'orchestrator-1',
+          agent: 'orchestrator',
+          model: { providerID: 'openai', modelID: 'parent' },
+        } as never,
+        {} as never,
+      );
+      const first = hooks['tool.execute.before']?.(
+        {
+          tool: 'task',
+          sessionID: 'orchestrator-1',
+          callID: 'call-1',
+        } as never,
+        {
+          args: {
+            background: true,
+            subagent_type: subagentType,
+            description: 'first admission',
+          },
+        } as never,
+      );
+      const second = hooks['tool.execute.before']?.(
+        {
+          tool: 'task',
+          sessionID: 'orchestrator-1',
+          callID: 'call-2',
+        } as never,
+        {
+          args: {
+            background: true,
+            subagent_type: subagentType,
+            description: 'second admission',
+          },
+        } as never,
+      );
+
+      await first;
+      const queued = await Promise.race([
+        second?.then(
+          () => 'admitted',
+          () => 'rejected',
+        ),
+        new Promise<string>((resolve) =>
+          setTimeout(() => resolve('still-queued'), 30),
+        ),
+      ]);
+      expect(queued).toBe('still-queued');
+
+      await hooks['tool.execute.after']?.(
+        {
+          tool: 'task',
+          sessionID: 'orchestrator-1',
+          callID: 'call-1',
+        } as never,
+        {
+          output: 'task_id: child-1\nstate: completed\nresult: done',
+        } as never,
+      );
+      await second;
+    } finally {
+      await hooks.dispose?.();
+    }
+  }
+
   test('session inheritance removes a stale host model in the final config', async () => {
     const hooks = await loadConfiguredPlugin({
       agents: {
@@ -622,6 +695,72 @@ describe('plugin config model inheritance', () => {
     } finally {
       await hooks.dispose?.();
     }
+  });
+
+  test('admission uses a direct host override from final agent config', async () => {
+    await assertAdmissionUsesFinalModel(
+      'fixer',
+      {
+        backgroundJobs: {
+          concurrency: {
+            defaultConcurrency: 0,
+            providerConcurrency: { host: 1 },
+          },
+        },
+        agents: { fixer: { model: 'plugin/fixer' } },
+      },
+      { fixer: { model: 'host/fixer' } },
+    );
+  });
+
+  test('admission uses a display-name host override before alias resolution', async () => {
+    await assertAdmissionUsesFinalModel(
+      'researcher',
+      {
+        backgroundJobs: {
+          concurrency: {
+            defaultConcurrency: 0,
+            providerConcurrency: { host: 1 },
+          },
+        },
+        agents: {
+          explorer: { model: 'plugin/explorer', displayName: 'researcher' },
+        },
+      },
+      { researcher: { model: 'host/researcher' } },
+    );
+  });
+
+  test('admission resolves a legacy agent alias to the final canonical entry', async () => {
+    await assertAdmissionUsesFinalModel(
+      'explore',
+      {
+        backgroundJobs: {
+          concurrency: {
+            defaultConcurrency: 0,
+            providerConcurrency: { host: 1 },
+          },
+        },
+        agents: { explorer: { model: 'plugin/explorer' } },
+      },
+      { explorer: { model: 'host/explorer' } },
+    );
+  });
+
+  test('ACP admission falls back to the parent only when its final config is model-less', async () => {
+    await assertAdmissionUsesFinalModel(
+      'external',
+      {
+        backgroundJobs: {
+          concurrency: {
+            defaultConcurrency: 0,
+            providerConcurrency: { openai: 1 },
+          },
+        },
+        acpAgents: { external: { command: 'bridge-acp' } },
+      },
+      { orchestrator: { model: 'openai/parent' } },
+    );
   });
 });
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -396,6 +396,106 @@ describe('plugin TUI agent activity', () => {
   });
 });
 
+describe('background task admission model resolution', () => {
+  let originalEnv: typeof process.env;
+  let projectDir: string;
+  let hooks: Awaited<ReturnType<typeof plugin>> | undefined;
+
+  const createPlugin = () =>
+    plugin({
+      client: createPluginClient(async () => ({})),
+      directory: projectDir,
+      worktree: projectDir,
+      serverUrl: new URL('http://127.0.0.1:4098'),
+    } as never);
+
+  beforeEach(async () => {
+    originalEnv = { ...process.env };
+    projectDir = await mkdtemp('/tmp/oh-my-opencode-slim-concurrency-');
+    process.env = {
+      ...originalEnv,
+      OPENCODE_CONFIG_DIR: projectDir,
+      XDG_DATA_HOME: `${projectDir}/data`,
+      XDG_CACHE_HOME: `${projectDir}/cache`,
+      OPENCODE_LOG_DIR: `${projectDir}/logs`,
+    };
+    delete process.env.OH_MY_OPENCODE_SLIM_DISABLE;
+    await Bun.write(
+      `${projectDir}/oh-my-opencode-slim.json`,
+      JSON.stringify({
+        companion: { enabled: false },
+        backgroundJobs: {
+          concurrency: {
+            defaultConcurrency: 0,
+            providerConcurrency: { openai: 1 },
+          },
+        },
+        agents: { fixer: { inheritModelFrom: 'session' } },
+      }),
+    );
+    hooks = await createPlugin();
+  });
+
+  afterEach(async () => {
+    await hooks?.dispose?.();
+    process.env = originalEnv;
+    await rm(projectDir, { recursive: true, force: true });
+  });
+
+  test('chat.message records the session model so session-inheriting tasks queue behind the parent provider cap', async () => {
+    // chat.message fires before message.updated and carries the message's
+    // model. Without recording it, a session-inheriting fixer task would be
+    // admitted with no model (default tier, no provider cap).
+    await hooks?.['chat.message']?.(
+      {
+        sessionID: 'orchestrator-1',
+        agent: 'orchestrator',
+        model: { providerID: 'openai', modelID: 'gpt-4o' },
+      } as never,
+      {} as never,
+    );
+
+    const before = hooks?.['tool.execute.before'];
+    expect(before).toBeFunction();
+
+    const first = before?.(
+      { tool: 'task', sessionID: 'orchestrator-1', callID: 'call-1' } as never,
+      {
+        args: {
+          background: true,
+          subagent_type: 'fixer',
+          description: 'first task',
+        },
+      } as never,
+    );
+    const second = before?.(
+      { tool: 'task', sessionID: 'orchestrator-1', callID: 'call-2' } as never,
+      {
+        args: {
+          background: true,
+          subagent_type: 'fixer',
+          description: 'second task',
+        },
+      } as never,
+    );
+
+    // The first fixer task holds the single openai slot (resolved from the
+    // parent's model recorded by chat.message); the second must stay queued.
+    // (Slot release happens via board terminal outcomes, out of scope here.)
+    await first;
+    const outcome = await Promise.race([
+      second?.then(
+        () => 'admitted',
+        (e) => `rejected:${String(e)}`,
+      ),
+      new Promise<string>((resolve) =>
+        setTimeout(() => resolve('still-queued'), 100),
+      ),
+    ]);
+    expect(outcome).toBe('still-queued');
+  });
+});
+
 describe('plugin config model inheritance', () => {
   let originalEnv: typeof process.env;
   const configDirs: string[] = [];

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,7 @@ import {
   BackgroundJobBoard,
   BackgroundJobCoordinator,
   BackgroundJobSupervisor,
+  BackgroundTaskConcurrency,
   createDisplayNameMentionRewriter,
   resolveRuntimeAgentName,
 } from './utils';
@@ -251,6 +252,7 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
   let taskSessionManagerAfter: (i: unknown, o: unknown) => Promise<void>;
   let backgroundJobBoard: BackgroundJobBoard;
   let backgroundJobSupervisor: BackgroundJobSupervisor;
+  let backgroundTaskConcurrency: BackgroundTaskConcurrency;
   let interviewManager: ReturnType<typeof createInterviewManager>;
   let companionManager: CompanionManager;
   let taskCancelTools: ReturnType<typeof createCancelTaskTool>;
@@ -365,6 +367,9 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
       readContextMinLines: runtime.backgroundJobs.readContextMinLines,
       readContextMaxFiles: runtime.backgroundJobs.readContextMaxFiles,
     });
+    backgroundTaskConcurrency = new BackgroundTaskConcurrency(
+      runtime.backgroundJobs.concurrency,
+    );
 
     // Initialize coordinator as the sole writer to the board
     const backgroundJobCoordinator = new BackgroundJobCoordinator(
@@ -381,6 +386,7 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
     });
     backgroundJobCoordinator.addTerminalOutcomeListener((record) => {
       backgroundJobSupervisor.onTerminal(record);
+      backgroundTaskConcurrency.releaseTask(record.taskID);
     });
     revivedRunTracker = createRevivedRunTracker({
       input: ctx,
@@ -447,6 +453,9 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
       readContextMaxFiles: runtime.backgroundJobs.readContextMaxFiles,
       backgroundJobBoard: backgroundJobCoordinator,
       backgroundJobSupervisor,
+      backgroundTaskConcurrency,
+      getModelForAgent: (agentType: string) =>
+        pickAgentModelRef(runtime.agent(agentType)?.model),
       shouldManageSession: (sessionID) =>
         sessionMetadata.getAgent(sessionID) === 'orchestrator',
       registerSessionAsOrchestrator: (sessionID) => {
@@ -1202,6 +1211,7 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
       await interviewManager.dispose();
       await multiplexerSessionManager.cleanupOnInstanceDisposed();
       clearTuiActivities();
+      backgroundTaskConcurrency.dispose();
     },
 
     'tool.execute.before': async (input, output) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import {
   createAgents,
   getAgentConfigs,
   isSubagent,
+  resolveAgentConfigModel,
 } from './agents';
 import { buildOrchestratorPrompt } from './agents/orchestrator';
 import { CompanionManager } from './companion/manager';
@@ -76,8 +77,9 @@ import {
   BackgroundJobBoard,
   BackgroundJobCoordinator,
   BackgroundJobSupervisor,
-  BackgroundTaskConcurrency,
+  type BackgroundTaskConcurrency,
   createDisplayNameMentionRewriter,
+  getBackgroundTaskConcurrency,
   resolveRuntimeAgentName,
 } from './utils';
 import type { ContextFile } from './utils/background-job-board';
@@ -367,7 +369,8 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
       readContextMinLines: runtime.backgroundJobs.readContextMinLines,
       readContextMaxFiles: runtime.backgroundJobs.readContextMaxFiles,
     });
-    backgroundTaskConcurrency = new BackgroundTaskConcurrency(
+    backgroundTaskConcurrency = getBackgroundTaskConcurrency(
+      ctx.directory,
       runtime.backgroundJobs.concurrency,
     );
 
@@ -440,6 +443,11 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
       ctx,
       runtime.fallback.maxRetries,
       sessionLifecycle,
+      // A managed background-task session switching models mid-flight must
+      // move its admission accounting (provider/model caps) to the new
+      // model. No-op for unknown/non-task sessions; idempotent per model.
+      (sessionID, model) =>
+        backgroundTaskConcurrency.migrateTask(sessionID, model),
     );
 
     deepworkCommandHook = createDeepworkCommandHook();
@@ -454,8 +462,16 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
       backgroundJobBoard: backgroundJobCoordinator,
       backgroundJobSupervisor,
       backgroundTaskConcurrency,
-      getModelForAgent: (agentType: string) =>
-        pickAgentModelRef(runtime.agent(agentType)?.model),
+      getModelForAgent: (agentType: string, parentSessionID?: string) =>
+        // The model the spawned subagent's config actually carries — the
+        // same resolution createAgents/final config use (explicit model,
+        // inheritModelFrom, fixer→librarian, preset primary). When the agent
+        // config ends up model-less (session inheritance), OpenCode serves
+        // the parent session's current model, tracked per session here.
+        resolveAgentConfigModel(runtime, agentType) ??
+        (parentSessionID
+          ? sessionMetadata.getModel(parentSessionID)
+          : undefined),
       shouldManageSession: (sessionID) =>
         sessionMetadata.getAgent(sessionID) === 'orchestrator',
       registerSessionAsOrchestrator: (sessionID) => {
@@ -1082,6 +1098,18 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
             : typeof info?.model?.modelID === 'string'
               ? info.model.modelID
               : undefined;
+        // Track each session's current model so background task admission
+        // can resolve the model a model-less subagent will inherit.
+        if (typeof info?.sessionID === 'string' && providerID && modelID) {
+          const model = `${providerID}/${modelID}`;
+          sessionMetadata.setModel(info.sessionID, model);
+          // Managed background-task sessions are identified by their session
+          // ID. If the model serving one changed (fallback re-prompt, runtime
+          // switch), migrate the admission accounting so provider/model caps
+          // keep tracking the model actually in use. No-op for other
+          // sessions and idempotent when the model is unchanged.
+          backgroundTaskConcurrency.migrateTask(info.sessionID, model);
+        }
         if (typeof info?.agent === 'string' && providerID && modelID) {
           const agentName = resolveRuntimeAgentName(runtime, info.agent);
           const model = `${providerID}/${modelID}`;
@@ -1211,7 +1239,12 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
       await interviewManager.dispose();
       await multiplexerSessionManager.cleanupOnInstanceDisposed();
       clearTuiActivities();
-      backgroundTaskConcurrency.dispose();
+      // The concurrency scheduler is process-scoped and deliberately NOT
+      // disposed here: the plugin dispose hook also runs on re-inits
+      // (config update → Instance.dispose), and disposing it would drop the
+      // admission state (running slots + queued tickets) that must survive
+      // for the new plugin generation. Its per-task slots are released as
+      // tasks reach terminal states; the process reaps it on exit.
     },
 
     'tool.execute.before': async (input, output) => {
@@ -1321,6 +1354,23 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
           agent,
           status: 'busy',
         });
+      }
+
+      // chat.message carries the model selected for this message, and it
+      // fires before the message.updated event that the event hook relies
+      // on. Recording it here closes the early window where a session-
+      // inheriting background task could be admitted before its parent's
+      // model is known — admission then resolves the correct provider/model
+      // cap immediately.
+      const messageModel = input.model ?? output?.message?.model;
+      if (
+        messageModel &&
+        typeof messageModel.providerID === 'string' &&
+        typeof messageModel.modelID === 'string'
+      ) {
+        const model = `${messageModel.providerID}/${messageModel.modelID}`;
+        sessionMetadata.setModel(input.sessionID, model);
+        backgroundTaskConcurrency.migrateTask(input.sessionID, model);
       }
       taskSessionManagerHook.observeChatMessage(input, output);
       orchestratorWakeScheduler.observeChatMessage(input, output);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,14 @@
 import type { Plugin, ToolDefinition } from '@opencode-ai/plugin';
 import {
+  type AdmissionRuntimeLease,
+  acquireAdmissionRuntime,
+} from './admission-runtime';
+import {
   applyModelInheritanceToConfig,
   createAgents,
   getAgentConfigs,
   isSubagent,
-  resolveAgentConfigModel,
+  resolvePrimaryModelValue,
 } from './agents';
 import { buildOrchestratorPrompt } from './agents/orchestrator';
 import { CompanionManager } from './companion/manager';
@@ -79,7 +83,6 @@ import {
   BackgroundJobSupervisor,
   type BackgroundTaskConcurrency,
   createDisplayNameMentionRewriter,
-  getBackgroundTaskConcurrency,
   resolveRuntimeAgentName,
 } from './utils';
 import type { ContextFile } from './utils/background-job-board';
@@ -255,6 +258,8 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
   let backgroundJobBoard: BackgroundJobBoard;
   let backgroundJobSupervisor: BackgroundJobSupervisor;
   let backgroundTaskConcurrency: BackgroundTaskConcurrency;
+  let admissionRuntimeLease: AdmissionRuntimeLease | undefined;
+  let finalHostAgentConfig: Record<string, unknown> | undefined;
   let interviewManager: ReturnType<typeof createInterviewManager>;
   let companionManager: CompanionManager;
   let taskCancelTools: ReturnType<typeof createCancelTaskTool>;
@@ -278,6 +283,21 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
 
   // Counters for post-init health check (set inside try, checked outside)
   let toolCount = 0;
+
+  const resolvePrimaryModelFromFinalHostConfig = (
+    agentType: string,
+  ): string | undefined => {
+    const readModel = (entry: unknown): string | undefined => {
+      if (entry === null || typeof entry !== 'object') return undefined;
+      return resolvePrimaryModelValue((entry as Record<string, unknown>).model);
+    };
+
+    const directModel = readModel(finalHostAgentConfig?.[agentType]);
+    if (directModel) return directModel;
+
+    const resolvedName = resolveRuntimeAgentName(runtime, agentType);
+    return readModel(finalHostAgentConfig?.[resolvedName]);
+  };
 
   try {
     config = loadPluginConfig(ctx.directory);
@@ -369,10 +389,11 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
       readContextMinLines: runtime.backgroundJobs.readContextMinLines,
       readContextMaxFiles: runtime.backgroundJobs.readContextMaxFiles,
     });
-    backgroundTaskConcurrency = getBackgroundTaskConcurrency(
+    admissionRuntimeLease = acquireAdmissionRuntime(
       ctx.directory,
       runtime.backgroundJobs.concurrency,
     );
+    backgroundTaskConcurrency = admissionRuntimeLease.backgroundTaskConcurrency;
 
     // Initialize coordinator as the sole writer to the board
     const backgroundJobCoordinator = new BackgroundJobCoordinator(
@@ -462,13 +483,14 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
       backgroundJobBoard: backgroundJobCoordinator,
       backgroundJobSupervisor,
       backgroundTaskConcurrency,
+      pendingCallTracker: admissionRuntimeLease.pendingCallTracker,
       getModelForAgent: (agentType: string, parentSessionID?: string) =>
-        // The model the spawned subagent's config actually carries — the
-        // same resolution createAgents/final config use (explicit model,
-        // inheritModelFrom, fixer→librarian, preset primary). When the agent
-        // config ends up model-less (session inheritance), OpenCode serves
-        // the parent session's current model, tracked per session here.
-        resolveAgentConfigModel(runtime, agentType) ??
+        // Admission must use the config after the host has merged all of its
+        // agent layers. The direct lookup preserves display-name keys; the
+        // resolved lookup handles canonical names and legacy aliases. A
+        // parent model is only an inheritance fallback when neither final
+        // agent entry carries one.
+        resolvePrimaryModelFromFinalHostConfig(agentType) ??
         (parentSessionID
           ? sessionMetadata.getModel(parentSessionID)
           : undefined),
@@ -638,6 +660,7 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
 
     toolCount = Object.keys(tools).length;
   } catch (err) {
+    admissionRuntimeLease?.release();
     // Plugin init failed: log visibly before re-throwing so the user
     // sees something actionable instead of a silent "loaded but empty".
     log('[plugin] FATAL: init failed', String(err));
@@ -969,6 +992,10 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
         configPreset: runtime.preset,
         runtimePreset: runtimePresetName,
       });
+      // This is the source of truth for admission. It is intentionally
+      // captured only after every host/plugin merge and the final model
+      // inheritance, array-primary, preset, and orchestrator-model passes.
+      finalHostAgentConfig = configAgent;
 
       // Merge MCP configs
       const configMcp = opencodeConfig.mcp as
@@ -1239,12 +1266,10 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
       await interviewManager.dispose();
       await multiplexerSessionManager.cleanupOnInstanceDisposed();
       clearTuiActivities();
-      // The concurrency scheduler is process-scoped and deliberately NOT
-      // disposed here: the plugin dispose hook also runs on re-inits
-      // (config update → Instance.dispose), and disposing it would drop the
-      // admission state (running slots + queued tickets) that must survive
-      // for the new plugin generation. Its per-task slots are released as
-      // tasks reach terminal states; the process reaps it on exit.
+      // Release only this generation's ownership. The admission runtime
+      // defers final scheduler/tracker teardown by one macrotask so an
+      // immediate config-update re-init can retain active and queued calls.
+      admissionRuntimeLease?.release();
     },
 
     'tool.execute.before': async (input, output) => {

--- a/src/utils/agent-variant.test.ts
+++ b/src/utils/agent-variant.test.ts
@@ -58,6 +58,12 @@ describe('resolveRuntimeAgentName', () => {
     );
   });
 
+  test('resolves legacy aliases to internal names', () => {
+    expect(
+      resolveRuntimeAgentName(runtimeFor({} as PluginConfig), 'explore'),
+    ).toBe('explorer');
+  });
+
   test('resolves displayName with @ prefix and whitespace', () => {
     const config = {
       agents: {

--- a/src/utils/agent-variant.ts
+++ b/src/utils/agent-variant.ts
@@ -75,7 +75,7 @@ export function resolveRuntimeAgentName(
     }
   }
 
-  return normalized;
+  return AGENT_ALIASES[normalized] ?? normalized;
 }
 
 export function escapeRegExp(value: string): string {

--- a/src/utils/background-task-concurrency.test.ts
+++ b/src/utils/background-task-concurrency.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  BackgroundTaskConcurrency,
+  BackgroundTaskConcurrencyQueueCancelledError,
+} from './background-task-concurrency';
+
+const limited = (overrides = {}) =>
+  new BackgroundTaskConcurrency({
+    defaultConcurrency: 1,
+    providerConcurrency: {},
+    modelConcurrency: {},
+    ...overrides,
+  });
+
+describe('BackgroundTaskConcurrency', () => {
+  test('admits one task and queues the next task', async () => {
+    const scheduler = limited();
+    const first = scheduler.acquire({ model: 'openai/fast' });
+    const second = scheduler.acquire({ model: 'openai/fast' });
+
+    await first.ready;
+    expect(scheduler.snapshot()).toEqual({ active: 1, queued: 1 });
+
+    let secondReady = false;
+    void second.ready.then(() => {
+      secondReady = true;
+    });
+    await Promise.resolve();
+    expect(secondReady).toBe(false);
+
+    first.bind('ses_first');
+    scheduler.releaseTask('ses_first');
+    await second.ready;
+    expect(scheduler.snapshot()).toEqual({ active: 1, queued: 0 });
+  });
+
+  test('preserves admission order under the default cap', async () => {
+    const scheduler = limited();
+    const first = scheduler.acquire({ model: 'openai/fast' });
+    const second = scheduler.acquire({ model: 'openai/fast' });
+    const order: string[] = [];
+
+    await first.ready;
+    order.push('first');
+    first.bind('ses_first');
+    void second.ready.then(() => order.push('second'));
+    scheduler.releaseTask('ses_first');
+    await second.ready;
+
+    expect(order).toEqual(['first', 'second']);
+  });
+
+  test('applies model and provider caps alongside the default cap', async () => {
+    const scheduler = new BackgroundTaskConcurrency({
+      defaultConcurrency: 3,
+      providerConcurrency: { openai: 1 },
+      modelConcurrency: { 'anthropic/slow': 1 },
+    });
+    const openaiFirst = scheduler.acquire({ model: 'openai/fast' });
+    const openaiSecond = scheduler.acquire({ model: 'openai/cheap' });
+    const anthropic = scheduler.acquire({ model: 'anthropic/slow' });
+
+    await openaiFirst.ready;
+    await anthropic.ready;
+    expect(scheduler.snapshot()).toEqual({ active: 2, queued: 1 });
+
+    openaiFirst.bind('ses_openai');
+    scheduler.releaseTask('ses_openai');
+    await openaiSecond.ready;
+    expect(scheduler.snapshot()).toEqual({ active: 2, queued: 0 });
+  });
+
+  test('a model cap takes precedence over an unrestricted default', async () => {
+    const scheduler = new BackgroundTaskConcurrency({
+      defaultConcurrency: 0,
+      providerConcurrency: {},
+      modelConcurrency: { 'openai/slow': 1 },
+    });
+    const first = scheduler.acquire({ model: 'openai/slow' });
+    const second = scheduler.acquire({ model: 'openai/slow' });
+
+    await first.ready;
+    expect(scheduler.snapshot()).toEqual({ active: 1, queued: 1 });
+    first.release();
+    await second.ready;
+  });
+
+  test('does not cap tasks when all limits are disabled', async () => {
+    const scheduler = new BackgroundTaskConcurrency({
+      defaultConcurrency: 0,
+      providerConcurrency: {},
+      modelConcurrency: {},
+    });
+    const first = scheduler.acquire({ model: 'openai/fast' });
+    const second = scheduler.acquire({ model: 'anthropic/slow' });
+
+    await Promise.all([first.ready, second.ready]);
+    expect(scheduler.snapshot()).toEqual({ active: 2, queued: 0 });
+  });
+
+  test('releasing an unbound ticket removes it from the queue', async () => {
+    const scheduler = limited();
+    const first = scheduler.acquire({ model: 'openai/fast' });
+    const second = scheduler.acquire({ model: 'openai/fast' });
+
+    await first.ready;
+    second.releaseIfUnbound();
+    await expect(second.ready).rejects.toBeInstanceOf(
+      BackgroundTaskConcurrencyQueueCancelledError,
+    );
+    expect(scheduler.snapshot()).toEqual({ active: 1, queued: 0 });
+    first.release();
+  });
+
+  test('dispose cancels queued tickets and releases active capacity', async () => {
+    const scheduler = limited();
+    const first = scheduler.acquire({ model: 'openai/fast' });
+    const second = scheduler.acquire({ model: 'openai/fast' });
+
+    await first.ready;
+    scheduler.dispose();
+
+    await expect(second.ready).rejects.toBeInstanceOf(
+      BackgroundTaskConcurrencyQueueCancelledError,
+    );
+    expect(scheduler.snapshot()).toEqual({ active: 0, queued: 0 });
+  });
+});

--- a/src/utils/background-task-concurrency.test.ts
+++ b/src/utils/background-task-concurrency.test.ts
@@ -297,7 +297,8 @@ describe('BackgroundTaskConcurrency', () => {
         const a = schedulerA.acquire({ model: 'openai/fast' });
         await a.ready;
         a.bind('ses_a_first');
-        schedulerA.acquire({ model: 'openai/fast' });
+        const a2 = schedulerA.acquire({ model: 'openai/fast' });
+        void a2.ready.catch(() => {});
         await Promise.resolve();
         expect(schedulerA.snapshot()).toEqual({ active: 1, queued: 1 });
 
@@ -313,9 +314,12 @@ describe('BackgroundTaskConcurrency', () => {
         );
         const b2 = schedulerB.acquire({ model: 'openai/fast' });
         let b2Ready = false;
-        void b2.ready.then(() => {
-          b2Ready = true;
-        });
+        void b2.ready.then(
+          () => {
+            b2Ready = true;
+          },
+          () => {},
+        );
         await Promise.resolve();
         expect(b2Ready).toBe(false);
         expect(schedulerB.snapshot()).toEqual({ active: 1, queued: 1 });

--- a/src/utils/background-task-concurrency.test.ts
+++ b/src/utils/background-task-concurrency.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from 'bun:test';
 import {
   BackgroundTaskConcurrency,
   BackgroundTaskConcurrencyQueueCancelledError,
+  getBackgroundTaskConcurrency,
+  resetBackgroundTaskConcurrencyForTests,
 } from './background-task-concurrency';
 
 const limited = (overrides = {}) =>
@@ -50,7 +52,7 @@ describe('BackgroundTaskConcurrency', () => {
     expect(order).toEqual(['first', 'second']);
   });
 
-  test('applies model and provider caps alongside the default cap', async () => {
+  test('applies provider and model caps for their own keys', async () => {
     const scheduler = new BackgroundTaskConcurrency({
       defaultConcurrency: 3,
       providerConcurrency: { openai: 1 },
@@ -85,6 +87,46 @@ describe('BackgroundTaskConcurrency', () => {
     await second.ready;
   });
 
+  test('the most specific configured cap wins: model > provider > default', async () => {
+    const scheduler = new BackgroundTaskConcurrency({
+      defaultConcurrency: 1,
+      providerConcurrency: { openai: 1 },
+      modelConcurrency: { 'openai/gpt-4o': 3 },
+    });
+    const first = scheduler.acquire({ model: 'openai/gpt-4o' });
+    const second = scheduler.acquire({ model: 'openai/gpt-4o' });
+    const third = scheduler.acquire({ model: 'openai/gpt-4o' });
+
+    await Promise.all([first.ready, second.ready, third.ready]);
+    expect(scheduler.snapshot()).toEqual({ active: 3, queued: 0 });
+  });
+
+  test('a provider cap overrides the default cap', async () => {
+    const scheduler = new BackgroundTaskConcurrency({
+      defaultConcurrency: 1,
+      providerConcurrency: { openai: 3 },
+      modelConcurrency: {},
+    });
+    const first = scheduler.acquire({ model: 'openai/fast' });
+    const second = scheduler.acquire({ model: 'openai/cheap' });
+
+    await Promise.all([first.ready, second.ready]);
+    expect(scheduler.snapshot()).toEqual({ active: 2, queued: 0 });
+  });
+
+  test('a provider cap of zero means unlimited for that provider', async () => {
+    const scheduler = new BackgroundTaskConcurrency({
+      defaultConcurrency: 1,
+      providerConcurrency: { openai: 0 },
+      modelConcurrency: {},
+    });
+    const first = scheduler.acquire({ model: 'openai/fast' });
+    const second = scheduler.acquire({ model: 'openai/fast' });
+
+    await Promise.all([first.ready, second.ready]);
+    expect(scheduler.snapshot()).toEqual({ active: 2, queued: 0 });
+  });
+
   test('does not cap tasks when all limits are disabled', async () => {
     const scheduler = new BackgroundTaskConcurrency({
       defaultConcurrency: 0,
@@ -95,6 +137,84 @@ describe('BackgroundTaskConcurrency', () => {
     const second = scheduler.acquire({ model: 'anthropic/slow' });
 
     await Promise.all([first.ready, second.ready]);
+    expect(scheduler.snapshot()).toEqual({ active: 2, queued: 0 });
+  });
+
+  test('restoreTask reclaims a slot for an already-running task and is idempotent', async () => {
+    const scheduler = limited();
+    scheduler.restoreTask('ses_running', 'openai/fast');
+    // A second restore for the same task must not double-count the slot.
+    scheduler.restoreTask('ses_running', 'openai/fast');
+
+    const next = scheduler.acquire({ model: 'openai/fast' });
+    let nextReady = false;
+    void next.ready.then(() => {
+      nextReady = true;
+    });
+    await Promise.resolve();
+    expect(nextReady).toBe(false);
+
+    scheduler.releaseTask('ses_running');
+    await next.ready;
+    expect(scheduler.snapshot()).toEqual({ active: 1, queued: 0 });
+  });
+
+  test('restored tasks are accounted against their resolved provider/model cap', async () => {
+    const scheduler = new BackgroundTaskConcurrency({
+      defaultConcurrency: 10,
+      providerConcurrency: { openai: 1 },
+      modelConcurrency: {},
+    });
+    scheduler.restoreTask('ses_running', 'openai/gpt-4o');
+
+    const next = scheduler.acquire({ model: 'openai/cheap' });
+    let nextReady = false;
+    void next.ready.then(() => {
+      nextReady = true;
+    });
+    await Promise.resolve();
+    expect(nextReady).toBe(false);
+
+    scheduler.releaseTask('ses_running');
+    await next.ready;
+  });
+
+  test('migrateTask moves provider accounting when a task switches models', async () => {
+    const scheduler = new BackgroundTaskConcurrency({
+      defaultConcurrency: 10,
+      providerConcurrency: { openai: 1, google: 1 },
+      modelConcurrency: {},
+    });
+    const openai = scheduler.acquire({ model: 'openai/gpt-4o' });
+    await openai.ready;
+    openai.bind('ses_openai');
+
+    // A second openai task is blocked by the openai cap.
+    const blockedOpenai = scheduler.acquire({ model: 'openai/cheap' });
+    let openaiBlocked = false;
+    void blockedOpenai.ready.then(() => {
+      openaiBlocked = true;
+    });
+    await Promise.resolve();
+    expect(openaiBlocked).toBe(false);
+
+    // The openai task falls back to google: the openai slot frees and the
+    // google accounting now includes this task.
+    scheduler.migrateTask('ses_openai', 'google/gemini-pro');
+    await blockedOpenai.ready;
+    expect(scheduler.snapshot()).toEqual({ active: 2, queued: 0 });
+
+    // Now the migrated task holds the single google slot.
+    const blockedGoogle = scheduler.acquire({ model: 'google/gemini-flash' });
+    let googleBlocked = false;
+    void blockedGoogle.ready.then(() => {
+      googleBlocked = true;
+    });
+    await Promise.resolve();
+    expect(googleBlocked).toBe(false);
+
+    scheduler.releaseTask('ses_openai');
+    await blockedGoogle.ready;
     expect(scheduler.snapshot()).toEqual({ active: 2, queued: 0 });
   });
 
@@ -124,5 +244,162 @@ describe('BackgroundTaskConcurrency', () => {
       BackgroundTaskConcurrencyQueueCancelledError,
     );
     expect(scheduler.snapshot()).toEqual({ active: 0, queued: 0 });
+  });
+
+  describe('process-scoped shared instances', () => {
+    const config = (overrides = {}) => ({
+      defaultConcurrency: 1,
+      providerConcurrency: {},
+      modelConcurrency: {},
+      ...overrides,
+    });
+
+    test('returns the same instance and keeps running + queued state across re-inits', async () => {
+      resetBackgroundTaskConcurrencyForTests();
+      try {
+        const scheduler = getBackgroundTaskConcurrency('proj-a', config());
+        const first = scheduler.acquire({ model: 'openai/fast' });
+        await first.ready;
+        first.bind('ses_first');
+
+        const second = scheduler.acquire({ model: 'openai/fast' });
+        let secondReady = false;
+        void second.ready.then(() => {
+          secondReady = true;
+        });
+        await Promise.resolve();
+        expect(secondReady).toBe(false);
+
+        // Simulate a plugin re-init: the factory re-runs and re-requests the
+        // shared scheduler. Running slots AND queued tickets must survive —
+        // the queued ticket is NOT rejected.
+        const again = getBackgroundTaskConcurrency('proj-a', config());
+        expect(again).toBe(scheduler);
+        expect(scheduler.snapshot()).toEqual({ active: 1, queued: 1 });
+        expect(secondReady).toBe(false);
+
+        scheduler.releaseTask('ses_first');
+        await second.ready;
+        expect(secondReady).toBe(true);
+        expect(scheduler.snapshot()).toEqual({ active: 1, queued: 0 });
+      } finally {
+        resetBackgroundTaskConcurrencyForTests();
+      }
+    });
+
+    test('isolates schedulers per project directory', async () => {
+      resetBackgroundTaskConcurrencyForTests();
+      try {
+        const schedulerA = getBackgroundTaskConcurrency('proj-a', config());
+        const schedulerB = getBackgroundTaskConcurrency('proj-b', config());
+        expect(schedulerA).not.toBe(schedulerB);
+
+        const a = schedulerA.acquire({ model: 'openai/fast' });
+        await a.ready;
+        a.bind('ses_a_first');
+        schedulerA.acquire({ model: 'openai/fast' });
+        await Promise.resolve();
+        expect(schedulerA.snapshot()).toEqual({ active: 1, queued: 1 });
+
+        // Project B is unaffected by A's saturated queue and A's re-init.
+        const b = schedulerB.acquire({ model: 'openai/fast' });
+        await b.ready;
+        expect(schedulerB.snapshot()).toEqual({ active: 1, queued: 0 });
+
+        // A re-init for A must not mutate B's config either.
+        getBackgroundTaskConcurrency(
+          'proj-a',
+          config({ defaultConcurrency: 2 }),
+        );
+        const b2 = schedulerB.acquire({ model: 'openai/fast' });
+        let b2Ready = false;
+        void b2.ready.then(() => {
+          b2Ready = true;
+        });
+        await Promise.resolve();
+        expect(b2Ready).toBe(false);
+        expect(schedulerB.snapshot()).toEqual({ active: 1, queued: 1 });
+      } finally {
+        resetBackgroundTaskConcurrencyForTests();
+      }
+    });
+
+    test('updateConfig re-resolves queued tiers and re-pumps', async () => {
+      const scheduler = new BackgroundTaskConcurrency({
+        defaultConcurrency: 1,
+        providerConcurrency: {},
+        modelConcurrency: {},
+      });
+      const first = scheduler.acquire({ model: 'openai/fast' });
+      await first.ready;
+      first.bind('ses_first');
+      const second = scheduler.acquire({ model: 'openai/fast' });
+      await Promise.resolve();
+      expect(scheduler.snapshot()).toEqual({ active: 1, queued: 1 });
+
+      // Raising the default cap admits the queued task immediately.
+      scheduler.updateConfig({
+        defaultConcurrency: 2,
+        providerConcurrency: {},
+        modelConcurrency: {},
+      });
+      await second.ready;
+      expect(scheduler.snapshot()).toEqual({ active: 2, queued: 0 });
+    });
+
+    test('updateConfig re-counts running tasks against a newly tightened provider cap', async () => {
+      // Two OpenAI tasks admitted while the provider was unrestricted, then
+      // the config tightens the openai cap to 1: the running tasks must now
+      // count against it, so a third openai task queues instead of starting.
+      const scheduler = new BackgroundTaskConcurrency({
+        defaultConcurrency: 10,
+        providerConcurrency: {},
+        modelConcurrency: {},
+      });
+      const first = scheduler.acquire({ model: 'openai/gpt-4o' });
+      const second = scheduler.acquire({ model: 'openai/cheap' });
+      await Promise.all([first.ready, second.ready]);
+      first.bind('ses_openai_1');
+      second.bind('ses_openai_2');
+      expect(scheduler.snapshot()).toEqual({ active: 2, queued: 0 });
+
+      scheduler.updateConfig({
+        defaultConcurrency: 10,
+        providerConcurrency: { openai: 1 },
+        modelConcurrency: {},
+      });
+
+      const third = scheduler.acquire({ model: 'openai/gpt-4o-mini' });
+      let thirdReady = false;
+      void third.ready.then(() => {
+        thirdReady = true;
+      });
+      await Promise.resolve();
+      expect(thirdReady).toBe(false);
+      expect(scheduler.snapshot()).toEqual({ active: 2, queued: 1 });
+
+      // Releasing one running openai task keeps the cap full (the other
+      // still runs); releasing both frees the slot for the queued task.
+      scheduler.releaseTask('ses_openai_2');
+      await Promise.resolve();
+      expect(thirdReady).toBe(false);
+
+      scheduler.releaseTask('ses_openai_1');
+      await third.ready;
+      expect(scheduler.snapshot()).toEqual({ active: 1, queued: 0 });
+    });
+
+    test('a disposed shared instance is replaced by a fresh one', () => {
+      resetBackgroundTaskConcurrencyForTests();
+      try {
+        const first = getBackgroundTaskConcurrency('proj-a', config());
+        first.dispose();
+        const second = getBackgroundTaskConcurrency('proj-a', config());
+        expect(second).not.toBe(first);
+        expect(second.isDisposed()).toBe(false);
+      } finally {
+        resetBackgroundTaskConcurrencyForTests();
+      }
+    });
   });
 });

--- a/src/utils/background-task-concurrency.ts
+++ b/src/utils/background-task-concurrency.ts
@@ -54,12 +54,10 @@ export class BackgroundTaskConcurrencyQueueCancelledError extends Error {
  * reaches a terminal state. The job board still owns task lifecycle; this
  * scheduler only controls admission.
  *
- * State is scoped to the scheduler instance. The plugin factory can re-run
- * on config updates (see src/agents/index.ts), and the scheduler is created
- * once per project through `getBackgroundTaskConcurrency` so admission state
- * (running slots AND queued tickets) survives re-inits. `restoreTask` covers
- * the one case the shared instance cannot: a genuine process restart that
- * resumes a still-running task from persisted message history.
+ * State is scoped to the scheduler instance. Plugin generations share this
+ * scheduler through the per-directory lease in `src/admission-runtime.ts`.
+ * `restoreTask` covers the one case the shared instance cannot: a genuine
+ * process restart that resumes a still-running task from persisted history.
  */
 export class BackgroundTaskConcurrency {
   private readonly waiting: QueueEntry[] = [];
@@ -307,49 +305,10 @@ export class BackgroundTaskConcurrency {
   }
 }
 
-// ── Process-scoped shared instances ──────────────────────────────────────
-//
-// The plugin factory re-runs on every config update (Instance.dispose →
-// re-init). A scheduler created inside the factory would lose its running
-// slots AND its queued tickets on every re-init. These module-level instances
-// survive re-inits: the factory calls `getBackgroundTaskConcurrency` with the
-// (possibly changed) config, which reuses the instance for the same project.
-//
-// One instance per project directory: multiple plugin instances (different
-// OpenCode workspaces in one process) must not share a queue or overwrite
-// each other's caps. Only a genuine process restart resets them —
-// `restoreTask` (wired into historical run rehydration) then reclaims slots
-// for tasks still running.
-
-const schedulersByDirectory = new Map<string, BackgroundTaskConcurrency>();
-
-/**
- * Return the process-scoped scheduler for a project directory, applying
- * `config` when the instance already exists (plugin re-init). Instances are
- * isolated per directory so concurrent plugin instances never share admission
- * state. Recreates an instance after a dispose so a caller that tore the
- * scheduler down (tests, genuine unload) gets a fresh one instead of a
- * permanently cancelled instance.
- */
-export function getBackgroundTaskConcurrency(
-  directory: string,
-  config: BackgroundTaskConcurrencyConfig,
-): BackgroundTaskConcurrency {
-  const key = directory || 'default';
-  const existing = schedulersByDirectory.get(key);
-  if (!existing || existing.isDisposed()) {
-    const scheduler = new BackgroundTaskConcurrency(config);
-    schedulersByDirectory.set(key, scheduler);
-    return scheduler;
-  }
-  existing.updateConfig(config);
-  return existing;
-}
-
-/** Test seam: drop all shared instances between tests. */
-export function resetBackgroundTaskConcurrencyForTests(): void {
-  schedulersByDirectory.clear();
-}
+export {
+  getBackgroundTaskConcurrency,
+  resetBackgroundTaskConcurrencyForTests,
+} from '../admission-runtime';
 
 /** Resolve the single applicable cap tier for a model (model > provider > default). */
 function resolveTier(

--- a/src/utils/background-task-concurrency.ts
+++ b/src/utils/background-task-concurrency.ts
@@ -15,10 +15,18 @@ export interface BackgroundTaskConcurrencyTicket {
   releaseIfUnbound(): void;
 }
 
+type ConcurrencyTier = 'model' | 'provider' | 'default';
+
 interface QueueEntry {
   id: number;
   model?: string;
   provider?: string;
+  /** Resolved cap tier. Only ONE tier applies per task (model > provider > default). */
+  tier: ConcurrencyTier;
+  /** Key counted against for model/provider tiers (model ID or provider ID). */
+  key?: string;
+  /** Resolved cap for the tier; Infinity when the tier is unlimited (0). */
+  limit: number;
   started: boolean;
   released: boolean;
   taskID?: string;
@@ -36,22 +44,73 @@ export class BackgroundTaskConcurrencyQueueCancelledError extends Error {
 /**
  * Process-local admission scheduler for native background task launches.
  *
- * Queued requests are admitted in order, but entries whose provider or model
- * quota is saturated are skipped in favor of admittable later entries
- * (FIFO with skip). A ticket owns capacity from the moment its `ready`
- * promise resolves until the bound task reaches a terminal state. The job
- * board still owns task lifecycle; this scheduler only controls admission.
+ * Limits follow the reference implementation's override semantics: a model
+ * cap for the task's model wins over a provider cap for its provider, which
+ * wins over the default cap — only the most specific configured cap applies.
+ * A configured value of `0` means unlimited for that key. Queued requests are
+ * admitted in order, but entries whose resolved tier is saturated are skipped
+ * in favor of admittable later entries (FIFO with skip). A ticket owns
+ * capacity from the moment its `ready` promise resolves until the bound task
+ * reaches a terminal state. The job board still owns task lifecycle; this
+ * scheduler only controls admission.
+ *
+ * State is scoped to the scheduler instance. The plugin factory can re-run
+ * on config updates (see src/agents/index.ts), and the scheduler is created
+ * once per project through `getBackgroundTaskConcurrency` so admission state
+ * (running slots AND queued tickets) survives re-inits. `restoreTask` covers
+ * the one case the shared instance cannot: a genuine process restart that
+ * resumes a still-running task from persisted message history.
  */
 export class BackgroundTaskConcurrency {
   private readonly waiting: QueueEntry[] = [];
   private readonly active = new Set<QueueEntry>();
-  private readonly activeByProvider = new Map<string, number>();
-  private readonly activeByModel = new Map<string, number>();
+  private readonly activeByKey = new Map<string, number>();
   private readonly activeByTaskID = new Map<string, QueueEntry>();
+  private activeDefault = 0;
   private nextID = 0;
   private disposed = false;
 
-  constructor(private readonly config: BackgroundTaskConcurrencyConfig) {}
+  constructor(private config: BackgroundTaskConcurrencyConfig) {}
+
+  /**
+   * Apply a new configuration to this instance (used when the plugin factory
+   * re-runs with changed config). Both running slots and queued tickets are
+   * re-resolved against the new config: active entries move their accounting
+   * to the tier their model now resolves to (so a newly lowered cap starts
+   * counting tasks that were admitted under an unlimited/looser config), and
+   * the queue re-pumps. Existing tasks are never terminated by a config
+   * change — a running task that now exceeds a tightened cap keeps running
+   * and blocks new admissions until it finishes.
+   */
+  updateConfig(config: BackgroundTaskConcurrencyConfig): void {
+    this.config = config;
+    for (const entry of this.active) {
+      const tier = resolveTier(this.config, entry.model);
+      if (
+        tier.tier === entry.tier &&
+        tier.key === entry.key &&
+        tier.limit === entry.limit
+      ) {
+        continue;
+      }
+      this.untrack(entry);
+      entry.tier = tier.tier;
+      entry.key = tier.key;
+      entry.limit = tier.limit;
+      this.track(entry);
+    }
+    for (const entry of this.waiting) {
+      const tier = resolveTier(this.config, entry.model);
+      entry.tier = tier.tier;
+      entry.key = tier.key;
+      entry.limit = tier.limit;
+    }
+    this.pump();
+  }
+
+  isDisposed(): boolean {
+    return this.disposed;
+  }
 
   acquire(
     request: BackgroundTaskConcurrencyRequest,
@@ -63,10 +122,14 @@ export class BackgroundTaskConcurrency {
       rejectReady = reject;
     });
     const model = normalizeModel(request.model);
+    const tier = resolveTier(this.config, model);
     const entry: QueueEntry = {
       id: ++this.nextID,
       model,
       provider: providerFromModel(model),
+      tier: tier.tier,
+      key: tier.key,
+      limit: tier.limit,
       started: false,
       released: false,
       resolve: resolveReady,
@@ -96,6 +159,61 @@ export class BackgroundTaskConcurrency {
     if (entry) this.release(entry);
   }
 
+  /**
+   * Claim a slot for a task that is already running. Used to restore the
+   * admission state after a plugin re-init (or a process restart that resumes
+   * a live run), where the fresh scheduler cannot know about tasks that were
+   * admitted by a previous generation. Idempotent: a task that already holds
+   * a slot is left untouched. Restores bypass the resolved caps because the
+   * task is already in flight — we are reconstructing reality, not admitting
+   * new work.
+   */
+  restoreTask(taskID: string, model?: string): void {
+    if (this.disposed || !taskID || this.activeByTaskID.has(taskID)) return;
+    const normalized = normalizeModel(model);
+    const tier = resolveTier(this.config, normalized);
+    const entry: QueueEntry = {
+      id: ++this.nextID,
+      model: normalized,
+      provider: providerFromModel(normalized),
+      tier: tier.tier,
+      key: tier.key,
+      limit: tier.limit,
+      started: true,
+      released: false,
+      taskID,
+      resolve: () => {},
+      reject: () => {},
+    };
+    this.active.add(entry);
+    this.activeByTaskID.set(taskID, entry);
+    this.track(entry);
+  }
+
+  /**
+   * Atomically move a running task's accounting from its admission
+   * model/provider to a new model. Keeps provider/model caps correct when a
+   * child session switches models mid-flight (foreground fallback, runtime
+   * model switch). No-op when the task is unknown or already on that model.
+   */
+  migrateTask(taskID: string, model: string | undefined): void {
+    const entry = this.activeByTaskID.get(taskID);
+    if (!entry || entry.released) return;
+    const nextModel = normalizeModel(model);
+    if (entry.model === nextModel) return;
+    const tier = resolveTier(this.config, nextModel);
+
+    this.untrack(entry);
+    entry.model = nextModel;
+    entry.provider = providerFromModel(nextModel);
+    entry.tier = tier.tier;
+    entry.key = tier.key;
+    entry.limit = tier.limit;
+    this.track(entry);
+    // Moving a task off a saturated key can free capacity for waiters.
+    this.pump();
+  }
+
   dispose(): void {
     if (this.disposed) return;
     this.disposed = true;
@@ -112,6 +230,13 @@ export class BackgroundTaskConcurrency {
   private bind(entry: QueueEntry, taskID: string): void {
     if (!entry.started || entry.released || !taskID) return;
     if (entry.taskID === taskID) return;
+    const existing = this.activeByTaskID.get(taskID);
+    if (existing && existing !== entry) {
+      // A restored slot already claims this taskID (e.g. the task was
+      // rehydrated after a re-init before this ticket got bound). Drop the
+      // restored slot so the admitted ticket becomes the single owner.
+      this.release(existing);
+    }
     if (entry.taskID !== undefined) {
       this.activeByTaskID.delete(entry.taskID);
     }
@@ -130,35 +255,33 @@ export class BackgroundTaskConcurrency {
 
       entry.started = true;
       this.active.add(entry);
-      increment(this.activeByProvider, entry.provider);
-      increment(this.activeByModel, entry.model);
+      this.track(entry);
       entry.resolve();
     }
   }
 
   private canStart(entry: QueueEntry): boolean {
-    const defaultLimit = enabledLimit(this.config.defaultConcurrency);
-    if (defaultLimit !== undefined && this.active.size >= defaultLimit) {
-      return false;
-    }
+    if (entry.limit === Infinity) return true;
+    if (entry.tier === 'default') return this.activeDefault < entry.limit;
+    return (this.activeByKey.get(entry.key ?? '') ?? 0) < entry.limit;
+  }
 
-    const providerLimit = entry.provider
-      ? enabledLimit(this.config.providerConcurrency[entry.provider])
-      : undefined;
-    if (
-      providerLimit !== undefined &&
-      (this.activeByProvider.get(entry.provider ?? '') ?? 0) >= providerLimit
-    ) {
-      return false;
+  private track(entry: QueueEntry): void {
+    if (entry.limit === Infinity) return;
+    if (entry.tier === 'default') {
+      this.activeDefault += 1;
+    } else {
+      increment(this.activeByKey, entry.key);
     }
+  }
 
-    const modelLimit = entry.model
-      ? enabledLimit(this.config.modelConcurrency[entry.model])
-      : undefined;
-    return (
-      modelLimit === undefined ||
-      (this.activeByModel.get(entry.model ?? '') ?? 0) < modelLimit
-    );
+  private untrack(entry: QueueEntry): void {
+    if (entry.limit === Infinity) return;
+    if (entry.tier === 'default') {
+      this.activeDefault -= 1;
+    } else {
+      decrement(this.activeByKey, entry.key);
+    }
   }
 
   private release(entry: QueueEntry): void {
@@ -175,14 +298,82 @@ export class BackgroundTaskConcurrency {
 
     if (entry.started) {
       this.active.delete(entry);
-      decrement(this.activeByProvider, entry.provider);
-      decrement(this.activeByModel, entry.model);
+      this.untrack(entry);
     }
     if (entry.taskID !== undefined) {
       this.activeByTaskID.delete(entry.taskID);
     }
     this.pump();
   }
+}
+
+// ── Process-scoped shared instances ──────────────────────────────────────
+//
+// The plugin factory re-runs on every config update (Instance.dispose →
+// re-init). A scheduler created inside the factory would lose its running
+// slots AND its queued tickets on every re-init. These module-level instances
+// survive re-inits: the factory calls `getBackgroundTaskConcurrency` with the
+// (possibly changed) config, which reuses the instance for the same project.
+//
+// One instance per project directory: multiple plugin instances (different
+// OpenCode workspaces in one process) must not share a queue or overwrite
+// each other's caps. Only a genuine process restart resets them —
+// `restoreTask` (wired into historical run rehydration) then reclaims slots
+// for tasks still running.
+
+const schedulersByDirectory = new Map<string, BackgroundTaskConcurrency>();
+
+/**
+ * Return the process-scoped scheduler for a project directory, applying
+ * `config` when the instance already exists (plugin re-init). Instances are
+ * isolated per directory so concurrent plugin instances never share admission
+ * state. Recreates an instance after a dispose so a caller that tore the
+ * scheduler down (tests, genuine unload) gets a fresh one instead of a
+ * permanently cancelled instance.
+ */
+export function getBackgroundTaskConcurrency(
+  directory: string,
+  config: BackgroundTaskConcurrencyConfig,
+): BackgroundTaskConcurrency {
+  const key = directory || 'default';
+  const existing = schedulersByDirectory.get(key);
+  if (!existing || existing.isDisposed()) {
+    const scheduler = new BackgroundTaskConcurrency(config);
+    schedulersByDirectory.set(key, scheduler);
+    return scheduler;
+  }
+  existing.updateConfig(config);
+  return existing;
+}
+
+/** Test seam: drop all shared instances between tests. */
+export function resetBackgroundTaskConcurrencyForTests(): void {
+  schedulersByDirectory.clear();
+}
+
+/** Resolve the single applicable cap tier for a model (model > provider > default). */
+function resolveTier(
+  config: BackgroundTaskConcurrencyConfig,
+  model: string | undefined,
+): { tier: ConcurrencyTier; key?: string; limit: number } {
+  if (model !== undefined) {
+    const modelLimit = config.modelConcurrency[model];
+    if (modelLimit !== undefined) {
+      return { tier: 'model', key: model, limit: enabledLimit(modelLimit) };
+    }
+    const provider = providerFromModel(model);
+    if (provider !== undefined) {
+      const providerLimit = config.providerConcurrency[provider];
+      if (providerLimit !== undefined) {
+        return {
+          tier: 'provider',
+          key: provider,
+          limit: enabledLimit(providerLimit),
+        };
+      }
+    }
+  }
+  return { tier: 'default', limit: enabledLimit(config.defaultConcurrency) };
 }
 
 function normalizeModel(model: string | undefined): string | undefined {
@@ -196,8 +387,9 @@ function providerFromModel(model: string | undefined): string | undefined {
   return slash > 0 ? model.slice(0, slash) : undefined;
 }
 
-function enabledLimit(limit: number | undefined): number | undefined {
-  return typeof limit === 'number' && limit > 0 ? limit : undefined;
+/** 0 (and absent/negative) means unlimited; a positive value caps the tier. */
+function enabledLimit(limit: number | undefined): number {
+  return typeof limit === 'number' && limit > 0 ? limit : Infinity;
 }
 
 function increment(map: Map<string, number>, key: string | undefined): void {

--- a/src/utils/background-task-concurrency.ts
+++ b/src/utils/background-task-concurrency.ts
@@ -1,0 +1,213 @@
+export interface BackgroundTaskConcurrencyConfig {
+  defaultConcurrency: number;
+  providerConcurrency: Readonly<Record<string, number>>;
+  modelConcurrency: Readonly<Record<string, number>>;
+}
+
+export interface BackgroundTaskConcurrencyRequest {
+  model?: string;
+}
+
+export interface BackgroundTaskConcurrencyTicket {
+  readonly ready: Promise<void>;
+  bind(taskID: string): void;
+  release(): void;
+  releaseIfUnbound(): void;
+}
+
+interface QueueEntry {
+  id: number;
+  model?: string;
+  provider?: string;
+  started: boolean;
+  released: boolean;
+  taskID?: string;
+  resolve: () => void;
+  reject: (error: Error) => void;
+}
+
+export class BackgroundTaskConcurrencyQueueCancelledError extends Error {
+  constructor() {
+    super('Background task concurrency queue was cancelled');
+    this.name = 'BackgroundTaskConcurrencyQueueCancelledError';
+  }
+}
+
+/**
+ * Process-local admission scheduler for native background task launches.
+ *
+ * Queued requests are admitted in order, but entries whose provider or model
+ * quota is saturated are skipped in favor of admittable later entries
+ * (FIFO with skip). A ticket owns capacity from the moment its `ready`
+ * promise resolves until the bound task reaches a terminal state. The job
+ * board still owns task lifecycle; this scheduler only controls admission.
+ */
+export class BackgroundTaskConcurrency {
+  private readonly waiting: QueueEntry[] = [];
+  private readonly active = new Set<QueueEntry>();
+  private readonly activeByProvider = new Map<string, number>();
+  private readonly activeByModel = new Map<string, number>();
+  private readonly activeByTaskID = new Map<string, QueueEntry>();
+  private nextID = 0;
+  private disposed = false;
+
+  constructor(private readonly config: BackgroundTaskConcurrencyConfig) {}
+
+  acquire(
+    request: BackgroundTaskConcurrencyRequest,
+  ): BackgroundTaskConcurrencyTicket {
+    let resolveReady!: () => void;
+    let rejectReady!: (error: Error) => void;
+    const ready = new Promise<void>((resolve, reject) => {
+      resolveReady = resolve;
+      rejectReady = reject;
+    });
+    const model = normalizeModel(request.model);
+    const entry: QueueEntry = {
+      id: ++this.nextID,
+      model,
+      provider: providerFromModel(model),
+      started: false,
+      released: false,
+      resolve: resolveReady,
+      reject: rejectReady,
+    };
+
+    if (this.disposed) {
+      entry.released = true;
+      rejectReady(new BackgroundTaskConcurrencyQueueCancelledError());
+    } else {
+      this.waiting.push(entry);
+      this.pump();
+    }
+
+    return {
+      ready,
+      bind: (taskID) => this.bind(entry, taskID),
+      release: () => this.release(entry),
+      releaseIfUnbound: () => {
+        if (entry.taskID === undefined) this.release(entry);
+      },
+    };
+  }
+
+  releaseTask(taskID: string): void {
+    const entry = this.activeByTaskID.get(taskID);
+    if (entry) this.release(entry);
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    for (const entry of [...this.waiting, ...this.active]) {
+      this.release(entry);
+    }
+  }
+
+  /** Test/diagnostic seam. */
+  snapshot(): { active: number; queued: number } {
+    return { active: this.active.size, queued: this.waiting.length };
+  }
+
+  private bind(entry: QueueEntry, taskID: string): void {
+    if (!entry.started || entry.released || !taskID) return;
+    if (entry.taskID === taskID) return;
+    if (entry.taskID !== undefined) {
+      this.activeByTaskID.delete(entry.taskID);
+    }
+    entry.taskID = taskID;
+    this.activeByTaskID.set(taskID, entry);
+  }
+
+  private pump(): void {
+    if (this.disposed) return;
+
+    while (true) {
+      const index = this.waiting.findIndex((entry) => this.canStart(entry));
+      if (index < 0) return;
+      const [entry] = this.waiting.splice(index, 1);
+      if (!entry || entry.released) continue;
+
+      entry.started = true;
+      this.active.add(entry);
+      increment(this.activeByProvider, entry.provider);
+      increment(this.activeByModel, entry.model);
+      entry.resolve();
+    }
+  }
+
+  private canStart(entry: QueueEntry): boolean {
+    const defaultLimit = enabledLimit(this.config.defaultConcurrency);
+    if (defaultLimit !== undefined && this.active.size >= defaultLimit) {
+      return false;
+    }
+
+    const providerLimit = entry.provider
+      ? enabledLimit(this.config.providerConcurrency[entry.provider])
+      : undefined;
+    if (
+      providerLimit !== undefined &&
+      (this.activeByProvider.get(entry.provider ?? '') ?? 0) >= providerLimit
+    ) {
+      return false;
+    }
+
+    const modelLimit = entry.model
+      ? enabledLimit(this.config.modelConcurrency[entry.model])
+      : undefined;
+    return (
+      modelLimit === undefined ||
+      (this.activeByModel.get(entry.model ?? '') ?? 0) < modelLimit
+    );
+  }
+
+  private release(entry: QueueEntry): void {
+    if (entry.released) return;
+    entry.released = true;
+
+    const waitingIndex = this.waiting.indexOf(entry);
+    if (waitingIndex >= 0) {
+      this.waiting.splice(waitingIndex, 1);
+      entry.reject(new BackgroundTaskConcurrencyQueueCancelledError());
+      this.pump();
+      return;
+    }
+
+    if (entry.started) {
+      this.active.delete(entry);
+      decrement(this.activeByProvider, entry.provider);
+      decrement(this.activeByModel, entry.model);
+    }
+    if (entry.taskID !== undefined) {
+      this.activeByTaskID.delete(entry.taskID);
+    }
+    this.pump();
+  }
+}
+
+function normalizeModel(model: string | undefined): string | undefined {
+  const value = model?.trim();
+  return value || undefined;
+}
+
+function providerFromModel(model: string | undefined): string | undefined {
+  if (!model) return undefined;
+  const slash = model.indexOf('/');
+  return slash > 0 ? model.slice(0, slash) : undefined;
+}
+
+function enabledLimit(limit: number | undefined): number | undefined {
+  return typeof limit === 'number' && limit > 0 ? limit : undefined;
+}
+
+function increment(map: Map<string, number>, key: string | undefined): void {
+  if (!key) return;
+  map.set(key, (map.get(key) ?? 0) + 1);
+}
+
+function decrement(map: Map<string, number>, key: string | undefined): void {
+  if (!key) return;
+  const next = (map.get(key) ?? 0) - 1;
+  if (next > 0) map.set(key, next);
+  else map.delete(key);
+}

--- a/src/utils/codemap.md
+++ b/src/utils/codemap.md
@@ -25,6 +25,8 @@ Centralized utilities and shared abstractions used across the oh-my-opencode-sli
 
 - **BackgroundJobSupervisor** (`background-job-supervisor.ts`): One-shot wall-clock deadline supervision for background task runs: deadline timer → abort → grace timer → terminal finalization. Owns only timer/generation/abort mechanics.
 
+- **BackgroundTaskConcurrency** (`background-task-concurrency.ts`): Process-local admission scheduler for native background tasks. Tracks queued tickets and active provider/model capacity without owning Job Board lifecycle state.
+
 - **Runtime Session Status** (`session-runtime-status.ts`): Reads and validates the in-process OpenCode session-status map once per observation (5s bounded timeout). It distinguishes a valid absent session (`idle`) from malformed data or lookup failure (`unknown`) so lifecycle policy never treats schema drift as completion.
 
 - **Session Metadata** (`session-metadata.ts`): `SessionMetadataStore` — bounded session → agent/directory map with LRU eviction that never evicts active orchestrator sessions.

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -3,6 +3,7 @@ export * from './background-job-board';
 export * from './background-job-coordinator';
 export * from './background-job-store';
 export * from './background-job-supervisor';
+export * from './background-task-concurrency';
 export * from './internal-initiator';
 export { initLogger, log } from './logger';
 export * from './polling';

--- a/src/utils/session-metadata.ts
+++ b/src/utils/session-metadata.ts
@@ -2,6 +2,7 @@ type SessionMetadataEviction = (sessionID: string) => void;
 
 export class SessionMetadataStore {
   readonly #agents = new Map<string, string>();
+  readonly #models = new Map<string, string>();
   readonly #directories = new Map<string, string>();
   readonly #insertionOrder = new Map<string, undefined>();
   readonly #activeOrchestratorSessionIDs = new Set<string>();
@@ -18,6 +19,15 @@ export class SessionMetadataStore {
 
   getAgent(sessionID: string): string | undefined {
     return this.#agents.get(sessionID);
+  }
+
+  getModel(sessionID: string): string | undefined {
+    return this.#models.get(sessionID);
+  }
+
+  setModel(sessionID: string, model: string): void {
+    this.#models.set(sessionID, model);
+    this.#track(sessionID);
   }
 
   getDirectory(sessionID: string): string | undefined {
@@ -53,6 +63,7 @@ export class SessionMetadataStore {
 
   delete(sessionID: string): void {
     this.#agents.delete(sessionID);
+    this.#models.delete(sessionID);
     this.#directories.delete(sessionID);
     this.#insertionOrder.delete(sessionID);
     this.#activeOrchestratorSessionIDs.delete(sessionID);
@@ -83,6 +94,7 @@ export class SessionMetadataStore {
 
       this.#insertionOrder.delete(evictableSessionID);
       this.#agents.delete(evictableSessionID);
+      this.#models.delete(evictableSessionID);
       this.#directories.delete(evictableSessionID);
       this.#onEvict?.(evictableSessionID);
     }


### PR DESCRIPTION
Fixes #975

## What problem are you solving?

Users on free-tier or rate-limited providers hit API request limits during parallel agent execution: some background tasks fail or stop unexpectedly. The issue asks for configurable concurrency limits so tasks queue and all eventually complete instead of failing, trading speed for reliability (e.g. overnight runs).

## What does this change?

- Add `backgroundJobs.concurrency` with three caps (issue's `background_task.*` names mapped onto the existing `backgroundJobs` namespace):
  - `defaultConcurrency` — global cap on concurrently running native background tasks; `0` (default) disables the cap
  - `providerConcurrency` — per-provider caps keyed by provider ID
  - `modelConcurrency` — per-model caps keyed by `provider/model` ID
- New `BackgroundTaskConcurrency` admission scheduler (`src/utils/background-task-concurrency.ts`): a ticket owns a slot from admission until the bound task reaches a terminal state. The job board keeps owning task lifecycle; this only controls admission.
- Admission happens in `tool.execute.before` before OpenCode creates the child session, so queued work consumes no provider request. Queued entries are admitted FIFO, skipping entries whose provider/model quota is saturated (FIFO with skip), so one hot model cannot block others.
- Nested-orchestration deadlock guard: a session that is itself a managed background task is exempt from admission — it already holds a slot, and waiting for a second one would self-deadlock once the queue saturates.
- Slots release on board terminal transition (coordinator listener), child/parent `session.deleted`, foreground status terminal fallback, and plugin disposal.
- Update the generated JSON Schema, `docs/configuration.md` (config table + example + behavior), `docs/background-orchestration.md` (new "Background Task Concurrency" section incl. the no-admission-timeout caveat and pairing with `wallClockTimeoutMs`), and codemaps.

## Why this approach?

Admission control at `tool.execute.before` keeps queued tasks from consuming provider requests at all, which is exactly what the issue's overnight-run use case needs — limits apply before cost, not after failures.

The scheduler is process-local and deliberately thin: it tracks queued tickets and active provider/model capacity without duplicating job board lifecycle state, so all existing terminal/release paths remain the single source of truth.

Nested exemption is fail-open by design: a nested background spawn bypasses the caps rather than risking a self-deadlock; over-admitting in that rare case is safer than hanging a session.

Known trade-off (documented): admission itself has no timeout. A task that never reaches a terminal state keeps its slot forever, so the docs recommend pairing `concurrency` with the opt-in `wallClockTimeoutMs` supervisor.

## Related work

- [x] Checked open and closed issues and PRs for duplicates.
- Related: #975

## Verification

- [x] `bun run check:ci` - clean
- [x] `bun run typecheck` - clean
- [x] `bun test` - 2380 passed, 0 failed
- [x] Generated schema is synchronized
- [x] `git diff --check` - clean