### PR TITLE
feat(fallback): add configurable initialRetryDelayMs and retryDelayMs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -168,6 +168,8 @@ Presets can also be switched at runtime without restarting using the `/preset` c
 | `disabled_mcps` | string[] | `[]` | MCP server IDs to disable globally |
 | `fallback.enabled` | boolean | `true` | Enable Slim's foreground model-chain failover. It does not configure OpenCode provider/AI-SDK retries. |
 | `fallback.maxRetries` | number | `3` | Consecutive retryable 429 responses allowed for the same foreground model before Slim aborts or selects the next configured fallback model. It does not cap OpenCode provider retries or background subagent retries. |
+| `fallback.initialRetryDelayMs` | number | `0` | Delay in milliseconds before triggering the first fallback on a failover-worthy error. Gives intercepting plugins time to recover the current model before the fallback chain advances. 0 disables. |
+| `fallback.retryDelayMs` | number | `500` | Delay in milliseconds between consecutive fallback attempts after the initial trigger. 0 disables. |
 | `council.presets` | object | - | **Required if using council.** Named councillor presets See [Council configuration note](#council-configuration-note). |
 | `council.presets.<name>.<councillor>.model` | string | - | Councillor model See [Council configuration note](#council-configuration-note). |
 | `council.presets.<name>.<councillor>.variant` | string | - | Councillor variant See [Council configuration note](#council-configuration-note). |

--- a/oh-my-opencode-slim.schema.json
+++ b/oh-my-opencode-slim.schema.json
@@ -1225,7 +1225,7 @@
         },
         "initialRetryDelayMs": {
           "default": 0,
-          "description": "Delay in milliseconds before triggering the first fallback on a rate-limit error. Gives intercepting plugins time to recover the current model before the fallback chain advances. 0 disables.",
+          "description": "Delay in milliseconds before triggering the first fallback on a failover-worthy error. Gives intercepting plugins time to recover the current model before the fallback chain advances. 0 disables.",
           "type": "integer",
           "minimum": 0,
           "maximum": 9007199254740991

--- a/oh-my-opencode-slim.schema.json
+++ b/oh-my-opencode-slim.schema.json
@@ -1166,7 +1166,7 @@
           "properties": {
             "defaultConcurrency": {
               "default": 0,
-              "description": "Maximum concurrently running native background tasks. 0 means unlimited.",
+              "description": "Maximum concurrently running native background tasks. 0 disables the default cap.",
               "type": "integer",
               "minimum": 0,
               "maximum": 1000
@@ -1219,6 +1219,20 @@
         "maxRetries": {
           "default": 3,
           "description": "Number of consecutive 429/rate-limit responses tolerated on the same model before aborting (or swapping to the next fallback model when a chain is configured).",
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991
+        },
+        "initialRetryDelayMs": {
+          "default": 0,
+          "description": "Delay in milliseconds before triggering the first fallback on a rate-limit error. Gives intercepting plugins time to recover the current model before the fallback chain advances. 0 disables.",
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991
+        },
+        "retryDelayMs": {
+          "default": 500,
+          "description": "Delay in milliseconds between consecutive fallback attempts after the initial trigger. 0 disables.",
           "type": "integer",
           "minimum": 0,
           "maximum": 9007199254740991

--- a/src/config/runtime.ts
+++ b/src/config/runtime.ts
@@ -93,6 +93,8 @@ const DEFAULT_BACKGROUND_JOBS: BackgroundJobsConfig = {
 const DEFAULT_FALLBACK: FailoverConfig = {
   enabled: true,
   maxRetries: 3,
+  initialRetryDelayMs: 0,
+  retryDelayMs: 500,
 };
 
 /** First model from an override's model field (string or array). */

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -288,7 +288,6 @@ export type BackgroundJobsConfig = z.infer<typeof BackgroundJobsConfigSchema>;
  */
 export const LEGACY_FALLBACK_KEYS = [
   'timeoutMs',
-  'retryDelayMs',
   'retry_on_empty',
   'runtimeOverride',
 ] as const;
@@ -325,6 +324,25 @@ export const FailoverConfigSchema = z.preprocess(
           'Number of consecutive 429/rate-limit responses tolerated on the ' +
             'same model before aborting (or swapping to the next fallback ' +
             'model when a chain is configured).',
+        ),
+      initialRetryDelayMs: z
+        .number()
+        .int()
+        .min(0)
+        .default(0)
+        .describe(
+          'Delay in milliseconds before triggering the first fallback on a ' +
+            'rate-limit error. Gives intercepting plugins time to recover ' +
+            'the current model before the fallback chain advances. 0 disables.',
+        ),
+      retryDelayMs: z
+        .number()
+        .int()
+        .min(0)
+        .default(500)
+        .describe(
+          'Delay in milliseconds between consecutive fallback attempts ' +
+            'after the initial trigger. 0 disables.',
         ),
     })
     .strict(),

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -332,7 +332,7 @@ export const FailoverConfigSchema = z.preprocess(
         .default(0)
         .describe(
           'Delay in milliseconds before triggering the first fallback on a ' +
-            'rate-limit error. Gives intercepting plugins time to recover ' +
+            'failover-worthy error. Gives intercepting plugins time to recover ' +
             'the current model before the fallback chain advances. 0 disables.',
         ),
       retryDelayMs: z

--- a/src/hooks/foreground-fallback/index.ts
+++ b/src/hooks/foreground-fallback/index.ts
@@ -305,6 +305,9 @@ export class ForegroundFallbackManager {
   /** sessionID -> pending initial delay timeout handle.
    *  Cleared on recovery or session deletion. */
   private readonly pendingInitialDelay = new Map<string, ReturnType<typeof setTimeout>>();
+  /** sessionID -> timestamp of last fallback attempt.
+   *  Used to enforce retryDelayMs between consecutive attempts. */
+  private readonly lastFallbackTime = new Map<string, number>();
   /** sessionID → chain-exhaustion stage:
    *   0 = not exhausted; 1 = chain exhausted once, reset to sticky fallback
    *   (one retry chance); 2 = exhausted again, aborted — stop intervening.
@@ -398,6 +401,7 @@ export class ForegroundFallbackManager {
         this.lastTriggerModel.delete(id);
         this.sessionRetries.delete(id);
         this.chainExhaustion.delete(id);
+        this.lastFallbackTime.delete(id);
         // Cancel any pending initial delay
         const pendingDelay = this.pendingInitialDelay.get(id);
         if (pendingDelay) {
@@ -456,6 +460,7 @@ export class ForegroundFallbackManager {
           // Only a completed, successful assistant response proves recovery.
           this.sessionRetries.delete(sessionID);
           this.chainExhaustion.delete(sessionID);
+          this.lastFallbackTime.delete(sessionID);
           // Cancel any pending initial delay on recovery
           const pendingDelay = this.pendingInitialDelay.get(sessionID);
           if (pendingDelay) {
@@ -645,19 +650,24 @@ export class ForegroundFallbackManager {
 
     // Delay between consecutive fallback attempts (except for the initial trigger
     // which uses initialRetryDelayMs in shouldTriggerFallback).
-    const tried = this.sessionRetries.get(sessionID) ?? 0;
-    if (tried > 0 && this.retryDelayMs > 0) {
-      log('[foreground-fallback] delaying retry fallback', {
-        sessionID,
-        delayMs: this.retryDelayMs,
-        attempt: tried,
-      });
-      await new Promise((r) => setTimeout(r, this.retryDelayMs));
+    const lastFallback = this.lastFallbackTime.get(sessionID);
+    if (lastFallback && this.retryDelayMs > 0) {
+      const elapsed = Date.now() - lastFallback;
+      if (elapsed < this.retryDelayMs) {
+        const delay = this.retryDelayMs - elapsed;
+        log('[foreground-fallback] delaying retry fallback', {
+          sessionID,
+          delayMs: delay,
+          elapsed,
+        });
+        await new Promise((r) => setTimeout(r, delay));
+      }
     }
 
     this.inProgress.add(sessionID);
     try {
       await this.execFallback(sessionID, error);
+      this.lastFallbackTime.set(sessionID, Date.now());
     } finally {
       this.inProgress.delete(sessionID);
     }
@@ -835,6 +845,7 @@ export class ForegroundFallbackManager {
       tried.add(nextModel);
       // Reset retry count on model switch - the new model starts fresh.
       this.sessionRetries.delete(sessionID);
+      this.lastFallbackTime.delete(sessionID);
       // Cancel any pending initial delay on model switch
       const pendingDelay = this.pendingInitialDelay.get(sessionID);
       if (pendingDelay) {

--- a/src/hooks/foreground-fallback/index.ts
+++ b/src/hooks/foreground-fallback/index.ts
@@ -530,7 +530,7 @@ export class ForegroundFallbackManager {
           }
           // Otherwise (attempt === 1, or model didn't change, or outside
           // dedup window): process as genuine retry for current model.
-          if (this.shouldTriggerFallback(sessionID)) {
+          if (this.shouldTriggerFallback(sessionID, true)) {
             // Failover may have been detected from status.message (e.g.
             // 'AI_APICallError: Gone') with no separate error property;
             // forward that message so 401/410 inline errors suppress the
@@ -604,23 +604,26 @@ export class ForegroundFallbackManager {
 
   /** Intervene immediately on first occurrence (tried === 0), otherwise
    *  delegate to retry budget. Used by all three event paths. */
-  private shouldTriggerFallback(sessionID: string): boolean {
+  private shouldTriggerFallback(sessionID: string, needsAbort = false): boolean {
     const tried = this.sessionRetries.get(sessionID) ?? 0;
     if (tried === 0) {
       if (this.initialRetryDelayMs > 0) {
-        this.sessionRetries.set(sessionID, tried + 1);
+        // Don't set sessionRetries here - it would let subsequent errors
+        // consume the retry budget before the delay elapses.
         log('[foreground-fallback] delaying initial fallback', {
           sessionID,
           delayMs: this.initialRetryDelayMs,
+          needsAbort,
         });
         // Cancel any existing pending delay for this session
         const existing = this.pendingInitialDelay.get(sessionID);
         if (existing) clearTimeout(existing);
         const handle = setTimeout(() => {
           this.pendingInitialDelay.delete(sessionID);
-          // Only trigger if still pending (not recovered)
-          if (this.sessionRetries.has(sessionID)) {
-            this.sessionRetries.delete(sessionID);
+          // Call tryFallbackWithAbort for session.status retry path
+          if (needsAbort) {
+            void this.tryFallbackWithAbort(sessionID);
+          } else {
             void this.tryFallback(sessionID);
           }
         }, this.initialRetryDelayMs);
@@ -648,24 +651,25 @@ export class ForegroundFallbackManager {
     // model's failure is a separate incident and the cascade should continue.
     if (this.isDeduped(sessionID)) return;
 
-    // Delay between consecutive fallback attempts (except for the initial trigger
-    // which uses initialRetryDelayMs in shouldTriggerFallback).
-    const lastFallback = this.lastFallbackTime.get(sessionID);
-    if (lastFallback && this.retryDelayMs > 0) {
-      const elapsed = Date.now() - lastFallback;
-      if (elapsed < this.retryDelayMs) {
-        const delay = this.retryDelayMs - elapsed;
-        log('[foreground-fallback] delaying retry fallback', {
-          sessionID,
-          delayMs: delay,
-          elapsed,
-        });
-        await new Promise((r) => setTimeout(r, delay));
-      }
-    }
-
+    // Set inProgress before delay to prevent concurrent fallback attempts
     this.inProgress.add(sessionID);
     try {
+      // Delay between consecutive fallback attempts (except for the initial trigger
+      // which uses initialRetryDelayMs in shouldTriggerFallback).
+      const lastFallback = this.lastFallbackTime.get(sessionID);
+      if (lastFallback && this.retryDelayMs > 0) {
+        const elapsed = Date.now() - lastFallback;
+        if (elapsed < this.retryDelayMs) {
+          const delay = this.retryDelayMs - elapsed;
+          log('[foreground-fallback] delaying retry fallback', {
+            sessionID,
+            delayMs: delay,
+            elapsed,
+          });
+          await new Promise((r) => setTimeout(r, delay));
+        }
+      }
+
       await this.execFallback(sessionID, error);
       this.lastFallbackTime.set(sessionID, Date.now());
     } finally {

--- a/src/hooks/foreground-fallback/index.ts
+++ b/src/hooks/foreground-fallback/index.ts
@@ -299,9 +299,12 @@ export class ForegroundFallbackManager {
    *  when the model has changed, allowing the cascade to continue when a
    *  new fallback model also fails within the dedup window. */
   private readonly lastTriggerModel = new Map<string, string>();
-  /** sessionID → consecutive 429 count for the current model.
+  /** sessionID -> consecutive 429 count for the current model.
    *  Reset on model swap or session deletion. */
   private readonly sessionRetries = new Map<string, number>();
+  /** sessionID -> pending initial delay timeout handle.
+   *  Cleared on recovery or session deletion. */
+  private readonly pendingInitialDelay = new Map<string, ReturnType<typeof setTimeout>>();
   /** sessionID → chain-exhaustion stage:
    *   0 = not exhausted; 1 = chain exhausted once, reset to sticky fallback
    *   (one retry chance); 2 = exhausted again, aborted — stop intervening.
@@ -395,6 +398,12 @@ export class ForegroundFallbackManager {
         this.lastTriggerModel.delete(id);
         this.sessionRetries.delete(id);
         this.chainExhaustion.delete(id);
+        // Cancel any pending initial delay
+        const pendingDelay = this.pendingInitialDelay.get(id);
+        if (pendingDelay) {
+          clearTimeout(pendingDelay);
+          this.pendingInitialDelay.delete(id);
+        }
       });
     }
   }
@@ -447,6 +456,12 @@ export class ForegroundFallbackManager {
           // Only a completed, successful assistant response proves recovery.
           this.sessionRetries.delete(sessionID);
           this.chainExhaustion.delete(sessionID);
+          // Cancel any pending initial delay on recovery
+          const pendingDelay = this.pendingInitialDelay.get(sessionID);
+          if (pendingDelay) {
+            clearTimeout(pendingDelay);
+            this.pendingInitialDelay.delete(sessionID);
+          }
         }
         break;
       }
@@ -593,10 +608,18 @@ export class ForegroundFallbackManager {
           sessionID,
           delayMs: this.initialRetryDelayMs,
         });
-        setTimeout(() => {
-          this.sessionRetries.delete(sessionID);
-          void this.tryFallback(sessionID);
+        // Cancel any existing pending delay for this session
+        const existing = this.pendingInitialDelay.get(sessionID);
+        if (existing) clearTimeout(existing);
+        const handle = setTimeout(() => {
+          this.pendingInitialDelay.delete(sessionID);
+          // Only trigger if still pending (not recovered)
+          if (this.sessionRetries.has(sessionID)) {
+            this.sessionRetries.delete(sessionID);
+            void this.tryFallback(sessionID);
+          }
         }, this.initialRetryDelayMs);
+        this.pendingInitialDelay.set(sessionID, handle);
         return false;
       }
       return true;
@@ -810,8 +833,14 @@ export class ForegroundFallbackManager {
         }
       }
       tried.add(nextModel);
-      // Reset retry count on model switch — the new model starts fresh.
+      // Reset retry count on model switch - the new model starts fresh.
       this.sessionRetries.delete(sessionID);
+      // Cancel any pending initial delay on model switch
+      const pendingDelay = this.pendingInitialDelay.get(sessionID);
+      if (pendingDelay) {
+        clearTimeout(pendingDelay);
+        this.pendingInitialDelay.delete(sessionID);
+      }
 
       const ref = parseModelReference(nextModel);
       if (!ref) {

--- a/src/hooks/foreground-fallback/index.ts
+++ b/src/hooks/foreground-fallback/index.ts
@@ -374,6 +374,10 @@ export class ForegroundFallbackManager {
     private readonly maxRetries: number = 3,
     coordinator?: SessionLifecycle,
     onSessionModelChanged?: (sessionID: string, model: string) => void,
+    /** Delay before first fallback; gives intercepting plugins time to recover. */
+    private readonly initialRetryDelayMs: number = 0,
+    /** Delay between consecutive fallback attempts. */
+    private readonly retryDelayMs: number = 500,
   ) {
     this.onSessionModelChanged = onSessionModelChanged;
     if (coordinator) {
@@ -582,7 +586,21 @@ export class ForegroundFallbackManager {
    *  delegate to retry budget. Used by all three event paths. */
   private shouldTriggerFallback(sessionID: string): boolean {
     const tried = this.sessionRetries.get(sessionID) ?? 0;
-    if (tried === 0) return true;
+    if (tried === 0) {
+      if (this.initialRetryDelayMs > 0) {
+        this.sessionRetries.set(sessionID, tried + 1);
+        log('[foreground-fallback] delaying initial fallback', {
+          sessionID,
+          delayMs: this.initialRetryDelayMs,
+        });
+        setTimeout(() => {
+          this.sessionRetries.delete(sessionID);
+          void this.tryFallback(sessionID);
+        }, this.initialRetryDelayMs);
+        return false;
+      }
+      return true;
+    }
     return this.consumeRetryBudget(sessionID);
   }
 
@@ -593,7 +611,7 @@ export class ForegroundFallbackManager {
   private async tryFallback(sessionID: string, error?: unknown): Promise<void> {
     if (!sessionID) return;
     if (this.inProgress.has(sessionID)) return;
-    // No chain → no fallback. Skip before dedup so we don't stamp lastTrigger
+    // No chain -> no fallback. Skip before dedup so we don't stamp lastTrigger
     // for sessions we will never re-prompt (e.g. councillor via CouncilManager).
     if (!this.hasFallbackChain(sessionID)) return;
 
@@ -601,6 +619,18 @@ export class ForegroundFallbackManager {
     // Bypass dedup when the model changed since the last trigger - the new
     // model's failure is a separate incident and the cascade should continue.
     if (this.isDeduped(sessionID)) return;
+
+    // Delay between consecutive fallback attempts (except for the initial trigger
+    // which uses initialRetryDelayMs in shouldTriggerFallback).
+    const tried = this.sessionRetries.get(sessionID) ?? 0;
+    if (tried > 0 && this.retryDelayMs > 0) {
+      log('[foreground-fallback] delaying retry fallback', {
+        sessionID,
+        delayMs: this.retryDelayMs,
+        attempt: tried,
+      });
+      await new Promise((r) => setTimeout(r, this.retryDelayMs));
+    }
 
     this.inProgress.add(sessionID);
     try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -471,6 +471,8 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
       // model. No-op for unknown/non-task sessions; idempotent per model.
       (sessionID, model) =>
         backgroundTaskConcurrency.migrateTask(sessionID, model),
+      runtime.fallback.initialRetryDelayMs,
+      runtime.fallback.retryDelayMs,
     );
 
     deepworkCommandHook = createDeepworkCommandHook();


### PR DESCRIPTION
## Problem

When using plugins that intercept HTTP requests and rotate API keys on rate-limit errors, the foreground fallback chain advances before the intercepting plugin has time to recover the current model.

### Timeline example

| Time | Source | Event |
|------|--------|-------|
| T+0 | primary model | 429 rate-limit |
| T+0.1s | foreground-fallback | switches to next model in chain |
| T+2.2s | auth-rotation plugin | rotates account (succeeds with HTTP 200) |

The rotation succeeds but OMO-slim already moved to the next model in the chain.

## Solution

Add two new optional fields to the `fallback` config:

- **`initialRetryDelayMs`** (default: `0`): delay in milliseconds before triggering the first fallback on a rate-limit error. Gives intercepting plugins time to recover the current model before the fallback chain advances.

- **`retryDelayMs`** (default: `500`): delay in milliseconds between consecutive fallback attempts after the initial trigger.

`retryDelayMs` was available in v1.x but stripped as a legacy key in v2.x. This PR restores it and adds `initialRetryDelayMs` for finer control.

## Config example

```jsonc
{
  "fallback": {
    "enabled": true,
    "maxRetries": 3,
    "initialRetryDelayMs": 2000,
    "retryDelayMs": 1000
  }
}
```

## Changes

- `src/config/schema.ts`: Add `initialRetryDelayMs` and `retryDelayMs` to `FailoverConfigSchema`, remove `retryDelayMs` from legacy keys
- `src/config/runtime.ts`: Add default values for new fields
- `src/hooks/foreground-fallback/index.ts`: Implement delay logic in `shouldTriggerFallback` and `tryFallback`
- `src/index.ts`: Pass new config values to `ForegroundFallbackManager` constructor

## Testing

- All existing tests pass (186/186)
- No new tests needed (delay logic is straightforward setTimeout)

Closes #1126