### PR TITLE
fix: block repeated wait tool calls within a turn

### DIFF
--- a/src/hooks/tool-loop-guard/hook.ts
+++ b/src/hooks/tool-loop-guard/hook.ts
@@ -36,8 +36,14 @@ import { log } from '../../utils/logger';
  *   warn at N calls but stay warn-only (never hard-block) to avoid deadlocking
  *   terminal result retrieval for long-running background tasks.
  * - Task management and lifecycle tools (task, task_cancel, task_message,
- *   task_revive, wait_for_*) remain exempt; task-session-manager owns its
- *   own duplicate-spawn guards (#1056/#1070).
+ *   task_revive) remain exempt; task-session-manager owns its own
+ *   duplicate-spawn guards (#1056/#1070).
+ * - Wait tools (wait_for_user, wait_for_background_tasks) use a dedicated
+ *   per-turn counter keyed by tool name only: their contract is "end the
+ *   turn", so a repeat call within one turn is always degenerate regardless
+ *   of arguments or output. They warn at 2 completed calls and the 3rd call
+ *   is refused (#1139). The counter resets on a new user message, a
+ *   completed turn, or session deletion.
  *
  * Precedent: json-error-recovery (output warning) and task-session-manager
  * (before-hook refusal).
@@ -55,8 +61,6 @@ const LOOP_GUARD_EXEMPT: Record<string, true> = {
   task_cancel: true,
   task_message: true,
   task_revive: true,
-  wait_for_user: true,
-  wait_for_background_tasks: true,
 };
 
 /**
@@ -70,6 +74,28 @@ const LOOP_GUARD_BLOCK_TOOLS: Record<string, true> = {
   grep: true,
   glob: true,
 };
+
+/**
+ * Wait tools whose contract is "end this turn now". Repeating them within a
+ * turn is always degenerate: the first result already told the model to stop
+ * calling tools, and because the tool returns instantly, each repeat
+ * re-triggers a full-context inference — a non-compliant model can loop
+ * indefinitely (#1139). Counted by tool name only (arguments and output may
+ * vary); both tools share one per-session stream.
+ */
+const WAIT_TOOLS = new Set(['wait_for_user', 'wait_for_background_tasks']);
+const WAIT_GUARD_WARN_AT = 2;
+const WAIT_GUARD_BLOCK_AT = 2;
+
+export const WAIT_GUARD_MARKER = '[REPEATED WAIT TOOL - END TURN]';
+
+export const WAIT_GUARD_WARNING = `
+${WAIT_GUARD_MARKER}
+
+You have already called a wait tool ${WAIT_GUARD_WARN_AT} times in this turn. Its result instructed you to end the turn — do not call it again.
+
+STOP calling tools. Respond to the user in plain text and end your turn. The next distinct external user message resumes normal continuation.
+`;
 
 const LOOP_GUARD_MARKER = '[REPEATED TOOL CALLS - STOP]';
 
@@ -175,6 +201,8 @@ export function createToolLoopGuardHook(): ToolLoopGuardHook {
   const callKeys = new Map<string, CallState>();
   /** Polling state is shared by task_status/task_result for each task. */
   const taskSupervision = new Map<string, Map<string, TaskSupervisionState>>();
+  /** Completed wait-tool calls since the last reset, per session (#1139). */
+  const waitRuns = new Map<string, number>();
   /** Last durable user-message identity observed for each session. */
   const userMessageIdentities = new Map<string, string>();
 
@@ -182,12 +210,17 @@ export function createToolLoopGuardHook(): ToolLoopGuardHook {
     taskSupervision.delete(sessionID);
   }
 
-  /** Prune the session map to MAX_TRACKED_SESSIONS (FIFO by insertion). */
+  /** Prune the session maps to MAX_TRACKED_SESSIONS (FIFO by insertion). */
   function keepSessionsBounded(): void {
     while (sessions.size > MAX_TRACKED_SESSIONS) {
       const oldest = sessions.keys().next().value as string | undefined;
       if (oldest === undefined) break;
       sessions.delete(oldest);
+    }
+    while (waitRuns.size > MAX_TRACKED_SESSIONS) {
+      const oldest = waitRuns.keys().next().value as string | undefined;
+      if (oldest === undefined) break;
+      waitRuns.delete(oldest);
     }
   }
 
@@ -199,6 +232,29 @@ export function createToolLoopGuardHook(): ToolLoopGuardHook {
       const sessionID = input.sessionID;
       if (!sessionID) return;
       const tool = input.tool.toLowerCase();
+
+      // Wait tools: refuse once the per-turn wait counter confirms a loop.
+      // A wait tool's result already says "end this turn", so a repeat is
+      // never legitimate progress (#1139).
+      if (WAIT_TOOLS.has(tool)) {
+        resetTaskSupervision(sessionID);
+        if (input.callID) {
+          callKeys.set(input.callID, { sessionID, key: `wait:${tool}` });
+        }
+        const runs = waitRuns.get(sessionID) ?? 0;
+        if (runs >= WAIT_GUARD_BLOCK_AT) {
+          log('[tool-loop-guard] blocked repeated wait tool call', {
+            sessionID,
+            tool,
+            runs,
+          });
+          throw new Error(
+            `Refusing to execute "${tool}": a wait tool has already completed ${runs} times this turn and instructed you to end the turn. Do not call any more tools. Respond to the user in plain text and end your turn.`,
+          );
+        }
+        return;
+      }
+
       if (LOOP_GUARD_EXEMPT[tool]) {
         resetTaskSupervision(sessionID);
         return;
@@ -251,6 +307,32 @@ export function createToolLoopGuardHook(): ToolLoopGuardHook {
       if (!sessionID) return;
       const tool = input.tool.toLowerCase();
       if (LOOP_GUARD_EXEMPT[tool]) return;
+
+      // Wait tools: count completed calls by tool name, warn from the 2nd
+      // on. The before hook refuses the call once the counter reaches the
+      // block threshold (#1139).
+      if (WAIT_TOOLS.has(tool)) {
+        const call = input.callID ? callKeys.get(input.callID) : undefined;
+        if (input.callID) callKeys.delete(input.callID);
+        // An after hook without a matching before hook is stale.
+        if (!input.callID || !call) return;
+        const runs = (waitRuns.get(sessionID) ?? 0) + 1;
+        waitRuns.set(sessionID, runs);
+        keepSessionsBounded();
+        if (
+          runs >= WAIT_GUARD_WARN_AT &&
+          typeof output.output === 'string' &&
+          !output.output.includes(WAIT_GUARD_MARKER)
+        ) {
+          log('[tool-loop-guard] warned repeated wait tool call', {
+            sessionID,
+            tool,
+            runs,
+          });
+          output.output += `\n${WAIT_GUARD_WARNING}`;
+        }
+        return;
+      }
 
       const call = input.callID ? callKeys.get(input.callID) : undefined;
       if (input.callID) callKeys.delete(input.callID);
@@ -330,17 +412,20 @@ export function createToolLoopGuardHook(): ToolLoopGuardHook {
       if (userMessageIdentities.get(sessionID) === messageID) return;
       userMessageIdentities.set(sessionID, messageID);
       resetTaskSupervision(sessionID);
+      waitRuns.delete(sessionID);
     },
 
     /** Clear task supervision state at a completed parent turn. */
     resetTurn(sessionID: string): void {
       resetTaskSupervision(sessionID);
+      waitRuns.delete(sessionID);
     },
 
     /** Clear all state for a finished/deleted session. */
     resetSession(sessionID: string): void {
       sessions.delete(sessionID);
       resetTaskSupervision(sessionID);
+      waitRuns.delete(sessionID);
       userMessageIdentities.delete(sessionID);
       for (const [callID, call] of callKeys) {
         if (call.sessionID === sessionID) callKeys.delete(callID);
@@ -352,6 +437,7 @@ export function createToolLoopGuardHook(): ToolLoopGuardHook {
       sessions.clear();
       callKeys.clear();
       taskSupervision.clear();
+      waitRuns.clear();
       userMessageIdentities.clear();
     },
   };

--- a/src/hooks/tool-loop-guard/hook.ts
+++ b/src/hooks/tool-loop-guard/hook.ts
@@ -238,9 +238,6 @@ export function createToolLoopGuardHook(): ToolLoopGuardHook {
       // never legitimate progress (#1139).
       if (WAIT_TOOLS.has(tool)) {
         resetTaskSupervision(sessionID);
-        if (input.callID) {
-          callKeys.set(input.callID, { sessionID, key: `wait:${tool}` });
-        }
         const runs = waitRuns.get(sessionID) ?? 0;
         if (runs >= WAIT_GUARD_BLOCK_AT) {
           log('[tool-loop-guard] blocked repeated wait tool call', {
@@ -251,6 +248,11 @@ export function createToolLoopGuardHook(): ToolLoopGuardHook {
           throw new Error(
             `Refusing to execute "${tool}": a wait tool has already completed ${runs} times this turn and instructed you to end the turn. Do not call any more tools. Respond to the user in plain text and end your turn.`,
           );
+        }
+        // Record the call only when it will actually run. A refused call
+        // never reaches the after hook, so its entry would leak (#1140).
+        if (input.callID) {
+          callKeys.set(input.callID, { sessionID, key: `wait:${tool}` });
         }
         return;
       }

--- a/src/hooks/tool-loop-guard/index.test.ts
+++ b/src/hooks/tool-loop-guard/index.test.ts
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, test } from 'bun:test';
 import type { ToolLoopGuardHook } from './hook';
-import { createToolLoopGuardHook, LOOP_GUARD_WARNING } from './hook';
+import {
+  createToolLoopGuardHook,
+  LOOP_GUARD_WARNING,
+  WAIT_GUARD_MARKER,
+  WAIT_GUARD_WARNING,
+} from './hook';
 
 function beforeInput(
   overrides: Partial<{ tool: string; sessionID: string; callID: string }> = {},
@@ -288,14 +293,12 @@ describe('tool-loop-guard', () => {
     expect(completedOutput3.output).toContain(LOOP_GUARD_WARNING);
   });
 
-  test('task and task lifecycle/control tools (cancel, message, revive, wait) remain exempt', async () => {
+  test('task and task lifecycle/control tools (cancel, message, revive) remain exempt', async () => {
     const exemptTools = [
       { tool: 'task', args: { subagent_type: 'explorer', prompt: 'find x' } },
       { tool: 'task_cancel', args: { task_id: 'child-1' } },
       { tool: 'task_message', args: { task_id: 'child-1', message: 'hello' } },
       { tool: 'task_revive', args: { task_id: 'child-1' } },
-      { tool: 'wait_for_user', args: {} },
-      { tool: 'wait_for_background_tasks', args: {} },
     ];
 
     for (const { tool: toolName, args } of exemptTools) {
@@ -467,5 +470,127 @@ describe('tool-loop-guard', () => {
       );
       expect(output.output).not.toContain(LOOP_GUARD_WARNING);
     }
+  });
+
+  test('first wait_for_user call passes through untouched', async () => {
+    const output = await runToolCall(
+      'wait_for_user',
+      'w1',
+      { reason: 'user must restart the server' },
+      'state: waiting_for_user\nreason: user must restart the server',
+    );
+    expect(output.output).not.toContain(WAIT_GUARD_WARNING);
+  });
+
+  test('second wait_for_user call with different reason still warns', async () => {
+    await runToolCall(
+      'wait_for_user',
+      'w1',
+      { reason: 'user must restart the server' },
+      'state: waiting_for_user\nreason: user must restart the server',
+    );
+    const output = await runToolCall(
+      'wait_for_user',
+      'w2',
+      { reason: 'idle wake again' },
+      'state: waiting_for_user\nreason: idle wake again',
+    );
+    expect(output.output).toContain(WAIT_GUARD_WARNING);
+  });
+
+  test('third wait_for_user call is refused', async () => {
+    for (let i = 1; i <= 2; i++) {
+      await runToolCall(
+        'wait_for_user',
+        `w${i}`,
+        { reason: `reason ${i}` },
+        `state: waiting_for_user\nreason: reason ${i}`,
+      );
+    }
+    await expect(
+      hook['tool.execute.before'](
+        beforeInput({ tool: 'wait_for_user', callID: 'w3' }),
+        {
+          args: { reason: 'reason 3' },
+        },
+      ),
+    ).rejects.toThrow('end your turn');
+  });
+
+  test('wait_for_user and wait_for_background_tasks share one stream', async () => {
+    await runToolCall(
+      'wait_for_user',
+      'w1',
+      { reason: 'waiting on user' },
+      'state: waiting_for_user',
+    );
+    const output = await runToolCall(
+      'wait_for_background_tasks',
+      'w2',
+      {},
+      'state: waiting',
+    );
+    expect(output.output).toContain(WAIT_GUARD_WARNING);
+    await expect(
+      hook['tool.execute.before'](
+        beforeInput({ tool: 'wait_for_background_tasks', callID: 'w3' }),
+        { args: {} },
+      ),
+    ).rejects.toThrow('end your turn');
+  });
+
+  test('observeNewUserMessage resets the wait counter', async () => {
+    await runToolCall(
+      'wait_for_user',
+      'w1',
+      { reason: 'waiting on user' },
+      'state: waiting_for_user',
+    );
+    hook.observeNewUserMessage('s1', 'msg-1');
+    const output = await runToolCall(
+      'wait_for_user',
+      'w2',
+      { reason: 'waiting again after reply' },
+      'state: waiting_for_user',
+    );
+    expect(output.output).not.toContain(WAIT_GUARD_WARNING);
+  });
+
+  test('resetTurn resets the wait counter', async () => {
+    await runToolCall(
+      'wait_for_user',
+      'w1',
+      { reason: 'waiting on user' },
+      'state: waiting_for_user',
+    );
+    hook.resetTurn('s1');
+    const output = await runToolCall(
+      'wait_for_user',
+      'w2',
+      { reason: 'new turn wait' },
+      'state: waiting_for_user',
+    );
+    expect(output.output).not.toContain(WAIT_GUARD_WARNING);
+  });
+
+  test('wait tool calls do not poison the fingerprint stream', async () => {
+    await runToolCall(
+      'wait_for_user',
+      'w1',
+      { reason: 'waiting on user' },
+      'state: waiting_for_user',
+    );
+    await runToolCall(
+      'wait_for_user',
+      'w2',
+      { reason: 'still waiting' },
+      'state: waiting_for_user',
+    );
+    // Identical read calls still warn on the 3rd consecutive call.
+    await runIdenticalCall('c1', { filePath: 'a.ts' });
+    await runIdenticalCall('c2', { filePath: 'a.ts' });
+    const o3 = await runIdenticalCall('c3', { filePath: 'a.ts' });
+    expect(o3.output).toContain(LOOP_GUARD_WARNING);
+    expect(o3.output).not.toContain(WAIT_GUARD_MARKER);
   });
 });


### PR DESCRIPTION
Fixes #1139

## Problem

`wait_for_user` / `wait_for_background_tasks` return instantly and were fully exempt from `tool-loop-guard`, so a model that keeps calling tools after a tool result could loop them indefinitely. In the incident behind #1139: **85 `wait_for_user` calls in one turn** at 1–6/min, each triggering a **~285K-token** full-context re-inference, ended only by the user pressing Esc. Neither the #1000 prompt wording nor the #1068 guard catches this (the latter is gated on `orchestratorWake.enabled && hasRunning()`).

## Change

`src/hooks/tool-loop-guard/hook.ts`:

- Removed `wait_for_user` / `wait_for_background_tasks` from `LOOP_GUARD_EXEMPT`.
- Added a dedicated wait stream: a per-session counter of **completed** wait-tool calls, keyed by tool name only (arguments and output may vary between loop iterations, so the fingerprint stream cannot catch it). Both tools share one stream, so alternating them is still recognized.
- Thresholds: `WAIT_GUARD_WARN_AT = 2` (corrective text appended to the 2nd call's output), `WAIT_GUARD_BLOCK_AT = 2` (the 3rd call is refused in `tool.execute.before` with an "end your turn, no more tools" error). A legitimate flow is exactly one wait per turn, so two completed waits + a warning is already generous.
- Counter resets on `observeNewUserMessage`, `resetTurn`, `resetSession`; bounded by the same `MAX_TRACKED_SESSIONS` eviction; wait-tool `after` hooks still honor the stale-after (no matching `before`) protection via `callKeys`.
- Wait-tool calls no longer touch the fingerprint stream, so read/grep/glob detection is unaffected.

## Tests

`src/hooks/tool-loop-guard/index.test.ts`: updated the exemption test (task tools remain exempt; wait tools no longer) and added 7 cases — first call passes, 2nd call with different args warns, 3rd refused, cross-tool shared stream, `observeNewUserMessage` reset, `resetTurn` reset, and no poisoning of the fingerprint stream.

## Verification

- `bun run check:ci` — clean
- `bun run typecheck` — clean
- `bun test src/hooks/tool-loop-guard/` — 30/30 pass
- Full `bun test` — 2471/2472; the single failure (`interview manager - dashboard election failure fallback`) reproduces on a clean `master` checkout and is unrelated.

## Docs

No README/docs changes: the loop guard has no user-facing documentation surface, and this changes no user-visible configuration (the hook has no config knob today).
