### PR TITLE
fix(v2): task board deletion cleanup, rehydrate ghost termination, and state persistence

### DIFF
--- a/docs/background-orchestration.md
+++ b/docs/background-orchestration.md
@@ -195,9 +195,10 @@ treated as completion. When the host client exposes `session.get`, each newly
 rehydrated task is also probed for existence: a session deleted while the plugin
 was down is tombstoned and torn down instead of resurrecting as a
 forever-running ghost, and a session that already reached a terminal host
-outcome is settled to it. On OpenCode v2 hosts with the optional `ctx.storage`
-domain, deletion tombstones and alias counters additionally persist across
-host restarts (see the
+outcome is settled to it (the typed NotFound classification is a v2
+in-process artifact — on v1 hosts the probe harmlessly never tombstones). On
+OpenCode v2 hosts with the optional `ctx.storage` domain, deletion tombstones
+and alias counters additionally persist across host restarts (see the
 [v2 compatibility doc](opencode-v2-compatibility.md#background-job-state-rehydrate-probe-and-persistence)).
 
 Specialist outputs are inputs, not final truth. The orchestrator reconciles them

--- a/docs/background-orchestration.md
+++ b/docs/background-orchestration.md
@@ -191,7 +191,14 @@ history is rehydrated into the local job board and immediately reconciled agains
 live host session status. A missing or idle child is a stop candidate: after a
 5s confirmation grace it is surfaced as `stopped, unreconciled`, while a busy
 child remains running; status lookup failures remain uncertain rather than being
-treated as completion.
+treated as completion. When the host client exposes `session.get`, each newly
+rehydrated task is also probed for existence: a session deleted while the plugin
+was down is tombstoned and torn down instead of resurrecting as a
+forever-running ghost, and a session that already reached a terminal host
+outcome is settled to it. On OpenCode v2 hosts with the optional `ctx.storage`
+domain, deletion tombstones and alias counters additionally persist across
+host restarts (see the
+[v2 compatibility doc](opencode-v2-compatibility.md#background-job-state-rehydrate-probe-and-persistence)).
 
 Specialist outputs are inputs, not final truth. The orchestrator reconciles them
 against each other and the original user goal.

--- a/docs/opencode-v2-compatibility.md
+++ b/docs/opencode-v2-compatibility.md
@@ -152,7 +152,13 @@ degrades that single feature with a log line instead of breaking the load.
       (`src/v2/event-adapter.ts`): additive synthesis only — the raw v2 event
       is always dispatched first (the interview bridge depends on it), then
       synthesized v1 shapes: flat child `session.created` → v1
-      early-registration `{info: {id, parentID, agent?}}`, usage telemetry
+      early-registration `{info: {id, parentID, agent?}}`, flat
+      `session.deleted` → the v1 deletion-cleanup shape carrying **both**
+      id spellings the v1 consumers read (`properties.info.id` for the
+      cache monitor's session eviction, `properties.sessionID` for the
+      task-session-manager's tombstone/board teardown; no `generation` is
+      fabricated, so the event-router's unproven-relaunch deletion fence
+      keeps its strength), usage telemetry
       (`session.usage.updated`/`session.step.ended`) → a deduplicated
       completed-assistant `message.updated` for the cache monitor, the Form
       flow (`form.created`/`form.replied`/`form.cancelled`) → v1
@@ -196,6 +202,7 @@ the rest, and a zero-registration load logs a loud health-check warning.
 | Tool execute hooks (apply-patch recovery, task-session, json-recovery) | ✅ | ✅ `createToolExecuteBridges` with subagent→task normalization | — |
 | Built-in MCPs (context7, gh_grep) auto-registered | ✅ | ✅ `ctx.mcp.transform` | — |
 | webfetch secondary-model summaries | ✅ | ✅ via `ctx.generate.text` | host without `ctx.generate` → summaries unavailable (logged) |
+| Background-job state persistence (tombstones, deletion epochs, alias high-water marks) | ➖ process-local | ✅ via `ctx.storage` | optional domain; absent → pure in-memory fallback, zero behavior change (see [Background job state](#background-job-state-rehydrate-probe-and-persistence)) |
 | Foreground model fallback (rate-limit failover) | ✅ | ✅ shim translates re-prompt into `session.switchModel` + `delivery:"steer"` prompt | — |
 | `/preset` (interactive switcher) | ✅ | ✅ TUI plugin entry (`./tui` → `dist/tui2.js`): sidebar + `/preset` dialog or `/preset <name>` fast path | The layer registers from an `append: "app"` slot render because the host's `keymap.layer` is provider-scoped (calling it from plugin `setup` throws `Keymap.Provider is missing`); the command carries an `id` and `slash.arguments`; host needs `ui.slot` + `keymap.layer`; the interactive picker needs `ui.dialog.select` while `/preset <name>` works without it; feedback uses `ui.toast.show`; config-file `preset` still applies at load |
 | TUI default agent | ✅ orchestrator | ✅ orchestrator — `draft.default("orchestrator")`; the v2 TUI honors `default_agent` and hoists the default to the head of the agent list | — |
@@ -217,7 +224,21 @@ currently break this plugin:
   with the optional `metadata?` key observed on some events).
   The adapter reads `data` first with `properties` as a legacy fallback and
   always writes `properties` on the synthesized v1 shapes, because that is
-  the key the v1 consumers read.
+  the key the v1 consumers read. The interview bridge's event handler
+  (`handleEvent` in `src/v2/interview-bridge.ts`) resolves its payload
+  data-first the same way — reading only `properties` had left its
+  transcript projection and deletion cleanup dead on live v2 for every
+  event (`handleContext` is unaffected; it consumes a different event
+  type).
+- **`session.deleted` is synthesized with a dual id spelling.** v2
+  delivers deletion flat (`{sessionID}`), and the v1 deletion consumers
+  read two different spellings: the cache monitor's session eviction
+  reads `properties.info.id`, while the task-session-manager's
+  deletion handler accepts `properties.sessionID`. The synthesized v1
+  event therefore carries both. Without this synthesis the deletion
+  cleanup (rehydrate tombstone, board teardown, idle-token/input-wait
+  clears) never fired on v2, and deleted runs resurrected as
+  forever-running ghost records on the next request.
 - **Lifecycle keys on `session.execution.*`.** V2 hosts publish durable
   `session.execution.started/succeeded/failed/interrupted` events
   (`{sessionID}`, plus `error` on `.failed` and `reason` on
@@ -339,6 +360,86 @@ hosts without `session.switchModel`, the fallback replay is rejected with
 a clear error instead of silently replaying on the model that just failed
 (other prompt callers, like the orchestrator-wake scheduler, only pin the
 current model and keep steering).
+
+## Background job state: rehydrate probe and persistence
+
+Two mechanisms keep the in-memory background job board honest against the
+host across process and plugin restarts:
+
+### Rehydrate existence probe (`session.get`)
+
+Rehydration re-registers persisted *running* task tool parts so a plugin
+restart does not orphan in-flight background lanes — but a session deleted
+while the plugin was down would resurrect as a forever-running ghost.
+After rehydration registers a task, the task-session-manager transform
+fires a fire-and-forget `client.session.get` probe per newly registered
+taskID:
+
+- **Capability-gated, not host-gated.** The probe runs whenever the client
+  exposes `session.get` (v1 hosts with the method benefit identically);
+  hosts without it skip silently. It lives inside the existing
+  task-session-manager transform — no new pipeline step.
+- **NotFound classification is typed, never heuristic.** A rejection
+  tombstones the task only when `err._tag === 'Session.NotFoundError'`
+  (property check; never `instanceof` or message matching — the SDK error
+  class identity is unstable across host builds). Tombstoning runs the
+  full deletion-cleanup set in one synchronous block: rehydrate
+  tombstone, board drop, concurrency `releaseTask`, supervisor
+  `onSessionDeleted` (all idempotent; a missing `releaseTask` would leak
+  an admission slot forever).
+- **Any other rejection fails open** — the job stays registered and the
+  normal reconciliation paths keep their chance. The probe never rejects
+  unhandled.
+- **A resolved terminal outcome settles the job** through the same
+  `updateStatus` semantics as the idle-reconciliation host-outcome path:
+  `succeeded` requires usable final assistant text (otherwise the
+  textless-completion diagnostics apply, per the #1115 precedent);
+  `failed`/`interrupted` settle as error with the host outcome recorded.
+
+Related injection hardening: a remembered (possibly stale) processed
+completion now skips *cleanly* — the fence check runs before the
+deletion-epoch fail-closed branch in `updateFromInjectedCompletion`, so
+replaying an old completion after a delete + same-ID relaunch can no
+longer poison the fresh generation with `markStatusUncertain`. Unobserved
+completions for a deleted task still fail closed for every provenance
+kind.
+
+### Persistence via `ctx.storage` (v2)
+
+When the v2 host exposes the optional `storage` domain, the plugin
+persists background-job lifecycle state through
+`src/utils/background-job-persistence.ts` (configured in `setup` before
+the v1 factory runs):
+
+- **Tombstones and deletion epochs** are write-through: the in-memory
+  ledger and the persisted state can never diverge. Clearing a tombstone
+  on a legitimate relaunch is persisted too — a deleted-then-relaunched
+  task is *not* ghost-skipped after a restart, while its deletion epoch
+  survives for generation fencing (restored epochs keep the epoch counter
+  monotonic).
+- **Alias counters** persist the last-seen counter per
+  `<parentSessionID>:<prefix>`. A post-restart board seeds from these
+  high-water marks, so a new alias never collides with a historical one.
+  The alias→taskID mapping itself is **not** restored — old aliases
+  resolve as not-found after a restart, which is the intended improvement
+  over silently reusing them for unrelated tasks.
+- **Seeding is backend-only.** Without `ctx.storage` (v1 hosts, hosts
+  without the domain) the module is a pure in-memory no-op sink: zero
+  behavior change, fresh boards and ledgers start exactly as
+  process-local as before.
+- **Bounded and serialized.** Persisted tombstones (and their epoch
+  entries) self-cap at the 500 most recent by recorded time; writes for
+  one key are serialized in-process (no concurrent read-modify-write);
+  write failures log and degrade to process-local behavior.
+
+### Diagnostics
+
+Two log lines aid drift diagnosis (both hosts): the task tool's terminal
+output that carries no parsable task id is logged with a ~120-char
+preview (`task output without a task id` — the host-output-drift
+detector), and an idle observation for a *tracked managed child* with no
+running board record logs with a `[task-session-manager] WARN:` prefix
+instead of the routine idle line.
 
 ## Limitations
 

--- a/docs/opencode-v2-compatibility.md
+++ b/docs/opencode-v2-compatibility.md
@@ -452,11 +452,26 @@ the v1 factory runs):
 ### Diagnostics
 
 Two log lines aid drift diagnosis (both hosts): the task tool's terminal
-output that carries no parsable task id is logged with a ~120-char
+output that carries no parsable task id is logged with a ~140-char
 preview (`task output without a task id` — the host-output-drift
 detector), and an idle observation for a *tracked managed child* with no
 running board record logs with a `[task-session-manager] WARN:` prefix
 instead of the routine idle line.
+
+**Secret redaction at the logger.** Every plugin log line — file sink,
+stderr fallback, and the append-failure path — passes through
+shape-based secret redaction at the logger's single compose point
+(`src/utils/redact.ts`): known vendor token prefixes (`sk-`, `gh*`,
+`glpat-`, `xox*`, `AKIA`/`ASIA`), URL credentials
+(`scheme://user:password@` — password only), authorization schemes
+(Bearer/Basic/token), and generic 32+-character opaque runs are masked
+to 4 leading + 2 trailing characters. The parse-miss preview redacts
+the full output before slicing so boundary-straddling secrets cannot
+leak a raw prefix. This is a best-effort barrier against *accidental*
+leaks in short previews, not an adversarial guarantee: unprefixed short
+secrets, secrets containing run-breaking characters, and chunked or
+obfuscated content remain residual gaps, while long opaque non-secrets
+(UUIDs, hashes, long paths) are masked as accepted false positives.
 
 ## Limitations
 

--- a/docs/opencode-v2-compatibility.md
+++ b/docs/opencode-v2-compatibility.md
@@ -375,18 +375,32 @@ After rehydration registers a task, the task-session-manager transform
 fires a fire-and-forget `client.session.get` probe per newly registered
 taskID:
 
-- **Capability-gated, not host-gated.** The probe runs whenever the client
-  exposes `session.get` (v1 hosts with the method benefit identically);
-  hosts without it skip silently. It lives inside the existing
+- **Capability-gated, not host-gated — but v2-effective.** The probe runs
+  whenever the client exposes `session.get`; hosts without it skip
+  silently. The typed NotFound classification only crosses the v2 plugin
+  boundary (the host passes the raw core effect in-process): the v1 SDK
+  wraps 4xx responses as plain `Error` with a `.cause` (or returns an
+  `{error}` tuple when `throwOnError: false`), so on v1 hosts the probe
+  runs but harmlessly never tombstones — the wrapped rejection falls into
+  the transient fail-open path. The probe lives inside the existing
   task-session-manager transform — no new pipeline step.
 - **NotFound classification is typed, never heuristic.** A rejection
   tombstones the task only when `err._tag === 'Session.NotFoundError'`
   (property check; never `instanceof` or message matching — the SDK error
-  class identity is unstable across host builds). Tombstoning runs the
-  full deletion-cleanup set in one synchronous block: rehydrate
-  tombstone, board drop, concurrency `releaseTask`, supervisor
-  `onSessionDeleted` (all idempotent; a missing `releaseTask` would leak
-  an admission slot forever).
+  class identity is unstable across host builds). Cleanup is
+  generation-freshness-guarded: the board record's generation is captured
+  before the async `get`, and a NotFound that resolves after a legitimate
+  same-ID relaunch (new generation, tombstone cleared) skips all cleanup
+  instead of deleting the live relaunched record. On a fresh hit, the four
+  probe cleanup actions run as one synchronous block — supervisor
+  `onSessionDeleted` first (it needs the record to exist so
+  deadline-exceeded runs finalize their wall-clock timeout; same ordering
+  as the event-router/coordinator deletion paths), then the rehydrate
+  tombstone, board drop, and concurrency `releaseTask` (all idempotent; a
+  missing `releaseTask` would leak an admission slot forever). The
+  canonical full deletion cleanup (input waits, idle tokens, pending-call
+  tracker, `clearParent`, task-context tracker, snapshots) runs via the
+  `session.deleted` event path.
 - **Any other rejection fails open** — the job stays registered and the
   normal reconciliation paths keep their chance. The probe never rejects
   unhandled.
@@ -411,8 +425,11 @@ persists background-job lifecycle state through
 `src/utils/background-job-persistence.ts` (configured in `setup` before
 the v1 factory runs):
 
-- **Tombstones and deletion epochs** are write-through: the in-memory
-  ledger and the persisted state can never diverge. Clearing a tombstone
+- **Tombstones and deletion epochs** are write-through: every in-memory
+  ledger mutation queues a matching persisted update, so the persisted
+  state tracks the ledger (writes are fire-and-forget — a crash between
+  the in-memory mutation and the queue flush loses that persisted entry,
+  an accepted degradation to process-local behavior). Clearing a tombstone
   on a legitimate relaunch is persisted too — a deleted-then-relaunched
   task is *not* ghost-skipped after a restart, while its deletion epoch
   survives for generation fencing (restored epochs keep the epoch counter

--- a/docs/opencode-v2-compatibility.md
+++ b/docs/opencode-v2-compatibility.md
@@ -465,13 +465,19 @@ shape-based secret redaction at the logger's single compose point
 `glpat-`, `xox*`, `AKIA`/`ASIA`), URL credentials
 (`scheme://user:password@` — password only), authorization schemes
 (Bearer/Basic/token), and generic 32+-character opaque runs are masked
-to 4 leading + 2 trailing characters. The parse-miss preview redacts
-the full output before slicing so boundary-straddling secrets cannot
-leak a raw prefix. This is a best-effort barrier against *accidental*
-leaks in short previews, not an adversarial guarantee: unprefixed short
-secrets, secrets containing run-breaking characters, and chunked or
-obfuscated content remain residual gaps, while long opaque non-secrets
-(UUIDs, hashes, long paths) are masked as accepted false positives.
+to 4 leading + 2 trailing characters. This is a best-effort barrier
+against *accidental* leaks in short previews, not an adversarial
+guarantee: unprefixed short secrets, secrets containing run-breaking
+characters, and chunked or obfuscated content remain residual gaps,
+while long opaque non-secrets (UUIDs, hashes, long paths) are masked as
+accepted false positives. The parse-miss preview (`task output without
+a task id`) is stricter still: it is **structure-only** — tag and field
+names survive for drift diagnosis, but every value (XML attribute
+values, `key:`/`key=` prose values) is fully replaced with `[masked]`
+before slicing, because parse-miss content is untrusted-by-format and
+values (description fields in particular) carry user-authored text.
+All other log sites rely on the shape-based redaction at the logger
+choke point.
 
 ## Limitations
 

--- a/src/hooks/task-session-manager/board-injection.ts
+++ b/src/hooks/task-session-manager/board-injection.ts
@@ -826,18 +826,12 @@ export function updateFromInjectedCompletion(
     }
   }
 
-  if (deletionEpoch !== undefined && origin === undefined) {
-    failClosedSyntheticTerminal(
-      state,
-      status,
-      occurrenceId,
-      provenanceKind,
-      existing,
-      'no message.part.updated origin was observed',
-    );
-    return undefined;
-  }
-
+  // Fence-first: a remembered (possibly stale) completion occurrence must
+  // skip CLEANLY before the deletion-epoch fail-closed branch below. A
+  // known occurrence is either a duplicate in the same lifecycle or stale
+  // history from an older generation — neither may update the current
+  // board, and neither justifies poisoning the fresh generation with
+  // markStatusUncertain when its occurrence bookkeeping is absent.
   if (
     hasRememberedInjectedCompletion(
       state,
@@ -847,6 +841,18 @@ export function updateFromInjectedCompletion(
       existing?.generation,
     )
   ) {
+    return undefined;
+  }
+
+  if (deletionEpoch !== undefined && origin === undefined) {
+    failClosedSyntheticTerminal(
+      state,
+      status,
+      occurrenceId,
+      provenanceKind,
+      existing,
+      'no message.part.updated origin was observed',
+    );
     return undefined;
   }
 

--- a/src/hooks/task-session-manager/event-router.ts
+++ b/src/hooks/task-session-manager/event-router.ts
@@ -479,18 +479,35 @@ export async function handleEvent(
       : undefined;
     if (observation?.stale || observation?.activityFenceOnly) return;
     const job = observation?.job;
-    log('[task-session-manager] idle/status idle observed', {
-      sessionID: sessionId,
-      managesSession: sessionId
-        ? deps.options.shouldManageSession(sessionId)
-        : false,
-      terminalJobsPending: sessionId
-        ? (deps.terminalJobsInjectedByParent.get(sessionId)?.executions.size ??
-            0) +
-          (deps.pendingInjectedTerminalJobsByParent.get(sessionId)?.size ?? 0)
-        : 0,
-      runningJobForSession: job?.state === 'running' || false,
-    });
+    const runningJobForSession = job?.state === 'running' || false;
+    // Warn elevation: a tracked managed child (session.created-observed,
+    // not yet settled by its terminal output) reporting idle while the
+    // board holds no running record for it is the host/board drift
+    // signature — without the warn prefix these hid inside the routine
+    // idle log line. The logger is single-level text, so the severity
+    // rides the `[task-session-manager] WARN:` prefix (same convention
+    // as the `[plugin] WARN:` lines in src/index.ts).
+    const trackedManagedChildWithoutJob =
+      sessionId !== undefined &&
+      !runningJobForSession &&
+      deps.taskContextTracker.pendingManagedTaskIds.has(sessionId);
+    log(
+      trackedManagedChildWithoutJob
+        ? '[task-session-manager] WARN: idle observed for tracked managed child with no running board record'
+        : '[task-session-manager] idle/status idle observed',
+      {
+        sessionID: sessionId,
+        managesSession: sessionId
+          ? deps.options.shouldManageSession(sessionId)
+          : false,
+        terminalJobsPending: sessionId
+          ? (deps.terminalJobsInjectedByParent.get(sessionId)?.executions
+              .size ?? 0) +
+            (deps.pendingInjectedTerminalJobsByParent.get(sessionId)?.size ?? 0)
+          : 0,
+        runningJobForSession,
+      },
+    );
     if (sessionId && deps.options.shouldManageSession(sessionId)) {
       deps.idleReconciler.scheduleIdleReconciliation(sessionId);
     }

--- a/src/hooks/task-session-manager/index.test.ts
+++ b/src/hooks/task-session-manager/index.test.ts
@@ -6047,6 +6047,122 @@ describe('task-session-manager hook', () => {
     expect(terminalListener).not.toHaveBeenCalled();
   });
 
+  test('fail-closed after deletion defers to idle settle, not a wedge', async () => {
+    // Documents why the retained fail-closed pin above is safe: the
+    // statusUncertain running record is not a dead end. The synthesized
+    // idle pair reaches the child idle-reconcile path, readSessionOutcome
+    // confirms the terminal host outcome with final text, and the job
+    // settles — the fail-closed branch only refuses the UNPROVEN injected
+    // completion, it does not block reconciliation.
+    const coordinator = new SessionLifecycle(() => {});
+    const board = new BackgroundJobBoard();
+    const first = createHook({
+      backgroundJobBoard: board,
+      coordinator,
+      runtimeStatusReconcileDelayMs: 60_000,
+    });
+    board.registerLaunch({
+      taskID: 'child-relaunch',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+      description: 'first run',
+    });
+
+    await first.hook.event({
+      event: {
+        type: 'session.deleted',
+        properties: { sessionID: 'child-relaunch' },
+      },
+    });
+    coordinator.dispatchSessionDeleted('child-relaunch');
+
+    const { hook } = createHook({
+      backgroundJobBoard: board,
+      runtimeStatusReconcileDelayMs: 60_000,
+      idleReconcileDelayMs: 0,
+      sessionClient: {
+        get: mock(async () => ({ data: { outcome: 'succeeded' } })),
+        messages: mock(async () => ({
+          data: [
+            {
+              info: { id: 'm1', role: 'assistant' },
+              parts: [{ type: 'text', text: 'settled final answer' }],
+            },
+          ],
+        })),
+      },
+    });
+    board.registerLaunch({
+      taskID: 'child-relaunch',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+      description: 'second run',
+    });
+
+    // Exact fail-closed shape as the pin above: unobserved, unfenced
+    // explicit completion after delete + same-board relaunch.
+    const replay = {
+      messages: [
+        {
+          info: {
+            role: 'user',
+            agent: 'orchestrator',
+            sessionID: 'parent-1',
+          },
+          parts: [
+            {
+              type: 'text',
+              id: 'unobserved-completion',
+              synthetic: true,
+              text: [
+                '<task id="child-relaunch" state="completed">',
+                '<summary>Background task completed: unknown origin</summary>',
+                '<task_result>',
+                'ambiguous result',
+                '</task_result>',
+                '</task>',
+              ].join('\n'),
+            },
+          ],
+        },
+      ],
+    };
+    await hook['experimental.chat.messages.transform']({}, replay as never);
+    expect(board.get('child-relaunch')).toMatchObject({
+      generation: 2,
+      state: 'running',
+      statusUncertain: true,
+      terminalUnreconciled: false,
+    });
+
+    // The synthesized idle pair (event-adapter's terminal
+    // session.execution.* products) settles the job via the host outcome.
+    await hook.event({
+      event: {
+        type: 'session.status',
+        properties: {
+          sessionID: 'child-relaunch',
+          status: { type: 'idle' },
+        },
+      },
+    });
+    await hook.event({
+      event: {
+        type: 'session.idle',
+        properties: { sessionID: 'child-relaunch' },
+      },
+    });
+    await flushChildIdleReconcile();
+
+    expect(board.get('child-relaunch')).toMatchObject({
+      generation: 2,
+      state: 'reconciled',
+      terminalState: 'completed',
+      statusUncertain: false,
+      resultSummary: 'settled final answer',
+    });
+  });
+
   test('skips an old remembered completion after relaunch without poisoning status (fence-first)', async () => {
     const board = new BackgroundJobBoard();
     const { hook } = createHook({

--- a/src/hooks/task-session-manager/index.test.ts
+++ b/src/hooks/task-session-manager/index.test.ts
@@ -6047,6 +6047,162 @@ describe('task-session-manager hook', () => {
     expect(terminalListener).not.toHaveBeenCalled();
   });
 
+  test('skips an old remembered completion after relaunch without poisoning status (fence-first)', async () => {
+    const board = new BackgroundJobBoard();
+    const { hook } = createHook({
+      backgroundJobBoard: board,
+      runtimeStatusReconcileDelayMs: 60_000,
+    });
+    board.registerLaunch({
+      taskID: 'child-stale-fence',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+      description: 'first run',
+    });
+    const completion = {
+      type: 'text',
+      id: 'stale-fence-occurrence',
+      synthetic: true,
+      text: [
+        '<task id="child-stale-fence" state="completed">',
+        '<summary>Background task completed: old run</summary>',
+        '<task_result>old result</task_result>',
+        '</task>',
+      ].join('\n'),
+    };
+    const replayable = { ...completion };
+    await hook.event({
+      event: {
+        type: 'message.part.updated',
+        properties: { part: completion },
+      },
+    });
+    await hook['experimental.chat.messages.transform']({}, {
+      messages: [
+        {
+          info: { role: 'user', agent: 'orchestrator', sessionID: 'parent-1' },
+          parts: [completion],
+        },
+      ],
+    } as never);
+    expect(board.get('child-stale-fence')).toMatchObject({
+      state: 'completed',
+      resultSummary: 'old result',
+    });
+
+    await hook.event({
+      event: {
+        type: 'session.deleted',
+        properties: { sessionID: 'child-stale-fence' },
+      },
+    });
+    const relaunched = board.registerLaunch({
+      taskID: 'child-stale-fence',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+      description: 'second run',
+    });
+
+    // Simulate the older lifecycle's occurrence bookkeeping being absent
+    // (only the processed-completion FENCE survives): the fence must skip
+    // the replay cleanly BEFORE the deletion-epoch fail-closed branch can
+    // mark the fresh running generation status-uncertain.
+    getBackgroundJobLifecycleLedger(board).syntheticTerminalOccurrences.clear();
+
+    await hook['experimental.chat.messages.transform']({}, {
+      messages: [
+        {
+          info: { role: 'user', agent: 'orchestrator', sessionID: 'parent-1' },
+          parts: [replayable],
+        },
+      ],
+    } as never);
+
+    expect(board.get('child-stale-fence')).toMatchObject({
+      generation: relaunched.generation,
+      state: 'running',
+      statusUncertain: false,
+      resultSummary: undefined,
+    });
+  });
+
+  test('keeps unobserved legacy and host-message completions fail-closed after deletion', async () => {
+    const board = new BackgroundJobBoard();
+    const terminalListener = mock(() => {});
+    board.addTerminalStateListener(terminalListener);
+    const { hook } = createHook({
+      backgroundJobBoard: board,
+      runtimeStatusReconcileDelayMs: 60_000,
+    });
+    board.registerLaunch({
+      taskID: 'child-unobserved-weak',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+      description: 'first run',
+    });
+    await hook.event({
+      event: {
+        type: 'session.deleted',
+        properties: { sessionID: 'child-unobserved-weak' },
+      },
+    });
+    board.registerLaunch({
+      taskID: 'child-unobserved-weak',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+      description: 'second run',
+    });
+
+    const legacyCompletion = {
+      type: 'text',
+      synthetic: true,
+      text: [
+        '<task id="child-unobserved-weak" state="completed">',
+        '<summary>Background task completed: legacy</summary>',
+        '<task_result>legacy result</task_result>',
+        '</task>',
+      ].join('\n'),
+    };
+    await hook['experimental.chat.messages.transform']({}, {
+      messages: [
+        {
+          info: { role: 'user', agent: 'orchestrator', sessionID: 'parent-1' },
+          parts: [legacyCompletion],
+        },
+      ],
+    } as never);
+    expect(board.get('child-unobserved-weak')).toMatchObject({
+      state: 'running',
+      statusUncertain: true,
+    });
+
+    const hostMessageCompletion = {
+      type: 'text',
+      synthetic: true,
+      messageID: 'unobserved-weak-message',
+      text: [
+        '<task id="child-unobserved-weak" state="completed">',
+        '<summary>Background task completed: host</summary>',
+        '<task_result>host result</task_result>',
+        '</task>',
+      ].join('\n'),
+    };
+    await hook['experimental.chat.messages.transform']({}, {
+      messages: [
+        {
+          info: { role: 'user', agent: 'orchestrator', sessionID: 'parent-1' },
+          parts: [hostMessageCompletion],
+        },
+      ],
+    } as never);
+    expect(board.get('child-unobserved-weak')).toMatchObject({
+      state: 'running',
+      statusUncertain: true,
+      resultSummary: undefined,
+    });
+    expect(terminalListener).not.toHaveBeenCalled();
+  });
+
   test('accepts a host messageID occurrence in the current generation', async () => {
     const board = new BackgroundJobBoard();
     const terminalListener = mock(() => {});

--- a/src/hooks/task-session-manager/index.ts
+++ b/src/hooks/task-session-manager/index.ts
@@ -315,7 +315,10 @@ export function createTaskSessionManagerHook(
         // Settle through the same updateStatus semantics the
         // readSessionOutcome consumers use (idle-reconciliation): a
         // succeeded outcome is only reconciled with usable final text.
-        // expectedGeneration makes the settle itself generation-safe.
+        // The settle is bound to the generation captured at probe start
+        // (same freshness anchor as the NotFound guard below): a probe
+        // that started at gen N must not terminalize a same-ID relaunch
+        // (gen N+1) that landed while the get was in flight.
         let resultText: string | undefined;
         if (outcome === 'succeeded') {
           resultText = await readFinalAssistantText(
@@ -326,7 +329,7 @@ export function createTaskSessionManagerHook(
         }
         const settled = backgroundJobBoard.updateStatus({
           taskID,
-          expectedGeneration: existing.generation,
+          expectedGeneration: generationAtProbeStart,
           state: outcome === 'succeeded' && resultText ? 'completed' : 'error',
           resultSummary:
             outcome === 'succeeded'

--- a/src/hooks/task-session-manager/index.ts
+++ b/src/hooks/task-session-manager/index.ts
@@ -282,10 +282,22 @@ export function createTaskSessionManagerHook(
     void (async () => {
       const client = getClient(_ctx);
       // Same presence gate as readSessionOutcome: capability is probed,
-      // not assumed, and deliberately NOT gated on hostFlavor — v1 hosts
-      // exposing session.get benefit identically. Absent method → skip
-      // silently.
+      // not assumed, and deliberately NOT gated on hostFlavor. The probe
+      // is v2-effective: the dotted `_tag === 'Session.NotFoundError'`
+      // classification only crosses the v2 plugin boundary (the host
+      // passes the raw core effect in-process). The v1 SDK wraps 4xx
+      // responses as plain `Error` with a `.cause` (or returns an
+      // `{error}` tuple when `throwOnError: false`), so on v1 the probe
+      // runs but harmlessly never tombstones — transient-error fail-open
+      // swallows the wrapped rejection. Absent method → skip silently.
       if (typeof client.session?.get !== 'function') return;
+      // Freshness anchor: the generation of the record rehydrate just
+      // registered (captured synchronously, before the async get). A
+      // legitimate same-ID relaunch while the get is in flight takes a
+      // NEW generation and clears the tombstone — a stale NotFound must
+      // not tombstone+drop the live relaunched record.
+      const generationAtProbeStart = backgroundJobBoard.get(taskID)?.generation;
+      if (generationAtProbeStart === undefined) return;
       try {
         const response = (await client.session.get({
           path: { id: taskID },
@@ -303,6 +315,7 @@ export function createTaskSessionManagerHook(
         // Settle through the same updateStatus semantics the
         // readSessionOutcome consumers use (idle-reconciliation): a
         // succeeded outcome is only reconciled with usable final text.
+        // expectedGeneration makes the settle itself generation-safe.
         let resultText: string | undefined;
         if (outcome === 'succeeded') {
           resultText = await readFinalAssistantText(
@@ -333,14 +346,35 @@ export function createTaskSessionManagerHook(
         return;
       } catch (err) {
         if ((err as { _tag?: string })?._tag === 'Session.NotFoundError') {
-          // The session no longer exists on the host: tombstone + the
-          // full deletion-cleanup set. All four actions are idempotent but
-          // all are required — a missing releaseTask would leak an
-          // admission slot forever.
+          // Freshness guard: only clean up when the board still holds the
+          // generation the probe started against. A record replaced by a
+          // same-ID relaunch (or already dropped) is not ours to delete.
+          const current = backgroundJobBoard.get(taskID);
+          if (current?.generation !== generationAtProbeStart) {
+            log(
+              '[task-session-manager] skipped stale NotFound cleanup after same-ID relaunch',
+              {
+                taskID,
+                generationAtProbeStart,
+                currentGeneration: current?.generation,
+              },
+            );
+            return;
+          }
+          // The session no longer exists on the host. The four probe
+          // cleanup actions run as one synchronous block — supervisor
+          // FIRST: its onSessionDeleted needs the record to still exist
+          // so deadline-exceeded runs finalize their wall-clock timeout
+          // (same ordering as the event-router/coordinator deletion
+          // paths). All four are idempotent but all are required — a
+          // missing releaseTask would leak an admission slot forever.
+          // The canonical full cleanup (input waits, idle tokens,
+          // pending-call tracker, clearParent, task-context tracker,
+          // snapshots) runs via the session.deleted event path.
+          options.backgroundJobSupervisor?.onSessionDeleted(taskID);
           recordBackgroundJobSuppression(backgroundJobBoard, taskID);
           backgroundJobBoard.drop(taskID);
           options.backgroundTaskConcurrency?.releaseTask(taskID);
-          options.backgroundJobSupervisor?.onSessionDeleted(taskID);
           log(
             '[task-session-manager] rehydrated task no longer exists on host; tombstoned',
             { taskID },

--- a/src/hooks/task-session-manager/index.ts
+++ b/src/hooks/task-session-manager/index.ts
@@ -5,11 +5,14 @@ import {
   type BackgroundJobStore,
   type BackgroundJobSupervisor,
   type BackgroundTaskConcurrency,
+  COMPLETED_WITHOUT_TEXT_DIAGNOSTIC,
   clearBackgroundJobSuppression,
   deriveFullObjective,
   deriveTaskSessionLabel,
   getBackgroundJobLifecycleLedger,
+  isHostTerminalOutcome,
   isInternalInitiatorPart,
+  log,
   parseTaskIdFromTaskOutput,
   parseTaskStateFromOutput,
   recordBackgroundJobSuppression,
@@ -100,8 +103,8 @@ function rehydrateHistoricalRunningTasks(
     agentType: string,
     parentSessionID?: string,
   ) => string | undefined,
-): number {
-  let rehydrated = 0;
+): string[] {
+  const rehydrated: string[] = [];
   const managedOrchestratorSessionIDs = new Set<string>();
 
   for (const message of messages) {
@@ -189,7 +192,7 @@ function rehydrateHistoricalRunningTasks(
         taskID,
         getModelForAgent?.(agent, parentSessionID),
       );
-      rehydrated += 1;
+      rehydrated.push(taskID);
     }
   }
 
@@ -257,6 +260,98 @@ export function createTaskSessionManagerHook(
     for (const job of backgroundJobBoard.list(sessionID)) {
       remember(job.taskID);
     }
+  };
+
+  /**
+   * Existence probe for a task registered by rehydrate: persisted running
+   * tool parts carry no host-side liveness, so a session deleted while the
+   * plugin was down would otherwise resurrect as a forever-running ghost
+   * on the next transform. Fire-and-forget from the transform hook; never
+   * awaited there. Classification is strictly by the host's typed `_tag`
+   * property (never instanceof — the SDK error class identity is not
+   * stable across host builds — and never message matching).
+   *
+   * wait()-discipline: never `await ctx.session.wait` (or any host wait
+   * API) inside chat.transform — a busy child would hang the transform
+   * for its entire run. This probe uses session.get only. If a wait ever
+   * becomes necessary outside transforms, wrap it in Promise.race with a
+   * timeout and attach a no-op `.catch` to the abandoned promise (a later
+   * NotFoundError rejection must not surface as unhandled).
+   */
+  const probeRehydratedTaskSession = (taskID: string): void => {
+    void (async () => {
+      const client = getClient(_ctx);
+      // Same presence gate as readSessionOutcome: capability is probed,
+      // not assumed, and deliberately NOT gated on hostFlavor — v1 hosts
+      // exposing session.get benefit identically. Absent method → skip
+      // silently.
+      if (typeof client.session?.get !== 'function') return;
+      try {
+        const response = (await client.session.get({
+          path: { id: taskID },
+          query: { directory: _ctx.directory },
+        })) as {
+          data?: { outcome?: unknown };
+          outcome?: unknown;
+        };
+        const info = response?.data ?? response;
+        const outcome =
+          typeof info?.outcome === 'string' ? info.outcome : undefined;
+        if (!isHostTerminalOutcome(outcome)) return;
+        const existing = backgroundJobBoard.get(taskID);
+        if (existing?.state !== 'running') return;
+        // Settle through the same updateStatus semantics the
+        // readSessionOutcome consumers use (idle-reconciliation): a
+        // succeeded outcome is only reconciled with usable final text.
+        let resultText: string | undefined;
+        if (outcome === 'succeeded') {
+          resultText = await readFinalAssistantText(
+            client,
+            taskID,
+            _ctx.directory,
+          );
+        }
+        const settled = backgroundJobBoard.updateStatus({
+          taskID,
+          expectedGeneration: existing.generation,
+          state: outcome === 'succeeded' && resultText ? 'completed' : 'error',
+          resultSummary:
+            outcome === 'succeeded'
+              ? resultText || COMPLETED_WITHOUT_TEXT_DIAGNOSTIC
+              : `Host reported outcome: ${outcome}.`,
+        });
+        if (settled !== undefined && settled.state !== 'running') {
+          backgroundJobBoard.markReconciled(taskID);
+          log('[task-session-manager] settled rehydrated task from host', {
+            taskID,
+            alias: settled.alias,
+            parentSessionID: settled.parentSessionID,
+            outcome,
+            hasResultText: Boolean(resultText),
+          });
+        }
+        return;
+      } catch (err) {
+        if ((err as { _tag?: string })?._tag === 'Session.NotFoundError') {
+          // The session no longer exists on the host: tombstone + the
+          // full deletion-cleanup set. All four actions are idempotent but
+          // all are required — a missing releaseTask would leak an
+          // admission slot forever.
+          recordBackgroundJobSuppression(backgroundJobBoard, taskID);
+          backgroundJobBoard.drop(taskID);
+          options.backgroundTaskConcurrency?.releaseTask(taskID);
+          options.backgroundJobSupervisor?.onSessionDeleted(taskID);
+          log(
+            '[task-session-manager] rehydrated task no longer exists on host; tombstoned',
+            { taskID },
+          );
+          return;
+        }
+        // Transient/unknown errors fail open: the job stays registered and
+        // the normal reconciliation paths keep their chance. Swallowed —
+        // the fire-and-forget probe must never reject unhandled.
+      }
+    })();
   };
 
   const pendingCallTracker =
@@ -562,7 +657,7 @@ export function createTaskSessionManagerHook(
       // cache. Terminal results are left untouched (they materialize once).
       stabilizeRunningTaskParts(messages);
 
-      const rehydratedCount = rehydrateHistoricalRunningTasks(
+      const rehydratedTaskIDs = rehydrateHistoricalRunningTasks(
         messages,
         backgroundJobBoard,
         options.shouldManageSession,
@@ -571,6 +666,9 @@ export function createTaskSessionManagerHook(
         options.backgroundTaskConcurrency,
         options.getModelForAgent,
       );
+      for (const taskID of rehydratedTaskIDs) {
+        probeRehydratedTaskSession(taskID);
+      }
 
       for (const [messageIndex, message] of messages.entries()) {
         if (!isUserMessageWithParts(message)) continue;
@@ -600,7 +698,7 @@ export function createTaskSessionManagerHook(
         }
       }
 
-      if (rehydratedCount > 0) {
+      if (rehydratedTaskIDs.length > 0) {
         await runtimeStatusReconciler.reconcile();
       }
     },

--- a/src/hooks/task-session-manager/rehydrate-probe.test.ts
+++ b/src/hooks/task-session-manager/rehydrate-probe.test.ts
@@ -205,6 +205,41 @@ describe('rehydrate session.get existence probe', () => {
     expect(releaseTask).not.toHaveBeenCalled();
   });
 
+  test('a terminal outcome resolving after a same-ID relaunch does not settle the new run', async () => {
+    const board = new BackgroundJobBoard();
+    const gate = deferred<void>();
+    const hook = createHook({
+      board,
+      // Hold the probe's get in flight until the relaunch below lands.
+      getSession: mock(() =>
+        gate.promise.then(async () => ({ outcome: 'failed' })),
+      ),
+    });
+
+    // Rehydrate registers generation 1 and the probe starts against it.
+    await runTransform(hook, 'child-stale-settle');
+    const relaunched = board.registerLaunch({
+      taskID: 'child-stale-settle',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+      description: 'legitimate relaunch while probe in flight',
+    });
+    expect(relaunched.generation).toBe(2);
+
+    // The stale probe's terminal outcome resolves only now — it must NOT
+    // terminalize the relaunched generation (updateStatus rejects via
+    // the probe-start generation; no markReconciled).
+    gate.resolve();
+    await flushProbe();
+
+    expect(board.get('child-stale-settle')).toMatchObject({
+      generation: relaunched.generation,
+      state: 'running',
+      terminalState: undefined,
+      resultSummary: undefined,
+    });
+  });
+
   test('transient probe rejection fails open (job stays registered)', async () => {
     const board = new BackgroundJobBoard();
     const hook = createHook({

--- a/src/hooks/task-session-manager/rehydrate-probe.test.ts
+++ b/src/hooks/task-session-manager/rehydrate-probe.test.ts
@@ -1,0 +1,271 @@
+import { describe, expect, mock, test } from 'bun:test';
+import {
+  BackgroundJobBoard,
+  type BackgroundJobSupervisor,
+  type BackgroundTaskConcurrency,
+  getBackgroundJobLifecycleLedger,
+} from '../../utils';
+
+// Route getClient back to _ctx.client so the mock ctx client is what the
+// rehydrate probe sees (same pattern as index.test.ts).
+mock.module('../../utils/opencode-client', () => ({
+  getClient: (input: { client: unknown }) => input.client as never,
+}));
+
+import { createTaskSessionManagerHook } from './index';
+
+function taskLaunchOutput(taskID: string): string {
+  return [
+    `task_id: ${taskID}`,
+    'state: running',
+    '',
+    '<task_result>',
+    'Background task started.',
+    '</task_result>',
+  ].join('\n');
+}
+
+function historicalRunningPart(taskID: string) {
+  return {
+    type: 'tool',
+    tool: 'task',
+    state: {
+      status: 'running',
+      input: {
+        background: true,
+        subagent_type: 'explorer',
+        description: 'probe task',
+        prompt: 'inspect state',
+      },
+      output: taskLaunchOutput(taskID),
+    },
+  };
+}
+
+function rehydrateMessages(taskID: string) {
+  return {
+    messages: [
+      {
+        info: {
+          role: 'assistant',
+          agent: 'orchestrator',
+          sessionID: 'parent-1',
+        },
+        parts: [historicalRunningPart(taskID)],
+      },
+      {
+        info: { role: 'user', agent: 'orchestrator', sessionID: 'parent-1' },
+        parts: [{ type: 'text', text: 'continue' }],
+      },
+    ],
+  };
+}
+
+/** Flush the fire-and-forget probe's promise chain. */
+function flushProbe() {
+  return new Promise((resolve) => setTimeout(resolve, 10));
+}
+
+function createHook(options: {
+  board: BackgroundJobBoard;
+  getSession?: (input: Record<string, unknown>) => Promise<unknown>;
+  getMessages?: (input: Record<string, unknown>) => Promise<unknown>;
+  supervisor?: BackgroundJobSupervisor;
+  concurrency?: BackgroundTaskConcurrency;
+}) {
+  return createTaskSessionManagerHook(
+    {
+      client: {
+        session: {
+          status: mock(async () => ({ data: {} })),
+          ...(options.getSession ? { get: options.getSession } : {}),
+          ...(options.getMessages ? { messages: options.getMessages } : {}),
+        },
+      },
+      directory: '/tmp',
+      worktree: '/tmp',
+    } as never,
+    {
+      maxSessionsPerAgent: 2,
+      maxRetainedSnapshots: 4,
+      backgroundJobBoard: options.board,
+      backgroundJobSupervisor: options.supervisor,
+      backgroundTaskConcurrency: options.concurrency,
+      shouldManageSession: () => true,
+      runtimeStatusReconcileDelayMs: 60_000,
+    },
+  );
+}
+
+async function runTransform(
+  hook: ReturnType<typeof createTaskSessionManagerHook>,
+  taskID: string,
+) {
+  await hook['experimental.chat.messages.transform'](
+    {},
+    rehydrateMessages(taskID) as never,
+  );
+}
+
+describe('rehydrate session.get existence probe', () => {
+  test('NotFound (_tag) tombstones the run and fires every cleanup action', async () => {
+    const board = new BackgroundJobBoard();
+    const onSessionDeleted = mock(() => true);
+    const releaseTask = mock(() => {});
+    const supervisor = {
+      onSessionDeleted,
+    } as unknown as BackgroundJobSupervisor;
+    const concurrency = {
+      releaseTask,
+      restoreTask: mock(() => {}),
+    } as unknown as BackgroundTaskConcurrency;
+    const notFound = Object.assign(new Error('session not found'), {
+      _tag: 'Session.NotFoundError',
+    });
+    const hook = createHook({
+      board,
+      supervisor,
+      concurrency,
+      getSession: mock(() => Promise.reject(notFound)),
+    });
+
+    await runTransform(hook, 'child-gone');
+    // The probe is fire-and-forget; flush its promise chain.
+    await flushProbe();
+
+    expect(board.get('child-gone')).toBeUndefined();
+    expect(onSessionDeleted).toHaveBeenCalledWith('child-gone');
+    expect(releaseTask).toHaveBeenCalledWith('child-gone');
+    expect(
+      getBackgroundJobLifecycleLedger(board).tombstones.has('child-gone'),
+    ).toBe(true);
+
+    // The tombstone prevents the next transform from resurrecting the run.
+    await runTransform(hook, 'child-gone');
+    await flushProbe();
+    expect(board.get('child-gone')).toBeUndefined();
+    expect(board.list()).toHaveLength(0);
+  });
+
+  test('transient probe rejection fails open (job stays registered)', async () => {
+    const board = new BackgroundJobBoard();
+    const hook = createHook({
+      board,
+      getSession: mock(() => Promise.reject(new Error('ECONNRESET'))),
+    });
+
+    await runTransform(hook, 'child-flaky');
+    await flushProbe();
+
+    expect(board.get('child-flaky')).toMatchObject({ state: 'running' });
+    expect(
+      getBackgroundJobLifecycleLedger(board).tombstones.has('child-flaky'),
+    ).toBe(false);
+  });
+
+  test('existing session with a succeeded outcome settles via final text', async () => {
+    const board = new BackgroundJobBoard();
+    const hook = createHook({
+      board,
+      getSession: mock(async () => ({
+        data: { id: 'child-done', outcome: 'succeeded' },
+      })),
+      getMessages: mock(async () => ({
+        data: [
+          {
+            info: { id: 'm1', role: 'assistant' },
+            parts: [{ type: 'text', text: 'final answer' }],
+          },
+        ],
+      })),
+    });
+
+    await runTransform(hook, 'child-done');
+    await flushProbe();
+
+    expect(board.get('child-done')).toMatchObject({
+      // markReconciled transitions state after settling (same as the
+      // idle-reconciliation outcome consumer); terminalState is the
+      // durable terminal record.
+      state: 'reconciled',
+      terminalState: 'completed',
+      resultSummary: 'final answer',
+    });
+  });
+
+  test('existing session with a failed outcome settles as error', async () => {
+    const board = new BackgroundJobBoard();
+    const hook = createHook({
+      board,
+      getSession: mock(async () => ({ outcome: 'failed' })),
+    });
+
+    await runTransform(hook, 'child-failed');
+    await flushProbe();
+
+    expect(board.get('child-failed')).toMatchObject({
+      state: 'reconciled',
+      terminalState: 'error',
+      resultSummary: 'Host reported outcome: failed.',
+    });
+  });
+
+  test('a still-running host session is left alone', async () => {
+    const board = new BackgroundJobBoard();
+    const hook = createHook({
+      board,
+      getSession: mock(async () => ({ outcome: undefined })),
+    });
+
+    await runTransform(hook, 'child-live');
+    await flushProbe();
+
+    expect(board.get('child-live')).toMatchObject({ state: 'running' });
+  });
+
+  test('hosts without session.get skip the probe silently', async () => {
+    const board = new BackgroundJobBoard();
+    const releaseTask = mock(() => {});
+    const hook = createHook({
+      board,
+      concurrency: {
+        releaseTask,
+        restoreTask: mock(() => {}),
+      } as unknown as BackgroundTaskConcurrency,
+    });
+
+    await runTransform(hook, 'child-inert');
+    await flushProbe();
+
+    expect(board.get('child-inert')).toMatchObject({ state: 'running' });
+    expect(releaseTask).not.toHaveBeenCalled();
+  });
+
+  test('the probe never surfaces an unhandled rejection', async () => {
+    const unhandled: unknown[] = [];
+    const onUnhandled = (err: unknown) => unhandled.push(err);
+    process.on('unhandledRejection', onUnhandled);
+    try {
+      const board = new BackgroundJobBoard();
+      const notFound = Object.assign(new Error('gone'), {
+        _tag: 'Session.NotFoundError',
+      });
+      const notFoundHook = createHook({
+        board,
+        getSession: mock(() => Promise.reject(notFound)),
+      });
+      await runTransform(notFoundHook, 'child-unhandled-gone');
+      const transientHook = createHook({
+        board,
+        getSession: mock(() =>
+          Promise.reject(new Error('boom before get resolves')),
+        ),
+      });
+      await runTransform(transientHook, 'child-unhandled-flaky');
+      await flushProbe();
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+    }
+    expect(unhandled).toEqual([]);
+  });
+});

--- a/src/hooks/task-session-manager/rehydrate-probe.test.ts
+++ b/src/hooks/task-session-manager/rehydrate-probe.test.ts
@@ -66,6 +66,15 @@ function flushProbe() {
   return new Promise((resolve) => setTimeout(resolve, 10));
 }
 
+/** Manually-resolved promise for holding a probe's get in flight. */
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
 function createHook(options: {
   board: BackgroundJobBoard;
   getSession?: (input: Record<string, unknown>) => Promise<unknown>;
@@ -145,6 +154,55 @@ describe('rehydrate session.get existence probe', () => {
     await flushProbe();
     expect(board.get('child-gone')).toBeUndefined();
     expect(board.list()).toHaveLength(0);
+  });
+
+  test('a NotFound resolving after a same-ID relaunch leaves the live record alone', async () => {
+    const board = new BackgroundJobBoard();
+    const releaseTask = mock(() => {});
+    const onSessionDeleted = mock(() => true);
+    const notFound = Object.assign(new Error('gone'), {
+      _tag: 'Session.NotFoundError',
+    });
+    const gate = deferred<void>();
+    const hook = createHook({
+      board,
+      supervisor: {
+        onSessionDeleted,
+      } as unknown as BackgroundJobSupervisor,
+      concurrency: {
+        releaseTask,
+        restoreTask: mock(() => {}),
+      } as unknown as BackgroundTaskConcurrency,
+      // Hold the probe's get in flight until the relaunch below lands.
+      getSession: mock(() => gate.promise.then(() => Promise.reject(notFound))),
+    });
+
+    // Rehydrate registers generation 1 and the probe starts against it.
+    await runTransform(hook, 'child-stale-probe');
+    const relaunched = board.registerLaunch({
+      taskID: 'child-stale-probe',
+      parentSessionID: 'parent-1',
+      agent: 'explorer',
+      description: 'legitimate relaunch while probe in flight',
+    });
+    expect(relaunched.generation).toBe(2);
+
+    // The stale NotFound resolves only now — it must NOT tombstone or
+    // drop the live relaunched record.
+    gate.resolve();
+    await flushProbe();
+
+    expect(board.get('child-stale-probe')).toMatchObject({
+      generation: relaunched.generation,
+      state: 'running',
+    });
+    expect(
+      getBackgroundJobLifecycleLedger(board).tombstones.has(
+        'child-stale-probe',
+      ),
+    ).toBe(false);
+    expect(onSessionDeleted).not.toHaveBeenCalled();
+    expect(releaseTask).not.toHaveBeenCalled();
   });
 
   test('transient probe rejection fails open (job stays registered)', async () => {

--- a/src/hooks/task-session-manager/tool-execute-hooks.ts
+++ b/src/hooks/task-session-manager/tool-execute-hooks.ts
@@ -15,10 +15,10 @@ import {
   deriveFullObjective,
   deriveTaskSessionLabel,
   guardCompletedStatusText,
+  maskTaskOutputStructure,
   parseTaskIdFromTaskOutput,
   parseTaskLaunchOutput,
   parseTaskStatusOutput,
-  redactSecretsForLog,
 } from '../../utils';
 import { isRecord as isObjectRecord } from '../../utils/guards';
 import { log } from '../../utils/logger';
@@ -480,15 +480,17 @@ export async function handleToolExecuteAfter(
       // host actually returned so format drift is diagnosable from the
       // plugin log (board-injection has its own textPreview for
       // synthetic parts — this one covers the native tool result path).
-      // Redact the FULL string BEFORE slicing: the logger-level
-      // redaction only sees the already-sliced preview, so a secret
-      // straddling the slice boundary would leak its raw prefix.
-      // Redact-then-slice to 140 (compensating the ellipsis shortening)
-      // shows the mask, not the raw prefix.
+      // Structure-preserving VALUE masking (maskTaskOutputStructure):
+      // parse-miss content is untrusted-by-format, so tag/field names
+      // survive for drift diagnosis but every value is fully hidden as
+      // [masked] — description fields carry orchestrator/user-authored
+      // text. The full string is masked BEFORE slicing (a straddling
+      // secret cannot leak a raw prefix); the logger-level redaction
+      // remains the backstop for every other log site.
       log('[task-session-manager] task output without a task id', {
         callID: pending.callId,
         sessionID: input.sessionID,
-        outputPreview: redactSecretsForLog(output.output).slice(0, 140),
+        outputPreview: maskTaskOutputStructure(output.output).slice(0, 140),
       });
       if (
         pending.resumedTaskId &&

--- a/src/hooks/task-session-manager/tool-execute-hooks.ts
+++ b/src/hooks/task-session-manager/tool-execute-hooks.ts
@@ -474,6 +474,16 @@ export async function handleToolExecuteAfter(
 
     const taskId = parseTaskIdFromTaskOutput(output.output);
     if (!taskId) {
+      // Host-output-drift detector: the task tool's terminal output no
+      // longer carries a parsable task id. The ~120-char preview shows
+      // what the host actually returned so format drift is diagnosable
+      // from the plugin log (board-injection has its own textPreview for
+      // synthetic parts — this one covers the native tool result path).
+      log('[task-session-manager] task output without a task id', {
+        callID: pending.callId,
+        sessionID: input.sessionID,
+        outputPreview: output.output.slice(0, 120),
+      });
       if (
         pending.resumedTaskId &&
         isMissingRememberedSessionError(output.output)

--- a/src/hooks/task-session-manager/tool-execute-hooks.ts
+++ b/src/hooks/task-session-manager/tool-execute-hooks.ts
@@ -476,16 +476,19 @@ export async function handleToolExecuteAfter(
     const taskId = parseTaskIdFromTaskOutput(output.output);
     if (!taskId) {
       // Host-output-drift detector: the task tool's terminal output no
-      // longer carries a parsable task id. The ~120-char preview shows
-      // what the host actually returned so format drift is diagnosable
-      // from the plugin log (board-injection has its own textPreview for
+      // longer carries a parsable task id. The preview shows what the
+      // host actually returned so format drift is diagnosable from the
+      // plugin log (board-injection has its own textPreview for
       // synthetic parts — this one covers the native tool result path).
-      // Redacted: plugin logs are collected into public GitHub issues by
-      // the report flow, and parse-miss content is untrusted-by-format.
+      // Redact the FULL string BEFORE slicing: the logger-level
+      // redaction only sees the already-sliced preview, so a secret
+      // straddling the slice boundary would leak its raw prefix.
+      // Redact-then-slice to 140 (compensating the ellipsis shortening)
+      // shows the mask, not the raw prefix.
       log('[task-session-manager] task output without a task id', {
         callID: pending.callId,
         sessionID: input.sessionID,
-        outputPreview: redactSecretsForLog(output.output.slice(0, 120)),
+        outputPreview: redactSecretsForLog(output.output).slice(0, 140),
       });
       if (
         pending.resumedTaskId &&

--- a/src/hooks/task-session-manager/tool-execute-hooks.ts
+++ b/src/hooks/task-session-manager/tool-execute-hooks.ts
@@ -18,6 +18,7 @@ import {
   parseTaskIdFromTaskOutput,
   parseTaskLaunchOutput,
   parseTaskStatusOutput,
+  redactSecretsForLog,
 } from '../../utils';
 import { isRecord as isObjectRecord } from '../../utils/guards';
 import { log } from '../../utils/logger';
@@ -479,10 +480,12 @@ export async function handleToolExecuteAfter(
       // what the host actually returned so format drift is diagnosable
       // from the plugin log (board-injection has its own textPreview for
       // synthetic parts — this one covers the native tool result path).
+      // Redacted: plugin logs are collected into public GitHub issues by
+      // the report flow, and parse-miss content is untrusted-by-format.
       log('[task-session-manager] task output without a task id', {
         callID: pending.callId,
         sessionID: input.sessionID,
-        outputPreview: output.output.slice(0, 120),
+        outputPreview: redactSecretsForLog(output.output.slice(0, 120)),
       });
       if (
         pending.resumedTaskId &&

--- a/src/utils/background-job-board.ts
+++ b/src/utils/background-job-board.ts
@@ -5,6 +5,10 @@ import {
   DEFAULT_READ_CONTEXT_MIN_LINES,
   formatSystemReminder,
 } from '../config/constants';
+import {
+  aliasHighWaterMark,
+  bumpAliasHighWaterMark,
+} from './background-job-persistence';
 import type { BackgroundJobStore } from './background-job-store';
 import {
   clearBackgroundJobSuppression,
@@ -95,6 +99,11 @@ export interface BackgroundJobBoardOptions {
   maxContextLines?: number;
   readContextMinLines?: number;
   readContextMaxFiles?: number;
+  /** Alias counter high-water seed per `<parentSessionID>:<prefix>` so a
+   * post-restart board never reuses a historical alias. Defaults to the
+   * shared persistence high-water marks (0 without a storage backend —
+   * exactly the pre-persistence behavior). */
+  aliasCounterHighWater?: (parentSessionID: string, prefix: string) => number;
 }
 
 export interface BackgroundJobLaunchInput {
@@ -178,6 +187,10 @@ export class BackgroundJobBoard implements BackgroundJobStore {
   private readonly maxContextLines: number;
   private readonly readContextMinLines: number;
   private readonly readContextMaxFiles: number;
+  private readonly aliasCounterHighWater: (
+    parentSessionID: string,
+    prefix: string,
+  ) => number;
 
   constructor(options: BackgroundJobBoardOptions = {}) {
     this.maxReusablePerAgent =
@@ -187,6 +200,8 @@ export class BackgroundJobBoard implements BackgroundJobStore {
       options.readContextMinLines ?? DEFAULT_READ_CONTEXT_MIN_LINES;
     this.readContextMaxFiles =
       options.readContextMaxFiles ?? DEFAULT_READ_CONTEXT_MAX_FILES;
+    this.aliasCounterHighWater =
+      options.aliasCounterHighWater ?? aliasHighWaterMark;
   }
 
   addTerminalStateListener(listener: TerminalStateListener): void {
@@ -1173,8 +1188,16 @@ export class BackgroundJobBoard implements BackgroundJobStore {
   private nextAlias(parentSessionID: string, agent: string): string {
     const prefix = AGENT_PREFIX[agent] ?? (agent.slice(0, 3) || 'job');
     const key = `${parentSessionID}:${prefix}`;
-    const next = (this.counters.get(key) ?? 0) + 1;
+    // Seed from the persisted high-water mark so a post-restart board
+    // never reuses a historical alias. The alias→taskID mapping is NOT
+    // restored: old aliases resolve as not-found, which is the intended
+    // improvement over silently reusing them for unrelated tasks.
+    const seeded = this.aliasCounterHighWater(parentSessionID, prefix);
+    const next = Math.max(this.counters.get(key) ?? 0, seeded) + 1;
     this.counters.set(key, next);
+    // Write-through: persist the last-seen counter (no-op without a
+    // storage backend).
+    bumpAliasHighWaterMark(parentSessionID, prefix, next);
 
     return `${prefix}-${next}`;
   }

--- a/src/utils/background-job-persistence.test.ts
+++ b/src/utils/background-job-persistence.test.ts
@@ -1,0 +1,255 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import {
+  aliasHighWaterMark,
+  type BackgroundJobStorageBackend,
+  bumpAliasHighWaterMark,
+  clearSuppression,
+  configureBackgroundJobPersistence,
+  loadInitialBackgroundJobPersistence,
+  MAX_PERSISTED_TOMBSTONES,
+  recordSuppression,
+} from './background-job-persistence';
+import {
+  BackgroundJobBoard,
+  clearBackgroundJobSuppression,
+  getBackgroundJobLifecycleLedger,
+  recordBackgroundJobSuppression,
+} from './index';
+
+/** In-memory v2-storage backend double with cursor pagination. */
+function createMemoryBackend() {
+  const map = new Map<string, unknown>();
+  const backend: BackgroundJobStorageBackend = {
+    get: async (key) => map.get(key),
+    set: async (key, value) => {
+      map.set(key, value);
+    },
+    remove: async (key) => {
+      map.delete(key);
+    },
+    scan: async (options) => {
+      const keys = [...map.keys()]
+        .filter(
+          (key) =>
+            key.startsWith(options.prefix) &&
+            (options.after === undefined || key > options.after),
+        )
+        .sort();
+      const limit = options.limit ?? 1000;
+      const page = keys.slice(0, limit);
+      const next = keys.length > limit ? page[page.length - 1] : undefined;
+      return {
+        entries: page.map((key) => ({ key, value: map.get(key) })),
+        next,
+      };
+    },
+  };
+  return { backend, map };
+}
+
+/** Flush serialized fire-and-forget persistence writes. */
+function flushWrites() {
+  return new Promise((resolve) => setTimeout(resolve, 10));
+}
+
+describe('background-job persistence', () => {
+  beforeEach(() => {
+    configureBackgroundJobPersistence(undefined);
+  });
+
+  afterEach(() => {
+    configureBackgroundJobPersistence(undefined);
+  });
+
+  test('tombstone round-trips across a simulated restart and seeds a fresh ledger', async () => {
+    const { backend, map } = createMemoryBackend();
+    configureBackgroundJobPersistence(backend);
+    await loadInitialBackgroundJobPersistence();
+
+    recordSuppression('ses_roundtrip', 1);
+    await flushWrites();
+    expect([...map.keys()].some((key) => key.includes('ses_roundtrip'))).toBe(
+      true,
+    );
+
+    // Simulated restart: same backend, fresh module + fresh board/ledger.
+    configureBackgroundJobPersistence(backend);
+    await loadInitialBackgroundJobPersistence();
+
+    const freshBoard = new BackgroundJobBoard();
+    const ledger = getBackgroundJobLifecycleLedger(freshBoard);
+    expect(ledger.tombstones.has('ses_roundtrip')).toBe(true);
+    expect(ledger.deletionEpochs.get('ses_roundtrip')).toBe(1);
+    // Next recorded epoch stays monotonic past the restored one.
+    recordBackgroundJobSuppression(freshBoard, 'ses_next');
+    expect(ledger.deletionEpochs.get('ses_next')).toBe(2);
+  });
+
+  test('clear-on-relaunch write-through removes the persisted tombstone but keeps the epoch', async () => {
+    const { backend } = createMemoryBackend();
+    configureBackgroundJobPersistence(backend);
+    await loadInitialBackgroundJobPersistence();
+
+    const board = new BackgroundJobBoard();
+    recordBackgroundJobSuppression(board, 'ses_relaunch');
+    expect(
+      getBackgroundJobLifecycleLedger(board).tombstones.has('ses_relaunch'),
+    ).toBe(true);
+    await flushWrites();
+
+    clearBackgroundJobSuppression(board, 'ses_relaunch');
+    await flushWrites();
+
+    // Simulated restart: the relaunch must NOT be ghost-skipped, but its
+    // deletion epoch survives for generation fencing.
+    configureBackgroundJobPersistence(backend);
+    await loadInitialBackgroundJobPersistence();
+    const freshLedger = getBackgroundJobLifecycleLedger(
+      new BackgroundJobBoard(),
+    );
+    expect(freshLedger.tombstones.has('ses_relaunch')).toBe(false);
+    expect(freshLedger.deletionEpochs.get('ses_relaunch')).toBe(1);
+  });
+
+  test('alias counters never reuse a historical alias across a simulated restart', async () => {
+    const { backend } = createMemoryBackend();
+    configureBackgroundJobPersistence(backend);
+    await loadInitialBackgroundJobPersistence();
+
+    const firstBoard = new BackgroundJobBoard();
+    const a = firstBoard.registerLaunch({
+      taskID: 'ses_a',
+      parentSessionID: 'parent-alias',
+      agent: 'fixer',
+      description: 'first',
+    });
+    const b = firstBoard.registerLaunch({
+      taskID: 'ses_b',
+      parentSessionID: 'parent-alias',
+      agent: 'fixer',
+      description: 'second',
+    });
+    expect(a.alias).toBe('fix-1');
+    expect(b.alias).toBe('fix-2');
+    await flushWrites();
+
+    // Simulated restart: fresh board seeds from the persisted high-water
+    // mark; the alias MAPPING is not restored (old ids resolve not-found),
+    // but no NEW alias collides with a historical one.
+    configureBackgroundJobPersistence(backend);
+    await loadInitialBackgroundJobPersistence();
+    expect(aliasHighWaterMark('parent-alias', 'fix')).toBe(2);
+
+    const restarted = new BackgroundJobBoard();
+    const c = restarted.registerLaunch({
+      taskID: 'ses_c',
+      parentSessionID: 'parent-alias',
+      agent: 'fixer',
+      description: 'third',
+    });
+    expect(c.alias).toBe('fix-3');
+  });
+
+  test('alias high-water marks never regress on concurrent bumps', async () => {
+    const { backend } = createMemoryBackend();
+    configureBackgroundJobPersistence(backend);
+    await loadInitialBackgroundJobPersistence();
+
+    bumpAliasHighWaterMark('parent-race', 'fix', 5);
+    bumpAliasHighWaterMark('parent-race', 'fix', 3); // stale writer
+    await flushWrites();
+
+    configureBackgroundJobPersistence(backend);
+    await loadInitialBackgroundJobPersistence();
+    expect(aliasHighWaterMark('parent-race', 'fix')).toBe(5);
+  });
+
+  test('storage-absent fallback: pure memory, zero behavior change', async () => {
+    configureBackgroundJobPersistence(undefined);
+
+    expect(() => {
+      recordSuppression('ses_fallback', 1);
+      clearSuppression('ses_fallback');
+      bumpAliasHighWaterMark('parent-fallback', 'fix', 7);
+    }).not.toThrow();
+    await flushWrites();
+
+    // No backend → nothing is seeded into fresh boards or ledgers and
+    // alias numbering restarts from 1 exactly as before persistence.
+    expect(aliasHighWaterMark('parent-fallback', 'fix')).toBe(0);
+    const board = new BackgroundJobBoard();
+    const record = board.registerLaunch({
+      taskID: 'ses_fresh',
+      parentSessionID: 'parent-fallback',
+      agent: 'fixer',
+      description: 'fresh',
+    });
+    expect(record.alias).toBe('fix-1');
+    expect(getBackgroundJobLifecycleLedger(board).tombstones.size).toBe(0);
+  });
+
+  test('tombstone entries self-cap at the recorded-time bound', async () => {
+    const { backend, map } = createMemoryBackend();
+    configureBackgroundJobPersistence(backend);
+    await loadInitialBackgroundJobPersistence();
+
+    for (let i = 0; i <= MAX_PERSISTED_TOMBSTONES + 2; i += 1) {
+      recordSuppression(`ses_cap_${String(i).padStart(4, '0')}`, i + 1);
+    }
+    await flushWrites();
+
+    const tombstoneKeys = [...map.keys()].filter((key) =>
+      key.includes('tombstone'),
+    );
+    expect(tombstoneKeys.length).toBeLessThanOrEqual(MAX_PERSISTED_TOMBSTONES);
+    // The oldest entries were evicted; the newest survives.
+    expect(tombstoneKeys.some((key) => key.includes('ses_cap_0000'))).toBe(
+      false,
+    );
+    expect(
+      tombstoneKeys.some((key) =>
+        key.includes(
+          `ses_cap_${String(MAX_PERSISTED_TOMBSTONES + 2).padStart(4, '0')}`,
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  test('loadInitial follows the paginated scan cursor', async () => {
+    const { backend, map } = createMemoryBackend();
+    // Page size 3 forces cursor pagination across the seeded entries.
+    const paged: BackgroundJobStorageBackend = {
+      get: backend.get,
+      set: backend.set,
+      remove: backend.remove,
+      scan: async (options) => {
+        const keys = [...map.keys()]
+          .filter(
+            (key) =>
+              key.startsWith(options.prefix) &&
+              (options.after === undefined || key > options.after),
+          )
+          .sort();
+        const limit = 3;
+        const page = keys.slice(0, limit);
+        const next = keys.length > limit ? page[page.length - 1] : undefined;
+        return {
+          entries: page.map((key) => ({ key, value: map.get(key) })),
+          next,
+        };
+      },
+    };
+    configureBackgroundJobPersistence(paged);
+    await loadInitialBackgroundJobPersistence();
+
+    for (let i = 0; i < 7; i += 1) {
+      recordSuppression(`ses_page_${i}`, i + 1);
+    }
+    await flushWrites();
+
+    configureBackgroundJobPersistence(paged);
+    const snapshot = await loadInitialBackgroundJobPersistence();
+    expect(snapshot.tombstones.size).toBe(7);
+    expect(snapshot.nextEpoch).toBe(7);
+  });
+});

--- a/src/utils/background-job-persistence.test.ts
+++ b/src/utils/background-job-persistence.test.ts
@@ -150,6 +150,44 @@ describe('background-job persistence', () => {
     expect(c.alias).toBe('fix-3');
   });
 
+  test('two concurrently-live boards sharing a prefix never reuse an alias', async () => {
+    const { backend } = createMemoryBackend();
+    configureBackgroundJobPersistence(backend);
+    await loadInitialBackgroundJobPersistence();
+
+    const boardA = new BackgroundJobBoard();
+    expect(
+      boardA.registerLaunch({
+        taskID: 'ses_live_a1',
+        parentSessionID: 'parent-live',
+        agent: 'fixer',
+        description: 'a1',
+      }).alias,
+    ).toBe('fix-1');
+    expect(
+      boardA.registerLaunch({
+        taskID: 'ses_live_a2',
+        parentSessionID: 'parent-live',
+        agent: 'fixer',
+        description: 'a2',
+      }).alias,
+    ).toBe('fix-2');
+    await flushWrites();
+
+    // A second LIVE board in the same process must seed from the live
+    // high-water max (writtenAliasMax), not only the backend snapshot
+    // frozen at configure time — otherwise it would hand out fix-1 again.
+    const boardB = new BackgroundJobBoard();
+    expect(
+      boardB.registerLaunch({
+        taskID: 'ses_live_b1',
+        parentSessionID: 'parent-live',
+        agent: 'fixer',
+        description: 'b1',
+      }).alias,
+    ).toBe('fix-3');
+  });
+
   test('alias high-water marks never regress on concurrent bumps', async () => {
     const { backend } = createMemoryBackend();
     configureBackgroundJobPersistence(backend);

--- a/src/utils/background-job-persistence.test.ts
+++ b/src/utils/background-job-persistence.test.ts
@@ -52,6 +52,15 @@ function flushWrites() {
   return new Promise((resolve) => setTimeout(resolve, 10));
 }
 
+/** Manually-resolved promise for holding queued writes in flight. */
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
 describe('background-job persistence', () => {
   beforeEach(() => {
     configureBackgroundJobPersistence(undefined);
@@ -186,6 +195,44 @@ describe('background-job persistence', () => {
         description: 'b1',
       }).alias,
     ).toBe('fix-3');
+  });
+
+  test('writes queued before a reconfiguration never land on the new backend', async () => {
+    const gate = deferred<void>();
+    const { backend: backendA, map: mapA } = createMemoryBackend();
+    const gatedA: BackgroundJobStorageBackend = {
+      ...backendA,
+      set: (key, value) => gate.promise.then(() => backendA.set(key, value)),
+      remove: (key) => gate.promise.then(() => backendA.remove(key)),
+    };
+    configureBackgroundJobPersistence(gatedA);
+    await loadInitialBackgroundJobPersistence();
+
+    // Tombstone + epoch writes queue behind the gate (old epoch).
+    recordSuppression('ses_stale_cross', 1);
+
+    const { backend: backendB, map: mapB } = createMemoryBackend();
+    configureBackgroundJobPersistence(backendB);
+    await loadInitialBackgroundJobPersistence();
+
+    gate.resolve();
+    await flushWrites();
+
+    // The stale queued op is discarded, not executed: it touches neither
+    // the old backend (refuse-to-run) nor — critically — the new one.
+    expect(
+      [...mapA.keys()].some((key) => key.includes('ses_stale_cross')),
+    ).toBe(false);
+    expect(
+      [...mapB.keys()].some((key) => key.includes('ses_stale_cross')),
+    ).toBe(false);
+
+    // New-epoch writes on the new backend work normally.
+    recordSuppression('ses_fresh_cross', 2);
+    await flushWrites();
+    expect(
+      [...mapB.keys()].some((key) => key.includes('ses_fresh_cross')),
+    ).toBe(true);
   });
 
   test('alias high-water marks never regress on concurrent bumps', async () => {

--- a/src/utils/background-job-persistence.ts
+++ b/src/utils/background-job-persistence.ts
@@ -1,0 +1,305 @@
+/**
+ * Persistence for background-job lifecycle state (tombstones, deletion
+ * epochs, alias high-water marks) over the optional v2 host storage
+ * domain (`ctx.storage`).
+ *
+ * Design invariants:
+ * - **Write-through.** `recordBackgroundJobSuppression` /
+ *   `clearBackgroundJobSuppression` (background-job-store.ts) call this
+ *   module on every mutation so the in-process ledger and the persisted
+ *   state can never diverge. A task deleted and then legitimately
+ *   relaunched must NOT be ghost-skipped after a restart — clearing the
+ *   tombstone on relaunch is load-bearing (the deletion EPOCH survives a
+ *   clear so generation fencing keeps working).
+ * - **Seeding is backend-only.** Fresh boards/ledgers seed from what a
+ *   real backend returned via `loadInitialBackgroundJobPersistence`.
+ *   Without a backend (v1 hosts, hosts without the domain) the module is
+ *   a pure in-memory no-op sink: zero behavior change, and no
+ *   cross-board contamination inside one process.
+ * - **Bounded growth.** Persisted tombstones (and their epoch entries)
+ *   are capped at `MAX_PERSISTED_TOMBSTONES` most-recent by recorded
+ *   time. Evicting an ancient tombstone can at worst resurrect an
+ *   equally ancient deleted run — the same trade a fresh process makes
+ *   today.
+ * - **Serialized writes.** Every storage mutation for one key is chained
+ *   through an in-process queue, so concurrent callers never race a
+ *   read-modify-write on the same key. Writes are fire-and-forget with
+ *   logged (never thrown) failures — persistence loss degrades to
+ *   today's process-local behavior.
+ *
+ * Alias counters persist the last-seen counter per
+ * `<parentSessionID>:<prefix>`; a post-restart board seeds its counters
+ * from these high-water marks so a new alias never collides with a
+ * historical one. The alias→taskID mapping itself is NOT restored: old
+ * aliases resolve as not-found after a restart, which is the intended
+ * improvement over silently reusing them for unrelated tasks.
+ */
+
+import { log } from './logger';
+
+/** Subset of the v2 `StorageDomain` this module consumes (see
+ * `V2Context['storage']` in src/v2/types.ts). */
+export interface BackgroundJobStorageBackend {
+  get(key: string): Promise<unknown> | unknown;
+  set(key: string, value: unknown): Promise<unknown> | unknown;
+  remove(key: string): Promise<unknown> | unknown;
+  scan(options: { prefix: string; after?: string; limit?: number }): Promise<{
+    entries: Array<{ key: string; value: unknown }>;
+    next?: string;
+  }>;
+}
+
+const KEY_ROOT = 'omo/bgj/';
+const TOMBSTONE_PREFIX = `${KEY_ROOT}tombstone/`;
+const EPOCH_PREFIX = `${KEY_ROOT}epoch/`;
+const ALIAS_PREFIX = `${KEY_ROOT}alias/`;
+
+/** Persisted tombstone entries self-cap at this many most-recent items. */
+export const MAX_PERSISTED_TOMBSTONES = 500;
+
+/** Defensive bound on scan pagination (a corrupted cursor loop). */
+const MAX_SCAN_PAGES = 10_000;
+
+export interface PersistedTombstoneEntry {
+  taskID: string;
+  epoch: number;
+  recordedAt: number;
+}
+
+export interface PersistedBackgroundJobState {
+  /** taskID → persisted tombstone entry (currently suppressed runs). */
+  tombstones: Map<string, PersistedTombstoneEntry>;
+  /** taskID → deletion epoch (survives clear-on-relaunch). */
+  deletionEpochs: Map<string, number>;
+  /** Highest deletion epoch seen; keeps future epochs monotonic. */
+  nextEpoch: number;
+  /** `<parentSessionID>:<prefix>` → last-seen alias counter. */
+  aliasHighWaterMarks: Map<string, number>;
+}
+
+function emptyState(): PersistedBackgroundJobState {
+  return {
+    tombstones: new Map(),
+    deletionEpochs: new Map(),
+    nextEpoch: 0,
+    aliasHighWaterMarks: new Map(),
+  };
+}
+
+let backend: BackgroundJobStorageBackend | undefined;
+/** State loaded from a real backend; the only seed source. */
+let loaded = emptyState();
+/** Live tombstone bookkeeping for cap enforcement (loaded ∪ recorded). */
+const liveTombstones = new Map<string, PersistedTombstoneEntry>();
+/** Per-key serialized write queues (no concurrent RMW on one key). */
+const writeQueues = new Map<string, Promise<void>>();
+/** In-process max of every value ever persisted per alias key. */
+const writtenAliasMax = new Map<string, number>();
+
+function enqueueWrite(key: string, op: () => Promise<void>): void {
+  const prior = writeQueues.get(key) ?? Promise.resolve();
+  const next = prior.then(op).catch((err) => {
+    log('[background-job-persistence] write failed', {
+      key,
+      err: err instanceof Error ? err.message : String(err),
+    });
+  });
+  writeQueues.set(key, next);
+  void next.then(() => {
+    if (writeQueues.get(key) === next) writeQueues.delete(key);
+  });
+}
+
+/**
+ * Configure the persistence sink. `undefined` (or an absent call — the v1
+ * default) selects the pure memory fallback: writes become no-ops and
+ * nothing is ever seeded. Re-configuring resets all module state; callers
+ * simulating a restart re-configure and then `await
+ * loadInitialBackgroundJobPersistence()`.
+ */
+export function configureBackgroundJobPersistence(
+  storage: BackgroundJobStorageBackend | undefined,
+): void {
+  backend = storage;
+  loaded = emptyState();
+  liveTombstones.clear();
+  writtenAliasMax.clear();
+  writeQueues.clear();
+}
+
+function aliasKey(parent: string, prefix: string): string {
+  return `${ALIAS_PREFIX}${parent}:${prefix}`;
+}
+
+function tombstoneKey(taskID: string): string {
+  return `${TOMBSTONE_PREFIX}${taskID}`;
+}
+
+function epochKey(taskID: string): string {
+  return `${EPOCH_PREFIX}${taskID}`;
+}
+
+/**
+ * Scan the storage backend (following the paginated `next` cursor) into
+ * the module's seed state. No backend → returns empty state and seeds
+ * nothing. The returned snapshot is the same object later boards/ledgers
+ * seed from.
+ */
+export async function loadInitialBackgroundJobPersistence(): Promise<PersistedBackgroundJobState> {
+  if (!backend) {
+    loaded = emptyState();
+    return loaded;
+  }
+
+  const state = emptyState();
+  let after: string | undefined;
+  let pages = 0;
+  do {
+    const page = await backend.scan({ prefix: KEY_ROOT, after, limit: 200 });
+    for (const entry of page.entries) {
+      if (entry.key.startsWith(TOMBSTONE_PREFIX)) {
+        const value = entry.value as Partial<PersistedTombstoneEntry>;
+        if (
+          typeof value?.taskID === 'string' &&
+          typeof value?.epoch === 'number' &&
+          Number.isFinite(value.epoch)
+        ) {
+          const record: PersistedTombstoneEntry = {
+            taskID: value.taskID,
+            epoch: value.epoch,
+            recordedAt:
+              typeof value.recordedAt === 'number' &&
+              Number.isFinite(value.recordedAt)
+                ? value.recordedAt
+                : 0,
+          };
+          state.tombstones.set(record.taskID, record);
+          state.deletionEpochs.set(record.taskID, record.epoch);
+        }
+      } else if (entry.key.startsWith(EPOCH_PREFIX)) {
+        const taskID = entry.key.slice(EPOCH_PREFIX.length);
+        if (typeof entry.value === 'number' && Number.isFinite(entry.value)) {
+          state.deletionEpochs.set(taskID, entry.value);
+        }
+      } else if (entry.key.startsWith(ALIAS_PREFIX)) {
+        const composite = entry.key.slice(ALIAS_PREFIX.length);
+        if (typeof entry.value === 'number' && Number.isFinite(entry.value)) {
+          state.aliasHighWaterMarks.set(composite, entry.value);
+          writtenAliasMax.set(composite, entry.value);
+        }
+      }
+    }
+    after = page.next;
+    pages += 1;
+  } while (after !== undefined && pages < MAX_SCAN_PAGES);
+
+  state.nextEpoch = Math.max(0, ...state.deletionEpochs.values(), 0);
+  for (const record of state.tombstones.values()) {
+    liveTombstones.set(record.taskID, record);
+  }
+  loaded = state;
+  return state;
+}
+
+/** Seed snapshot for fresh boards/ledgers (backend-loaded state only). */
+export function persistedBackgroundJobState(): PersistedBackgroundJobState {
+  return loaded;
+}
+
+/**
+ * Record a suppression tombstone (write-through from
+ * `recordBackgroundJobSuppression`). The epoch comes from the ledger so
+ * in-memory and persisted epochs stay identical.
+ */
+export function recordSuppression(taskID: string, epoch?: number): void {
+  const effectiveEpoch = epoch ?? nextFreeEpoch();
+  const record: PersistedTombstoneEntry = {
+    taskID,
+    epoch: effectiveEpoch,
+    recordedAt: Date.now(),
+  };
+  liveTombstones.set(taskID, record);
+  enforceTombstoneCap();
+
+  if (!backend) return;
+  enqueueWrite(tombstoneKey(taskID), async () => {
+    await backend?.set(tombstoneKey(taskID), { ...record });
+  });
+  enqueueWrite(epochKey(taskID), async () => {
+    await backend?.set(epochKey(taskID), effectiveEpoch);
+  });
+}
+
+/** Epoch suggestion when no ledger epoch was supplied. */
+function nextFreeEpoch(): number {
+  let max = loaded.nextEpoch;
+  for (const record of liveTombstones.values()) {
+    if (record.epoch > max) max = record.epoch;
+  }
+  return max + 1;
+}
+
+/**
+ * Clear the suppression tombstone (write-through from
+ * `clearBackgroundJobSuppression`). The deletion EPOCH is deliberately
+ * kept — a relaunch must not be ghost-skipped after a restart, but its
+ * generation fencing must survive.
+ */
+export function clearSuppression(taskID: string): void {
+  liveTombstones.delete(taskID);
+  if (!backend) return;
+  enqueueWrite(tombstoneKey(taskID), async () => {
+    await backend?.remove(tombstoneKey(taskID));
+  });
+}
+
+function enforceTombstoneCap(): void {
+  if (liveTombstones.size <= MAX_PERSISTED_TOMBSTONES) return;
+  const ordered = [...liveTombstones.values()].sort(
+    (left, right) => left.recordedAt - right.recordedAt,
+  );
+  const evict = ordered.slice(
+    0,
+    liveTombstones.size - MAX_PERSISTED_TOMBSTONES,
+  );
+  for (const record of evict) {
+    liveTombstones.delete(record.taskID);
+  }
+  if (!backend) return;
+  for (const record of evict) {
+    enqueueWrite(tombstoneKey(record.taskID), async () => {
+      await backend?.remove(tombstoneKey(record.taskID));
+    });
+    enqueueWrite(epochKey(record.taskID), async () => {
+      await backend?.remove(epochKey(record.taskID));
+    });
+  }
+}
+
+/** Last-seen alias counter restored from the backend (seed source). */
+export function aliasHighWaterMark(
+  parentSessionID: string,
+  prefix: string,
+): number {
+  return loaded.aliasHighWaterMarks.get(`${parentSessionID}:${prefix}`) ?? 0;
+}
+
+/**
+ * Persist the last-seen alias counter. Monotonic: a stale writer can
+ * never regress the high-water mark. Serialized per key so concurrent
+ * launches never race the same entry.
+ */
+export function bumpAliasHighWaterMark(
+  parentSessionID: string,
+  prefix: string,
+  counter: number,
+): void {
+  if (!backend) return; // memory fallback: nothing to protect against
+  const key = aliasKey(parentSessionID, prefix);
+  const current = writtenAliasMax.get(key) ?? 0;
+  if (counter <= current) return;
+  writtenAliasMax.set(key, counter);
+  enqueueWrite(key, async () => {
+    await backend?.set(key, counter);
+  });
+}

--- a/src/utils/background-job-persistence.ts
+++ b/src/utils/background-job-persistence.ts
@@ -6,8 +6,11 @@
  * Design invariants:
  * - **Write-through.** `recordBackgroundJobSuppression` /
  *   `clearBackgroundJobSuppression` (background-job-store.ts) call this
- *   module on every mutation so the in-process ledger and the persisted
- *   state can never diverge. A task deleted and then legitimately
+ *   module on every mutation so the persisted state tracks the in-process
+ *   ledger. Writes are queued fire-and-forget: a crash between the
+ *   in-memory mutation and the queue flush loses that persisted entry —
+ *   an accepted degradation to process-local behavior. A task deleted and
+ *   then legitimately
  *   relaunched must NOT be ghost-skipped after a restart — clearing the
  *   tombstone on relaunch is load-bearing (the deletion EPOCH survives a
  *   clear so generation fencing keeps working).
@@ -276,12 +279,22 @@ function enforceTombstoneCap(): void {
   }
 }
 
-/** Last-seen alias counter restored from the backend (seed source). */
+/** Alias counter high-water mark: the max of the backend-restored
+ * snapshot and every value persisted in this process. Seeding from the
+ * live max too means two concurrently-live boards sharing one
+ * `<parent, prefix>` never collide even before a restart replays the
+ * backend. */
 export function aliasHighWaterMark(
   parentSessionID: string,
   prefix: string,
 ): number {
-  return loaded.aliasHighWaterMarks.get(`${parentSessionID}:${prefix}`) ?? 0;
+  const composite = `${parentSessionID}:${prefix}`;
+  return Math.max(
+    loaded.aliasHighWaterMarks.get(composite) ?? 0,
+    // writtenAliasMax is keyed by the full storage key (same key the
+    // bump writes), not the bare composite.
+    writtenAliasMax.get(aliasKey(parentSessionID, prefix)) ?? 0,
+  );
 }
 
 /**

--- a/src/utils/background-job-persistence.ts
+++ b/src/utils/background-job-persistence.ts
@@ -26,9 +26,12 @@
  *   today.
  * - **Serialized writes.** Every storage mutation for one key is chained
  *   through an in-process queue, so concurrent callers never race a
- *   read-modify-write on the same key. Writes are fire-and-forget with
- *   logged (never thrown) failures — persistence loss degrades to
- *   today's process-local behavior.
+ *   read-modify-write on the same key. Queued writes are also fenced
+ *   across reconfigurations: a write enqueued before a configure() call
+ *   refuses to execute afterwards, so it can never land on — and reorder
+ *   against new-epoch writes on — the replacement backend. Writes are
+ *   fire-and-forget with logged (never thrown) failures — persistence
+ *   loss degrades to today's process-local behavior.
  *
  * Alias counters persist the last-seen counter per
  * `<parentSessionID>:<prefix>`; a post-restart board seeds its counters
@@ -98,15 +101,37 @@ const liveTombstones = new Map<string, PersistedTombstoneEntry>();
 const writeQueues = new Map<string, Promise<void>>();
 /** In-process max of every value ever persisted per alias key. */
 const writtenAliasMax = new Map<string, number>();
+/**
+ * Reconfiguration fence: incremented on every configure() call. Queued
+ * writes capture the epoch at enqueue time and refuse to execute after a
+ * reconfiguration — an already-scheduled promise chain would otherwise
+ * read the module-global backend at execution time and land a stale
+ * write on the NEW backend, reordering against new-epoch writes for the
+ * same key (e.g. resurrecting a tombstone a newer clear removed).
+ */
+let configEpoch = 0;
 
 function enqueueWrite(key: string, op: () => Promise<void>): void {
+  const epochAtEnqueue = configEpoch;
   const prior = writeQueues.get(key) ?? Promise.resolve();
-  const next = prior.then(op).catch((err) => {
-    log('[background-job-persistence] write failed', {
-      key,
-      err: err instanceof Error ? err.message : String(err),
+  const next = prior
+    .then(() => {
+      if (epochAtEnqueue !== configEpoch) {
+        // Refuse to run: the new epoch's writes own the state now.
+        log(
+          '[background-job-persistence] discarded stale persistence write across reconfiguration',
+          { key },
+        );
+        return;
+      }
+      return op();
+    })
+    .catch((err) => {
+      log('[background-job-persistence] write failed', {
+        key,
+        err: err instanceof Error ? err.message : String(err),
+      });
     });
-  });
   writeQueues.set(key, next);
   void next.then(() => {
     if (writeQueues.get(key) === next) writeQueues.delete(key);
@@ -123,6 +148,10 @@ function enqueueWrite(key: string, op: () => Promise<void>): void {
 export function configureBackgroundJobPersistence(
   storage: BackgroundJobStorageBackend | undefined,
 ): void {
+  // Fence off every write queued by the previous epoch before swapping
+  // the backend: queued ops compare their captured epoch against the new
+  // one and refuse to execute (see enqueueWrite).
+  configEpoch += 1;
   backend = storage;
   loaded = emptyState();
   liveTombstones.clear();

--- a/src/utils/background-job-store.ts
+++ b/src/utils/background-job-store.ts
@@ -8,6 +8,11 @@ import type {
   WallClockTimeoutClaimInput,
   WallClockTimeoutFinalizeInput,
 } from './background-job-board';
+import {
+  clearSuppression as clearSuppressionPersisted,
+  persistedBackgroundJobState,
+  recordSuppression as recordSuppressionPersisted,
+} from './background-job-persistence';
 
 export type BackgroundJobSyntheticTerminalOccurrencePhase =
   | 'observed'
@@ -73,6 +78,30 @@ function backingStore(store: BackgroundJobStore): object {
   return store as object;
 }
 
+/**
+ * Seed a freshly created ledger from backend-loaded persistence state.
+ * No-op without a configured storage backend (v1 / hosts without the
+ * domain) — fresh ledgers then stay exactly as process-local as before.
+ */
+function seedFromPersistence(ledger: BackgroundJobLifecycleLedger): void {
+  const snapshot = persistedBackgroundJobState();
+  if (snapshot.tombstones.size === 0 && snapshot.deletionEpochs.size === 0) {
+    return;
+  }
+  for (const [taskID, record] of snapshot.tombstones) {
+    ledger.tombstones.add(taskID);
+    ledger.deletionEpochs.set(taskID, record.epoch);
+  }
+  for (const [taskID, epoch] of snapshot.deletionEpochs) {
+    if (!ledger.deletionEpochs.has(taskID)) {
+      ledger.deletionEpochs.set(taskID, epoch);
+    }
+  }
+  if (snapshot.nextEpoch > ledger.nextEpoch) {
+    ledger.nextEpoch = snapshot.nextEpoch;
+  }
+}
+
 export function getBackgroundJobLifecycleLedger(
   store: BackgroundJobStore,
 ): BackgroundJobLifecycleLedger {
@@ -90,11 +119,15 @@ export function getBackgroundJobLifecycleLedger(
     processedInjectedCompletionOrder: [],
     nextEpoch: 0,
   };
+  seedFromPersistence(ledger);
   lifecycleLedgers.set(key, ledger);
   return ledger;
 }
 
-/** Record a task drop/eviction as a rehydrate and late-output tombstone. */
+/** Record a task drop/eviction as a rehydrate and late-output tombstone.
+ * Write-through: the persisted tombstone (and its deletion epoch) is
+ * updated together with the in-memory ledger so the two can never
+ * diverge across a restart. */
 export function recordBackgroundJobSuppression(
   store: BackgroundJobStore,
   taskID: string,
@@ -102,15 +135,22 @@ export function recordBackgroundJobSuppression(
   const ledger = getBackgroundJobLifecycleLedger(store);
   if (ledger.tombstones.has(taskID)) return;
   ledger.tombstones.add(taskID);
-  ledger.deletionEpochs.set(taskID, ++ledger.nextEpoch);
+  const epoch = ++ledger.nextEpoch;
+  ledger.deletionEpochs.set(taskID, epoch);
+  recordSuppressionPersisted(taskID, epoch);
 }
 
-/** Clear only the active rehydrate tombstone for a proven new launch. */
+/** Clear only the active rehydrate tombstone for a proven new launch.
+ * Write-through: clearing on relaunch is load-bearing — a task deleted
+ * then legitimately relaunched must NOT be ghost-skipped after a
+ * restart. The deletion epoch intentionally survives (generation
+ * fencing), matching the in-memory ledger semantics. */
 export function clearBackgroundJobSuppression(
   store: BackgroundJobStore,
   taskID: string,
 ): void {
   getBackgroundJobLifecycleLedger(store).tombstones.delete(taskID);
+  clearSuppressionPersisted(taskID);
 }
 
 /**

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -8,6 +8,7 @@ export * from './background-task-concurrency';
 export * from './internal-initiator';
 export { initLogger, log } from './logger';
 export * from './polling';
+export * from './redact';
 export * from './session';
 export * from './session-runtime-status';
 export * from './task';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,6 +1,7 @@
 export * from './agent-variant';
 export * from './background-job-board';
 export * from './background-job-coordinator';
+export * from './background-job-persistence';
 export * from './background-job-store';
 export * from './background-job-supervisor';
 export * from './background-task-concurrency';

--- a/src/utils/logger.test.ts
+++ b/src/utils/logger.test.ts
@@ -363,4 +363,45 @@ describe('logger', () => {
     expect(content).toContain('"array":[1,2,3]');
     expect(content).toContain('"boolean":true');
   });
+
+  test('applies shape-based secret redaction at the compose point', async () => {
+    initLogger('session1');
+    // Runtime-joined so secret scanning does not flag the fixture.
+    const token = ['sk-', 'proj-', 'abcdef1234567890', 'abcdef'].join('');
+    log('token leaked', { data: { token } });
+    await flushLoggerForTesting();
+
+    const logPath = path.join(tmpDir, 'oh-my-opencode-slim.session1.log');
+    const content = fs.readFileSync(logPath, 'utf-8');
+    // Mask marker present, raw token gone …
+    expect(content).toContain('sk-p…ef');
+    expect(content).not.toContain(token);
+    // … while the entry furniture (timestamp + message) stays intact.
+    expect(content).toMatch(/\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\]/);
+    expect(content).toContain('token leaked');
+  });
+
+  test('stderr fallback entries are redacted too', async () => {
+    const blockedLogDir = path.join(tmpDir, 'not-a-directory');
+    fs.writeFileSync(blockedLogDir, 'not a directory');
+    process.env.OPENCODE_LOG_DIR = blockedLogDir;
+    const errorSpy = spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      initLogger('session1');
+      // Runtime-joined so secret scanning does not flag the fixture.
+      const token = ['ghp_', 'ABCDEFGHIJKLMNOP', 'QRSTUVWXYZ1234'].join('');
+      log('stderr leak', { token });
+      await flushLoggerForTesting();
+
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('ghp_…34'));
+      const entry = errorSpy.mock.calls.find(
+        (call) =>
+          typeof call[0] === 'string' && call[0].includes('stderr leak'),
+      );
+      expect(entry?.[0]).not.toContain(token);
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
 });

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -2,6 +2,7 @@ import * as fs from 'node:fs';
 import { appendFile } from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { redactSecretsForLog } from './redact';
 
 const LOG_PREFIX = 'oh-my-opencode-slim.';
 const LOG_SUFFIX = '.log';
@@ -144,7 +145,14 @@ export function log(message: string, data?: unknown): void {
       }
     }
 
-    const logEntry = `[${timestamp}] ${message} ${dataStr}\n`;
+    // Redaction choke point: every sink below (file append, stderr, and
+    // the append-failure stderr fallback) receives this one composed,
+    // already-redacted entry, so no call site can bypass the masking.
+    // Best-effort shape-based barrier against accidental credential
+    // leaks — see src/utils/redact.ts for the documented limits.
+    const logEntry = redactSecretsForLog(
+      `[${timestamp}] ${message} ${dataStr}\n`,
+    );
 
     if (sink.kind === 'stderr') {
       safeStderr(logEntry.trimEnd());

--- a/src/utils/redact.test.ts
+++ b/src/utils/redact.test.ts
@@ -1,24 +1,35 @@
 import { describe, expect, test } from 'bun:test';
 import { redactSecretsForLog } from './redact';
 
+// Partner-pattern fixtures are runtime-joined rather than written as
+// contiguous string literals so secret scanning / GitHub push protection
+// (repo blob scanning) does not flag this repository for carrying
+// live-shaped credentials. AKIAIOSFODNN7EXAMPLE below stays verbatim:
+// it is AWS's canonical documented example access key id.
+const SK_TOKEN = ['sk-', 'proj-', 'abcdef1234567890', 'abcdef'].join('');
+const GH_TOKEN = (kind: 'ghp' | 'gho' | 'ghu' | 'ghs' | 'ghr') =>
+  [`${kind}`, '_', 'ABCDEFGHIJKLMNOP', 'QRSTUVWXYZ1234'].join('');
+const XOX_TOKEN = (kind: 'b' | 'a' | 'p' | 'r' | 's') =>
+  ['xox', kind, '-123456789012-', '1234567890123-', 'abcdefghijklmnop'].join(
+    '',
+  );
+const BEARER_TOKEN = [
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9',
+  '.payload.sig',
+].join('');
+
 describe('redactSecretsForLog', () => {
   test('masks OpenAI-style sk- tokens (prefix/suffix kept, middle gone)', () => {
-    const token = 'sk-proj-abcdef1234567890abcdef';
-    const out = redactSecretsForLog(`call failed with ${token} in env`);
+    const out = redactSecretsForLog(`call failed with ${SK_TOKEN} in env`);
     expect(out).toContain('sk-p');
     expect(out.endsWith('ef') || out.includes('…ef')).toBe(true);
-    expect(out).not.toContain(token);
+    expect(out).not.toContain(SK_TOKEN);
     expect(out).toContain('…');
   });
 
   test('masks GitHub tokens (ghp_/gho_/ghu_/ghs_/ghr_)', () => {
-    for (const token of [
-      'ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234',
-      'gho_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234',
-      'ghu_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234',
-      'ghs_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234',
-      'ghr_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234',
-    ]) {
+    for (const kind of ['ghp', 'gho', 'ghu', 'ghs', 'ghr'] as const) {
+      const token = GH_TOKEN(kind);
       const out = redactSecretsForLog(`auth: ${token}`);
       expect(out.startsWith('auth: gh')).toBe(true);
       expect(out).not.toContain(token);
@@ -26,34 +37,60 @@ describe('redactSecretsForLog', () => {
     }
   });
 
+  test('masks GitLab personal access tokens (glpat-…)', () => {
+    const token = 'glpat-Abcdef1234567890123';
+    const out = redactSecretsForLog(`gitlab ${token}`);
+    expect(out).not.toContain(token);
+    expect(out).toContain('glpa…23');
+  });
+
   test('masks Slack tokens (xox[baprs]-…)', () => {
-    // Fixtures use letter segments (not the real digit-segment format) so
-    // GitHub push protection does not classify them as live Slack tokens.
-    for (const token of [
-      'xoxb-testworkspac-testagentid-abcdefghijklmnop',
-      'xoxa-testworkspac-testbotauthn-abcdefghijklmnop',
-      'xoxp-testworkspac-testusertokn-abcdefghijklmnop',
-      'xoxr-testworkspac-testrefresht-abcdefghijklmnop',
-      'xoxs-testworkspac-testsessiont-abcdefghijklmnop',
-    ]) {
+    for (const kind of ['b', 'a', 'p', 'r', 's'] as const) {
+      const token = XOX_TOKEN(kind);
       const out = redactSecretsForLog(`slack ${token}`);
       expect(out).not.toContain(token);
       expect(out).toContain('xox');
     }
   });
 
-  test('masks AWS access key ids (AKIA…)', () => {
-    const token = 'AKIAIOSFODNN7EXAMPLE';
-    const out = redactSecretsForLog(`key=${token}`);
-    expect(out).toContain('AKIA');
-    expect(out).not.toContain(token);
+  test('masks AWS access key ids and STS temporary keys (AKIA/ASIA…)', () => {
+    // Canonical AWS-documented example key id — intentionally verbatim.
+    const akia = 'AKIAIOSFODNN7EXAMPLE';
+    const asia = 'ASIAIOSFODNN7EXAMPLE';
+    for (const token of [akia, asia]) {
+      const out = redactSecretsForLog(`key=${token}`);
+      expect(out).toContain(token.slice(0, 4));
+      expect(out).not.toContain(token);
+    }
   });
 
-  test('masks Bearer tokens (scheme kept, token masked)', () => {
-    const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.payload.sig';
-    const out = redactSecretsForLog(`Authorization: Bearer ${token}`);
+  test('masks Bearer tokens (scheme kept, credential masked)', () => {
+    const out = redactSecretsForLog(`Authorization: Bearer ${BEARER_TOKEN}`);
     expect(out).toContain('Bearer');
-    expect(out).not.toContain(token);
+    expect(out).not.toContain(BEARER_TOKEN);
+  });
+
+  test('masks Basic and token-scheme credentials', () => {
+    const basic = 'dXNlcjpwYXNzd29yZA==';
+    const out = redactSecretsForLog(`Authorization: Basic ${basic}`);
+    expect(out).toContain('Basic');
+    expect(out).not.toContain(basic);
+    const tokenScheme = 'sup3r-s3cret-session-token_value';
+    const out2 = redactSecretsForLog(`token ${tokenScheme}`);
+    expect(out2).toContain('token');
+    expect(out2).not.toContain(tokenScheme);
+  });
+
+  test('masks ONLY the password in URL credentials (user+host visible)', () => {
+    const dsn = 'postgres://deploy:S3cr3tPass_w0rd@db.internal.io:5432/app';
+    const out = redactSecretsForLog(`dsn: ${dsn}`);
+    expect(out).toContain('postgres://deploy:');
+    expect(out).toContain('@db.internal.io:5432/app');
+    expect(out).not.toContain('S3cr3tPass_w0rd');
+    expect(out).toContain('S3cr…rd');
+    // scheme://user@ without a password is untouched.
+    const plain = 'postgres://deploy@db.internal.io:5432/app';
+    expect(redactSecretsForLog(`dsn: ${plain}`)).toBe(`dsn: ${plain}`);
   });
 
   test('masks generic long opaque runs (32+ chars)', () => {
@@ -64,8 +101,8 @@ describe('redactSecretsForLog', () => {
   });
 
   test('masks every occurrence, not just the first', () => {
-    const a = 'sk-aaaaaaaaaaaaaaaaaaaaaa';
-    const b = 'ghp_BBBBBBBBBBBBBBBBBBBBBBBB';
+    const a = ['sk-', 'aaaaaaaaaaaaaaaa', 'aaaaaa'].join('');
+    const b = GH_TOKEN('ghp');
     const out = redactSecretsForLog(`${a} and ${b}`);
     expect(out).not.toContain(a);
     expect(out).not.toContain(b);
@@ -83,7 +120,7 @@ describe('redactSecretsForLog', () => {
     expect(redactSecretsForLog(text)).toBe(text);
   });
 
-  test('short session ids, urls, and xml-ish content stay readable', () => {
+  test('short session ids, short urls, and xml-ish content stay readable', () => {
     const text =
       '<task id="ses_abc123" state="completed">' +
       ' see https://api.example.com/v1 ' +
@@ -91,8 +128,52 @@ describe('redactSecretsForLog', () => {
     expect(redactSecretsForLog(text)).toBe(text);
   });
 
+  test('long url paths are masked by the generic-run rule (accepted FP)', () => {
+    // Honest assertion: a >32-char unbroken run inside a URL is masked.
+    // Documented false-positive acceptance — the generic rule cannot
+    // tell a long path from a secret.
+    const long =
+      'https://github.com/alvinunreal/oh-my-opencode-slim/pull/1174/files';
+    const out = redactSecretsForLog(`see ${long} for review`);
+    expect(out).not.toContain(long);
+    expect(out).toContain('…');
+  });
+
   test('empty and short strings pass through', () => {
     expect(redactSecretsForLog('')).toBe('');
     expect(redactSecretsForLog('plain text')).toBe('plain text');
+  });
+
+  test('straddle case: redact-then-slice shows the mask, not a raw prefix', () => {
+    // Call-site ordering semantics: redact the FULL string, then slice
+    // (here to 140, like the parse-miss preview). A 40-char opaque
+    // secret starting at offset 100 must appear as its mask — slicing
+    // first would leak the raw prefix of a boundary-straddling secret.
+    const filler = 'a b '.repeat(25); // 100 chars, no long runs
+    const secret = 'Q1w2e3r4t5y6u7i8o9p0a1s2d3f4g5h6j7k8l9z0'; // 40 chars
+    const tail = ' t u'.repeat(15); // 60 chars (leading space: exact run end)
+    const input = `${filler}${secret}${tail}`;
+    expect(input.length).toBe(200);
+
+    const out = redactSecretsForLog(input).slice(0, 140);
+    expect(out.length).toBe(140);
+    expect(out).toContain('…');
+    // The raw secret — and any 20-char raw prefix of it — is gone.
+    expect(out).not.toContain(secret);
+    expect(out).not.toContain(secret.slice(0, 20));
+    // The mask marker sits right after the filler.
+    expect(out.slice(100, 107)).toBe('Q1w2…z0');
+  });
+
+  test('accepted false positives: long paths, UUIDs, and hashes are masked', () => {
+    // Documented as intended: the generic 32+ run rule masks long opaque
+    // non-secrets too. Redaction errs toward masking.
+    const filePath = '/mnt/d/GitRepos/oh-my-opencode-slim/dist/server/index.js';
+    expect(redactSecretsForLog(filePath)).not.toContain(filePath);
+    const uuid = '550e8400-e29b-41d4-a716-446655440000';
+    expect(redactSecretsForLog(`id ${uuid}`)).not.toContain(uuid);
+    const sha256 =
+      'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855';
+    expect(redactSecretsForLog(`sha ${sha256}`)).not.toContain(sha256);
   });
 });

--- a/src/utils/redact.test.ts
+++ b/src/utils/redact.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { redactSecretsForLog } from './redact';
+import { maskTaskOutputStructure, redactSecretsForLog } from './redact';
 
 // Partner-pattern fixtures are runtime-joined rather than written as
 // contiguous string literals so secret scanning / GitHub push protection
@@ -175,5 +175,103 @@ describe('redactSecretsForLog', () => {
     const sha256 =
       'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855';
     expect(redactSecretsForLog(`sha ${sha256}`)).not.toContain(sha256);
+  });
+});
+
+describe('maskTaskOutputStructure', () => {
+  // Structure-only disclosure for untrusted-format previews: field/tag
+  // names survive, every VALUE is fully masked as [masked].
+  test('live v2 sample (a): subagent XML — attr names kept, values masked, inner text survives', () => {
+    const input =
+      '<subagent sessionID="ses_1a2b3c" state="completed" description="Fix login bug">done</subagent>';
+    const out = maskTaskOutputStructure(input);
+    expect(out).toContain('<subagent');
+    expect(out).toContain('sessionID=');
+    expect(out).toContain('state=');
+    expect(out).toContain('description=');
+    expect(out).toContain('"[masked]"');
+    expect(out).not.toContain('ses_1a2b3c');
+    expect(out).not.toContain('completed');
+    expect(out).not.toContain('Fix login bug');
+    expect(out).toContain('>done</subagent>');
+  });
+
+  test('live v2 sample (b): prose key-value — words intact, value masked', () => {
+    const input =
+      'The subagent is working in the background (sessionID: ses_9f8e7d).';
+    const out = maskTaskOutputStructure(input);
+    expect(out).toBe(
+      'The subagent is working in the background (sessionID: [masked]).',
+    );
+  });
+
+  test('live v2 sample (c): key-value masked AND prose pass redacts the DSN password', () => {
+    const input =
+      'Subagent failed (sessionID: ses_5d4c3b): connection refused for postgres://deploy:hunter2@db';
+    const out = maskTaskOutputStructure(input);
+    expect(out).toContain('(sessionID: [masked])');
+    expect(out).toContain('connection refused');
+    expect(out).not.toContain('ses_5d4c3b');
+    expect(out).not.toContain('hunter2');
+    // The prose pass kept user+host readable and masked only the password.
+    expect(out).toContain('postgres://deploy:');
+    expect(out).toContain('@db');
+  });
+
+  test('v1 task XML: names kept, values masked', () => {
+    expect(maskTaskOutputStructure('<task id="abc" state="running">')).toBe(
+      '<task id="[masked]" state="[masked]">',
+    );
+  });
+
+  test('single-quoted, unquoted, and self-closing attribute forms', () => {
+    expect(maskTaskOutputStructure("<task id='abc' />")).toBe(
+      "<task id='[masked]' />",
+    );
+    expect(maskTaskOutputStructure('<task id=abc/>')).toBe(
+      '<task id=[masked]/>',
+    );
+    expect(maskTaskOutputStructure('<task state=running>')).toBe(
+      '<task state=[masked]>',
+    );
+  });
+
+  test('unquoted prose key=value form masks the value', () => {
+    expect(maskTaskOutputStructure('state=running task_id=abc123')).toBe(
+      'state=[masked] task_id=[masked]',
+    );
+    expect(maskTaskOutputStructure('task_id: abc123')).toBe(
+      'task_id: [masked]',
+    );
+  });
+
+  test('malformed pseudo-tags are left to the prose pass unbroken', () => {
+    const malformed = '<not xml';
+    expect(maskTaskOutputStructure(malformed)).toBe(malformed);
+    const mixed = 'a < b and 3 > 2';
+    expect(maskTaskOutputStructure(mixed)).toBe(mixed);
+  });
+
+  test('a secret-looking attribute value never leaks (masked before prose)', () => {
+    // Runtime-joined so secret scanning does not flag the fixture.
+    const token = ['ghp_', 'ABCDEFGHIJKLMNOP', 'QRSTUVWXYZ1234'].join('');
+    const out = maskTaskOutputStructure(
+      `<subagent sessionID="${token}" state="completed">`,
+    );
+    expect(out).not.toContain(token);
+    expect(out).toContain('sessionID="[masked]"');
+  });
+
+  test('URL schemes are not treated as key-value tokens', () => {
+    const input = 'see https://api.example.com/v1 and postgres://deploy@db';
+    // Schemes survive the key-value pass; the prose pass leaves the short
+    // benign URL and the password-less DSN untouched.
+    expect(maskTaskOutputStructure(input)).toBe(input);
+  });
+
+  test('deterministic: same input twice → identical output', () => {
+    const input =
+      '<task id="abc" state="running">text (sessionID: ses_9f8e7d) postgres://deploy:hunter2@db';
+    expect(maskTaskOutputStructure(input)).toBe(maskTaskOutputStructure(input));
   });
 });

--- a/src/utils/redact.test.ts
+++ b/src/utils/redact.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from 'bun:test';
+import { redactSecretsForLog } from './redact';
+
+describe('redactSecretsForLog', () => {
+  test('masks OpenAI-style sk- tokens (prefix/suffix kept, middle gone)', () => {
+    const token = 'sk-proj-abcdef1234567890abcdef';
+    const out = redactSecretsForLog(`call failed with ${token} in env`);
+    expect(out).toContain('sk-p');
+    expect(out.endsWith('ef') || out.includes('…ef')).toBe(true);
+    expect(out).not.toContain(token);
+    expect(out).toContain('…');
+  });
+
+  test('masks GitHub tokens (ghp_/gho_/ghu_/ghs_/ghr_)', () => {
+    for (const token of [
+      'ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234',
+      'gho_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234',
+      'ghu_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234',
+      'ghs_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234',
+      'ghr_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234',
+    ]) {
+      const out = redactSecretsForLog(`auth: ${token}`);
+      expect(out.startsWith('auth: gh')).toBe(true);
+      expect(out).not.toContain(token);
+      expect(out.slice('auth: '.length)).toContain('…');
+    }
+  });
+
+  test('masks Slack tokens (xox[baprs]-…)', () => {
+    // Fixtures use letter segments (not the real digit-segment format) so
+    // GitHub push protection does not classify them as live Slack tokens.
+    for (const token of [
+      'xoxb-testworkspac-testagentid-abcdefghijklmnop',
+      'xoxa-testworkspac-testbotauthn-abcdefghijklmnop',
+      'xoxp-testworkspac-testusertokn-abcdefghijklmnop',
+      'xoxr-testworkspac-testrefresht-abcdefghijklmnop',
+      'xoxs-testworkspac-testsessiont-abcdefghijklmnop',
+    ]) {
+      const out = redactSecretsForLog(`slack ${token}`);
+      expect(out).not.toContain(token);
+      expect(out).toContain('xox');
+    }
+  });
+
+  test('masks AWS access key ids (AKIA…)', () => {
+    const token = 'AKIAIOSFODNN7EXAMPLE';
+    const out = redactSecretsForLog(`key=${token}`);
+    expect(out).toContain('AKIA');
+    expect(out).not.toContain(token);
+  });
+
+  test('masks Bearer tokens (scheme kept, token masked)', () => {
+    const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.payload.sig';
+    const out = redactSecretsForLog(`Authorization: Bearer ${token}`);
+    expect(out).toContain('Bearer');
+    expect(out).not.toContain(token);
+  });
+
+  test('masks generic long opaque runs (32+ chars)', () => {
+    const token = 'Z9xQ1w2e3r4t5y6u7i8o9p0a1s2d3f4g5h6j7';
+    const out = redactSecretsForLog(`api returned ${token} please check`);
+    expect(out.startsWith('api returned Z9xQ')).toBe(true);
+    expect(out).not.toContain(token);
+  });
+
+  test('masks every occurrence, not just the first', () => {
+    const a = 'sk-aaaaaaaaaaaaaaaaaaaaaa';
+    const b = 'ghp_BBBBBBBBBBBBBBBBBBBBBBBB';
+    const out = redactSecretsForLog(`${a} and ${b}`);
+    expect(out).not.toContain(a);
+    expect(out).not.toContain(b);
+  });
+
+  test('benign task-output structure passes through unchanged', () => {
+    const text = [
+      'task_id: ses_8db21a44fe0a97cf',
+      'state: running',
+      '',
+      '<task_result>',
+      'Background task started.',
+      '</task_result>',
+    ].join('\n');
+    expect(redactSecretsForLog(text)).toBe(text);
+  });
+
+  test('short session ids, urls, and xml-ish content stay readable', () => {
+    const text =
+      '<task id="ses_abc123" state="completed">' +
+      ' see https://api.example.com/v1 ' +
+      'parent ses_deadbeef42';
+    expect(redactSecretsForLog(text)).toBe(text);
+  });
+
+  test('empty and short strings pass through', () => {
+    expect(redactSecretsForLog('')).toBe('');
+    expect(redactSecretsForLog('plain text')).toBe('plain text');
+  });
+});

--- a/src/utils/redact.ts
+++ b/src/utils/redact.ts
@@ -5,6 +5,11 @@
  * semantics only) at the parse-miss preview call site in
  * task-session-manager/tool-execute-hooks.ts.
  *
+ * A second, stricter mode — maskTaskOutputStructure, below — provides
+ * structure-only disclosure for untrusted-format previews (the
+ * parse-miss site): field/tag names survive, values are NEVER disclosed
+ * there, not even partially.
+ *
  * Threat model — honest limits: this is a best-effort barrier against
  * ACCIDENTAL leaks in short log previews (a credential that rides along
  * in a tool-output preview, error message, or data blob). It is NOT an
@@ -93,4 +98,69 @@ export function redactSecretsForLog(input: string): string {
     );
   }
   return output;
+}
+
+// ── Structure-preserving value masking (parse-miss previews) ──────────
+//
+// Structure-only disclosure for untrusted-format content: tag and field
+// NAMES survive (enough to diagnose host output drift), but every VALUE
+// is fully hidden behind the literal [masked] placeholder — including
+// benign-looking ones, because values (description fields in particular)
+// carry orchestrator/user-authored text. The placeholder is deliberately
+// distinct from the partial-keep `…` convention above: this site never
+// discloses value bytes at all.
+
+const MASKED_PLACEHOLDER = '[masked]';
+
+/** A well-formed XML-ish tag: `<name attr=value ...>` or `<name/>`.
+ * Attribute values may be double-quoted, single-quoted, or unquoted
+ * (unquoted values stop at `/` so a self-closing `/>` marker is not
+ * swallowed). Anything that does not parse as name + attribute pairs
+ * (no closing `>`, stray `=`/quotes) does not match and is left to the
+ * prose pass. */
+const XML_TAG_PATTERN =
+  /<[A-Za-z][\w.-]*(?:\s+[\w:.-]+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s"'<>/=]+))*\s*\/?>/g;
+
+/** One `name="value"` / `name='value'` / `name=value` pair inside a
+ * matched tag (unquoted values stop at `/` for the same reason). */
+const XML_ATTR_PATTERN = /([\w:.-]+)(\s*=\s*)("[^"]*"|'[^']*'|[^\s"'<>/=]+)/g;
+
+/** Prose key-value token: `key: value` / `key=value`. The key is a
+ * word/hyphen run; URL schemes are excluded both ways — a key followed
+ * by `://` is a scheme (`postgres://…`), and a key preceded by `/` is a
+ * URL authority component (`…//deploy:password@…`) — so URL credentials
+ * stay intact for the precise redactSecretsForLog URL rule instead of
+ * being blunt-masked here. The value run stops at common punctuation
+ * delimiters so surrounding prose (parens, sentence ends) survives. */
+const KEY_VALUE_PATTERN =
+  /(?<!\/)\b([\w-]+)(\s*[:=]\s*)(?!\/\/)([A-Za-z0-9_\-/.+=:@~]+)/g;
+
+function maskXmlAttribute(
+  _match: string,
+  name: string,
+  eq: string,
+  value: string,
+): string {
+  if (value.startsWith('"')) return `${name}${eq}"${MASKED_PLACEHOLDER}"`;
+  if (value.startsWith("'")) return `${name}${eq}'${MASKED_PLACEHOLDER}'`;
+  return `${name}${eq}${MASKED_PLACEHOLDER}`;
+}
+
+/**
+ * Structure-preserving value masking for untrusted-format task output
+ * previews: XML-ish tags keep tag + attribute names with every attribute
+ * value replaced by `[masked]`; prose `key:`/`key=` tokens keep the key
+ * and mask the value run; everything else passes through
+ * redactSecretsForLog (vendor/generic/URL-credential rules still apply
+ * to free text). Deterministic — no wall-clock or randomness.
+ */
+export function maskTaskOutputStructure(input: string): string {
+  const xmlMasked = input.replace(XML_TAG_PATTERN, (tag) =>
+    tag.replace(XML_ATTR_PATTERN, maskXmlAttribute),
+  );
+  const kvMasked = xmlMasked.replace(
+    KEY_VALUE_PATTERN,
+    (_match, key: string, eq: string) => `${key}${eq}${MASKED_PLACEHOLDER}`,
+  );
+  return redactSecretsForLog(kvMasked);
 }

--- a/src/utils/redact.ts
+++ b/src/utils/redact.ts
@@ -1,19 +1,28 @@
 /**
- * Secret-shaped token redaction for plugin log previews.
+ * Shape-based secret redaction, applied at the logger compose point
+ * (src/utils/logger.ts) so every sink — file, stderr, and the append-
+ * failure fallback — emits redacted entries, plus (for ordering
+ * semantics only) at the parse-miss preview call site in
+ * task-session-manager/tool-execute-hooks.ts.
  *
- * Plugin logs are collected into public GitHub issues by the report flow,
- * and tool outputs are untrusted-by-format: the parse-miss preview path
- * (task output without a parsable task id) logs raw host output, so any
- * secret-shaped token it happens to carry must be masked before it
- * reaches the log file. Masking keeps 4 leading + 2 trailing characters
- * (enough to identify the credential KIND and correlate occurrences)
- * and replaces the middle with an ellipsis.
+ * Threat model — honest limits: this is a best-effort barrier against
+ * ACCIDENTAL leaks in short log previews (a credential that rides along
+ * in a tool-output preview, error message, or data blob). It is NOT an
+ * adversarial guarantee. Residual gaps, documented: unprefixed secrets
+ * shorter than the generic 32-char run rule; secrets containing
+ * run-breaking characters (spaces, colons, quotes); and chunked or
+ * obfuscated content that never forms one contiguous matchable token.
  *
- * Deliberately cheap and shape-based (no heuristics about "suspicious"
- * context): known vendor prefixes first, then a generic long opaque-run
- * rule that catches high-entropy tokens of unknown scheme. Benign short
- * identifiers — session ids, short URLs, XML-ish task output structure —
- * pass through unchanged.
+ * Masking keeps 4 leading + 2 trailing characters (enough to identify
+ * the credential KIND and correlate occurrences) and replaces the
+ * middle with an ellipsis. Rules are deliberately cheap and shape-based
+ * (no heuristics about "suspicious" context): known vendor prefixes
+ * first, then authorization schemes and URL credentials, then a generic
+ * long opaque-run rule that catches high-entropy tokens of unknown
+ * scheme. Benign short identifiers — session ids, short URLs, XML-ish
+ * task output structure — pass through unchanged; long opaque
+ * non-secrets (UUIDs, hashes, long paths) are masked as an accepted
+ * false positive.
  */
 
 /** Replace a masked token's middle, keeping 4 leading + 2 trailing chars. */
@@ -24,35 +33,64 @@ function maskToken(token: string): string {
 
 interface RedactionRule {
   pattern: RegExp;
-  /** Extract the secret part to mask from the match (default: whole). */
-  group?: number;
+  /** Build the redacted replacement for one match of `pattern`. */
+  replace: (match: string, groups: string[]) => string;
+}
+
+/** Default replacement: mask the whole match. */
+function maskWhole(match: string): string {
+  return maskToken(match);
 }
 
 const REDACTION_RULES: RedactionRule[] = [
   // OpenAI-style API keys.
-  { pattern: /\bsk-[A-Za-z0-9_-]{8,}\b/g },
+  { pattern: /\bsk-[A-Za-z0-9_-]{8,}\b/g, replace: maskWhole },
   // GitHub tokens (pat, oauth, user, server, refresh).
-  { pattern: /\bgh[pousr]_[A-Za-z0-9]{8,}\b/g },
+  { pattern: /\bgh[pousr]_[A-Za-z0-9]{8,}\b/g, replace: maskWhole },
+  // GitLab personal access tokens.
+  { pattern: /\bglpat-[A-Za-z0-9_-]{8,}\b/g, replace: maskWhole },
   // Slack tokens.
-  { pattern: /\bxox[baprs]-[A-Za-z0-9-]{8,}\b/g },
-  // AWS access key ids.
-  { pattern: /\bAKIA[0-9A-Z]{12,}\b/g },
-  // Bearer scheme: keep the scheme, mask the token.
-  { pattern: /\bBearer\s+([A-Za-z0-9._-]{12,})/g, group: 1 },
+  { pattern: /\bxox[baprs]-[A-Za-z0-9-]{8,}\b/g, replace: maskWhole },
+  // AWS access key ids and STS temporary credentials.
+  {
+    pattern: /\b(?:AKIA|ASIA)[0-9A-Z]{12,}\b/g,
+    replace: maskWhole,
+  },
+  // Authorization schemes: keep the scheme word, mask the credential.
+  {
+    pattern: /\b(?:Bearer|Basic|token|Token)\s+[A-Za-z0-9._+/=-]{8,}/g,
+    replace: (match) => {
+      const split = match.match(/^(\S+)(\s+)([\s\S]+)$/);
+      if (!split) return maskWhole(match);
+      return `${split[1]}${split[2]}${maskToken(split[3])}`;
+    },
+  },
+  // URL credentials scheme://user:password@ — mask ONLY the password;
+  // scheme://user@ without a password stays untouched.
+  {
+    pattern: /[a-zA-Z][a-zA-Z0-9+.-]*:\/\/[^\s:@/]+:([^@\s]+)@/g,
+    replace: (match, groups) =>
+      groups.length === 0 || groups[0].length === 0
+        ? maskWhole(match)
+        : `${match.slice(0, match.length - groups[0].length - 1)}${maskToken(groups[0])}@`,
+  },
   // Generic long opaque run (unknown vendor scheme, high-entropy blob).
-  { pattern: /\b[A-Za-z0-9_\-/.+=]{32,}\b/g },
+  { pattern: /\b[A-Za-z0-9_\-/.+=]{32,}\b/g, replace: maskWhole },
 ];
 
 export function redactSecretsForLog(input: string): string {
   let output = input;
   for (const rule of REDACTION_RULES) {
-    output = output.replace(rule.pattern, (match, ...rest) => {
-      const secret = rule.group === undefined ? match : rest[rule.group - 1];
-      if (typeof secret !== 'string' || secret.length === 0) return match;
-      return rule.group === undefined
-        ? maskToken(secret)
-        : `${match.slice(0, match.length - secret.length)}${maskToken(secret)}`;
-    });
+    output = output.replace(
+      rule.pattern,
+      (match: string, ...rest: unknown[]) => {
+        // Replace-callback args: match, capture groups, offset, string.
+        const groups = rest
+          .slice(0, Math.max(rest.length - 2, 0))
+          .map((group) => (typeof group === 'string' ? group : ''));
+        return rule.replace(match, groups);
+      },
+    );
   }
   return output;
 }

--- a/src/utils/redact.ts
+++ b/src/utils/redact.ts
@@ -1,0 +1,58 @@
+/**
+ * Secret-shaped token redaction for plugin log previews.
+ *
+ * Plugin logs are collected into public GitHub issues by the report flow,
+ * and tool outputs are untrusted-by-format: the parse-miss preview path
+ * (task output without a parsable task id) logs raw host output, so any
+ * secret-shaped token it happens to carry must be masked before it
+ * reaches the log file. Masking keeps 4 leading + 2 trailing characters
+ * (enough to identify the credential KIND and correlate occurrences)
+ * and replaces the middle with an ellipsis.
+ *
+ * Deliberately cheap and shape-based (no heuristics about "suspicious"
+ * context): known vendor prefixes first, then a generic long opaque-run
+ * rule that catches high-entropy tokens of unknown scheme. Benign short
+ * identifiers — session ids, short URLs, XML-ish task output structure —
+ * pass through unchanged.
+ */
+
+/** Replace a masked token's middle, keeping 4 leading + 2 trailing chars. */
+function maskToken(token: string): string {
+  if (token.length <= 8) return '…';
+  return `${token.slice(0, 4)}…${token.slice(-2)}`;
+}
+
+interface RedactionRule {
+  pattern: RegExp;
+  /** Extract the secret part to mask from the match (default: whole). */
+  group?: number;
+}
+
+const REDACTION_RULES: RedactionRule[] = [
+  // OpenAI-style API keys.
+  { pattern: /\bsk-[A-Za-z0-9_-]{8,}\b/g },
+  // GitHub tokens (pat, oauth, user, server, refresh).
+  { pattern: /\bgh[pousr]_[A-Za-z0-9]{8,}\b/g },
+  // Slack tokens.
+  { pattern: /\bxox[baprs]-[A-Za-z0-9-]{8,}\b/g },
+  // AWS access key ids.
+  { pattern: /\bAKIA[0-9A-Z]{12,}\b/g },
+  // Bearer scheme: keep the scheme, mask the token.
+  { pattern: /\bBearer\s+([A-Za-z0-9._-]{12,})/g, group: 1 },
+  // Generic long opaque run (unknown vendor scheme, high-entropy blob).
+  { pattern: /\b[A-Za-z0-9_\-/.+=]{32,}\b/g },
+];
+
+export function redactSecretsForLog(input: string): string {
+  let output = input;
+  for (const rule of REDACTION_RULES) {
+    output = output.replace(rule.pattern, (match, ...rest) => {
+      const secret = rule.group === undefined ? match : rest[rule.group - 1];
+      if (typeof secret !== 'string' || secret.length === 0) return match;
+      return rule.group === undefined
+        ? maskToken(secret)
+        : `${match.slice(0, match.length - secret.length)}${maskToken(secret)}`;
+    });
+  }
+  return output;
+}

--- a/src/v2/event-adapter.test.ts
+++ b/src/v2/event-adapter.test.ts
@@ -861,3 +861,93 @@ describe('mapV2EventToV1 permission field mapping', () => {
     expect(hook.hasInputWait('parent-1')).toBe(false);
   });
 });
+
+describe('mapV2EventToV1 session.deleted synthesis', () => {
+  // v2 delivers deletion flat ({sessionID}) under `data` on live hosts;
+  // without synthesis the v1 deletion cleanup (task-session-manager
+  // rememberDeletedSession + cache-monitor deletedSessionID) never fires on
+  // v2. The v1 consumers read two different spellings of the session id —
+  // properties.info.id (cache-monitor) and properties.sessionID (event
+  // router) — so the synthesized event must carry BOTH.
+  function liveDeletedEvent(sessionID: string): Record<string, unknown> {
+    return deepFreeze({
+      id: 'evt_session_deleted',
+      created: 1_788_961_637_000,
+      type: 'session.deleted',
+      durable: { aggregateID: sessionID, seq: 1, version: 1 },
+      data: { sessionID },
+    });
+  }
+
+  test('legacy `properties` spelling synthesizes the dual-spelling v1 shape', () => {
+    const ev = deepFreeze({
+      type: 'session.deleted',
+      properties: { sessionID: 'ses_del' },
+    });
+    const out = mapV2EventToV1(ev);
+    expect(out).toHaveLength(2);
+    expect(out[0]).toBe(ev);
+    expect(out[1]).toEqual({
+      type: 'session.deleted',
+      properties: {
+        info: { id: 'ses_del' },
+        sessionID: 'ses_del',
+      },
+    });
+  });
+
+  test('live `data` spelling synthesizes the same dual-spelling v1 shape', () => {
+    const ev = liveDeletedEvent('ses_gone');
+    const out = mapV2EventToV1(ev);
+    expect(out).toHaveLength(2);
+    expect(out[0]).toBe(ev);
+    expect(out[1]).toEqual({
+      type: 'session.deleted',
+      properties: {
+        info: { id: 'ses_gone' },
+        sessionID: 'ses_gone',
+      },
+    });
+  });
+
+  test('session.deleted without a sessionID stays passthrough-only', () => {
+    const ev = deepFreeze({ type: 'session.deleted', properties: {} });
+    expect(mapV2EventToV1(ev)).toEqual([ev]);
+    const emptyData = deepFreeze({
+      type: 'session.deleted',
+      data: {},
+    });
+    expect(mapV2EventToV1(emptyData)).toEqual([emptyData]);
+  });
+
+  test('synthesized session.deleted feeds the real task-session-manager cleanup (tombstone)', async () => {
+    const { createTaskSessionManagerHook } = await import(
+      '../hooks/task-session-manager'
+    );
+    const { BackgroundJobBoard, getBackgroundJobLifecycleLedger } =
+      await import('../utils');
+    const board = new BackgroundJobBoard();
+    const hook = createTaskSessionManagerHook({} as never, {
+      maxSessionsPerAgent: 2,
+      maxRetainedSnapshots: 2,
+      backgroundJobBoard: board,
+      shouldManageSession: (id: string) => id === 'parent-1',
+    });
+    board.registerLaunch({
+      taskID: 'child-del',
+      parentSessionID: 'parent-1',
+      agent: 'fixer',
+      description: 'deletion synthesis e2e',
+      now: 0,
+    });
+    // Dispatch like the v2 pump: raw first, then every synthesized product.
+    // The raw data-keyed event is inert in the v1 handler (no properties);
+    // only the synthesized dual-spelling shape can record the tombstone.
+    for (const mapped of mapV2EventToV1(liveDeletedEvent('child-del'))) {
+      await hook.event({ event: mapped });
+    }
+    expect(
+      getBackgroundJobLifecycleLedger(board).tombstones.has('child-del'),
+    ).toBe(true);
+  });
+});

--- a/src/v2/event-adapter.ts
+++ b/src/v2/event-adapter.ts
@@ -35,6 +35,12 @@
  * - `session.created` early registration (task-session-manager
  *   event-router): `properties.info.{id,parentID,agent?}` — plugin
  *   relevance is gated on `info.parentID` (child sessions only).
+ * - `session.deleted` deletion cleanup (task-session-manager
+ *   rememberDeletedSession tombstone/teardown, cache-monitor session
+ *   eviction): `properties.info.id` AND `properties.sessionID` — the two
+ *   consumers read different spellings, so the synthesized event carries
+ *   both. Synthesized from v2's flat `{sessionID}` payload; no
+ *   `generation` is fabricated.
  * - `message.updated` telemetry (cache-monitor
  *   parseCompletedAssistantMessage): `properties.info.{role:'assistant',
  *   sessionID, id, time.completed, tokens.input, tokens.cache.read,
@@ -262,6 +268,11 @@ function permissionAskedToV1(
  *   guessing a lifecycle meaning;
  * - child `session.created` (parentID present) → v1 early-registration
  *   shape `{info: {id, parentID, title?, agent?}}`;
+ * - `session.deleted` → v1 deletion-cleanup shape with the DUAL id
+ *   spelling (`properties.info.id` + `properties.sessionID`) the v1
+ *   consumers read (cache-monitor keys on `info.id`, the event router on
+ *   either; no `generation` is fabricated so the router's
+ *   unproven-relaunch deletion fence keeps its strength);
  * - usage telemetry → v1 completed-assistant `message.updated`;
  * - `form.created/replied/cancelled` → v1 `question.asked/replied/
  *   rejected` (QuestionV1 shapes; "global"-owned forms skipped);
@@ -352,6 +363,25 @@ export function mapV2EventToV1(
       // host-provided value through when present, never fabricate one.
       if (typeof props.agent === 'string') info.agent = props.agent;
       out.push({ type: 'session.created', properties: { info } });
+    }
+  } else if (type === 'session.deleted') {
+    // v2 delivers deletion flat (`{sessionID}`); without this synthesis the
+    // v1 deletion cleanup (task-session-manager rememberDeletedSession
+    // tombstone + board teardown, cache-monitor session eviction) never
+    // fires on v2 and deleted runs resurrect via rehydrate. The v1
+    // consumers read two different spellings — `properties.info.id`
+    // (cache-monitor deletedSessionID) and `properties.sessionID`
+    // (event-router deletion handler) — so BOTH are carried. No
+    // `generation` is fabricated: the event-router's unproven-relaunch
+    // deletion fence must stay free to reject same-ID replaunch deletions.
+    if (typeof props.sessionID === 'string') {
+      out.push({
+        type: 'session.deleted',
+        properties: {
+          info: { id: props.sessionID },
+          sessionID: props.sessionID,
+        },
+      });
     }
   } else if (
     type === 'session.usage.updated' ||

--- a/src/v2/interview-bridge.test.ts
+++ b/src/v2/interview-bridge.test.ts
@@ -284,6 +284,44 @@ describe('v2 interview bridge', () => {
     bridge.dispose();
   });
 
+  test('resolves sessionID from live `data`-keyed events (text + deletion)', async () => {
+    // Live v2 hosts key the event payload under `data`; reading only
+    // `event.properties` left handleEvent dead on live v2 for ALL events.
+    const bridge = createV2InterviewBridge(createContext());
+    await bridge.handleContext({
+      sessionID: 'ses_live',
+      agent: 'orchestrator',
+      model: {},
+      system: [],
+      tools: {},
+      messages: [
+        {
+          id: 'u',
+          role: 'user',
+          content: [{ type: 'text', text: 'hello' }],
+        },
+      ],
+    });
+    await bridge.handleEvent({
+      type: 'session.next.text.started',
+      data: { sessionID: 'ses_live' },
+    });
+    await bridge.handleEvent({
+      type: 'session.next.text.delta',
+      data: { sessionID: 'ses_live', delta: 'from data' },
+    });
+    expect(bridge.getTranscript('ses_live').at(-1)?.parts?.[0]?.text).toBe(
+      'from data',
+    );
+
+    await bridge.handleEvent({
+      type: 'session.deleted',
+      data: { sessionID: 'ses_live' },
+    });
+    expect(bridge.getTranscript('ses_live')).toEqual([]);
+    bridge.dispose();
+  });
+
   test('shares one configured dashboard across multiple v2 sessions', async () => {
     const directory = `.tmp-v2-dashboard-${Date.now()}`;
     const { port, server } = await bindFreePort();

--- a/src/v2/interview-bridge.ts
+++ b/src/v2/interview-bridge.ts
@@ -6,6 +6,7 @@ import type { InterviewSessionRuntime } from '../interview/runtime';
 import { createInterviewServer } from '../interview/server';
 import { createInterviewService } from '../interview/service';
 import type { InterviewMessage } from '../interview/types';
+import { isRecord } from '../utils/guards';
 import { log } from '../utils/logger';
 import { createSessionListShim } from './client-shim';
 import { createSessionSubmit, textFromContent } from './session-submit';
@@ -266,7 +267,15 @@ export function createV2InterviewBridge(
 
   async function handleEvent(event: Record<string, unknown>): Promise<void> {
     const type = typeof event.type === 'string' ? event.type : '';
-    const properties = (event.properties ?? {}) as Record<string, unknown>;
+    // Data-first: live v2 hosts key the event payload under `data` (the
+    // OpenCodeEvent wire shape); `properties` is the legacy/test spelling.
+    // Reading only `properties` left this handler dead on live v2 for ALL
+    // events. handleContext is unaffected (different event type).
+    const properties = isRecord(event.data)
+      ? event.data
+      : isRecord(event.properties)
+        ? event.properties
+        : {};
     const sessionID =
       (typeof properties.sessionID === 'string' && properties.sessionID) ||
       ((properties.info as { id?: string } | undefined)?.id ?? '');

--- a/src/v2/setup.e2e.test.ts
+++ b/src/v2/setup.e2e.test.ts
@@ -525,11 +525,25 @@ describe('createV2Setup e2e', () => {
 
   test('ctx.storage (when present) enables background-job persistence before the v1 factory runs', async () => {
     const { ctx } = makeMockV2Context(projectDir);
+    // Pre-seeded persisted tombstone: proves the storage activation
+    // loads backend state, and later that a storage-less reactivation
+    // resets it instead of retaining the previous activation.
+    const seeded = new Map<string, unknown>([
+      [
+        'omo/bgj/tombstone/ses_seeded_before_setup',
+        { taskID: 'ses_seeded_before_setup', epoch: 1, recordedAt: 1 },
+      ],
+    ]);
     (ctx as { storage?: unknown }).storage = {
-      get: async () => undefined,
+      get: async (key: string) => seeded.get(key),
       set: async () => {},
       remove: async () => {},
-      scan: async () => ({ entries: [] }),
+      scan: async () => ({
+        entries: [...seeded.entries()].map(([key, value]) => ({
+          key,
+          value,
+        })),
+      }),
     };
     const cleanup = await createV2Setup()(ctx);
 
@@ -539,6 +553,19 @@ describe('createV2Setup e2e', () => {
       expect(logText).toContain(
         '[v2] background-job persistence enabled via ctx.storage',
       );
+      const persistence = await import('../utils/background-job-persistence');
+      expect(
+        persistence
+          .persistedBackgroundJobState()
+          .tombstones.has('ses_seeded_before_setup'),
+      ).toBe(true);
+
+      // A storage-less reactivation resets to the documented
+      // process-local fallback instead of retaining this activation's
+      // backend/seed state.
+      const { ctx: bareCtx } = makeMockV2Context(projectDir);
+      await (await createV2Setup()(bareCtx))();
+      expect(persistence.persistedBackgroundJobState().tombstones.size).toBe(0);
     } finally {
       // Reset the persistence singleton so later test files in this
       // process see the pure memory fallback.
@@ -548,7 +575,7 @@ describe('createV2Setup e2e', () => {
       configureBackgroundJobPersistence(undefined);
       await cleanup();
     }
-  }, 20_000);
+  }, 30_000);
 
   test('dispose runs the v1 dispose hook (server.instance.disposed synthesis for wake timers)', async () => {
     const { ctx } = makeMockV2Context(projectDir);

--- a/src/v2/setup.e2e.test.ts
+++ b/src/v2/setup.e2e.test.ts
@@ -495,6 +495,34 @@ describe('createV2Setup e2e', () => {
     expect(logAfterDispose).not.toContain('ses_after');
   }, 20_000);
 
+  test('event pump synthesizes session.deleted from the live `data` shape into the v1 cleanup path', async () => {
+    const { ctx, events } = makeMockV2Context(projectDir);
+    const cleanup = await createV2Setup()(ctx);
+
+    try {
+      // Live wire shape: payload keyed under `data` (verified live).
+      // Only the SYNTHESIZED dual-spelling session.deleted
+      // reaches the v1 event-router cleanup path — the raw passthrough is
+      // inert there — so this log line is name-specific to the mapping.
+      events.push({
+        id: 'evt_session_deleted',
+        created: 1_788_961_637_000,
+        type: 'session.deleted',
+        durable: { aggregateID: 'ses_gone', seq: 1, version: 1 },
+        data: { sessionID: 'ses_gone' },
+      });
+
+      await settlePump();
+      const logText = readPluginLog();
+      expect(logText).toContain(
+        '[task-session-manager] session.deleted observed',
+      );
+      expect(logText).toContain('ses_gone');
+    } finally {
+      await cleanup();
+    }
+  }, 20_000);
+
   test('dispose runs the v1 dispose hook (server.instance.disposed synthesis for wake timers)', async () => {
     const { ctx } = makeMockV2Context(projectDir);
     const cleanup = await createV2Setup()(ctx);

--- a/src/v2/setup.e2e.test.ts
+++ b/src/v2/setup.e2e.test.ts
@@ -523,6 +523,33 @@ describe('createV2Setup e2e', () => {
     }
   }, 20_000);
 
+  test('ctx.storage (when present) enables background-job persistence before the v1 factory runs', async () => {
+    const { ctx } = makeMockV2Context(projectDir);
+    (ctx as { storage?: unknown }).storage = {
+      get: async () => undefined,
+      set: async () => {},
+      remove: async () => {},
+      scan: async () => ({ entries: [] }),
+    };
+    const cleanup = await createV2Setup()(ctx);
+
+    try {
+      await flushLoggerForTesting();
+      const logText = readPluginLog();
+      expect(logText).toContain(
+        '[v2] background-job persistence enabled via ctx.storage',
+      );
+    } finally {
+      // Reset the persistence singleton so later test files in this
+      // process see the pure memory fallback.
+      const { configureBackgroundJobPersistence } = await import(
+        '../utils/background-job-persistence'
+      );
+      configureBackgroundJobPersistence(undefined);
+      await cleanup();
+    }
+  }, 20_000);
+
   test('dispose runs the v1 dispose hook (server.instance.disposed synthesis for wake timers)', async () => {
     const { ctx } = makeMockV2Context(projectDir);
     const cleanup = await createV2Setup()(ctx);

--- a/src/v2/setup.ts
+++ b/src/v2/setup.ts
@@ -20,6 +20,10 @@ import {
 } from '../hooks/cache-safe-injection';
 import { OhMyOpenCodeLite } from '../index';
 import type { McpConfig } from '../mcp/types';
+import {
+  configureBackgroundJobPersistence,
+  loadInitialBackgroundJobPersistence,
+} from '../utils/background-job-persistence';
 import { INTERNAL_INITIATOR_METADATA_KEY } from '../utils/internal-initiator';
 import { initLogger, log } from '../utils/logger';
 import { adaptTool, applyAgentToDraft } from './adapters';
@@ -893,6 +897,31 @@ export function createV2Setup(): (ctx: V2Context) => Promise<V2Cleanup> {
     const directory = resolveV2Directory(ctx);
     const disposers: Array<() => Promise<void> | void> = [];
     let v1Hooks: Record<string, unknown> | undefined;
+
+    // ── Storage domain (optional): background-job persistence ──
+    // Configured BEFORE the v1 factory runs so board/ledger creation
+    // seeds from the persisted state. Absent domain → pure in-memory
+    // fallback with zero behavior change (v1 hosts never reach here).
+    try {
+      const storage = ctx.storage;
+      if (
+        storage &&
+        typeof storage.get === 'function' &&
+        typeof storage.set === 'function' &&
+        typeof storage.remove === 'function' &&
+        typeof storage.scan === 'function'
+      ) {
+        configureBackgroundJobPersistence(storage);
+        await loadInitialBackgroundJobPersistence();
+        log('[v2] background-job persistence enabled via ctx.storage');
+      } else {
+        log(
+          '[v2] ctx.storage unavailable; background-job state stays process-local',
+        );
+      }
+    } catch (err) {
+      log('[v2] background-job persistence init failed', String(err));
+    }
 
     try {
       log('[v2] importing v1 factory...');

--- a/src/v2/setup.ts
+++ b/src/v2/setup.ts
@@ -915,6 +915,11 @@ export function createV2Setup(): (ctx: V2Context) => Promise<V2Cleanup> {
         await loadInitialBackgroundJobPersistence();
         log('[v2] background-job persistence enabled via ctx.storage');
       } else {
+        // Storage-less reactivation: actively reset to the documented
+        // process-local fallback instead of retaining the previous
+        // activation's backend/seed state (fenced — pending writes from
+        // the old epoch are discarded).
+        configureBackgroundJobPersistence(undefined);
         log(
           '[v2] ctx.storage unavailable; background-job state stays process-local',
         );

--- a/src/v2/types.ts
+++ b/src/v2/types.ts
@@ -214,6 +214,19 @@ export interface V2Context {
   event: {
     subscribe(): AsyncIterable<Record<string, unknown>>;
   };
+  /** v2 storage domain (runtime-probed optional, like session.list —
+   * hosts without it keep plugin state process-local). Mirrors the
+   * upstream StorageDomain subset: `scan` is cursor-paginated via the
+   * optional `next` field. Values are JSON. */
+  readonly storage?: {
+    get(key: string): Promise<unknown>;
+    set(key: string, value: unknown): Promise<void>;
+    remove(key: string): Promise<void>;
+    scan(options: { prefix: string; after?: string; limit?: number }): Promise<{
+      entries: Array<{ key: string; value: unknown }>;
+      next?: string;
+    }>;
+  };
   /** v2 mcp domain (present on hosts ≥ #45408; probe before use). */
   mcp?: {
     transform(cb: (draft: V2McpDraft) => void): Promise<V2Registration>;


### PR DESCRIPTION
## Problem

On OpenCode v2, the task board (Background Job Board / task-session-manager) has three classes of state-correctness defects, root-caused against the v2 source (event payloads under `data`, `session.deleted` durable `{sessionID}`, plugin ctx session domain is a narrow `Pick`):

1. **P0 — deletion cleanup never fires.** `mapV2EventToV1` had no `session.deleted` synthesis, and every v1 consumer reads `properties` only. Tombstones, board teardown, admission-slot release, tracker cleanup were all dead on live v2 → deleted runs resurrected via rehydrate as forever-running ghosts (nothing terminalized them), admission slots leaked, interview-bridge was dead for ALL events.
2. **P0 — board state is process-local.** Plugin re-activation (config/source/plugin-list changes) wiped tombstones/epochs/alias counters; after restart the transcript's running tool parts re-registered deleted runs; alias counters reset → cross-generation alias collisions (wrong-task resolution).
3. **P2 — silent loss paths.** Task-tool output parse misses returned silently (host-output-drift invisible); child idle without a board record was easy to miss.

## Changes (6 atomic commits, each independently green)

1. **`1947858a`** — `session.deleted` synthesis with dual id spelling (`properties.info.id` + `properties.sessionID`; cache-monitor reads one, the event router the other; no fabricated `generation` so the unproven-relaunch deletion fence keeps its strength). Interview-bridge `handleEvent` resolves payload data-first. `updateFromInjectedCompletion`: fence check moved **before** the deletion-epoch fail-closed branch so stale fenced occurrences skip cleanly instead of poisoning the fresh generation with `markStatusUncertain`.
2. **`a0933323`** — rehydrate existence probe: fire-and-forget `session.get` per rehydrated running job; NotFound classified strictly by `_tag === 'Session.NotFoundError'` (raw core effect reaches the v2 plugin in-process; never `instanceof`/message) → supervisor cleanup (first, record still needed for deadline finalize) + tombstone + drop + admission release in one synchronous block, guarded by a **generation freshness check**; transient errors fail open. Success with a terminal outcome settles via the idle-reconciliation `updateStatus` semantics (succeeded requires final assistant text). On v1 the probe harmlessly never tombstones (SDK wraps 4xx differently).
3. **`719f6f4a`** — persistence via `ctx.storage` (runtime-probed, memory fallback): tombstones + deletion epochs write-through (`record/clearBackgroundJobSuppression`), 500-tombstone cap with paginated scan, alias high-water marks per `(parent, prefix)` seeded into `nextAlias` (fixes collisions; mapping intentionally not restored — old aliases become not-found, never wrong-task). Epochs deliberately survive clear-on-relaunch (lifecycle boundary for stale-occurrence fences).
4. **`823c5e72`** — parse-miss logs a ~120-char output preview (host-output-drift detector); idle-without-record elevated to `WARN:` for tracked managed children.
5. **`55019ed5`** — docs (`opencode-v2-compatibility.md`, `background-orchestration.md`).
6. **`351717bd`** — review fixes: probe freshness guard vs same-ID relaunch race (pin test proven load-bearing), supervisor-first cleanup ordering, alias high-water `Math.max(loaded, live)` (test caught a real key-lookup bug), docs precision, and the settle regression test.

## Design decision: deletion fail-closed is retained for ALL provenance kinds

The initially-planned explicit-provenance self-observe exemption was deliberately **not** implemented: it conflicts with the existing hardening pin (`index.test.ts:5977`, commit f427ea70), and with the new settlers in place its failure mode (silent wrong data + permanent stale-terminal block) is strictly worse than fail-closed's (transient display-only uncertainty). The new regression test `fail-closed after deletion defers to idle settle, not a wedge` pins that fail-closed means *defer to the idle/outcome settler*, not a permanent wedge.

## Verification

- `bun run check:ci` / `bun run typecheck` / `bun test` green at **every** commit; HEAD: **2719 pass / 0 fail** (149 files).
- Scope: no `src/index.ts` transform-step changes, `cache-safe-injection.ts` untouched; cache-safety property/snapshot/tripwire suites pass unchanged.
- Existing pins kept green (host-completion fail-closed, collision independence, fallback-in-progress semantics, generation-fence ambiguity, `:5977`).
- Independently reviewed against both this repo and the OpenCode v2 source (event wire shapes, plugin ctx surfaces, `ctx.storage` semantics, `Session.remove` partial-failure modes).

## Follow-ups (out of scope)

- Cross-restart interaction pin (persistence-seeded epoch + relaunch + unobserved completion stays fail-closed).
- Uncertainty sweeper (P3): one-shot idle-reconciliation sweep for live relaunched jobs whose idle event is lost.
- Merge-ordering notes: textual conflicts with `fix/task-session-parallel-pairing` (preview log placement); probe's `readFinalAssistantText` should migrate to the shared `utils/child-transcript` extractor once `refactor/child-transcript-util` lands.