### PR TITLE
chore: remove provably-dead checks in orchestrator-wake scheduler

### DIFF
--- a/src/hooks/orchestrator-wake/index.ts
+++ b/src/hooks/orchestrator-wake/index.ts
@@ -1094,12 +1094,9 @@ export function createOrchestratorWakeScheduler(
 
       // Reserve before promptAsync so a failed call cannot storm retries and
       // concurrent hook instances cannot double-wake.
-      if (applyArchiveState(sessionID, state, latest.archiveState)) return;
       if (!commitWakeReservation(sessionID, owner, latestFingerprint)) {
         return;
       }
-
-      if (!capabilities.ready) return;
 
       const wakeText = recoveryWake
         ? ORCHESTRATOR_STOPPED_JOB_WAKE_TEXT
@@ -1232,18 +1229,16 @@ export function createOrchestratorWakeScheduler(
     ) {
       return;
     }
+    pendingStoppedRecoveries.add(sessionID);
     if (localSessions.get(sessionID)?.archived) {
-      pendingStoppedRecoveries.add(sessionID);
       return;
     }
-    pendingStoppedRecoveries.add(sessionID);
     rearmWakeProgress(sessionID);
     if (!canSchedule(sessionID)) return;
     const state = touchLocal(sessionID);
     clearTimer(state);
     bumpGeneration(state);
     state.continuousIdle = true;
-    rearmWakeProgress(sessionID);
     void evaluate(sessionID, state.generation, true);
   }
 
@@ -1355,18 +1350,16 @@ export function createOrchestratorWakeScheduler(
       return;
     }
 
-    if (type === 'session.error' || type === 'session.status') {
-      if (
-        type === 'session.error' ||
-        (type === 'session.status' &&
-          properties?.status?.type !== 'idle' &&
-          properties?.status?.type !== 'busy')
-      ) {
-        if (options.shouldManageSession(sessionID)) {
-          // Errors / retry are external lifecycle — rearm.
-          clearExpectingWakeBusy(sessionID);
-          endIdleSpell(sessionID, true);
-        }
+    if (
+      type === 'session.error' ||
+      (type === 'session.status' &&
+        properties?.status?.type !== 'idle' &&
+        properties?.status?.type !== 'busy')
+    ) {
+      if (options.shouldManageSession(sessionID)) {
+        // Errors / retry are external lifecycle — rearm.
+        clearExpectingWakeBusy(sessionID);
+        endIdleSpell(sessionID, true);
       }
     }
   }
@@ -1397,7 +1390,3 @@ export function createOrchestratorWakeScheduler(
     },
   };
 }
-
-export type OrchestratorWakeScheduler = ReturnType<
-  typeof createOrchestratorWakeScheduler
->;


### PR DESCRIPTION
## Summary

Pure subtraction in `src/hooks/orchestrator-wake/index.ts` — five dead checks identified during a post-v2.2.17 review, each with a local correctness proof:

1. **Duplicate `applyArchiveState` re-check** — the second call repeated an earlier identical call with no `await` in between (the intervening fingerprint → `noteHostProgress` → progress checks are synchronous) and `applyArchiveState` is a pure function of `(state.archived, archiveState)`, so it could only return false. The first call (guarding the genuine post-read race) is kept.
2. **Third `capabilities.ready` re-check** — `capabilities` is a const static record created once ("the client never changes"); `canSchedule` already gated on it twice inside the same synchronous stretch.
3. **`triggerStoppedJobRecovery` duplication** — `pendingStoppedRecoveries.add` executed on both arms (hoisted); `rearmWakeProgress` called twice in the same prologue (idempotent fixed 4-field reset; the second was a no-op). One call kept, ordering of all other logic preserved exactly.
4. **Tautological nested condition in `event()`** — the inner condition logically implied its outer gate (`outer && inner ≡ inner`); idle/busy `session.status` had already returned in the earlier `isIdleEvent`/`isBusyEvent` branches. Collapsed to one condition.
5. **`OrchestratorWakeScheduler`** — `ReturnType` convenience type alias with zero importers repo-wide.

## Verification

- [x] `bun run check:ci` — clean
- [x] `bun run typecheck` — clean
- [x] `bun test` — 2689 pass / 0 fail (orchestrator-wake suite: 64 pass)

No behavior change by construction; net −22/+11 (insertions are re-indentation of the collapsed block). No docs impact.