### PR TITLE
chore(v2): surface shim degradation explicitly and trim dangling barrel re-exports

### DIFF
--- a/docs/opencode-v2-compatibility.md
+++ b/docs/opencode-v2-compatibility.md
@@ -84,10 +84,15 @@ degrades that single feature with a log line instead of breaking the load.
    sessions leaking), and `session.list` (v2 `Session.Info` page → the v1
    `{data}` envelope with `directory` derived from `location` and `outcome`
    mapped, used by the interview dashboard's session scan and the
-   orchestrator-wake children enumeration). The shim marks the input
-   `hostFlavor: 'v2'` and never fakes success shapes: methods the host
-   lacks degrade with an honest log (or are omitted entirely, as with
-   `session.get`, so capability probes see the truth).
+   orchestrator-wake children enumeration). Note that `remove` and `list`
+   are **not part of the stock v2 plugin session domain** — the
+   capability probes only succeed on hosts that extend it, and current
+   v2 hosts always take the degraded paths (see
+   [Not exposed to plugins: `session.list` / `session.remove`](#not-exposed-to-plugins-sessionlist-sessionremove)).
+   The shim marks the input `hostFlavor: 'v2'` and never fakes success
+   shapes: methods the host lacks degrade with an honest log (or are
+   omitted entirely, as with `session.get`, so capability probes see the
+   truth).
 2. Invokes `OhMyOpenCodeLite(pluginInput)` to reuse **all** existing build
    logic (config, agents, tools, hooks, job board, multiplexer, companion).
 3. Runs the v1 `config()` hook against a synthesized config to resolve agent
@@ -365,6 +370,48 @@ Q&A history.
   exists, `session.hook("model.request")` with mutable `headers`, if
   demand appears).
 
+### Not exposed to plugins: `session.list` / `session.remove`
+
+The v2 plugin session domain (`packages/plugin/src/promise/session.ts`,
+`SessionDomain`, mirrored by the runtime object the promise adapter
+builds) exposes exactly `create`/`get`/`switchAgent`/`switchModel`/
+`prompt`/`generate`/`command`/`synthetic`/`interrupt`/`rename`/`move`/
+`wait`/`context` — **`list` and `remove` are not handed to plugins**.
+Both endpoints exist on the host's HTTP API, but the plugin context never
+receives them. The client shim capability-probes both at runtime
+(`typeof s.list === 'function'`, `s.remove`), so a future host that
+extends the domain gets real delegation with no plugin change; on current
+v2 hosts both probes fail and the shims degrade:
+
+- **Children enumeration (orchestrator-wake).** The shim's
+  `client.session.list` returns the v1-parity empty page `{data: []}`,
+  so `session.list({parentID})`-based enumeration never yields children
+  and the scheduler always runs its **event-tracked fallback**
+  (adapter-synthesized `session.created` parentID links plus tracked
+  busy/idle statuses — the mode the doc's wake section describes as the
+  fallback is effectively the only path on v2). The gate still passes
+  because it probes the *shim's* `list` function, which always exists.
+  The interview dashboard's session scan likewise sees no sessions from
+  `list` on v2.
+- **Session delete.** `client.session.delete` is a **no-op**: the
+  smartfetch secondary-model temp-session cleanup cannot remove sessions
+  through the shim on v2 (the temp sessions simply persist; nothing
+  fails loudly).
+
+Both degradations announce themselves in the plugin log with a single
+deterministic, **one-time-per-process** warning instead of degrading
+silently (`list`) or logging on every call (`remove`):
+
+```
+[v2][shim] session.list unavailable on this host build; children enumeration falls back to event tracking
+[v2][shim] session.remove unavailable on this host build; session delete is a no-op
+```
+
+The guards are module-level booleans with fixed text — no timestamps,
+session ids, or per-call payloads — so repeated wake polls and cleanup
+calls do not flood the log (the remove warning used to fire once per
+delete attempt).
+
 ### Orchestrator-wake on v2 (children-driven degraded mode)
 
 The wake scheduler is **active on v2** in a degraded mode, configured with
@@ -379,16 +426,18 @@ How it differs from the v1 path:
   historical probe set (`get`/`todo`/`children`/`status`/`promptAsync`).
 - **Children enumeration:** `session.list({ parentID })` through the shim
   (v2 `Session.Info` → v1 envelope; `outcome` and `time.updated` mapped).
-  The in-process session surface of current v2 hosts does not expose
-  `list`, so the empty page falls back to an event-tracked view — the
-  adapter-synthesized `session.created` parentID links plus tracked
-  busy/idle statuses — refreshed on every evaluation with the host's
+  When the listing is unavailable (missing/erroring/empty), an event-tracked
+  fallback uses the adapter-synthesized `session.created` parentID links plus
+  tracked busy/idle statuses — refreshed on every evaluation with the host's
   authoritative `outcome`/`time.updated` via `session.get` (fail-soft per
   child). A finished child is therefore terminal immediately instead of
   reading active for the whole staleness window, and a live child stays
   visible on its host evidence rather than dropping out on stale local
-  evidence. Results are scoped to the session's directory when the host
-  reports one.
+  evidence. On stock v2 hosts `session.list` is never exposed to plugins
+  (see
+  [Not exposed to plugins](#not-exposed-to-plugins-sessionlist-sessionremove)),
+  so the event-tracked fallback is the operative path. Results are scoped
+  to the session's directory when the host reports one.
 - **Wake condition:** children with `outcome === undefined` (v2 records an
   outcome only on terminal transition: succeeded|failed|interrupted) that
   still have fresh update evidence — host `time.updated` or a tracked status

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,35 +1,13 @@
 export { createApplyPatchHook } from './apply-patch';
-export type { AutoUpdateCheckerOptions } from './auto-update-checker';
 export { createAutoUpdateCheckerHook } from './auto-update-checker';
-export {
-  type CacheMonitorOptions,
-  createCacheMonitorHook,
-} from './cache-monitor';
-export {
-  appendTaggedSyntheticPart,
-  appendTrailingVolatileMessage,
-  createTaggedSyntheticPart,
-  hasTaggedPart,
-  isTaggedPart,
-  isVolatileTaggedMessage,
-  stripTaggedContent,
-} from './cache-safe-injection';
+export { createCacheMonitorHook } from './cache-monitor';
 export { createChatHeadersHook } from './chat-headers';
 export { createDeepworkCommandHook } from './deepwork';
 export { createFilterAvailableSkillsHook } from './filter-available-skills';
-export {
-  ForegroundFallbackManager,
-  isFailoverError,
-} from './foreground-fallback';
-export { processImageAttachments } from './image-hook';
+export { ForegroundFallbackManager } from './foreground-fallback';
 export { createJsonErrorRecoveryHook } from './json-error-recovery/hook';
 export { createLoopCommandHook } from './loop-command';
-export {
-  createOrchestratorWakeScheduler,
-  ORCHESTRATOR_CHILDREN_WAKE_TEXT,
-  ORCHESTRATOR_WAKE_TEXT,
-  ORCHESTRATOR_WAKE_UNCHANGED_CAP,
-} from './orchestrator-wake';
+export { createOrchestratorWakeScheduler } from './orchestrator-wake';
 export { createPhaseReminderHook } from './phase-reminder';
 export { createPostFileToolNudgeHook } from './post-file-tool-nudge';
 export { createReflectCommandHook } from './reflect';

--- a/src/v2/client-shim.test.ts
+++ b/src/v2/client-shim.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import {
   isReplayableUserMessage,
   partsFromReplayMessage,
@@ -1146,5 +1150,86 @@ describe('v2 client shim replay attachment preservation', () => {
       },
     });
     expect(prompts[0]?.files).toEqual([{ uri: 'https://example.com/x.png' }]);
+  });
+});
+
+describe('v2 client shim degradation notices (one-time per process)', () => {
+  test('list/remove unavailability logs exactly one warning each, never per call', async () => {
+    // Log-file assertions run in a subprocess: other test files
+    // mock.module the logger globally in shared-process runs, so the
+    // real logger (and its file sink) is only observable with a pristine
+    // module registry (same approach as the runtime-status
+    // reconciliation disable-notice test). The subprocess also gives the
+    // shim's module-level one-time guards a fresh process — exactly the
+    // "per plugin process" contract under test.
+    const logDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'omos-client-shim-log-'),
+    );
+    const workerSource = `
+      const { buildPluginInput } = await import(
+        process.env.SHIM_MODULE_URL
+      );
+      const { initLogger, flushLoggerForTesting } = await import(
+        process.env.LOGGER_MODULE_URL
+      );
+      const { readFileSync } = await import('node:fs');
+      initLogger('client-shim-degradation');
+      // Stock v2 plugin session domain: no list, no remove.
+      const input = buildPluginInput({ session: {} });
+      const session = input.client.session;
+      for (let index = 0; index < 3; index += 1) {
+        await session.list({ query: {} });
+        await session.delete({ path: { id: 'ses_tmp' } });
+      }
+      await flushLoggerForTesting();
+      const contents = readFileSync(process.env.LOG_FILE_PATH, 'utf8');
+      const lines = contents.split('\\n');
+      console.log(
+        JSON.stringify({
+          listWarnings: lines.filter((line) =>
+            line.includes('session.list unavailable'),
+          ).length,
+          removeWarnings: lines.filter((line) =>
+            line.includes('session.remove unavailable'),
+          ).length,
+        }),
+      );
+    `;
+    const proc = Bun.spawn([process.execPath, '-e', workerSource], {
+      cwd: import.meta.dir,
+      env: {
+        ...process.env,
+        OPENCODE_LOG_DIR: logDir,
+        SHIM_MODULE_URL: pathToFileURL(
+          path.join(import.meta.dir, 'client-shim.ts'),
+        ).href,
+        LOGGER_MODULE_URL: pathToFileURL(
+          path.join(import.meta.dir, '../utils/logger.ts'),
+        ).href,
+        LOG_FILE_PATH: path.join(
+          logDir,
+          'oh-my-opencode-slim.client-shim-degradation.log',
+        ),
+      },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    await fs.rm(logDir, { recursive: true, force: true });
+    if (exitCode !== 0) {
+      console.error(stderr);
+      expect(exitCode).toBe(0);
+    }
+    const counts = JSON.parse(stdout.trim()) as {
+      listWarnings: number;
+      removeWarnings: number;
+    };
+    // Three calls each, exactly one deterministic notice per capability.
+    expect(counts.listWarnings).toBe(1);
+    expect(counts.removeWarnings).toBe(1);
   });
 });

