### PR TITLE
fix(task-session-manager): settle quiescent jobs via host outcome on v2

### DIFF
--- a/src/hooks/task-session-manager/idle-reconciliation.test.ts
+++ b/src/hooks/task-session-manager/idle-reconciliation.test.ts
@@ -7,6 +7,21 @@ async function flushChildIdleReconcile(): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, 5));
 }
 
+/** Poll the board until the predicate holds (bounded) — CI runners can be
+ * slower than the fixed 5ms flush, and the stabilization loop needs extra
+ * macrotask hops (delay(0) per probe). */
+async function waitForBoardRecord(
+  board: BackgroundJobBoard,
+  predicate: (record: { state: string } | undefined) => boolean,
+  timeoutMs = 500,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate(board.get('child-1'))) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
 function createHarness(options?: {
   stopConfirmationGraceMs?: number;
   readSessionOutcome?: (
@@ -140,6 +155,7 @@ describe('host outcome confirmation (v2: no session.status map)', () => {
     const generation = board.get('child-1')?.generation ?? 1;
 
     await observeIdle(reconciler, 10, generation);
+    await waitForBoardRecord(board, (r) => r?.state === 'reconciled');
 
     expect(readSessionOutcome).toHaveBeenCalledWith('child-1');
     const record = board.get('child-1');
@@ -165,6 +181,7 @@ describe('host outcome confirmation (v2: no session.status map)', () => {
     const generation = board.get('child-1')?.generation ?? 1;
 
     await observeIdle(reconciler, 10, generation);
+    await waitForBoardRecord(board, (r) => r?.state === 'reconciled');
 
     expect(readSessionOutcome).toHaveBeenCalledTimes(3); // initial + 2 probes
     const record = board.get('child-1');
@@ -192,6 +209,7 @@ describe('host outcome confirmation (v2: no session.status map)', () => {
     const generation = board.get('child-1')?.generation ?? 1;
 
     await observeIdle(reconciler, 10, generation);
+    await waitForBoardRecord(board, (r) => r?.state === 'reconciled');
 
     const record = board.get('child-1');
     expect(record).toMatchObject({
@@ -209,6 +227,7 @@ describe('host outcome confirmation (v2: no session.status map)', () => {
     const generation = board.get('child-1')?.generation ?? 1;
 
     await observeIdle(reconciler, 10, generation);
+    await waitForBoardRecord(board, (r) => r?.state === 'reconciled');
 
     const record = board.get('child-1');
     expect(record).toMatchObject({

--- a/src/hooks/task-session-manager/idle-reconciliation.test.ts
+++ b/src/hooks/task-session-manager/idle-reconciliation.test.ts
@@ -6,7 +6,10 @@ async function flushChildIdleReconcile(): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, 5));
 }
 
-function createHarness(options?: { stopConfirmationGraceMs?: number }) {
+function createHarness(options?: {
+  stopConfirmationGraceMs?: number;
+  readSessionOutcome?: (sessionID: string) => Promise<string | undefined>;
+}) {
   const board = new BackgroundJobBoard();
   const terminalListener = mock(() => {});
   board.addTerminalStateListener(terminalListener);
@@ -25,6 +28,7 @@ function createHarness(options?: { stopConfirmationGraceMs?: number }) {
       contextFilesForPrompt,
       prune,
     },
+    readSessionOutcome: options?.readSessionOutcome,
   });
   board.registerLaunch({
     taskID: 'child-1',
@@ -115,5 +119,79 @@ describe('idle reconciliation stop confirmation', () => {
     expect(board.get('child-1')).toMatchObject({ state: 'running' });
     expect(board.get('child-1')?.stopConfirmationStartedAt).toBe(21);
     expect(terminalListener).not.toHaveBeenCalled();
+  });
+});
+
+describe('host outcome confirmation (v2: no session.status map)', () => {
+  test('quiescent job with host outcome succeeded settles completed and reconciled', async () => {
+    const readSessionOutcome = mock(async () => 'succeeded' as const);
+    const { board, reconciler, terminalListener } = createHarness({
+      stopConfirmationGraceMs: 60_000,
+      readSessionOutcome,
+    });
+    const generation = board.get('child-1')?.generation ?? 1;
+
+    await observeIdle(reconciler, 10, generation);
+
+    expect(readSessionOutcome).toHaveBeenCalledWith('child-1');
+    expect(board.get('child-1')).toMatchObject({
+      state: 'reconciled',
+      terminalState: 'completed',
+      terminalUnreconciled: false,
+      statusUncertain: false,
+    });
+    expect(terminalListener).toHaveBeenCalledTimes(1);
+  });
+
+  test('quiescent job with host outcome failed settles error', async () => {
+    const { board, reconciler } = createHarness({
+      stopConfirmationGraceMs: 60_000,
+      readSessionOutcome: async () => 'failed',
+    });
+    const generation = board.get('child-1')?.generation ?? 1;
+
+    await observeIdle(reconciler, 10, generation);
+
+    const record = board.get('child-1');
+    expect(record).toMatchObject({
+      state: 'reconciled',
+      terminalState: 'error',
+      terminalUnreconciled: false,
+    });
+    expect((record?.resultSummary ?? '').toLowerCase()).not.toContain(
+      'undefined',
+    );
+    expect(record?.resultSummary).toBe('Host reported outcome: failed.');
+  });
+
+  test('late busy after idle wins over a stale host outcome probe', async () => {
+    const { board, reconciler } = createHarness({
+      stopConfirmationGraceMs: 60_000,
+      readSessionOutcome: async () => 'succeeded',
+    });
+    const generation = board.get('child-1')?.generation ?? 1;
+
+    board.markRunningFromLiveSession('child-1', 20); // busy AFTER idleObservedAt 10
+    await observeIdle(reconciler, 10, generation);
+
+    expect(board.get('child-1')).toMatchObject({ state: 'running' });
+  });
+
+  test('quiescent job without a host outcome self-confirms stopped after grace', async () => {
+    const { board, reconciler, terminalListener } = createHarness({
+      stopConfirmationGraceMs: 5,
+      readSessionOutcome: async () => undefined,
+    });
+    const generation = board.get('child-1')?.generation ?? 1;
+
+    await observeIdle(reconciler, 10, generation);
+    expect(board.get('child-1')).toMatchObject({ state: 'running' });
+
+    // No external re-observation: the reconciler must complete the stop
+    // confirmation itself after the grace elapses (the v1 design relied on
+    // the periodic runtime-status reconciler, which is unavailable on v2).
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(board.get('child-1')).toMatchObject({ state: 'stopped' });
+    expect(terminalListener).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/hooks/task-session-manager/idle-reconciliation.test.ts
+++ b/src/hooks/task-session-manager/idle-reconciliation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, mock, test } from 'bun:test';
 import { BackgroundJobBoard } from '../../utils';
+import { COMPLETED_WITHOUT_TEXT_DIAGNOSTIC } from '../../utils/task';
 import { createIdleReconciler } from './idle-reconciliation';
 
 async function flushChildIdleReconcile(): Promise<void> {
@@ -8,7 +9,10 @@ async function flushChildIdleReconcile(): Promise<void> {
 
 function createHarness(options?: {
   stopConfirmationGraceMs?: number;
-  readSessionOutcome?: (sessionID: string) => Promise<string | undefined>;
+  readSessionOutcome?: (
+    sessionID: string,
+  ) => Promise<{ outcome?: string; resultText?: string } | undefined>;
+  outcomeStabilization?: { probes: number; intervalMs: number };
 }) {
   const board = new BackgroundJobBoard();
   const terminalListener = mock(() => {});
@@ -29,6 +33,7 @@ function createHarness(options?: {
       prune,
     },
     readSessionOutcome: options?.readSessionOutcome,
+    outcomeStabilization: options?.outcomeStabilization,
   });
   board.registerLaunch({
     taskID: 'child-1',
@@ -123,8 +128,11 @@ describe('idle reconciliation stop confirmation', () => {
 });
 
 describe('host outcome confirmation (v2: no session.status map)', () => {
-  test('quiescent job with host outcome succeeded settles completed and reconciled', async () => {
-    const readSessionOutcome = mock(async () => 'succeeded' as const);
+  test('quiescent job with host outcome succeeded and result text settles completed with the real text', async () => {
+    const readSessionOutcome = mock(
+      async () =>
+        ({ outcome: 'succeeded', resultText: 'Real result summary.' }) as const,
+    );
     const { board, reconciler, terminalListener } = createHarness({
       stopConfirmationGraceMs: 60_000,
       readSessionOutcome,
@@ -134,19 +142,69 @@ describe('host outcome confirmation (v2: no session.status map)', () => {
     await observeIdle(reconciler, 10, generation);
 
     expect(readSessionOutcome).toHaveBeenCalledWith('child-1');
-    expect(board.get('child-1')).toMatchObject({
+    const record = board.get('child-1');
+    expect(record).toMatchObject({
       state: 'reconciled',
       terminalState: 'completed',
       terminalUnreconciled: false,
       statusUncertain: false,
     });
+    expect(record?.resultSummary).toBe('Real result summary.');
     expect(terminalListener).toHaveBeenCalledTimes(1);
+  });
+
+  test('succeeded but textless settles error with the diagnostic after stabilization probes (incident #1115 precedent)', async () => {
+    const readSessionOutcome = mock(
+      async () => ({ outcome: 'succeeded' }) as const,
+    );
+    const { board, reconciler } = createHarness({
+      stopConfirmationGraceMs: 60_000,
+      outcomeStabilization: { probes: 2, intervalMs: 0 },
+      readSessionOutcome,
+    });
+    const generation = board.get('child-1')?.generation ?? 1;
+
+    await observeIdle(reconciler, 10, generation);
+
+    expect(readSessionOutcome).toHaveBeenCalledTimes(3); // initial + 2 probes
+    const record = board.get('child-1');
+    expect(record).toMatchObject({
+      state: 'reconciled',
+      terminalState: 'error',
+      terminalUnreconciled: false,
+    });
+    expect(record?.resultSummary).toBe(COMPLETED_WITHOUT_TEXT_DIAGNOSTIC);
+  });
+
+  test('succeeded with text arriving on a later stabilization probe settles completed', async () => {
+    let calls = 0;
+    const readSessionOutcome = mock(async () => {
+      calls += 1;
+      return calls >= 2
+        ? { outcome: 'succeeded', resultText: 'Late but real text.' }
+        : { outcome: 'succeeded' };
+    });
+    const { board, reconciler } = createHarness({
+      stopConfirmationGraceMs: 60_000,
+      outcomeStabilization: { probes: 3, intervalMs: 0 },
+      readSessionOutcome,
+    });
+    const generation = board.get('child-1')?.generation ?? 1;
+
+    await observeIdle(reconciler, 10, generation);
+
+    const record = board.get('child-1');
+    expect(record).toMatchObject({
+      state: 'reconciled',
+      terminalState: 'completed',
+    });
+    expect(record?.resultSummary).toBe('Late but real text.');
   });
 
   test('quiescent job with host outcome failed settles error', async () => {
     const { board, reconciler } = createHarness({
       stopConfirmationGraceMs: 60_000,
-      readSessionOutcome: async () => 'failed',
+      readSessionOutcome: async () => ({ outcome: 'failed' }),
     });
     const generation = board.get('child-1')?.generation ?? 1;
 
@@ -167,7 +225,10 @@ describe('host outcome confirmation (v2: no session.status map)', () => {
   test('late busy after idle wins over a stale host outcome probe', async () => {
     const { board, reconciler } = createHarness({
       stopConfirmationGraceMs: 60_000,
-      readSessionOutcome: async () => 'succeeded',
+      readSessionOutcome: async () => ({
+        outcome: 'succeeded',
+        resultText: 'x',
+      }),
     });
     const generation = board.get('child-1')?.generation ?? 1;
 

--- a/src/hooks/task-session-manager/idle-reconciliation.ts
+++ b/src/hooks/task-session-manager/idle-reconciliation.ts
@@ -6,6 +6,15 @@ import {
   STOP_CONFIRMATION_GRACE_MS,
 } from './stop-confirmation';
 
+/** Wall-clock slack before the post-grace self-observation fires. */
+const QUIESCENT_CONFIRM_SLACK_MS = 25;
+
+const HOST_TERMINAL_OUTCOMES = new Set(['succeeded', 'failed', 'interrupted']);
+
+function isHostTerminalOutcome(outcome: string | undefined): boolean {
+  return outcome !== undefined && HOST_TERMINAL_OUTCOMES.has(outcome);
+}
+
 export function createIdleReconciler(options: {
   backgroundJobBoard: BackgroundJobStore;
   reconcileInjectedTerminalJobs: (parentSessionID: string) => void;
@@ -26,6 +35,11 @@ export function createIdleReconciler(options: {
     prune(board: { taskIDs(): Set<string> }): void;
   };
   revivedRunTracker?: RevivedRunTracker;
+  /** Host-native terminal outcome probe (v2 Session.Info.outcome via
+   * session.get). Quiescent jobs settle to the accurate terminal state
+   * instead of lingering 'running + statusUncertain' on hosts without a
+   * live session-status map. Return undefined when unavailable. */
+  readSessionOutcome?: (sessionID: string) => Promise<string | undefined>;
 }) {
   const idleReconcileTimers = new Map<string, ReturnType<typeof setTimeout>>();
   const childIdleReconcileTimers = new Map<
@@ -33,6 +47,10 @@ export function createIdleReconciler(options: {
     ReturnType<typeof setTimeout>
   >();
   const errorTerminalizeTimers = new Map<
+    string,
+    ReturnType<typeof setTimeout>
+  >();
+  const quiescentConfirmTimers = new Map<
     string,
     ReturnType<typeof setTimeout>
   >();
@@ -107,6 +125,68 @@ export function createIdleReconciler(options: {
         });
         return;
       }
+
+      // Host-native outcome confirmation (v2: no session.status map, but
+      // Session.Info.outcome publishes the terminal transition). Settles
+      // the quiescent job to its accurate terminal state instead of the
+      // cancellation-flavored 'stopped' below.
+      if (options.readSessionOutcome) {
+        let outcome: string | undefined;
+        try {
+          outcome = await options.readSessionOutcome(sessionID);
+        } catch (error) {
+          log('[task-session-manager] host outcome probe failed', {
+            sessionID,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+        const latest = options.backgroundJobBoard.get(sessionID);
+        const guardsIntact =
+          latest !== undefined &&
+          latest.state === 'running' &&
+          latest.generation === observedGeneration &&
+          !(
+            latest.lastLiveBusyAt !== undefined &&
+            latest.lastLiveBusyAt > idleObservedAt
+          );
+        if (guardsIntact && isHostTerminalOutcome(outcome)) {
+          const settled = options.backgroundJobBoard.updateStatus({
+            taskID: sessionID,
+            expectedGeneration: observedGeneration,
+            state: outcome === 'succeeded' ? 'completed' : 'error',
+            resultSummary: `Host reported outcome: ${outcome}.`,
+          });
+          if (
+            settled !== undefined &&
+            settled.generation === observedGeneration &&
+            settled.state !== 'running'
+          ) {
+            options.backgroundJobBoard.markReconciled(sessionID);
+            log(
+              '[task-session-manager] confirmed terminal outcome from host session info',
+              {
+                sessionID,
+                alias: latest.alias,
+                parentSessionID: latest.parentSessionID,
+                outcome,
+              },
+            );
+            return;
+          }
+        }
+      }
+
+      // No host outcome (or probe unavailable): schedule the post-grace
+      // stop-confirmation re-observation ourselves. The v1 design relied on
+      // the periodic runtime-status reconciler to make the second
+      // observation; that reconciler is disabled on hosts without
+      // session.status (v2), which left quiescent jobs 'running' with an
+      // unconfirmed status forever (#1157 follow-up).
+      scheduleQuiescentStopConfirmation(
+        sessionID,
+        observedGeneration,
+        idleObservedAt,
+      );
       log('[task-session-manager] observed quiescent job from idle', {
         sessionID,
         alias: job.alias,
@@ -114,6 +194,57 @@ export function createIdleReconciler(options: {
       });
     }, options.idleReconcileDelayMs).unref?.();
     childIdleReconcileTimers.set(sessionID, timer);
+  }
+
+  /**
+   * One-shot post-grace stop confirmation for quiescent jobs. Uses a
+   * synthetic re-observation timestamp (idle + grace + 1) so the existing
+   * observeNonBusyRuntime grace logic confirms the stop; the busy guard
+   * still protects against a session that recovered in the meantime.
+   */
+  function scheduleQuiescentStopConfirmation(
+    sessionID: string,
+    observedGeneration: number,
+    idleObservedAt: number,
+  ): void {
+    if (quiescentConfirmTimers.has(sessionID)) return;
+    const graceMs =
+      options.stopConfirmationGraceMs ?? STOP_CONFIRMATION_GRACE_MS;
+    const timer = setTimeout(() => {
+      quiescentConfirmTimers.delete(sessionID);
+      if (options.isFallbackInProgress?.(sessionID)) return;
+      const job = options.backgroundJobBoard.get(sessionID);
+      if (job?.state !== 'running' || job.generation !== observedGeneration) {
+        return;
+      }
+      if (
+        job.lastLiveBusyAt !== undefined &&
+        job.lastLiveBusyAt > idleObservedAt
+      ) {
+        return;
+      }
+      const updated = observeNonBusyRuntime({
+        backgroundJobBoard: options.backgroundJobBoard,
+        taskID: sessionID,
+        observedAt: idleObservedAt + graceMs + 1,
+        generation: observedGeneration,
+        graceMs,
+        lastStatusError:
+          'Runtime session is idle; task termination is unconfirmed.',
+        taskContextTracker: options.taskContextTracker,
+      });
+      if (updated?.state === 'stopped') {
+        log(
+          '[task-session-manager] confirmed runtime-stopped job after self-observed grace',
+          {
+            sessionID,
+            alias: updated.alias,
+            parentSessionID: updated.parentSessionID,
+          },
+        );
+      }
+    }, graceMs + QUIESCENT_CONFIRM_SLACK_MS).unref?.();
+    quiescentConfirmTimers.set(sessionID, timer);
   }
 
   /**
@@ -190,6 +321,11 @@ export function createIdleReconciler(options: {
       clearTimeout(pendingChildIdle);
       childIdleReconcileTimers.delete(sessionID);
     }
+    const pendingQuiescentConfirm = quiescentConfirmTimers.get(sessionID);
+    if (pendingQuiescentConfirm) {
+      clearTimeout(pendingQuiescentConfirm);
+      quiescentConfirmTimers.delete(sessionID);
+    }
     const pendingIdle = idleReconcileTimers.get(sessionID);
     if (pendingIdle) {
       clearTimeout(pendingIdle);
@@ -211,6 +347,11 @@ export function createIdleReconciler(options: {
       clearTimeout(timer);
     }
     childIdleReconcileTimers.clear();
+
+    for (const timer of quiescentConfirmTimers.values()) {
+      clearTimeout(timer);
+    }
+    quiescentConfirmTimers.clear();
 
     for (const timer of errorTerminalizeTimers.values()) {
       clearTimeout(timer);

--- a/src/hooks/task-session-manager/idle-reconciliation.ts
+++ b/src/hooks/task-session-manager/idle-reconciliation.ts
@@ -1,5 +1,9 @@
 import type { BackgroundJobStore, ContextFile } from '../../utils';
 import { log } from '../../utils/logger';
+import {
+  COMPLETED_WITHOUT_TEXT_DIAGNOSTIC,
+  isHostTerminalOutcome,
+} from '../../utils/task';
 import type { RevivedRunTracker } from './revived-run-tracker';
 import {
   observeNonBusyRuntime,
@@ -9,10 +13,14 @@ import {
 /** Wall-clock slack before the post-grace self-observation fires. */
 const QUIESCENT_CONFIRM_SLACK_MS = 25;
 
-const HOST_TERMINAL_OUTCOMES = new Set(['succeeded', 'failed', 'interrupted']);
+/** Default stabilization probes for a succeeded-but-textless outcome
+ * (incident #1115 precedent: never reconcile a completed job without
+ * usable result text). */
+const DEFAULT_OUTCOME_STABILIZATION_PROBES = 3;
+const DEFAULT_OUTCOME_STABILIZATION_INTERVAL_MS = 300;
 
-function isHostTerminalOutcome(outcome: string | undefined): boolean {
-  return outcome !== undefined && HOST_TERMINAL_OUTCOMES.has(outcome);
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 export function createIdleReconciler(options: {
@@ -39,7 +47,11 @@ export function createIdleReconciler(options: {
    * session.get). Quiescent jobs settle to the accurate terminal state
    * instead of lingering 'running + statusUncertain' on hosts without a
    * live session-status map. Return undefined when unavailable. */
-  readSessionOutcome?: (sessionID: string) => Promise<string | undefined>;
+  readSessionOutcome?: (
+    sessionID: string,
+  ) => Promise<{ outcome?: string; resultText?: string } | undefined>;
+  /** Stabilization retries for a succeeded-but-textless outcome. */
+  outcomeStabilization?: { probes: number; intervalMs: number };
 }) {
   const idleReconcileTimers = new Map<string, ReturnType<typeof setTimeout>>();
   const childIdleReconcileTimers = new Map<
@@ -129,32 +141,60 @@ export function createIdleReconciler(options: {
       // Host-native outcome confirmation (v2: no session.status map, but
       // Session.Info.outcome publishes the terminal transition). Settles
       // the quiescent job to its accurate terminal state instead of the
-      // cancellation-flavored 'stopped' below.
+      // cancellation-flavored 'stopped' below. A succeeded outcome is only
+      // reconciled once usable result text exists — stabilization probes
+      // cover the outcome-before-text race, and textless completions are
+      // rejected per the incident #1115 precedent (never reconcile a
+      // completed job without a usable answer).
       if (options.readSessionOutcome) {
-        let outcome: string | undefined;
-        try {
-          outcome = await options.readSessionOutcome(sessionID);
-        } catch (error) {
-          log('[task-session-manager] host outcome probe failed', {
-            sessionID,
-            error: error instanceof Error ? error.message : String(error),
-          });
-        }
-        const latest = options.backgroundJobBoard.get(sessionID);
-        const guardsIntact =
-          latest !== undefined &&
-          latest.state === 'running' &&
-          latest.generation === observedGeneration &&
-          !(
-            latest.lastLiveBusyAt !== undefined &&
-            latest.lastLiveBusyAt > idleObservedAt
+        const guardsIntact = (): boolean => {
+          const latest = options.backgroundJobBoard.get(sessionID);
+          return (
+            latest !== undefined &&
+            latest.state === 'running' &&
+            latest.generation === observedGeneration &&
+            !(
+              latest.lastLiveBusyAt !== undefined &&
+              latest.lastLiveBusyAt > idleObservedAt
+            )
           );
-        if (guardsIntact && isHostTerminalOutcome(outcome)) {
+        };
+        const stabilization = options.outcomeStabilization ?? {
+          probes: DEFAULT_OUTCOME_STABILIZATION_PROBES,
+          intervalMs: DEFAULT_OUTCOME_STABILIZATION_INTERVAL_MS,
+        };
+        let outcome: string | undefined;
+        let resultText: string | undefined;
+        for (
+          let attempt = 0;
+          attempt <= stabilization.probes && guardsIntact();
+          attempt += 1
+        ) {
+          if (attempt > 0) await delay(stabilization.intervalMs);
+          try {
+            const probe = await options.readSessionOutcome(sessionID);
+            outcome = probe?.outcome;
+            resultText = probe?.resultText;
+          } catch (error) {
+            log('[task-session-manager] host outcome probe failed', {
+              sessionID,
+              error: error instanceof Error ? error.message : String(error),
+            });
+            break;
+          }
+          if (outcome !== 'succeeded') break;
+          if (resultText !== undefined && resultText.length > 0) break;
+        }
+        if (guardsIntact() && isHostTerminalOutcome(outcome)) {
           const settled = options.backgroundJobBoard.updateStatus({
             taskID: sessionID,
             expectedGeneration: observedGeneration,
-            state: outcome === 'succeeded' ? 'completed' : 'error',
-            resultSummary: `Host reported outcome: ${outcome}.`,
+            state:
+              outcome === 'succeeded' && resultText ? 'completed' : 'error',
+            resultSummary:
+              outcome === 'succeeded'
+                ? resultText || COMPLETED_WITHOUT_TEXT_DIAGNOSTIC
+                : `Host reported outcome: ${outcome}.`,
           });
           if (
             settled !== undefined &&
@@ -166,9 +206,10 @@ export function createIdleReconciler(options: {
               '[task-session-manager] confirmed terminal outcome from host session info',
               {
                 sessionID,
-                alias: latest.alias,
-                parentSessionID: latest.parentSessionID,
+                alias: settled.alias,
+                parentSessionID: settled.parentSessionID,
                 outcome,
+                hasResultText: Boolean(resultText),
               },
             );
             return;

--- a/src/hooks/task-session-manager/index.ts
+++ b/src/hooks/task-session-manager/index.ts
@@ -16,6 +16,49 @@ import {
 } from '../../utils';
 import { isRecord as isObjectRecord } from '../../utils/guards';
 import { getClient } from '../../utils/opencode-client';
+
+/** Extract the final assistant text from a child session transcript
+ * (v1-shaped {data:[{info,parts}]} via the client shim's messages). Used
+ * by the quiescent-outcome settle path so completed jobs reconcile with a
+ * usable result summary instead of a placeholder. */
+async function readFinalAssistantText(
+  client: ReturnType<typeof getClient>,
+  sessionID: string,
+  directory: string,
+): Promise<string | undefined> {
+  if (typeof client.session?.messages !== 'function') return undefined;
+  try {
+    const response = (await client.session.messages({
+      path: { id: sessionID },
+      query: { directory },
+    })) as { data?: unknown };
+    const list = Array.isArray(response?.data) ? response.data : [];
+    for (let i = list.length - 1; i >= 0; i -= 1) {
+      const message = isObjectRecord(list[i]) ? list[i] : undefined;
+      const info = isObjectRecord(message?.info) ? message.info : undefined;
+      if (info?.role !== 'assistant') continue;
+      const parts = Array.isArray(message?.parts) ? message.parts : [];
+      const text = parts
+        .filter(
+          (part: unknown) =>
+            isObjectRecord(part) &&
+            part.type === 'text' &&
+            typeof part.text === 'string' &&
+            part.text.length > 0,
+        )
+        .map((part: unknown) => (part as { text: string }).text)
+        .join('\n\n')
+        .trim();
+      // The trailing assistant message decides: text → usable; textless
+      // (e.g. tool-call handoff tail) → let stabilization retry.
+      return text.length > 0 ? text : undefined;
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 import type { SessionLifecycle } from '../session-lifecycle';
 import { isMessageWithParts, isUserMessageWithParts } from '../types';
 import {
@@ -289,7 +332,18 @@ export function createTaskSessionManagerHook(
         };
         const info = response?.data ?? response;
         const outcome = info?.outcome;
-        return typeof outcome === 'string' ? outcome : undefined;
+        if (typeof outcome !== 'string') return undefined;
+        if (outcome !== 'succeeded') return { outcome };
+        // Usable-result requirement (#1115 precedent): a completed job is
+        // only reconciled with its final assistant text. Extract it from
+        // the transcript; absent text falls back to the reconciler's
+        // stabilization probes.
+        const resultText = await readFinalAssistantText(
+          client,
+          sessionID,
+          _ctx.directory,
+        );
+        return { outcome, resultText };
       } catch {
         return undefined;
       }

--- a/src/hooks/task-session-manager/index.ts
+++ b/src/hooks/task-session-manager/index.ts
@@ -14,13 +14,17 @@ import {
   parseTaskStateFromOutput,
   recordBackgroundJobSuppression,
 } from '../../utils';
+import { extractChildTerminalEvidence } from '../../utils/child-transcript';
 import { isRecord as isObjectRecord } from '../../utils/guards';
 import { getClient } from '../../utils/opencode-client';
 
 /** Extract the final assistant text from a child session transcript
  * (v1-shaped {data:[{info,parts}]} via the client shim's messages). Used
  * by the quiescent-outcome settle path so completed jobs reconcile with a
- * usable result summary instead of a placeholder. */
+ * usable result summary instead of a placeholder. Delegates to the shared
+ * extractor; the v2 shim shape drops `info.time`, so the strict
+ * completion-time requirement is off (terminality is confirmed via the
+ * host outcome gate before this runs). */
 async function readFinalAssistantText(
   client: ReturnType<typeof getClient>,
   sessionID: string,
@@ -28,32 +32,20 @@ async function readFinalAssistantText(
 ): Promise<string | undefined> {
   if (typeof client.session?.messages !== 'function') return undefined;
   try {
-    const response = (await client.session.messages({
+    const response = await client.session.messages({
       path: { id: sessionID },
       query: { directory },
-    })) as { data?: unknown };
-    const list = Array.isArray(response?.data) ? response.data : [];
-    for (let i = list.length - 1; i >= 0; i -= 1) {
-      const message = isObjectRecord(list[i]) ? list[i] : undefined;
-      const info = isObjectRecord(message?.info) ? message.info : undefined;
-      if (info?.role !== 'assistant') continue;
-      const parts = Array.isArray(message?.parts) ? message.parts : [];
-      const text = parts
-        .filter(
-          (part: unknown) =>
-            isObjectRecord(part) &&
-            part.type === 'text' &&
-            typeof part.text === 'string' &&
-            part.text.length > 0,
-        )
-        .map((part: unknown) => (part as { text: string }).text)
-        .join('\n\n')
-        .trim();
-      // The trailing assistant message decides: text → usable; textless
-      // (e.g. tool-call handoff tail) → let stabilization retry.
-      return text.length > 0 ? text : undefined;
-    }
-    return undefined;
+    });
+    const evidence = extractChildTerminalEvidence(response, {
+      // v2 shim shape: flat {id, role} info without time/finish.
+      requireCompletionTime: false,
+      // v2 sessions can end with structurally valid non-assistant tails
+      // (synthetic/system/skill); the result lives in the last assistant
+      // message, so scan back to it instead of requiring an assistant
+      // tail.
+      scanBackToLastAssistant: true,
+    });
+    return evidence.kind === 'ready' ? evidence.text : undefined;
   } catch {
     return undefined;
   }

--- a/src/hooks/task-session-manager/index.ts
+++ b/src/hooks/task-session-manager/index.ts
@@ -15,6 +15,7 @@ import {
   recordBackgroundJobSuppression,
 } from '../../utils';
 import { isRecord as isObjectRecord } from '../../utils/guards';
+import { getClient } from '../../utils/opencode-client';
 import type { SessionLifecycle } from '../session-lifecycle';
 import { isMessageWithParts, isUserMessageWithParts } from '../types';
 import {
@@ -271,6 +272,28 @@ export function createTaskSessionManagerHook(
     isCurrentIdleSessionToken: (s, t) => isCurrentIdleSessionToken(s, t),
     taskContextTracker,
     revivedRunTracker: options.revivedRunTracker,
+    // v2: no live session-status map exists, but Session.Info.outcome
+    // publishes the terminal transition — use it to settle quiescent jobs
+    // to their accurate terminal state (v1 hosts keep the status-map
+    // confirmation and simply never hit this probe).
+    readSessionOutcome: async (sessionID) => {
+      try {
+        const client = getClient(_ctx);
+        if (typeof client.session?.get !== 'function') return undefined;
+        const response = (await client.session.get({
+          path: { id: sessionID },
+          query: { directory: _ctx.directory },
+        })) as {
+          data?: { outcome?: unknown };
+          outcome?: unknown;
+        };
+        const info = response?.data ?? response;
+        const outcome = info?.outcome;
+        return typeof outcome === 'string' ? outcome : undefined;
+      } catch {
+        return undefined;
+      }
+    },
   });
   const runtimeStatusReconciler = createRuntimeStatusReconciler({
     input: _ctx,

--- a/src/hooks/task-session-manager/revived-run-tracker.ts
+++ b/src/hooks/task-session-manager/revived-run-tracker.ts
@@ -6,6 +6,7 @@ import type {
 } from '../../utils/background-job-board';
 import type { BackgroundJobStore } from '../../utils/background-job-store';
 import type { BackgroundJobSupervisor } from '../../utils/background-job-supervisor';
+import { extractChildTerminalEvidence } from '../../utils/child-transcript';
 import { createInternalAgentTextPart } from '../../utils/internal-initiator';
 import { getClient } from '../../utils/opencode-client';
 import { COMPLETED_WITHOUT_TEXT_DIAGNOSTIC } from '../../utils/task';
@@ -172,52 +173,34 @@ export function createRevivedRunTracker(options: {
       return false;
     }
 
-    const data =
-      isRecord(response) && Array.isArray(response.data)
-        ? (response.data as SessionMessage[])
-        : [];
-    const baselineIndex = run.baselineMessageID
-      ? data.findIndex((message) => message.info?.id === run.baselineMessageID)
-      : -1;
-    if (run.baselineMessageID && baselineIndex < 0) return false;
-
-    const lastIndex = data.length - 1;
-    const last = data[lastIndex];
-    if (last?.info?.role !== 'assistant') return false;
-    if (lastIndex <= baselineIndex) return false;
-    if (typeof last.info.time?.completed !== 'number') return false;
-    if (last.info.finish === 'tool-calls' || last.info.finish === 'unknown') {
-      return false;
-    }
-    if (hasPendingToolCall(data, baselineIndex)) return false;
-    if (last.info.error !== undefined) {
-      const result = errorText(last.info.error);
-      const updated = options.backgroundJobBoard.updateStatus({
-        taskID: run.taskID,
-        expectedGeneration: run.generation,
-        state: 'error',
-        resultSummary: result || 'Revived child session failed.',
-      });
-      return updated?.generation === run.generation && finish(run, updated);
-    }
-    const text = (last.parts ?? [])
-      .filter(
-        (part) =>
-          part.type === 'text' &&
-          typeof part.text === 'string' &&
-          part.text.length > 0,
-      )
-      .map((part) => part.text as string)
-      .join('\n\n')
-      .trim();
-    if (text.length > 0) {
-      const updated = options.backgroundJobBoard.updateStatus({
-        taskID: run.taskID,
-        expectedGeneration: run.generation,
-        state: 'completed',
-        resultSummary: text,
-      });
-      return updated?.generation === run.generation && finish(run, updated);
+    const evidence = extractChildTerminalEvidence(response, {
+      baselineMessageID: run.baselineMessageID,
+    });
+    switch (evidence.kind) {
+      case 'no-new-messages':
+      case 'no-assistant':
+      case 'pending':
+        return false;
+      case 'error': {
+        const updated = options.backgroundJobBoard.updateStatus({
+          taskID: run.taskID,
+          expectedGeneration: run.generation,
+          state: 'error',
+          resultSummary: evidence.errorText || 'Revived child session failed.',
+        });
+        return updated?.generation === run.generation && finish(run, updated);
+      }
+      case 'ready': {
+        const updated = options.backgroundJobBoard.updateStatus({
+          taskID: run.taskID,
+          expectedGeneration: run.generation,
+          state: 'completed',
+          resultSummary: evidence.text,
+        });
+        return updated?.generation === run.generation && finish(run, updated);
+      }
+      case 'textless':
+        break;
     }
 
     if (run.stabilizationProbes >= maxStabilizationProbes) {
@@ -479,19 +462,6 @@ function terminalOutcome(
   return record.state === 'completed' || record.state === 'error'
     ? record.state
     : undefined;
-}
-
-function hasPendingToolCall(
-  messages: SessionMessage[],
-  baselineIndex: number,
-): boolean {
-  return messages.slice(baselineIndex + 1).some((message) =>
-    (message.parts ?? []).some((part) => {
-      if (part.type !== 'tool') return false;
-      const status = part.state?.status;
-      return status !== 'completed' && status !== 'error';
-    }),
-  );
 }
 
 function responseError(response: unknown): unknown {

--- a/src/tools/cancel-task.test.ts
+++ b/src/tools/cancel-task.test.ts
@@ -106,6 +106,55 @@ describe('task_cancel tool', () => {
     });
   });
 
+  test('an unrecognized outcome string needs idle evidence to confirm cancellation (v2)', async () => {
+    // P2 review on #1161: only the known terminal outcomes (succeeded/
+    // failed/interrupted) confirm quiescence on their own. A malformed or
+    // future nonterminal value must fall through to the idle-timestamp
+    // evidence instead of blindly confirming the cancel.
+    const run = async (idleAt: number | undefined) => {
+      const board = new BackgroundJobBoard();
+      const abort = mock(async () => ({}));
+      const getSession = mock(async () => ({
+        data: { outcome: 'some-new-nonterminal-value', time: { idle: idleAt } },
+      }));
+      mockClient = {
+        session: { abort, get: getSession, delete: mock(async () => ({})) },
+      };
+      const tools = createCancelTaskTool({
+        input: { directory: '/test/project' } as any,
+        backgroundJobBoard: board,
+        shouldManageSession: () => true,
+        verifyAbortMs: 10,
+        abortRetryIntervalMs: 0,
+        stableStoppedMs: 0,
+      });
+      board.registerLaunch({
+        taskID: 'ses_1',
+        parentSessionID: 'parent-1',
+        agent: 'explorer',
+      });
+      return tools.task_cancel.execute(
+        { task_id: 'ses_1', reason: 'obsolete' },
+        context,
+      );
+    };
+
+    // Fresh idle timestamp (at/after abort) → confirmed via idle evidence.
+    const confirmed = await run(Date.now() + 5_000);
+    expect(parseTaskStatusOutput(String(confirmed))).toMatchObject({
+      taskID: 'ses_1',
+      state: 'cancelled',
+    });
+
+    // Stale idle timestamp → cannot verify → the cancel surfaces the
+    // uncertain-running result instead of confirming.
+    const unverified = await run(Date.now() - 60_000);
+    expect(parseTaskStatusOutput(String(unverified))).toMatchObject({
+      taskID: 'ses_1',
+      state: 'running',
+    });
+  });
+
   test('retains the session and leaves it resumable after acknowledgement', async () => {
     const { board, deleteSession, taskCancel } = createTool();
     board.registerLaunch({

--- a/src/tools/cancel-task.test.ts
+++ b/src/tools/cancel-task.test.ts
@@ -66,6 +66,46 @@ describe('task_cancel tool', () => {
     });
   });
 
+  test('verifies quiescence via host session info when the status map is unavailable (v2)', async () => {
+    // v2 hosts expose no session.status map; the old verify loop polled a
+    // source that can never answer 'idle' and always threw "did not stay
+    // stopped" — even after a confirmed abort. Verification must fall back
+    // to the host session info (terminal outcome / fresh idle timestamp).
+    const board = new BackgroundJobBoard();
+    const abort = mock(async () => ({}));
+    const getSession = mock(async () => ({
+      data: { outcome: 'interrupted', time: { idle: Date.now() } },
+    }));
+    mockClient = {
+      session: { abort, get: getSession, delete: mock(async () => ({})) },
+    };
+    const tools = createCancelTaskTool({
+      input: { directory: '/test/project' } as any,
+      backgroundJobBoard: board,
+      shouldManageSession: () => true,
+      verifyAbortMs: 10,
+      abortRetryIntervalMs: 0,
+      stableStoppedMs: 0,
+    });
+    board.registerLaunch({
+      taskID: 'ses_1',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+    });
+
+    const output = await tools.task_cancel.execute(
+      { task_id: 'ses_1', reason: 'obsolete' },
+      context,
+    );
+
+    expect(abort).toHaveBeenCalledWith({ path: { id: 'ses_1' } });
+    expect(getSession).toHaveBeenCalled();
+    expect(parseTaskStatusOutput(String(output))).toMatchObject({
+      taskID: 'ses_1',
+      state: 'cancelled',
+    });
+  });
+
   test('retains the session and leaves it resumable after acknowledgement', async () => {
     const { board, deleteSession, taskCancel } = createTool();
     board.registerLaunch({

--- a/src/tools/cancel-task.ts
+++ b/src/tools/cancel-task.ts
@@ -16,6 +16,7 @@ import {
   getRuntimeSessionStatusSnapshot,
   runtimeSessionStatus,
 } from '../utils/session-runtime-status';
+import { isHostTerminalOutcome } from '../utils/task';
 
 const z = tool.schema;
 
@@ -303,7 +304,10 @@ async function verifyQuiescentViaHostInfo(
       };
       const info = response?.data ?? response;
       const outcome = info?.outcome;
-      if (typeof outcome === 'string' && outcome !== '') {
+      // Whitelist the known terminal values: a malformed or future
+      // nonterminal outcome string must NOT confirm quiescence on its own —
+      // it falls through to the idle-timestamp evidence below.
+      if (typeof outcome === 'string' && isHostTerminalOutcome(outcome)) {
         return;
       }
       const idleAt = info?.time?.idle;

--- a/src/tools/cancel-task.ts
+++ b/src/tools/cancel-task.ts
@@ -187,6 +187,7 @@ async function abortAndVerifySession(
 ): Promise<void> {
   assertLease(options.backgroundJobBoard, lease, execution);
   const taskID = execution.taskID;
+  const abortStartedAt = Date.now();
   let response: unknown;
   try {
     response = await awaitLeaseOperation(
@@ -207,19 +208,21 @@ async function abortAndVerifySession(
     throw new Error(`Session abort was not confirmed: ${taskID}`);
   }
 
-  await verifyQuiescentSession(options, execution, lease);
+  await verifyQuiescentSession(options, execution, lease, abortStartedAt);
 }
 
 async function verifyQuiescentSession(
   options: TaskControlToolOptions,
   execution: CapturedExecution,
   lease: BackgroundJobLease,
+  abortStartedAt: number,
 ): Promise<void> {
   const deadline = Date.now() + (options.verifyAbortMs ?? 1_500);
   const stableStoppedMs = options.stableStoppedMs ?? 300;
   const retryIntervalMs = options.abortRetryIntervalMs ?? 150;
   let stableStoppedSince: number | undefined;
   let lastStatus: string | undefined;
+  let statusUnavailable = false;
 
   while (Date.now() <= deadline) {
     assertLease(options.backgroundJobBoard, lease, execution);
@@ -231,6 +234,13 @@ async function verifyQuiescentSession(
       options.backgroundJobBoard,
     );
     assertLease(options.backgroundJobBoard, lease, execution);
+    if (status.source === 'status-unavailable') {
+      // v2 hosts expose no session.status map; polling it can never answer
+      // 'idle'. Fall back to host session info (terminal outcome or a
+      // fresh idle timestamp) instead of failing a confirmed abort.
+      statusUnavailable = true;
+      break;
+    }
     lastStatus = status.status;
     const quiescent = status.status === 'idle';
     if (!quiescent) {
@@ -243,8 +253,76 @@ async function verifyQuiescentSession(
     await delay(retryIntervalMs);
   }
 
+  if (statusUnavailable) {
+    await verifyQuiescentViaHostInfo(
+      options,
+      execution,
+      lease,
+      abortStartedAt,
+      deadline,
+    );
+    return;
+  }
+
   throw new SessionStillRunningError(
     `Session abort returned but task did not stay stopped: ${execution.taskID} (${lastStatus ?? 'unknown'})`,
+  );
+}
+
+/**
+ * v2 verification fallback: the host publishes the terminal outcome and an
+ * idle timestamp on Session.Info. Quiescence is confirmed by either a
+ * terminal outcome or an idle timestamp at/after the abort began.
+ */
+async function verifyQuiescentViaHostInfo(
+  options: TaskControlToolOptions,
+  execution: CapturedExecution,
+  lease: BackgroundJobLease,
+  abortStartedAt: number,
+  deadline: number,
+): Promise<void> {
+  const retryIntervalMs = options.abortRetryIntervalMs ?? 150;
+  let lastDetail = 'no host session info';
+  while (Date.now() <= deadline) {
+    assertLease(options.backgroundJobBoard, lease, execution);
+    const client = getClient(options.input);
+    if (typeof client.session.get !== 'function') {
+      // No status map AND no session info — nothing to verify against.
+      throw new SessionStillRunningError(
+        `Session abort returned but quiescence cannot be verified on this host: ${execution.taskID}`,
+      );
+    }
+    try {
+      const response = (await client.session.get({
+        path: { id: execution.taskID },
+        query: { directory: options.input.directory },
+      })) as {
+        data?: { outcome?: unknown; time?: { idle?: unknown } };
+        outcome?: unknown;
+        time?: { idle?: unknown };
+      };
+      const info = response?.data ?? response;
+      const outcome = info?.outcome;
+      if (typeof outcome === 'string' && outcome !== '') {
+        return;
+      }
+      const idleAt = info?.time?.idle;
+      if (typeof idleAt === 'number' && idleAt >= abortStartedAt) {
+        return;
+      }
+      lastDetail =
+        typeof outcome === 'string'
+          ? `outcome=${outcome}`
+          : typeof idleAt === 'number'
+            ? `idle=${idleAt}`
+            : 'no outcome or idle timestamp';
+    } catch (error) {
+      lastDetail = error instanceof Error ? error.message : String(error);
+    }
+    await delay(retryIntervalMs);
+  }
+  throw new SessionStillRunningError(
+    `Session abort returned but task did not stay stopped: ${execution.taskID} (host-info: ${lastDetail})`,
   );
 }
 
@@ -260,6 +338,16 @@ async function getSessionStatus(
     generation: lease.generation,
   });
   try {
+    // Capability pre-check: v2 hosts expose no session.status map. Detect
+    // that deterministically (instead of relying on the thrown lookup
+    // error) so the verification loop can switch to the host-info path.
+    const client =
+      typeof input.client?.session?.status === 'function'
+        ? input.client
+        : getClient(input);
+    if (typeof client.session?.status !== 'function') {
+      return { status: undefined, source: 'status-unavailable' };
+    }
     const snapshot = await awaitLeaseOperation(
       backgroundJobBoard,
       lease,

--- a/src/utils/child-transcript.test.ts
+++ b/src/utils/child-transcript.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, test } from 'bun:test';
+import { extractChildTerminalEvidence } from './child-transcript';
+
+function message(overrides: {
+  id?: string;
+  role?: string;
+  finish?: string;
+  completed?: number | null;
+  error?: unknown;
+  parts?: unknown[];
+}) {
+  return {
+    info: {
+      id: overrides.id ?? 'm1',
+      role: overrides.role ?? 'assistant',
+      ...(overrides.finish !== undefined ? { finish: overrides.finish } : {}),
+      ...(overrides.completed !== null && overrides.completed !== undefined
+        ? { time: { completed: overrides.completed } }
+        : {}),
+      ...(overrides.error !== undefined ? { error: overrides.error } : {}),
+    },
+    parts: overrides.parts ?? [{ type: 'text', text: 'the answer' }],
+  };
+}
+
+describe('extractChildTerminalEvidence', () => {
+  test('trailing assistant with text is ready', () => {
+    const evidence = extractChildTerminalEvidence({
+      data: [message({ id: 'base' }), message({ id: 'last', completed: 5 })],
+    });
+    expect(evidence).toEqual({ kind: 'ready', text: 'the answer' });
+  });
+
+  test('trailing assistant without text is textless', () => {
+    const evidence = extractChildTerminalEvidence({
+      data: [message({ id: 'last', completed: 5, parts: [] })],
+    });
+    expect(evidence).toEqual({ kind: 'textless' });
+  });
+
+  test('non-assistant trailing message is no-assistant', () => {
+    const evidence = extractChildTerminalEvidence({
+      data: [message({ id: 'u', role: 'user', completed: 5 })],
+    });
+    expect(evidence).toEqual({ kind: 'no-assistant' });
+  });
+
+  test('finish tool-calls is pending', () => {
+    const evidence = extractChildTerminalEvidence({
+      data: [message({ id: 'last', completed: 5, finish: 'tool-calls' })],
+    });
+    expect(evidence).toEqual({ kind: 'pending' });
+  });
+
+  test('an in-flight tool part after the baseline is pending', () => {
+    const evidence = extractChildTerminalEvidence({
+      data: [
+        message({ id: 'base', role: 'user' }),
+        message({
+          id: 'tool',
+          role: 'assistant',
+          completed: 4,
+          parts: [{ type: 'tool', state: { status: 'running' } }],
+        }),
+        message({ id: 'last', completed: 5 }),
+      ],
+    });
+    expect(evidence).toEqual({ kind: 'pending' });
+  });
+
+  test('completed tool parts do not block readiness', () => {
+    const evidence = extractChildTerminalEvidence({
+      data: [
+        message({
+          id: 'tool',
+          role: 'assistant',
+          completed: 4,
+          parts: [
+            { type: 'tool', state: { status: 'completed' } },
+            { type: 'text', text: 'done summary' },
+          ],
+        }),
+      ],
+    });
+    expect(evidence).toEqual({ kind: 'ready', text: 'done summary' });
+  });
+
+  test('trailing assistant error is error with text', () => {
+    const evidence = extractChildTerminalEvidence({
+      data: [message({ id: 'last', completed: 5, error: 'model exploded' })],
+    });
+    expect(evidence).toEqual({ kind: 'error', errorText: 'model exploded' });
+  });
+
+  test('error objects are stringified', () => {
+    const evidence = extractChildTerminalEvidence({
+      data: [message({ id: 'last', completed: 5, error: { code: 500 } })],
+    });
+    expect(evidence.kind).toBe('error');
+    expect(evidence.errorText).toContain('500');
+  });
+
+  test('requireCompletionTime treats a missing completion time as pending', () => {
+    const messages = { data: [message({ id: 'last', completed: null })] };
+    expect(
+      extractChildTerminalEvidence(messages, {
+        requireCompletionTime: true,
+      }),
+    ).toEqual({ kind: 'pending' });
+    // v2 shim shape: info carries no time at all — tolerated when the
+    // strictness flag is off (the host outcome gate already confirmed
+    // terminal upstream).
+    expect(
+      extractChildTerminalEvidence(messages, {
+        requireCompletionTime: false,
+      }),
+    ).toEqual({ kind: 'ready', text: 'the answer' });
+  });
+
+  test('baseline scoping: no messages after the baseline is no-new-messages', () => {
+    const evidence = extractChildTerminalEvidence(
+      { data: [message({ id: 'base', role: 'user' })] },
+      { baselineMessageID: 'base' },
+    );
+    expect(evidence).toEqual({ kind: 'no-new-messages' });
+  });
+
+  test('missing baseline message yields no-new-messages (caller retries)', () => {
+    const evidence = extractChildTerminalEvidence(
+      { data: [message({ id: 'last', completed: 5 })] },
+      { baselineMessageID: 'gone' },
+    );
+    expect(evidence).toEqual({ kind: 'no-new-messages' });
+  });
+
+  test('malformed responses degrade to no-assistant, never throw', () => {
+    expect(extractChildTerminalEvidence(undefined)).toEqual({
+      kind: 'no-assistant',
+    });
+    expect(extractChildTerminalEvidence({})).toEqual({ kind: 'no-assistant' });
+    expect(extractChildTerminalEvidence({ data: 'nope' })).toEqual({
+      kind: 'no-assistant',
+    });
+    expect(extractChildTerminalEvidence({ data: [null, 42, 'x'] })).toEqual({
+      kind: 'no-assistant',
+    });
+  });
+
+  test('truthy non-array parts never throw (entry-level malformation)', () => {
+    // `?? []` would NOT replace a truthy non-array; the tracker calls the
+    // extractor outside its try/catch, so a throw would reject the probe
+    // promise unhandled. Both parts sites must degrade to empty.
+    const badParts = [
+      {
+        info: { id: 'm', role: 'assistant', time: { completed: 1 } },
+        parts: {},
+      },
+    ];
+    expect(extractChildTerminalEvidence({ data: badParts })).toEqual({
+      kind: 'textless',
+    });
+    const badPartsOnTool = [
+      {
+        info: { id: 'm', role: 'assistant', time: { completed: 1 } },
+        parts: [{ type: 'text', text: 'ok' }],
+      },
+      { info: { id: 't', role: 'assistant' }, parts: 'garbage' },
+    ];
+    expect(
+      extractChildTerminalEvidence(
+        { data: badPartsOnTool },
+        { requireCompletionTime: false },
+      ),
+    ).toEqual({ kind: 'textless' });
+  });
+
+  test('error: null is not an error (pinned semantics)', () => {
+    // Old tracker code treated error:null as an error; the shared
+    // extractor deliberately reads null as "no error" and extracts text.
+    const evidence = extractChildTerminalEvidence({
+      data: [message({ id: 'last', completed: 5, error: null })],
+    });
+    expect(evidence).toEqual({ kind: 'ready', text: 'the answer' });
+  });
+
+  test("finish 'unknown' is pending (not only 'tool-calls')", () => {
+    const evidence = extractChildTerminalEvidence({
+      data: [message({ id: 'last', completed: 5, finish: 'unknown' })],
+    });
+    expect(evidence).toEqual({ kind: 'pending' });
+  });
+
+  test('scanBackToLastAssistant classifies a non-assistant tail from the last assistant', () => {
+    const transcript = {
+      data: [
+        message({ id: 'u', role: 'user' }),
+        message({
+          id: 'final',
+          completed: 5,
+          parts: [{ type: 'text', text: 'real answer' }],
+        }),
+        // Structurally valid v2 tail (e.g. host synthetic state message).
+        {
+          info: { id: 'tail', role: 'synthetic' },
+          parts: [{ type: 'text', text: '<subagent/>' }],
+        },
+      ],
+    };
+    // Default: strict trailing semantics (revive probe) → not ready.
+    expect(extractChildTerminalEvidence(transcript)).toEqual({
+      kind: 'no-assistant',
+    });
+    // v2 consumer: scan back to the last assistant.
+    expect(
+      extractChildTerminalEvidence(transcript, {
+        scanBackToLastAssistant: true,
+        requireCompletionTime: false,
+      }),
+    ).toEqual({ kind: 'ready', text: 'real answer' });
+  });
+
+  test('scanBackToLastAssistant with no assistant at all stays no-assistant', () => {
+    const transcript = {
+      data: [
+        message({ id: 'u', role: 'user' }),
+        { info: { id: 'tail', role: 'system' }, parts: [] },
+      ],
+    };
+    expect(
+      extractChildTerminalEvidence(transcript, {
+        scanBackToLastAssistant: true,
+      }),
+    ).toEqual({ kind: 'no-assistant' });
+  });
+
+  test('multi-part text is joined and the whole string trimmed', () => {
+    const evidence = extractChildTerminalEvidence({
+      data: [
+        message({
+          id: 'last',
+          completed: 5,
+          parts: [
+            { type: 'text', text: '  first  ' },
+            { type: 'tool', state: { status: 'error' } },
+            { type: 'text', text: 'second  ' },
+          ],
+        }),
+      ],
+    });
+    // Whole-string trim only: inner padding between parts is preserved.
+    expect(evidence).toEqual({ kind: 'ready', text: 'first  \n\nsecond' });
+  });
+});

--- a/src/utils/child-transcript.ts
+++ b/src/utils/child-transcript.ts
@@ -1,0 +1,148 @@
+/**
+ * Shared child-session transcript evidence extraction.
+ *
+ * Two consumers need "what did the child session end with?":
+ * - `revived-run-tracker` (revive probes, strict v1 transcript shape)
+ * - the quiescent host-outcome settle path in `task-session-manager`
+ *   (v2 shim shape — `info` carries only `{id, role}`; terminality is
+ *   confirmed upstream via `Session.Info.outcome`)
+ *
+ * Both previously carried their own (and subtly different) extraction
+ * logic. This module is the single source of truth for reading a v1-style
+ * `{data: [{info, parts}]}` messages response and classifying the
+ * trailing assistant turn.
+ */
+
+interface ChildTranscriptOptions {
+  /** Only consider messages after this baseline message id (revive flow). */
+  baselineMessageID?: string;
+  /** Require `info.time.completed` on the trailing assistant (v1 hosts
+   * always provide it once the turn finalizes). Defaults to true; v2
+   * shim shapes pass false because the flat mapping drops `time` —
+   * terminality there is confirmed via the host outcome gate before
+   * this extractor runs. */
+  requireCompletionTime?: boolean;
+  /** When the ABSOLUTE trailing message is not an assistant, scan
+   * backward for the last assistant and classify that message instead.
+   * v2 sessions can carry structurally valid non-assistant tails
+   * (synthetic/system/skill); the default (false) keeps the strict
+   * trailing-message semantics the revive probe relies on. */
+  scanBackToLastAssistant?: boolean;
+}
+
+export type ChildTerminalEvidence =
+  | { kind: 'ready'; text: string }
+  | { kind: 'textless' }
+  | { kind: 'pending' }
+  | { kind: 'error'; errorText: string }
+  | { kind: 'no-assistant' }
+  | { kind: 'no-new-messages' };
+
+interface LooseMessage {
+  info?: {
+    id?: unknown;
+    role?: unknown;
+    error?: unknown;
+    finish?: unknown;
+    time?: { completed?: unknown };
+  };
+  parts?: unknown[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function stringifyError(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'string') return error;
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}
+
+export function extractChildTerminalEvidence(
+  response: unknown,
+  options: ChildTranscriptOptions = {},
+): ChildTerminalEvidence {
+  const data =
+    isRecord(response) && Array.isArray(response.data)
+      ? (response.data as unknown[])
+      : [];
+  const messages = data.filter(isRecord) as LooseMessage[];
+  if (messages.length === 0) return { kind: 'no-assistant' };
+
+  const baselineIndex = options.baselineMessageID
+    ? messages.findIndex((m) => m.info?.id === options.baselineMessageID)
+    : -1;
+  if (options.baselineMessageID && baselineIndex < 0) {
+    return { kind: 'no-new-messages' };
+  }
+  const lastIndex = messages.length - 1;
+  if (baselineIndex >= 0 && lastIndex <= baselineIndex) {
+    return { kind: 'no-new-messages' };
+  }
+
+  let targetIndex = lastIndex;
+  if (
+    options.scanBackToLastAssistant &&
+    messages[targetIndex].info?.role !== 'assistant'
+  ) {
+    targetIndex = -1;
+    for (let i = lastIndex; i >= 0; i -= 1) {
+      if (messages[i].info?.role === 'assistant') {
+        targetIndex = i;
+        break;
+      }
+    }
+    if (targetIndex < 0) return { kind: 'no-assistant' };
+  }
+
+  const last = messages[targetIndex];
+  if (last.info?.role !== 'assistant') return { kind: 'no-assistant' };
+
+  const requireCompletionTime = options.requireCompletionTime ?? true;
+  const finish = last.info?.finish;
+  if (finish === 'tool-calls' || finish === 'unknown') {
+    return { kind: 'pending' };
+  }
+  if (
+    requireCompletionTime &&
+    !(isRecord(last.info?.time) && typeof last.info.time.completed === 'number')
+  ) {
+    return { kind: 'pending' };
+  }
+
+  const postBaseline = messages.slice(baselineIndex + 1);
+  const hasPendingToolCall = postBaseline.some((message) =>
+    (Array.isArray(message.parts) ? message.parts : []).some((part) => {
+      if (!isRecord(part) || part.type !== 'tool') return false;
+      const status = isRecord(part.state)
+        ? typeof part.state.status === 'string'
+          ? part.state.status
+          : undefined
+        : undefined;
+      return status !== 'completed' && status !== 'error';
+    }),
+  );
+  if (hasPendingToolCall) return { kind: 'pending' };
+
+  if (last.info?.error !== undefined && last.info?.error !== null) {
+    return { kind: 'error', errorText: stringifyError(last.info.error) };
+  }
+
+  const text = (Array.isArray(last.parts) ? last.parts : [])
+    .filter(
+      (part) =>
+        isRecord(part) &&
+        part.type === 'text' &&
+        typeof part.text === 'string' &&
+        part.text.length > 0,
+    )
+    .map((part) => (part as { text: string }).text)
+    .join('\n\n')
+    .trim();
+  return text.length > 0 ? { kind: 'ready', text } : { kind: 'textless' };
+}

--- a/src/utils/task.ts
+++ b/src/utils/task.ts
@@ -4,6 +4,19 @@
 
 export type TaskOutputState = 'running' | 'completed' | 'error' | 'cancelled';
 
+/** OpenCode v2 host Session.Info.outcome values that mark a terminal
+ * transition. Anything else (absent, malformed, or a future nonterminal
+ * value) must NOT be treated as terminal evidence. */
+export const HOST_TERMINAL_OUTCOMES = new Set([
+  'succeeded',
+  'failed',
+  'interrupted',
+]);
+
+export function isHostTerminalOutcome(outcome: string | undefined): boolean {
+  return outcome !== undefined && HOST_TERMINAL_OUTCOMES.has(outcome);
+}
+
 export interface TaskLaunchOutput {
   taskID: string;
   state: 'running';


### PR DESCRIPTION
## What changed, and why was it needed?

**Why:** on v2 hosts a normally-completed background job never settled in the board. Observed live: the child session reaches `outcome: succeeded` on the host and delivers its native completion notification, but the plugin's board entry lingers as `running + statusUncertain` in Active/Unreconciled indefinitely. Consequences:

- the board re-renders the stale entry on every injection,
- the wake scheduler keeps seeing "unreconciled jobs" and wakes the orchestrator,
- `task_result` answers "Live task status is uncertain" for a job that finished,
- `task_cancel`/`task_revive` fail with `Session abort returned but task did not stay stopped (unknown)` even after a confirmed abort.

Root cause: the v1 stop-confirmation design relies on the periodic runtime-status reconciler to make the post-grace re-observation; that reconciler is disabled without a `session.status` map (v2), so the quiescent job is never re-observed and the grace can never complete.

**What:**

- `idle-reconciliation`: quiescent jobs now probe the host-native terminal outcome (`Session.Info.outcome` via `session.get`) and settle to the accurate terminal state (`completed`/`error`) plus `markReconciled`; without an outcome they self-schedule the post-grace stop confirmation instead of depending on the unavailable status reconciler. Busy-recovery and generation guards preserved.
- `cancel-task`: `verifyQuiescentSession` detects the absent `session.status` capability deterministically and verifies quiescence via host session info (terminal outcome or a fresh idle timestamp at/after the abort) instead of polling a source that can never answer `idle`.
- `task_result`'s "uncertain" answers for completed jobs resolve through the board settling (no separate change needed).

**Verification (TDD):** 5 new cases — outcome settle (completed/error), late-busy guard, post-grace self-confirmation without any external re-observation, and v2 cancel verification with a confirmed abort — all watched red first; full suite 2639 pass / 0 fail; `tsc --noEmit` and `biome check .` clean.