### PR TITLE
perf(v2): single-pass allocation-free trailing user detection in setup

### DIFF
--- a/src/v2/setup-command.test.ts
+++ b/src/v2/setup-command.test.ts
@@ -1009,12 +1009,15 @@ describe('tool execute bridge normalization', () => {
     );
     expect(chatCalls.at(-1)).toEqual({ ...base, messageID: 'u1' });
 
-    // user-not-last: the LAST user message wins, not the first.
+    // user-not-last: the LAST user message wins, not the first —
+    // and a trailing NON-user message must be skipped by the
+    // backward scan (a `messages.at(-1)`-only regression would fail).
     await handler(
       makeEvent([
         { id: 'u2', role: 'user', content: [] },
         { id: 'a2', role: 'assistant', content: [] },
         { id: 'u3', role: 'user', content: [] },
+        { id: 'a3', role: 'assistant', content: [] },
       ]),
     );
     expect(chatCalls.at(-1)).toEqual({ ...base, messageID: 'u3' });

--- a/src/v2/setup-command.test.ts
+++ b/src/v2/setup-command.test.ts
@@ -989,6 +989,48 @@ describe('tool execute bridge normalization', () => {
     );
     expect(nextTurn).not.toContain(LOOP_GUARD_WARNING);
   });
+
+  test('per-request chat.message emulation keys on the trailing user message', async () => {
+    const chatCalls: Array<Record<string, unknown>> = [];
+    const handler = createSessionContextHandler({
+      interviewHandleContext: async () => {},
+      chatMessage: async (input) => {
+        chatCalls.push(input as Record<string, unknown>);
+      },
+    });
+    const base = { sessionID: 'ses_cmd', agent: 'orchestrator' };
+
+    // user-last: the trailing user message id is forwarded.
+    await handler(
+      makeEvent([
+        { id: 'a1', role: 'assistant', content: [] },
+        { id: 'u1', role: 'user', content: [] },
+      ]),
+    );
+    expect(chatCalls.at(-1)).toEqual({ ...base, messageID: 'u1' });
+
+    // user-not-last: the LAST user message wins, not the first.
+    await handler(
+      makeEvent([
+        { id: 'u2', role: 'user', content: [] },
+        { id: 'a2', role: 'assistant', content: [] },
+        { id: 'u3', role: 'user', content: [] },
+      ]),
+    );
+    expect(chatCalls.at(-1)).toEqual({ ...base, messageID: 'u3' });
+
+    // no-user: no messageID.
+    await handler(makeEvent([{ id: 'a3', role: 'assistant', content: [] }]));
+    expect(chatCalls.at(-1)).toEqual(base);
+
+    // empty message list: no messageID.
+    await handler(makeEvent([]));
+    expect(chatCalls.at(-1)).toEqual(base);
+
+    // trailing user message with an empty-string id: no messageID.
+    await handler(makeEvent([{ id: '', role: 'user', content: [] }]));
+    expect(chatCalls.at(-1)).toEqual(base);
+  });
 });
 
 describe('tool execute bridge status discrimination', () => {
@@ -1234,6 +1276,40 @@ describe('createSessionPromptBridge (native session.prompt hook)', () => {
       providerID: 'anthropic',
       modelID: 'claude-fallback',
     });
+  });
+
+  test('observeContext omits messageID when the trailing user id is empty or absent', async () => {
+    const calls: Array<Record<string, unknown>> = [];
+    const bridge = createSessionPromptBridge(async (input) => {
+      calls.push(input as Record<string, unknown>);
+    });
+    // Trailing user message with an empty-string id: the newly-learned
+    // forward carries state but no messageID.
+    await bridge.observeContext(
+      makeEvent([{ id: '', role: 'user', content: [] }], {
+        sessionID: 'ses_p',
+        agent: 'orchestrator',
+      }),
+    );
+    expect(calls).toEqual([{ sessionID: 'ses_p', agent: 'orchestrator' }]);
+
+    // No user message at all: same omission (the model change forces a
+    // new forward, so the shape is observable).
+    await bridge.observeContext(
+      makeEvent([{ id: 'a1', role: 'assistant', content: [] }], {
+        sessionID: 'ses_p',
+        agent: 'orchestrator',
+        model: { id: 'claude-x', providerID: 'anthropic' },
+      }),
+    );
+    expect(calls).toEqual([
+      { sessionID: 'ses_p', agent: 'orchestrator' },
+      {
+        sessionID: 'ses_p',
+        agent: 'orchestrator',
+        model: { providerID: 'anthropic', modelID: 'claude-x' },
+      },
+    ]);
   });
 
   test('agent learned from context is carried by the next admission', async () => {

--- a/src/v2/setup.ts
+++ b/src/v2/setup.ts
@@ -270,9 +270,7 @@ export function createSessionContextHandler(
     // only when the native prompt hook did NOT take over).
     if (deps.chatMessage) {
       try {
-        const userMessage = [...event.messages]
-          .reverse()
-          .find((message) => message.role === 'user');
+        const userMessage = trailingUserMessage(event.messages);
         await deps.chatMessage(
           {
             sessionID: event.sessionID,
@@ -412,6 +410,26 @@ export interface V2SessionPromptBridge {
   agentForSession(sessionID: string): string | undefined;
 }
 
+/** Trailing (last) message with `role === 'user'`, or undefined. Hot
+ * path — runs per LLM request on v2 hosts — so it scans backward in
+ * place instead of allocating a reversed copy. */
+function trailingUserMessage(
+  messages: V2SessionContextEvent['messages'],
+): V2SessionContextEvent['messages'][number] | undefined {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (message.role === 'user') return message;
+  }
+  return undefined;
+}
+
+/** Non-empty id of the trailing user message (see `trailingUserMessage`),
+ * or undefined when there is none. */
+function trailingUserId(event: V2SessionContextEvent): string | undefined {
+  const id = trailingUserMessage(event.messages)?.id;
+  return typeof id === 'string' && id ? id : undefined;
+}
+
 /**
  * Native `session.prompt` hook → v1 `chat.message` bridge.
  *
@@ -462,13 +480,6 @@ export function createSessionPromptBridge(
   /** First admitted prompt per session, deferred until the agent is
    * learned from a context event (bounded: one per session). */
   const pendingPrompts = new Map<string, V1ChatMessageInput>();
-
-  function trailingUserId(event: V2SessionContextEvent): string | undefined {
-    const id = [...event.messages]
-      .reverse()
-      .find((message) => message.role === 'user')?.id;
-    return typeof id === 'string' && id ? id : undefined;
-  }
 
   async function deliver(
     label: string,
@@ -575,6 +586,7 @@ export function createSessionPromptBridge(
         });
         pruneSessionMap(sessionState);
       }
+      const trailingId = trailingUserId(event);
       const pending = pendingPrompts.get(sessionID);
       if (pending) {
         if (agent && previous?.agent !== agent) {
@@ -592,10 +604,7 @@ export function createSessionPromptBridge(
           });
           return;
         }
-        if (
-          trailingUserId(event) &&
-          trailingUserId(event) !== pending.messageID
-        ) {
+        if (trailingId && trailingId !== pending.messageID) {
           // The conversation moved past the pending admission without the
           // agent ever being learned (e.g. a synthetic/compaction request
           // followed): flush best-known so the delivery is not lost.
@@ -608,7 +617,7 @@ export function createSessionPromptBridge(
         sessionID,
         ...(agent ? { agent } : {}),
         ...(model ? { model } : {}),
-        ...(trailingUserId(event) ? { messageID: trailingUserId(event) } : {}),
+        ...(trailingId ? { messageID: trailingId } : {}),
       });
     },
 


### PR DESCRIPTION
## Summary

Eliminates per-request allocation waste on the v2 host hot path in `src/v2/setup.ts`:

- `[...messages].reverse().find(role === 'user')` — an O(n) full-array copy **per call** — is now a shared, allocation-free backward scan (`trailingUserMessage`), with `trailingUserId` deriving from it.
- The trailing-user logic previously existed **twice** in the file (the closure in `createSessionPromptBridge` and an inline copy in `createSessionContextHandler`'s chat-message emulation); it now exists exactly once.
- `observeContext` evaluated `trailingUserId(event)` up to **3× per invocation** (twice inside one condition, once more at the state-forward); it is now computed once into a local and reused. Safe to hoist: the scan is pure and the `chatMessage` hook never receives the event, so `event.messages` cannot mutate across the interleaved awaits.

This code runs per LLM request on v2 hosts while a pending first-admission exists, over transcripts that can span hundreds of messages — the spread-reverse allocated a full copy of the message array on every evaluation.

## Verification

- [x] `bun run check:ci` — clean
- [x] `bun run typecheck` — clean
- [x] `bun test` — 2691 pass / 0 fail; **cache-payload golden snapshots unchanged** (no prompt-prefix drift)
- [x] New tests via existing seams (`createSessionContextHandler`'s `chatMessage` dep, `createSessionPromptBridge.observeContext`): user-last, user-not-last (last wins), no-user, empty array, empty-string-id → no `messageID`

Semantics identical on all inputs; lookup mechanics only.