### PR TITLE
fix(task-session-manager): stain only consumed unresolved takes and gate adoption labels

### DIFF
--- a/src/hooks/task-session-manager/parallel-same-agent-pairing.test.ts
+++ b/src/hooks/task-session-manager/parallel-same-agent-pairing.test.ts
@@ -398,9 +398,10 @@ describe('parallel same-agent pairing (incident 2026-09-12)', () => {
         },
       ] as const;
 
-    // Burst of three no-ID, no-title calls; the pending cap evicts the
-    // oldest pending (its ticket was released at eviction —
-    // pre-existing behavior) before any after-hook fires.
+    // Burst of three no-ID, no-title calls. The direct tracker.take
+    // simulates the oldest pending disappearing without its after-hook
+    // (e.g. a real pending-cap eviction would also release its ticket;
+    // immaterial here since no concurrency limiter is injected).
     await hook['tool.execute.before'](...noIDBefore(L_A));
     await hook['tool.execute.before'](...noIDBefore(L_B));
     await hook['tool.execute.before'](...noIDBefore(L_C));

--- a/src/hooks/task-session-manager/pending-call-tracker.test.ts
+++ b/src/hooks/task-session-manager/pending-call-tracker.test.ts
@@ -170,6 +170,37 @@ describe('take', () => {
     const hit = tracker.peekByParentAndAgent('parent-1', 'oracle');
     expect(hit?.callId).toBe('b');
   });
+
+  test('fenced sole-survivor take does not stain the unconsumed pending', () => {
+    const tracker = createPendingCallTracker();
+    const ownerBoard = new BackgroundJobBoard();
+    const otherBoard = new BackgroundJobBoard();
+    tracker.add(
+      pending({
+        callId: 'a',
+        earlyRegisteredTaskID: 'ses_x',
+        earlyRegistration: {
+          taskID: 'ses_x',
+          generation: 1,
+          backgroundJobBoard: ownerBoard,
+        },
+      }),
+    );
+    tracker.add(pending({ callId: 'b' }));
+    // Arm the parent's unresolved window via a drain (the flagged
+    // early-registered pending is skipped; 'b' is consumed).
+    tracker.takeUnresolvedFirstMatch('parent-1', { identityTaskID: 'ses_y' });
+
+    // The sole survivor is fenced for another board generation: the
+    // no-callId take refuses WITHOUT consuming — the armed window must
+    // not stain the still-tracked pending.
+    expect(tracker.take(undefined, 'parent-1', otherBoard)).toBeUndefined();
+
+    // The owning generation resolves it by claim, unflagged.
+    const claimed = tracker.takeByTaskID('parent-1', 'ses_x', ownerBoard);
+    expect(claimed?.callId).toBe('a');
+    expect(claimed?.identityUnresolved).toBeUndefined();
+  });
 });
 
 describe('takeByTaskID', () => {
@@ -370,5 +401,48 @@ describe('takeUnresolvedFirstMatch', () => {
     tracker.add(pending({ callId: 'b', parentSessionId: 'parent-1' }));
     const sole = tracker.take(undefined, 'parent-1');
     expect(sole?.identityUnresolved).toBeUndefined();
+  });
+});
+
+describe('adoptEarlyRegistrations', () => {
+  test('identity-unresolved pendings adopt with generic metadata', () => {
+    const oldBoard = new BackgroundJobBoard();
+    const newBoard = new BackgroundJobBoard();
+    const tracker = createPendingCallTracker();
+    tracker.add(
+      pending({
+        callId: 'flagged',
+        label: 'Flagged label',
+        identityUnresolved: true,
+        earlyRegisteredTaskID: 'ses_flagged',
+        earlyRegistration: {
+          taskID: 'ses_flagged',
+          generation: 1,
+          backgroundJobBoard: oldBoard,
+        },
+      }),
+    );
+    tracker.add(
+      pending({
+        callId: 'clean',
+        label: 'Clean label',
+        earlyRegisteredTaskID: 'ses_clean',
+        earlyRegistration: {
+          taskID: 'ses_clean',
+          generation: 1,
+          backgroundJobBoard: oldBoard,
+        },
+      }),
+    );
+
+    tracker.adoptEarlyRegistrations(newBoard);
+
+    // A flagged pending never paints its label: the adopted record
+    // falls back to the board's generic default description.
+    expect(newBoard.get('ses_flagged')?.description).toBe(
+      'background oracle task',
+    );
+    // A resolved pending keeps its verified label.
+    expect(newBoard.get('ses_clean')?.description).toBe('Clean label');
   });
 });

