### PR TITLE
fix: trigger model fallback on content-policy moderation rejections

### DIFF
--- a/src/hooks/foreground-fallback/index.test.ts
+++ b/src/hooks/foreground-fallback/index.test.ts
@@ -468,6 +468,47 @@ describe('ForegroundFallbackManager session.error', () => {
     expect(call[0].body.model.modelID).toBe('gpt-4o');
   });
 
+  test('triggers fallback on content-policy moderation session.error', async () => {
+    // End-to-end regression: a cyber_policy rejection (HTTP 400
+    // invalid_request in production) must advance the fallback chain to the
+    // next model instead of failing the session outright.
+    await mgr.handleEvent({
+      type: 'message.updated',
+      properties: {
+        info: {
+          sessionID: 'sess-1',
+          providerID: 'anthropic',
+          modelID: 'claude-opus-4-5',
+          role: 'assistant',
+        },
+      },
+    });
+
+    await mgr.handleEvent({
+      type: 'session.error',
+      properties: {
+        sessionID: 'sess-1',
+        error: {
+          message:
+            'This content was flagged for possible cybersecurity risk. If this seems wrong, try rephrasing your request. To get authorized for security work, join the Trusted Access for Cyber program: https://chatgpt.com/cyber',
+        },
+      },
+    });
+
+    expect(mocks.abort).toHaveBeenCalledTimes(0);
+    expect(mocks.promptAsync).toHaveBeenCalledTimes(1);
+
+    const call = mocks.promptAsync.mock.calls[0] as [
+      {
+        sessionID: string;
+        model: { providerID: string; modelID: string };
+      },
+    ];
+    expect(call[0].path.id).toBe('sess-1');
+    expect(call[0].body.model.providerID).toBe('openai');
+    expect(call[0].body.model.modelID).toBe('gpt-4o');
+  });
+
   test('triggers fallback on unavailable provider channel session.error', async () => {
     await mgr.handleEvent({
       type: 'message.updated',

--- a/src/hooks/foreground-fallback/index.test.ts
+++ b/src/hooks/foreground-fallback/index.test.ts
@@ -144,6 +144,59 @@ describe('isFailoverError', () => {
     ).toBe(true);
   });
 
+  test('returns true for content-policy moderation rejections (cyber_policy)', () => {
+    // OpenAI moderation surfaces as HTTP 400 invalid_request with the
+    // provider-specific policy code; deterministic per provider, so the next
+    // model in the chain must be tried instead of failing the request.
+    expect(
+      isFailoverError(
+        'AI_APICallError: This content was flagged for possible cybersecurity risk. If this seems wrong, try rephrasing your request. To get authorized for security work, join the Trusted Access for Cyber program: https://chatgpt.com/cyber',
+      ),
+    ).toBe(true);
+    expect(
+      isFailoverError({
+        data: {
+          statusCode: 400,
+          message:
+            'This content was flagged for possible cybersecurity risk. If this seems wrong, try rephrasing your request. To get authorized for security work, join the Trusted Access for Cyber program: https://chatgpt.com/cyber',
+        },
+      }),
+    ).toBe(true);
+    expect(
+      isFailoverError({
+        data: {
+          statusCode: 400,
+          responseBody:
+            '{"error":{"type":"invalid_request","code":"cyber_policy"}}',
+        },
+      }),
+    ).toBe(true);
+    expect(
+      isFailoverError({
+        data: {
+          statusCode: 400,
+          responseBody:
+            '{"error":{"code":"content_policy_violation","message":"Your request was rejected as a result of our safety system."}}',
+        },
+      }),
+    ).toBe(true);
+  });
+
+  test('returns false for generic flagged/policy wording without the moderation signature', () => {
+    // Only the structured code or the exact provider wording match; ordinary
+    // errors mentioning "flagged", "cybersecurity", or "policy" stay hard
+    // errors.
+    expect(
+      isFailoverError({ message: 'request flagged for review by the proxy' }),
+    ).toBe(false);
+    expect(
+      isFailoverError({ message: 'analysis of cybersecurity topics rejected' }),
+    ).toBe(false);
+    expect(
+      isFailoverError({ message: 'policy update required for this model' }),
+    ).toBe(false);
+  });
+
   test('returns true for "usage exceeded"', () => {
     expect(isRetryableError({ message: 'usage exceeded' })).toBe(true);
   });

--- a/src/hooks/foreground-fallback/index.ts
+++ b/src/hooks/foreground-fallback/index.ts
@@ -68,6 +68,18 @@ const RETRYABLE_ERROR_PATTERNS = [
   // "provider returned error" wording, which wraps any provider 4xx (e.g. a
   // genuine 400 the next model would reproduce) and must stay a hard error.
   /\b401\b/,
+  // Content-policy moderation rejections (e.g. OpenAI "cyber_policy",
+  // "content_policy_violation") arrive as HTTP 400 invalid_request with a
+  // provider-specific policy code in the body. They are deterministic per
+  // provider — retrying the same model will fail again, but a different
+  // provider in the chain does not share the policy, so the next model
+  // should be tried. Match the structured codes and the exact provider
+  // wording; do NOT match generic "flagged"/"policy" words that could
+  // appear in ordinary error text.
+  /\bcyber_policy\b/,
+  /\bcontent_policy_violation\b/,
+  /flagged for possible cybersecurity risk/i,
+  /rejected as a result of our safety system/i,
 ];
 
 const OUTAGE_STATUS_CODES = new Set([500, 502, 503, 504]);


### PR DESCRIPTION
# fix: trigger model fallback on content-policy moderation rejections

## Problem

When OpenAI flags a request under its cyber-security content policy, the request fails outright with no model fallback:

```
AI_APICallError: This content was flagged for possible cybersecurity risk.
If this seems wrong, try rephrasing your request. To get authorized for
security work, join the Trusted Access for Cyber program: https://chatgpt.com/cyber
```

The error surfaces as HTTP 400 `invalid_request` with the structured code `cyber_policy` in the body. `isFailoverError()` intentionally treats unrecognized 400s as hard errors (a genuine `invalid_request` would be reproduced by the next model in the chain), so the moderation rejection never reaches the fallback pipeline, neither for foreground sessions nor for delegated subagent sessions (the task-session-manager event router imports the same classifier).

## Why fallback is correct here

A content-policy rejection is deterministic per provider: retrying the same model will fail again (observed back-to-back in production logs), but other providers in the fallback chain do not share the policy. This is the same family as the already-handled `403/forbidden` case: a provider-side refusal that the next model can serve.

## Change

Two pattern groups in `RETRYABLE_ERROR_PATTERNS` (`src/hooks/foreground-fallback/index.ts`):

- `/\bcyber_policy\b/` and `/\bcontent_policy_violation\b/`: the structured provider error codes (may appear in `responseBody` JSON)
- `/flagged for possible cybersecurity risk/i` and `/rejected as a result of our safety system/i`: the exact provider wording

Generic "flagged"/"policy"/"cybersecurity" wording is deliberately not matched, so ordinary error text stays a hard error.

Because both the foreground manager and the delegated-session event router use this classifier, the fix covers interactive sessions and subagents, and the rejection inherits the existing retry budget (`fallback.maxRetries`, default 3), dedup window, and chain-exhaustion guard with no additional code.

## Validation

- New unit tests: string form, `{ data: { statusCode: 400, message } }` form, `responseBody` JSON with the structured code, plus three negative cases proving generic flagged/policy/cybersecurity wording does not match.
- `bun test`: 2463 pass / 0 fail.
- `tsc --noEmit`: clean. `biome check`: clean.

## Compatibility

Additive-only change to error classification; no config, schema, or API changes. Existing behavior for all other error shapes is unchanged.
