### PR TITLE
fix(task-session-manager): mark task notifications as internal initiators

### DIFF
--- a/src/hooks/task-session-manager/revived-run-tracker.test.ts
+++ b/src/hooks/task-session-manager/revived-run-tracker.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, mock, test } from 'bun:test';
 import { BackgroundJobBoard } from '../../utils/background-job-board';
+import { SLIM_INTERNAL_INITIATOR_MARKER } from '../../utils/internal-initiator';
 import { createRevivedRunTracker } from './revived-run-tracker';
 
 function createHarness(
@@ -123,9 +124,27 @@ describe('revived run tracker', () => {
       path: { id: 'parent' },
       body: {
         agent: 'orchestrator',
-        parts: [{ type: 'text', synthetic: true }],
+        // The notification part must carry the internal-initiator metadata
+        // (and marker suffix) so the v2 client-shim routes it through
+        // session.synthetic — a bare `synthetic: true` part drops its flag
+        // in the flat prompt translation and regresses into a visible
+        // user message + external-user-activity classification (#1157).
+        parts: [
+          {
+            type: 'text',
+            synthetic: true,
+            metadata: { 'oh-my-opencode-slim.internalInitiator': true },
+          },
+        ],
       },
     });
+    const notifiedText = (
+      harness.prompt.mock.calls[0]?.[0] as
+        | { body?: { parts?: Array<{ text?: string }> } }
+        | undefined
+    )?.body?.parts?.[0]?.text;
+    expect(notifiedText).toContain('<task ');
+    expect(notifiedText).toContain(SLIM_INTERNAL_INITIATOR_MARKER);
   });
 
   test('keeps a non-terminal idle turn running and rejects historical output', async () => {

--- a/src/hooks/task-session-manager/revived-run-tracker.ts
+++ b/src/hooks/task-session-manager/revived-run-tracker.ts
@@ -6,6 +6,7 @@ import type {
 } from '../../utils/background-job-board';
 import type { BackgroundJobStore } from '../../utils/background-job-store';
 import type { BackgroundJobSupervisor } from '../../utils/background-job-supervisor';
+import { createInternalAgentTextPart } from '../../utils/internal-initiator';
 import { getClient } from '../../utils/opencode-client';
 import { COMPLETED_WITHOUT_TEXT_DIAGNOSTIC } from '../../utils/task';
 
@@ -318,7 +319,14 @@ export function createRevivedRunTracker(options: {
             query: { directory: options.input.directory },
             body: {
               agent: 'orchestrator',
-              parts: [{ type: 'text', synthetic: true, text }],
+              // Internal-initiator part (synthetic flag + metadata + marker):
+              // the v2 client-shim routes these through session.synthetic so
+              // the notification stays machine-context instead of a visible
+              // user message, and the session-prompt bridge classifies the
+              // admission as internal (not external user activity). A bare
+              // `synthetic: true` part loses its flag in the flat v2 prompt
+              // translation (#1157).
+              parts: [createInternalAgentTextPart(text)],
             },
           }),
       );


### PR DESCRIPTION
## What changed, and why was it needed?

Follow-up to #1158 / #1157.

**Why:** The revived-run tracker notifies the orchestrator parent when a background task settles by calling `promptAsync` with a bare `synthetic: true` text part (the `<task …>` XML block). On v2 the flat prompt translation drops the part-level `synthetic` flag, so the notification regressed the same way the wake nudges did:

- rendered as a visible user message, and
- classified as **external user activity** by the session-prompt bridge's non-synthetic-part gate — rearming wake no-progress caps and clearing input-wait latches as if the user had spoken.

**What:** Build the notification part with `createInternalAgentTextPart`, which stamps the internal-initiator metadata and marker suffix:

- with #1158, the v2 client-shim routes it through `session.synthetic` (machine context, no user bubble, wake semantics preserved)
- the session-prompt bridge classifies the admission as internal on all hosts, fixing the external-activity misclassification independently of #1158
- the marker suffix matches the filtering the phase-reminder/board paths already anticipate

**Verification (TDD):** the notification-body test was extended first and watched fail (bare part, no metadata), then the call-site change made it pass; full suite `bun test` 2634 pass / 0 fail; `tsc --noEmit` and `biome check .` clean. `responseError` compatibility with the synthetic admission ack and the board-injection ambiguous-completion provenance were checked (keyed on generation/occurrence, unaffected by the marker).