--- a/src/hooks/task-session-manager/pending-call-tracker.ts
+++ b/src/hooks/task-session-manager/pending-call-tracker.ts
@@ -186,6 +186,12 @@ export function createPendingCallTracker(
       ownerBoard?: BackgroundJobStore,
       takeOptions?: { recordConsumed?: boolean },
     ) {
+      // Set for a no-callId sole-survivor take on a parent whose
+      // unresolved window is armed; the flag is applied only after the
+      // fence checks below confirm this take actually consumes the
+      // pending (a fenced take returns without consuming and must not
+      // stain the pending for its owning generation).
+      let unresolvedWindowTake = false;
       if (!callId && parentSessionId) {
         // Without a tool call ID a take can only be sound when exactly
         // one pending exists for the parent. "A sole survivor belongs
@@ -203,11 +209,9 @@ export function createPendingCallTracker(
         callId = sole;
         // Window-shift propagation: an unresolved drain earlier in this
         // parent's burst means "sole survivor belongs to this call" no
-        // longer proves identity — flag the taken pending unresolved.
-        if (unresolvedDrainParents.has(parentSessionId)) {
-          const solePending = pendingCalls.get(sole);
-          if (solePending) solePending.identityUnresolved = true;
-        }
+        // longer proves identity — the consumed pending is flagged
+        // unresolved below.
+        unresolvedWindowTake = unresolvedDrainParents.has(parentSessionId);
       }
       if (!callId) return undefined;
       const pending = pendingCalls.get(callId);
@@ -219,6 +223,9 @@ export function createPendingCallTracker(
         return undefined;
       }
       pendingCalls.delete(callId);
+      if (pending && unresolvedWindowTake) {
+        pending.identityUnresolved = true;
+      }
       if (pending && takeOptions?.recordConsumed !== false) {
         recordConsumed(pending);
       }
@@ -411,8 +418,15 @@ export function createPendingCallTracker(
               taskID: registration.taskID,
               parentSessionID: pending.parentSessionId,
               agent: pending.agentType,
-              description: pending.label,
-              objective: pending.fullObjective ?? pending.label,
+              // Never paint call-specific metadata from an unresolved
+              // identity (mirrors registerTaskOutputLaunch): a flagged
+              // pending falls back to the board's generic description.
+              ...(pending.identityUnresolved
+                ? {}
+                : {
+                    description: pending.label,
+                    objective: pending.fullObjective ?? pending.label,
+                  }),
               background: false,
               preserveRun: true,
             });


### PR DESCRIPTION
## Summary

Follow-up to #1167. That PR was merged at `3011fcaa` just before this fix was pushed to its branch, so these two review fixes from the independent post-merge review are not in master yet.

Both close ordering/gate gaps in the unresolved-identity handling added by #1167:

1. **Flag was set before the owner-board fence check in `take()`** — a no-callId sole-survivor take stained its pending `identityUnresolved` *before* the board-generation fence could refuse it. A fenced refusal returns without consuming, leaving a permanently-stained pending in the map; a later claim-verified `takeByTaskID` of that pending then wrongly dropped its label despite verified identity (contradicting #1167's own pinned invariant). **Fix:** record the decision separately and apply the stain only after the fence passes, onto the pending actually consumed — no path can return a flagged-but-unconsumed pending anymore.
2. **`adoptEarlyRegistrations` missed the gate** — the one remaining label-painting path for a flagged pending: fresh adoption re-registered with `description: pending.label` unconditionally. **Fix:** mirror `registerTaskOutputLaunch`'s conditional spread — flagged pendings adopt with generic metadata (board default), clean ones keep their label.

## Verification

- [x] `bun run check:ci` / `bun run typecheck` — clean
- [x] `bun test` — 2695 pass / 0 fail on this branch rebased to current master
- [x] 2 new regression tests: fenced sole-survivor take does not stain the unconsumed pending (subsequent claim-verified take stays unflagged); identity-unresolved pendings adopt with generic metadata while clean siblings keep theirs
- [x] #1167's invariant test ("armed window never flags a claim-verified takeByTaskID take") unchanged and green