### PR TITLE
fix(v2): only purely-internal bodies take the session.synthetic route

### DIFF
--- a/src/v2/client-shim.test.ts
+++ b/src/v2/client-shim.test.ts
@@ -377,6 +377,70 @@ describe('v2 client shim delegation', () => {
     });
   });
 
+  test('mixed fallback replays (user parts + internal reminder) stay on session.prompt with files', async () => {
+    // Regression for the greptile P1 on #1158: foreground-fallback appends
+    // an internal-initiator reminder part to the user's real replay parts.
+    // An ANY-part gate routed the whole mixed body through
+    // session.synthetic — dropping the file attachments (the synthetic
+    // branch forwards text only) and skipping user-input persistence.
+    // Only PURELY internal bodies may take the synthetic route.
+    const seq: Array<{ m: string; i: unknown }> = [];
+    const input = buildPluginInput(
+      makeCtx({
+        switchModel: async () => {},
+        prompt: async (i: unknown) => {
+          seq.push({ m: 'prompt', i });
+          return {};
+        },
+        synthetic: async (i: unknown) => {
+          seq.push({ m: 'synthetic', i });
+          return {};
+        },
+      } as never),
+    );
+    await (
+      input.client as {
+        session: {
+          promptAsync: (
+            a: Record<string, unknown> & {
+              delivery?: 'steer' | 'queue';
+              modelSwitch?: 'required';
+            },
+          ) => Promise<unknown>;
+        };
+      }
+    ).session.promptAsync({
+      path: { id: 'ses_1' },
+      body: {
+        agent: 'orchestrator',
+        model: { providerID: 'anthropic', modelID: 'claude-fallback' },
+        parts: [
+          { type: 'text', text: 'analyze this screenshot' },
+          {
+            type: 'file',
+            url: 'file:///tmp/shot.png',
+            mime: 'image/png',
+          },
+          createInternalAgentTextPart(
+            "<system-reminder>\nThe previous model request failed and is being retried with a fallback model. Continue processing the user's original request above. Do not respond to this reminder.\n</system-reminder>",
+          ),
+        ],
+      },
+      modelSwitch: 'required',
+    });
+    expect(seq).toHaveLength(1);
+    expect(seq[0].m).toBe('prompt');
+    expect(seq[0].i).toMatchObject({
+      sessionID: 'ses_1',
+      delivery: 'steer',
+      metadata: { 'oh-my-opencode-slim.internalInitiator': true },
+    });
+    expect((seq[0].i as { text: string }).text).toContain(
+      'analyze this screenshot',
+    );
+    expect((seq[0].i as { files: unknown[] }).files).toHaveLength(1);
+  });
+
   test('abort delegates to interrupt', async () => {
     const calls: unknown[] = [];
     const input = buildPluginInput(

--- a/src/v2/client-shim.ts
+++ b/src/v2/client-shim.ts
@@ -152,6 +152,25 @@ function internalInitiatorMetadataFromBody(
 }
 
 /**
+ * Pure-internal routing gate: ONLY bodies whose every part is an internal
+ * initiator may take the session.synthetic admission. Mixed bodies —
+ * notably foreground-fallback's replay of the user's real parts with an
+ * appended internal reminder — must stay on session.prompt so they remain
+ * persisted user input and keep their file attachments (the synthetic
+ * branch forwards text only). See the mixed-replay regression test and
+ * the greptile P1 review on #1158.
+ */
+function isPureInternalInitiatorBody(args: Record<string, unknown>): boolean {
+  const body = (args?.body ?? {}) as {
+    parts?: Array<Record<string, unknown>>;
+  };
+  const parts = Array.isArray(body.parts) ? body.parts : [];
+  return (
+    parts.length > 0 && parts.every((part) => isInternalInitiatorPart(part))
+  );
+}
+
+/**
  * Map one v2 `Session.Info` to the v1 list shape the shim's consumers
  * read (interview dashboard directory discovery: `directory`,
  * `time.updated`; identity fields for any future consumer). Only fields
@@ -321,10 +340,15 @@ export function buildPluginInput(
         // flag, which regressed them into visible user bubbles. v2's
         // dedicated session.synthetic admission keeps the text model-visible
         // while skipping user-message persistence, and its default `resume`
-        // preserves the wake semantics. Hosts without session.synthetic
-        // keep the pre-fix prompt path (visible wake, metadata intact).
+        // preserves the wake semantics. ONLY purely-internal bodies take
+        // this route — mixed bodies (foreground-fallback's user-parts +
+        // internal reminder replay) must stay on session.prompt to preserve
+        // user-input persistence and file attachments. Hosts without
+        // session.synthetic keep the pre-fix prompt path (visible wake,
+        // metadata intact).
         const internalViaSynthetic =
-          metadata !== undefined && typeof s.synthetic === 'function';
+          isPureInternalInitiatorBody(args) &&
+          typeof s.synthetic === 'function';
         if (!s.prompt && !internalViaSynthetic) {
           throw new Error('[v2] session.prompt unavailable for promptAsync');
         }


### PR DESCRIPTION
## What changed, and why was it needed?

Addresses the greptile P1 review finding on #1158.

**Why:** foreground-fallback replays the user's real parts with an appended internal-initiator reminder part (`src/hooks/foreground-fallback/index.ts`). The #1158 routing gate classified the body when ANY part was internal, so that mixed replay went through `session.synthetic` on synthetic-capable hosts:

- the replay was no longer persisted as user input, and
- file/image attachments were silently lost — the synthetic branch forwards text only.

**What:** routing now requires EVERY part to be an internal initiator (`isPureInternalInitiatorBody`). Mixed bodies stay on `session.prompt` with their files and user-input semantics; the internal-initiator metadata stamping for the session-prompt bridge (and pure-internal wake/notification routing from #1158/#1159) is unchanged.

**Verification (TDD):** regression test replays the exact fallback shape (text + image file + `createInternalAgentTextPart` reminder, `modelSwitch: 'required'`) and was watched fail first (routed to synthetic, files dropped), then pass on the prompt path with the attachment preserved. Full suite 2638 pass / 0 fail; `tsc --noEmit` and `biome check .` clean.