### PR TITLE
refactor(task-session-manager): extract shared child transcript fetch and error helpers

### DIFF
--- a/src/hooks/task-session-manager/index.ts
+++ b/src/hooks/task-session-manager/index.ts
@@ -14,7 +14,10 @@ import {
   parseTaskStateFromOutput,
   recordBackgroundJobSuppression,
 } from '../../utils';
-import { extractChildTerminalEvidence } from '../../utils/child-transcript';
+import {
+  extractChildTerminalEvidence,
+  fetchChildTranscript,
+} from '../../utils/child-transcript';
 import { isRecord as isObjectRecord } from '../../utils/guards';
 import { getClient } from '../../utils/opencode-client';
 import type { SessionLifecycle } from '../session-lifecycle';
@@ -48,21 +51,21 @@ import {
 /** Extract the final assistant text from a child session transcript
  * (v1-shaped {data:[{info,parts}]} via the client shim's messages). Used
  * by the quiescent-outcome settle path so completed jobs reconcile with a
- * usable result summary instead of a placeholder. Delegates to the shared
- * extractor; the v2 shim shape drops `info.time`, so the strict
- * completion-time requirement is off (terminality is confirmed via the
- * host outcome gate before this runs). */
+ * usable result summary instead of a placeholder. Delegates the fetch to
+ * the shared `fetchChildTranscript` (which surfaces `response.error` as
+ * a thrown Error — absorbed here, the settle path degrades to no text)
+ * and classification to the shared extractor; the v2 shim shape drops
+ * `info.time`, so the strict completion-time requirement is off
+ * (terminality is confirmed via the host outcome gate before this
+ * runs). */
 async function readFinalAssistantText(
   client: ReturnType<typeof getClient>,
   sessionID: string,
   directory: string,
 ): Promise<string | undefined> {
-  if (typeof client.session?.messages !== 'function') return undefined;
   try {
-    const response = await client.session.messages({
-      path: { id: sessionID },
-      query: { directory },
-    });
+    const response = await fetchChildTranscript(client, sessionID, directory);
+    if (response === undefined) return undefined;
     const evidence = extractChildTerminalEvidence(response, {
       // v2 shim shape: flat {id, role} info without time/finish.
       requireCompletionTime: false,

--- a/src/hooks/task-session-manager/parallel-same-agent-pairing.test.ts
+++ b/src/hooks/task-session-manager/parallel-same-agent-pairing.test.ts
@@ -398,9 +398,10 @@ describe('parallel same-agent pairing (incident 2026-09-12)', () => {
         },
       ] as const;
 
-    // Burst of three no-ID, no-title calls; the pending cap evicts the
-    // oldest pending (its ticket was released at eviction —
-    // pre-existing behavior) before any after-hook fires.
+    // Burst of three no-ID, no-title calls. The direct tracker.take
+    // simulates the oldest pending disappearing without its after-hook
+    // (e.g. a real pending-cap eviction would also release its ticket;
+    // immaterial here since no concurrency limiter is injected).
     await hook['tool.execute.before'](...noIDBefore(L_A));
     await hook['tool.execute.before'](...noIDBefore(L_B));
     await hook['tool.execute.before'](...noIDBefore(L_C));

--- a/src/hooks/task-session-manager/pending-call-tracker.test.ts
+++ b/src/hooks/task-session-manager/pending-call-tracker.test.ts
@@ -170,6 +170,37 @@ describe('take', () => {
     const hit = tracker.peekByParentAndAgent('parent-1', 'oracle');
     expect(hit?.callId).toBe('b');
   });
+
+  test('fenced sole-survivor take does not stain the unconsumed pending', () => {
+    const tracker = createPendingCallTracker();
+    const ownerBoard = new BackgroundJobBoard();
+    const otherBoard = new BackgroundJobBoard();
+    tracker.add(
+      pending({
+        callId: 'a',
+        earlyRegisteredTaskID: 'ses_x',
+        earlyRegistration: {
+          taskID: 'ses_x',
+          generation: 1,
+          backgroundJobBoard: ownerBoard,
+        },
+      }),
+    );
+    tracker.add(pending({ callId: 'b' }));
+    // Arm the parent's unresolved window via a drain (the flagged
+    // early-registered pending is skipped; 'b' is consumed).
+    tracker.takeUnresolvedFirstMatch('parent-1', { identityTaskID: 'ses_y' });
+
+    // The sole survivor is fenced for another board generation: the
+    // no-callId take refuses WITHOUT consuming — the armed window must
+    // not stain the still-tracked pending.
+    expect(tracker.take(undefined, 'parent-1', otherBoard)).toBeUndefined();
+
+    // The owning generation resolves it by claim, unflagged.
+    const claimed = tracker.takeByTaskID('parent-1', 'ses_x', ownerBoard);
+    expect(claimed?.callId).toBe('a');
+    expect(claimed?.identityUnresolved).toBeUndefined();
+  });
 });
 
 describe('takeByTaskID', () => {
@@ -370,5 +401,48 @@ describe('takeUnresolvedFirstMatch', () => {
     tracker.add(pending({ callId: 'b', parentSessionId: 'parent-1' }));
     const sole = tracker.take(undefined, 'parent-1');
     expect(sole?.identityUnresolved).toBeUndefined();
+  });
+});
+
+describe('adoptEarlyRegistrations', () => {
+  test('identity-unresolved pendings adopt with generic metadata', () => {
+    const oldBoard = new BackgroundJobBoard();
+    const newBoard = new BackgroundJobBoard();
+    const tracker = createPendingCallTracker();
+    tracker.add(
+      pending({
+        callId: 'flagged',
+        label: 'Flagged label',
+        identityUnresolved: true,
+        earlyRegisteredTaskID: 'ses_flagged',
+        earlyRegistration: {
+          taskID: 'ses_flagged',
+          generation: 1,
+          backgroundJobBoard: oldBoard,
+        },
+      }),
+    );
+    tracker.add(
+      pending({
+        callId: 'clean',
+        label: 'Clean label',
+        earlyRegisteredTaskID: 'ses_clean',
+        earlyRegistration: {
+          taskID: 'ses_clean',
+          generation: 1,
+          backgroundJobBoard: oldBoard,
+        },
+      }),
+    );
+
+    tracker.adoptEarlyRegistrations(newBoard);
+
+    // A flagged pending never paints its label: the adopted record
+    // falls back to the board's generic default description.
+    expect(newBoard.get('ses_flagged')?.description).toBe(
+      'background oracle task',
+    );
+    // A resolved pending keeps its verified label.
+    expect(newBoard.get('ses_clean')?.description).toBe('Clean label');
   });
 });

--- a/src/hooks/task-session-manager/pending-call-tracker.ts
+++ b/src/hooks/task-session-manager/pending-call-tracker.ts
@@ -186,6 +186,12 @@ export function createPendingCallTracker(
       ownerBoard?: BackgroundJobStore,
       takeOptions?: { recordConsumed?: boolean },
     ) {
+      // Set for a no-callId sole-survivor take on a parent whose
+      // unresolved window is armed; the flag is applied only after the
+      // fence checks below confirm this take actually consumes the
+      // pending (a fenced take returns without consuming and must not
+      // stain the pending for its owning generation).
+      let unresolvedWindowTake = false;
       if (!callId && parentSessionId) {
         // Without a tool call ID a take can only be sound when exactly
         // one pending exists for the parent. "A sole survivor belongs
@@ -203,11 +209,9 @@ export function createPendingCallTracker(
         callId = sole;
         // Window-shift propagation: an unresolved drain earlier in this
         // parent's burst means "sole survivor belongs to this call" no
-        // longer proves identity — flag the taken pending unresolved.
-        if (unresolvedDrainParents.has(parentSessionId)) {
-          const solePending = pendingCalls.get(sole);
-          if (solePending) solePending.identityUnresolved = true;
-        }
+        // longer proves identity — the consumed pending is flagged
+        // unresolved below.
+        unresolvedWindowTake = unresolvedDrainParents.has(parentSessionId);
       }
       if (!callId) return undefined;
       const pending = pendingCalls.get(callId);
@@ -219,6 +223,9 @@ export function createPendingCallTracker(
         return undefined;
       }
       pendingCalls.delete(callId);
+      if (pending && unresolvedWindowTake) {
+        pending.identityUnresolved = true;
+      }
       if (pending && takeOptions?.recordConsumed !== false) {
         recordConsumed(pending);
       }
@@ -411,8 +418,15 @@ export function createPendingCallTracker(
               taskID: registration.taskID,
               parentSessionID: pending.parentSessionId,
               agent: pending.agentType,
-              description: pending.label,
-              objective: pending.fullObjective ?? pending.label,
+              // Never paint call-specific metadata from an unresolved
+              // identity (mirrors registerTaskOutputLaunch): a flagged
+              // pending falls back to the board's generic description.
+              ...(pending.identityUnresolved
+                ? {}
+                : {
+                    description: pending.label,
+                    objective: pending.fullObjective ?? pending.label,
+                  }),
               background: false,
               preserveRun: true,
             });

--- a/src/hooks/task-session-manager/revived-run-tracker.test.ts
+++ b/src/hooks/task-session-manager/revived-run-tracker.test.ts
@@ -220,6 +220,13 @@ describe('revived run tracker', () => {
     ).toBe(false);
     expect(scheduled).toHaveLength(1);
 
+    // Drain the probe's microtask chain: the shared fetch helper adds a
+    // couple of await hops, so give the chain a bounded settle loop
+    // rather than pinning an exact tick count.
+    const settle = async () => {
+      for (let i = 0; i < 10; i += 1) await Promise.resolve();
+    };
+
     for (
       let attempt = 0;
       harness.board.get('ses_child')?.state === 'running' && attempt < 4;
@@ -228,8 +235,8 @@ describe('revived run tracker', () => {
       const callback = scheduled.shift();
       if (!callback) throw new Error('missing stabilization probe');
       callback();
-      await Promise.resolve();
-      await Promise.resolve();
+      await settle();
+      await settle();
     }
 
     expect(harness.board.get('ses_child')).toMatchObject({

--- a/src/hooks/task-session-manager/revived-run-tracker.ts
+++ b/src/hooks/task-session-manager/revived-run-tracker.ts
@@ -6,7 +6,13 @@ import type {
 } from '../../utils/background-job-board';
 import type { BackgroundJobStore } from '../../utils/background-job-store';
 import type { BackgroundJobSupervisor } from '../../utils/background-job-supervisor';
-import { extractChildTerminalEvidence } from '../../utils/child-transcript';
+import {
+  extractChildTerminalEvidence,
+  fetchChildTranscript,
+  responseError,
+  stringifyError,
+} from '../../utils/child-transcript';
+import { isRecord } from '../../utils/guards';
 import { createInternalAgentTextPart } from '../../utils/internal-initiator';
 import { getClient } from '../../utils/opencode-client';
 import { COMPLETED_WITHOUT_TEXT_DIAGNOSTIC } from '../../utils/task';
@@ -92,19 +98,14 @@ export function createRevivedRunTracker(options: {
   const captureBaseline = async (
     taskID: string,
   ): Promise<string | undefined> => {
-    const session = getClient(options.input).session;
-    const messages =
-      typeof session.messages === 'function'
-        ? session.messages.bind(session)
-        : undefined;
-    if (typeof messages !== 'function') return undefined;
-    const response = await messages({
-      path: { id: taskID },
-      query: { directory: options.input.directory },
-    });
-    const error = responseError(response);
-    if (error !== undefined) throw new Error(errorText(error));
-    const data = Array.isArray(response.data) ? response.data : [];
+    const response = await fetchChildTranscript(
+      getClient(options.input),
+      taskID,
+      options.input.directory,
+    );
+    if (response === undefined) return undefined;
+    const data =
+      isRecord(response) && Array.isArray(response.data) ? response.data : [];
     const last = data.at(-1) as SessionMessage | undefined;
     return typeof last?.info?.id === 'string' ? last.info.id : undefined;
   };
@@ -157,21 +158,19 @@ export function createRevivedRunTracker(options: {
   };
 
   async function probeRun(run: RevivedRun): Promise<boolean> {
-    const session = getClient(options.input).session;
-    const messages =
-      typeof session.messages === 'function'
-        ? session.messages.bind(session)
-        : undefined;
-    if (typeof messages !== 'function') return false;
     let response: unknown;
     try {
-      response = await messages({
-        path: { id: run.taskID },
-        query: { directory: options.input.directory },
-      });
+      response = await fetchChildTranscript(
+        getClient(options.input),
+        run.taskID,
+        options.input.directory,
+      );
     } catch {
+      // Transport failures and error payloads both degrade to "not yet
+      // settled" — the probe retries on its stabilization schedule.
       return false;
     }
+    if (response === undefined) return false;
 
     const evidence = extractChildTerminalEvidence(response, {
       baselineMessageID: run.baselineMessageID,
@@ -314,7 +313,7 @@ export function createRevivedRunTracker(options: {
           }),
       );
       const error = responseError(response);
-      if (error !== undefined) throw new Error(errorText(error));
+      if (error !== undefined) throw new Error(stringifyError(error));
       const latest = options.backgroundJobBoard.get(run.taskID);
       if (
         !latest ||
@@ -462,25 +461,4 @@ function terminalOutcome(
   return record.state === 'completed' || record.state === 'error'
     ? record.state
     : undefined;
-}
-
-function responseError(response: unknown): unknown {
-  if (!isRecord(response)) return undefined;
-  return response.error === undefined || response.error === null
-    ? undefined
-    : response.error;
-}
-
-function errorText(error: unknown): string {
-  if (error instanceof Error) return error.message;
-  if (typeof error === 'string') return error;
-  try {
-    return JSON.stringify(error);
-  } catch {
-    return String(error);
-  }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
 }

--- a/src/tools/cancel-task.ts
+++ b/src/tools/cancel-task.ts
@@ -5,6 +5,8 @@ import {
 } from '@opencode-ai/plugin';
 import type { BackgroundJobLease } from '../utils/background-job-board';
 import type { BackgroundJobStore } from '../utils/background-job-store';
+import { responseError, stringifyError } from '../utils/child-transcript';
+import { isRecord } from '../utils/guards';
 import { getClient } from '../utils/opencode-client';
 import { delay } from '../utils/polling';
 import {
@@ -203,8 +205,8 @@ async function abortAndVerifySession(
     throw error;
   }
   assertLease(options.backgroundJobBoard, lease, execution);
-  const responseError = operationError(response);
-  if (responseError !== undefined) throw new Error(errorText(responseError));
+  const error = responseError(response);
+  if (error !== undefined) throw new Error(stringifyError(error));
   if (operationBoolean(response) === false) {
     throw new Error(`Session abort was not confirmed: ${taskID}`);
   }
@@ -480,31 +482,10 @@ async function getSessionParentID(
   }
 }
 
-function operationError(response: unknown): unknown {
-  if (!isRecord(response)) return undefined;
-  return response.error === undefined || response.error === null
-    ? undefined
-    : response.error;
-}
-
 function operationBoolean(response: unknown): boolean | undefined {
   if (response === true || response === false) return response;
   if (!isRecord(response)) return undefined;
   return typeof response.data === 'boolean' ? response.data : undefined;
-}
-
-function errorText(error: unknown): string {
-  if (error instanceof Error) return error.message;
-  if (typeof error === 'string') return error;
-  try {
-    return JSON.stringify(error);
-  } catch {
-    return String(error);
-  }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
 }
 
 function unknownTaskOutput(taskID: string, message: string): string {

--- a/src/utils/child-transcript.test.ts
+++ b/src/utils/child-transcript.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from 'bun:test';
-import { extractChildTerminalEvidence } from './child-transcript';
+import type { PluginInput } from '@opencode-ai/plugin';
+import {
+  extractChildTerminalEvidence,
+  fetchChildTranscript,
+} from './child-transcript';
 
 function message(overrides: {
   id?: string;
@@ -249,5 +253,106 @@ describe('extractChildTerminalEvidence', () => {
     });
     // Whole-string trim only: inner padding between parts is preserved.
     expect(evidence).toEqual({ kind: 'ready', text: 'first  \n\nsecond' });
+  });
+});
+
+describe('fetchChildTranscript', () => {
+  function clientWith(
+    session: Record<string, unknown> | undefined,
+  ): PluginInput['client'] {
+    // Structural stand-in mirroring the v2 client-shim's degraded hosts.
+    return { session } as PluginInput['client'];
+  }
+
+  test('returns the raw response on success', async () => {
+    const response = { data: [] };
+    const client = clientWith({ messages: () => response });
+    await expect(
+      fetchChildTranscript(client, 'ses_child', '/test'),
+    ).resolves.toBe(response);
+  });
+
+  test('passes sessionID and directory through path and query', async () => {
+    const seen: unknown[] = [];
+    const client = clientWith({
+      messages(...args: unknown[]) {
+        seen.push(args[0]);
+        return { data: [] };
+      },
+    });
+    await fetchChildTranscript(client, 'ses_child', '/test');
+    expect(seen[0]).toEqual({
+      path: { id: 'ses_child' },
+      query: { directory: '/test' },
+    });
+  });
+
+  test('binds session.messages to the session object', async () => {
+    const session: Record<string, unknown> = {};
+    session.messages = function (this: unknown) {
+      expect(this).toBe(session);
+      return { data: [] };
+    };
+    await fetchChildTranscript(clientWith(session), 'ses_child', '/test');
+  });
+
+  test('returns undefined when session.messages is not callable', async () => {
+    await expect(
+      fetchChildTranscript(clientWith({}), 'ses_child', '/test'),
+    ).resolves.toBeUndefined();
+    await expect(
+      fetchChildTranscript(clientWith(undefined), 'ses_child', '/test'),
+    ).resolves.toBeUndefined();
+  });
+
+  test('propagates transport failures', async () => {
+    const client = clientWith({
+      messages: () => Promise.reject(new Error('transport down')),
+    });
+    await expect(
+      fetchChildTranscript(client, 'ses_child', '/test'),
+    ).rejects.toThrow('transport down');
+  });
+
+  test('string error payload is surfaced as-is', async () => {
+    const client = clientWith({
+      messages: () => ({ error: 'session not found' }),
+    });
+    await expect(
+      fetchChildTranscript(client, 'ses_child', '/test'),
+    ).rejects.toThrow('session not found');
+  });
+
+  test('Error payload is surfaced via its message', async () => {
+    const client = clientWith({
+      messages: () => ({ error: new Error('boom') }),
+    });
+    await expect(
+      fetchChildTranscript(client, 'ses_child', '/test'),
+    ).rejects.toThrow('boom');
+  });
+
+  test('object error payload is JSON-stringified', async () => {
+    const client = clientWith({
+      messages: () => ({ error: { code: 500, message: 'internal' } }),
+    });
+    await expect(
+      fetchChildTranscript(client, 'ses_child', '/test'),
+    ).rejects.toThrow('{"code":500,"message":"internal"}');
+  });
+
+  test('error: null is not an error (mirrors pinned extractor semantics)', async () => {
+    const response = { data: [], error: null };
+    const client = clientWith({ messages: () => response });
+    await expect(
+      fetchChildTranscript(client, 'ses_child', '/test'),
+    ).resolves.toBe(response);
+  });
+
+  test('non-record responses are returned untouched', async () => {
+    const client = clientWith({ messages: () => 'flat-shape' });
+    await expect(
+      fetchChildTranscript(client, 'ses_child', '/test'),
+    ).resolves.toBe('flat-shape');
   });
 });

--- a/src/utils/child-transcript.ts
+++ b/src/utils/child-transcript.ts
@@ -1,5 +1,5 @@
 /**
- * Shared child-session transcript evidence extraction.
+ * Shared child-session transcript evidence extraction and fetch.
  *
  * Two consumers need "what did the child session end with?":
  * - `revived-run-tracker` (revive probes, strict v1 transcript shape)
@@ -10,8 +10,19 @@
  * Both previously carried their own (and subtly different) extraction
  * logic. This module is the single source of truth for reading a v1-style
  * `{data: [{info, parts}]}` messages response and classifying the
- * trailing assistant turn.
+ * trailing assistant turn — and for fetching that transcript:
+ * `fetchChildTranscript` binds the client's `session.messages` endpoint
+ * (degraded hosts may not expose it) and surfaces `response.error` as a
+ * normalized `Error`, replacing the bind/call/unwrap boilerplate that was
+ * previously duplicated at every call site. `responseError` and
+ * `stringifyError` are the shared response-error extraction and error-text
+ * helpers for session-endpoint call sites (revive probes, notification
+ * transport, task cancellation).
  */
+
+import type { PluginInput } from '@opencode-ai/plugin';
+
+import { isRecord } from './guards';
 
 interface ChildTranscriptOptions {
   /** Only consider messages after this baseline message id (revive flow). */
@@ -38,6 +49,56 @@ export type ChildTerminalEvidence =
   | { kind: 'no-assistant' }
   | { kind: 'no-new-messages' };
 
+/**
+ * Fetch a child session's transcript via `client.session.messages`.
+ *
+ * Returns the raw response, or `undefined` when the host client does not
+ * expose a callable `session.messages` endpoint (degraded hosts) — each
+ * call site decides how to degrade. Transport failures propagate to the
+ * caller. A `response.error` payload is surfaced as a normalized `Error`
+ * whose message is `stringifyError(response.error)`, matching the
+ * error-surfacing style previously duplicated at the call sites.
+ */
+export async function fetchChildTranscript(
+  client: PluginInput['client'],
+  sessionID: string,
+  directory: string,
+): Promise<unknown> {
+  const session = client.session;
+  const messages =
+    typeof session?.messages === 'function'
+      ? session.messages.bind(session)
+      : undefined;
+  if (typeof messages !== 'function') return undefined;
+  const response = await messages({
+    path: { id: sessionID },
+    query: { directory },
+  });
+  const error = responseError(response);
+  if (error !== undefined) throw new Error(stringifyError(error));
+  return response;
+}
+
+/** Extract a non-null `response.error` payload from an SDK-style
+ * response; `undefined` when the response carries no error. */
+export function responseError(response: unknown): unknown {
+  if (!isRecord(response)) return undefined;
+  return response.error === undefined || response.error === null
+    ? undefined
+    : response.error;
+}
+
+/** Normalize an unknown error payload to a displayable message string. */
+export function stringifyError(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'string') return error;
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}
+
 interface LooseMessage {
   info?: {
     id?: unknown;
@@ -47,20 +108,6 @@ interface LooseMessage {
     time?: { completed?: unknown };
   };
   parts?: unknown[];
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}
-
-function stringifyError(error: unknown): string {
-  if (error instanceof Error) return error.message;
-  if (typeof error === 'string') return error;
-  try {
-    return JSON.stringify(error);
-  } catch {
-    return String(error);
-  }
 }
 
 export function extractChildTerminalEvidence(


### PR DESCRIPTION
## Summary

The "bind `client.session.messages`, call `{path:{id}, query:{directory}}`, surface `response.error`" boilerplate was implemented three times (each with its own error unwrapping), and the error-text/type-guard helpers it needs were re-declared locally in three more places. This extracts them into the module whose header already declares it the single source of truth for this concern (`src/utils/child-transcript.ts`):

- **`fetchChildTranscript(client, sessionID, directory)`** — shared fetch with normalized `response.error` throwing; returns `undefined` when the host exposes no callable `messages` endpoint so each call site keeps its own degrade policy.
- **`responseError` / `stringifyError`** exported — identical bodies to the deleted local `responseError`/`operationError`/`errorText` copies; `notifyParent` and `cancel-task` abort-unwrapping now use them.
- Local `isRecord` copies removed in favor of the canonical `src/utils/guards` predicate.

Call-site equivalences (each preserved deliberately):
- `captureBaseline` remains the only site that *throws* on `response.error`.
- `probeRun` keeps its own catch → `false` (transport + error payloads both degrade to `false`, observably identical to the old extraction path — v1 SDK returns `data` XOR `error`, the v2 shim never sets `error`).
- `readFinalAssistantText` keeps its catch-all → `undefined`.

## Verification

- [x] `bun run check:ci` / `bun run typecheck` — clean
- [x] `bun test` — 2705 pass / 0 fail (full suite)
- [x] +10 unit tests for the helper (success passthrough, path/query shape, this-binding, unavailable endpoint, transport propagation, error normalization, `error: null` pinned non-error)
- [x] Independently reviewed: every equivalence claim checked against the shim, extractor, and call sites — APPROVE (informational notes only)