--- a/src/v2/client-shim.ts
+++ b/src/v2/client-shim.ts
@@ -117,6 +117,23 @@ function toV1Message(m: Record<string, unknown>) {
   };
 }
 
+/**
+ * One-time degradation notices for host surfaces the v2 plugin session
+ * domain does not expose. Verified against the upstream promise-plugin
+ * adapter (`packages/plugin/src/promise/{session,adapter}.ts`): the
+ * domain is built with exactly create/get/switchAgent/switchModel/
+ * prompt/generate/command/synthetic/interrupt/rename/move/wait/context —
+ * NO `list` and NO `remove`. On such hosts the `list` shim used to
+ * return the empty page silently (children enumeration quietly fell
+ * back to event tracking) and `delete` logged a no-op notice per call.
+ * Both now emit ONE deterministic warning per plugin process
+ * (module-level guard; fixed text, no timestamps or per-call ids) so a
+ * missing host capability is observable in the plugin log without
+ * per-poll noise.
+ */
+let warnedListUnavailable = false;
+let warnedRemoveUnavailable = false;
+
 /** v1 body model (`{providerID, modelID}`) → v2 model ref
  * (`{id, providerID}`). */
 function modelRefFromBody(body: {
@@ -216,13 +233,23 @@ function toV1SessionInfo(
  * (session id or root-only: the literal `"null"` string, with a real
  * `null` normalized to it) — and wraps the mapped page in the v1
  * `{data}` envelope. Hosts without `session.list` keep the v1-parity
- * empty page (honest absence, not a fake success).
+ * empty page (honest absence, not a fake success) after a one-time
+ * process-level warning — stock v2 hosts match this path because the
+ * plugin session domain does not expose `list` (see the notice above).
  */
 export function createSessionListShim(
   s: V2Context['session'],
 ): (args: Record<string, unknown>) => Promise<{ data: unknown[] }> {
   return async (args) => {
-    if (typeof s.list !== 'function') return { data: [] };
+    if (typeof s.list !== 'function') {
+      if (!warnedListUnavailable) {
+        warnedListUnavailable = true;
+        log(
+          '[v2][shim] session.list unavailable on this host build; children enumeration falls back to event tracking',
+        );
+      }
+      return { data: [] };
+    }
     const query = ((args?.query as Record<string, unknown> | undefined) ??
       (args as Record<string, unknown> | undefined) ??
       {}) as Record<string, unknown>;
@@ -448,15 +475,21 @@ export function buildPluginInput(
       // the same DELETE /api/session/:id. Capability-probed like `get`
       // above — smartfetch's secondary-model cleanup (the real caller)
       // relies on this to not leak temp sessions on v2. Hosts without
-      // `remove` degrade with the honest log below (no fake success).
+      // `remove` (the stock v2 plugin session domain — see the one-time
+      // notice block near the top of this file) degrade to a no-op with
+      // a single process-level warning (no fake success, no per-call
+      // noise).
       delete: s.remove
         ? async (args: Record<string, unknown>) => {
             await s.remove?.({ sessionID: sessionIDOf(args) });
           }
-        : async (args: Record<string, unknown>) => {
-            log('[v2][shim] session.remove unavailable; delete is a no-op', {
-              id: sessionIDOf(args),
-            });
+        : async () => {
+            if (!warnedRemoveUnavailable) {
+              warnedRemoveUnavailable = true;
+              log(
+                '[v2][shim] session.remove unavailable on this host build; session delete is a no-op',
+              );
+            }
           },
     },
     app: {

--- a/src/v2/index.ts
+++ b/src/v2/index.ts
@@ -12,24 +12,4 @@
  * the peer modules. See `codemap.md`.
  */
 
-export type { V2InterviewBridge } from './interview-bridge';
-export {
-  createV2InterviewBridge,
-  INTERVIEW_COMMAND_MARKER,
-} from './interview-bridge';
 export { createV2Setup } from './setup';
-export type {
-  ModelRef,
-  V2AgentDraft,
-  V2Cleanup,
-  V2CommandDefinition,
-  V2CommandDraft,
-  V2Context,
-  V2Registration,
-  V2SessionContextEvent,
-  V2ToolAfterEvent,
-  V2ToolBeforeEvent,
-  V2ToolDefinition,
-  V2ToolDraft,
-  V2ToolOptions,
-} from './types';


### PR DESCRIPTION
Two small v2 surface housekeeping changes, zero overlap, combined to keep PR count down.

## Part 1 — fix(v2): surface client-shim list/remove degradation explicitly

Re-verified against current v2 source (`packages/plugin/src/promise/{session,adapter}.ts`): the plugin session domain exposes exactly `create/get/switchAgent/switchModel/prompt/generate/command/synthetic/interrupt/rename/move/wait/context` — **no `list`, no `remove`**, at both the type and runtime level. The client-shim hand-codes optimistic delegation to both anyway:

- `createSessionListShim` silently returned `{data: []}` on every call (orchestrator-wake children enumeration always falls back to event tracking; interview session scan gets nothing)
- `delete` logged a no-op notice **per call**

Now both emit **one** deterministic warning per plugin process (module-level guard, fixed text, no timestamps/ids), and the limitation is documented precisely in `docs/opencode-v2-compatibility.md` (consequences: wake enumeration always event-tracked — the capability gate still passes because it probes the shim's always-present `list` function; `delete` is a no-op so smartfetch temp sessions persist). No translation logic touched. Subprocess test proves the one-time semantics (3 calls → exactly 1 warning each).

## Part 2 — chore: trim dangling barrel re-exports

Full re-enumeration on current master (every name in `src/hooks/index.ts` and `src/v2/index.ts` grepped for importers via barrel vs direct module paths, incl. dynamic import/require and package exports map): **30 dead re-export lines removed** — 14 in `hooks/index.ts` (keeping exactly the 17 names `src/index.ts` imports), 16 in `v2/index.ts` (keeping only `createV2Setup`). Nothing removed that any file — test or non-test — imports through either barrel. Note: `INTERVIEW_COMMAND_MARKER` in `v2/index.ts` is also removed by an open branch's refactor; whichever merges second drops to a no-op.

## Verification

- [x] `bun run check:ci` / `bun run typecheck` — clean
- [x] `bun test` — 2694 pass / 0 fail (full suite, combined branch)
- [x] Enumeration table and one-time-warning evidence in the commits; no behavior change beyond the two warning lines