### PR TITLE
fix: point default_agent at the visible orchestrator entry when a displayName is set

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -751,6 +751,38 @@ describe('plugin config model inheritance', () => {
     }
   });
 
+  test('config() writes the visible orchestrator display name as default_agent', async () => {
+    const hooks = await loadConfiguredPlugin({
+      council: {
+        presets: { default: { alpha: { model: 'test/councillor' } } },
+      },
+      agents: {
+        orchestrator: { displayName: 'EngineeringLead' },
+        council: { displayName: 'ArchitectureCouncil' },
+      },
+    });
+    const hostConfig: Record<string, unknown> = {};
+
+    try {
+      await hooks.config?.(hostConfig);
+
+      // The orchestrator's visible entry is keyed by its display name;
+      // canonical 'orchestrator' is only a hidden alias, so default_agent
+      // must target the display-name entry.
+      expect(hostConfig.default_agent).toBe('EngineeringLead');
+      const agents = hostConfig.agent as Record<
+        string,
+        Record<string, unknown>
+      >;
+      expect(agents.EngineeringLead?.hidden).toBeUndefined();
+      expect(agents.orchestrator?.hidden).toBe(true);
+      expect(agents.ArchitectureCouncil?.hidden).toBeUndefined();
+      expect(agents.council?.hidden).toBe(true);
+    } finally {
+      await hooks.dispose?.();
+    }
+  });
+
   test('admission uses a direct host override from final agent config', async () => {
     await assertAdmissionUsesFinalModel(
       'fixer',

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,6 +84,7 @@ import {
   BackgroundJobSupervisor,
   type BackgroundTaskConcurrency,
   createDisplayNameMentionRewriter,
+  normalizeAgentName,
   resolveRuntimeAgentName,
 } from './utils';
 import type { ContextFile } from './utils/background-job-board';
@@ -785,9 +786,11 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
       // ones (host override > runtime override > plugin file).
       RuntimeConfig.get(ctx.directory).captureHostConfig(opencodeConfig);
 
-      // Force default_agent to 'orchestrator' when unset, and also when the
-      // user pointed it at an omos subagent name (opencode rejects subagent
-      // names as default_agent with "default agent must be a primary agent").
+      // Force default_agent to the orchestrator's visible entry when unset,
+      // and also when the user pointed it at an omos subagent name (opencode
+      // rejects subagent names as default_agent with "default agent must be a
+      // primary agent"). With a display name, the canonical 'orchestrator'
+      // registration is a hidden alias, so default to its visible entry.
       // Other values (opencode's built-in 'build'/'plan', or a user-defined
       // primary agent) are respected. This guards against promptAsync calls
       // that omit the `agent` field from falling back to 'build' when the
@@ -796,8 +799,16 @@ export const OhMyOpenCodeLite: Plugin = async (ctx) => {
         const existing = (opencodeConfig as { default_agent?: string })
           .default_agent;
         if (!existing || isSubagent(existing)) {
+          const orchestratorAlias = agents.orchestrator as
+            | {
+                displayName?: string;
+                hidden?: boolean;
+              }
+            | undefined;
           (opencodeConfig as { default_agent?: string }).default_agent =
-            'orchestrator';
+            orchestratorAlias?.hidden && orchestratorAlias.displayName
+              ? normalizeAgentName(orchestratorAlias.displayName)
+              : 'orchestrator';
         }
       }
 


### PR DESCRIPTION
## Summary

- When `agents.orchestrator.displayName` is configured, the plugin registers two entries: the visible display-name entry (e.g. `EngineeringLead`) and a hidden `orchestrator` alias (`getAgentConfigs`). The `config()` hook still forced `default_agent: "orchestrator"` when unset — now pointing at the hidden alias.
- OpenCode rejects hidden agents as `default_agent` (`default agent "orchestrator" is hidden`), so after a restart the default agent fell back to the first visible agent in the alphabetically sorted agent list. With several display names configured, that could be a subagent's display name (e.g. `AgentImprover`) instead of the orchestrator.
- The hook now detects the dual registration (`orchestrator` entry hidden + `displayName` set) and writes `default_agent` as the normalized display name, so the orchestrator stays the default agent. Without a display name, behavior is unchanged (`'orchestrator'`).
- Adds a regression test asserting `default_agent` targets the visible entry while the canonical `orchestrator`/`council` registrations stay hidden aliases.

## Testing

- `bun test src/index.test.ts` (new test: "config() writes the visible orchestrator display name as default_agent")
- `bun run typecheck`